### PR TITLE
The ILSVRC original image url somehow changed, use the new one if failed

### DIFF
--- a/inception/inception/data/download_imagenet.sh
+++ b/inception/inception/data/download_imagenet.sh
@@ -56,6 +56,12 @@ BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nonpub"
 BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
 BBOX_TAR_BALL="${BBOX_DIR}/annotations.tar.gz"
 echo "Downloading bounding box annotations."
+wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}" || BASE_URL_CHANGE=1
+if [ $BASE_URL_CHANGE ]; then
+  BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nnoupb"
+  BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
+  BBOX_TAR_BALL="${BBOX_DIR}/annotations.tar.gz"
+fi
 wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}"
 echo "Uncompressing bounding box annotations ..."
 tar xzf "${BBOX_TAR_BALL}" -C "${BBOX_DIR}"


### PR DESCRIPTION
The base url changed from `nonpub` to `nnoupb`. The `nonpub` is not working now. I guess the maintainer might change back to `nonpub`?