### PR TITLE
Add gpu_id for distributed training worker

### DIFF
--- a/inception/inception/inception_distributed_train.py
+++ b/inception/inception/inception_distributed_train.py
@@ -56,6 +56,10 @@ tf.app.flags.DEFINE_boolean('log_device_placement', False,
 tf.app.flags.DEFINE_integer(
     'task_id', 0, 'Task ID of the worker/replica running the training.')
 
+# GPU ID is used to select the local GPU for each worker
+tf.app.flags.DEFINE_integer(
+    'gpu_id', 0, 'GPU ID of the worker/replica running on the local device.')
+
 # More details can be found in the sync_replicas_optimizer class:
 # tensorflow/python/training/sync_replicas_optimizer.py
 tf.app.flags.DEFINE_integer('num_replicas_to_aggregate', -1,
@@ -110,7 +114,7 @@ def train(target, dataset, cluster_spec):
   is_chief = (FLAGS.task_id == 0)
 
   # Ops are assigned to worker by default.
-  with tf.device('/job:worker/task:%d' % FLAGS.task_id):
+  with tf.device('/job:worker/task:%d/gpu:%d' % (FLAGS.task_id, FLAGS.gpu_id)):
     # Variables and its related init/assign ops are assigned to ps.
     with slim.scopes.arg_scope(
         [slim.variables.variable, slim.variables.global_step],


### PR DESCRIPTION
when solve the issue [here](https://github.com/tensorflow/tensorflow/issues/2322#event-658034616) I use the same start script to start my two machines. Then this error occured: 

```
E tensorflow/stream_executor/cuda/cuda_driver.cc:932] failed to allocate 2.2K (2304 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY
E tensorflow/stream_executor/cuda/cuda_driver.cc:932] failed to allocate 2.2K (2304 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY
E tensorflow/stream_executor/cuda/cuda_driver.cc:932] failed to allocate 2.2K (2304 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY
...
```

I find the error occurs because framework assign all the memory on the first gpu, `/gpu:0`. finally I solve the problem by [this commit](https://github.com/ZhuFengdaaa/models/commit/6a1176c0d9fc4db4affea85ce524aee0dfb03b2c).

According to the tensorflow source code [gpu_device.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device.cc) line 553, **the framework create all the GPU device local avaliable for each worker. So all workers allocate memory on first GPU, causing OUT_OF_MEMORY** (however I just want assign 1 GPU for 1 worker). 

So I'm wondering whether `inception_distributed_train.py` call the API in a correct way. If we want to achieve the goal that 

> Multiple worker tasks can run on the same machine with multiple GPUs so machine_A with 2 GPUs may have 2 workers while machine_B with 1 GPU just has 1 worker.

 (discribed in the [document](https://github.com/tensorflow/models/blob/master/inception/README.md))

According to [this issue](https://github.com/tensorflow/models/issues/72).
