### PR TITLE
Fix issue in neural_gpu.py where TypeError is raised.

### DIFF
--- a/neural_gpu/neural_gpu.py
+++ b/neural_gpu/neural_gpu.py
@@ -23,7 +23,7 @@ import data_utils
 
 def conv_linear(args, kw, kh, nin, nout, do_bias, bias_start, prefix):
   """Convolutional linear map."""
-  assert args
+  assert args is not None
   if not isinstance(args, (list, tuple)):
     args = [args]
   with tf.variable_scope(prefix):


### PR DESCRIPTION
* `python neural_gpu_trainer.py --task=rev` raises the following TypeError:

  File “..models/neural_gpu/neural_gpu.py", line 26, in conv_linear
    assert args
  File “..tensorflow/python/framework/ops.py", line 475, in __nonzero__
    raise TypeError("Using a `tf.Tensor` as a Python `bool` is not allowed. "
TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.