### PR TITLE
Using a `tf.Tensor` as a Python `bool` is not allowed

### DIFF
--- a/inception/inception/inception_train.py
+++ b/inception/inception/inception_train.py
@@ -266,7 +266,7 @@ def train(dataset):
 
     # Add histograms for gradients.
     for grad, var in grads:
-      if grad:
+      if grad is not None:
         summaries.append(
             tf.histogram_summary(var.op.name + '/gradients', grad))
 


### PR DESCRIPTION
raise TypeError("Using a `tf.Tensor` as a Python `bool` is not allowed. "
TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.