### PR TITLE
Fix an issue of token overwriting in conll2tree.py of SyntaxNet

### DIFF
--- a/syntaxnet/syntaxnet/conll2tree.py
+++ b/syntaxnet/syntaxnet/conll2tree.py
@@ -45,8 +45,8 @@ def to_dict(sentence):
   Returns:
     Dictionary mapping tokens to children.
   """
-  token_str = ['%s %s %s' % (token.word, token.tag, token.label)
-               for token in sentence.token]
+  token_str = ['%s %s %s %d' % (token.word, token.tag, token.label, i)
+               for i, token in enumerate(sentence.token)]
   children = [[] for token in sentence.token]
   root = -1
   for i in range(0, len(sentence.token)):


### PR DESCRIPTION
There is an issue of token overwriting in conll2tree of SyntaxNet. Because parsed trees are built using dictionary and dictionaries use a token as a key, if the same token appears more than once, the previous key-value pair is overwritten by new one.

For example, if input is given as 'Two iced Americanos, two plain lattes and two vanilla lattes.', there are repeated words ('lattes') on the same level. Then the parsed tree is given by:

Americanos NNP ROOT
 +-- Two CD num
 +-- iced JJ amod
 +-- , , punct
 +-- lattes NNS conj
 |   +-- two CD num
 |   +-- vanilla NN amod
 +-- and CC cc
 +-- . . punct

Note that the nodes of the first 'lattes' are gone.
So to solve this issue, I suggest to include each token's identifier to key for items of dictionary, and the index of token in original input is good candidate because they are unique and we can map tokens of the parse tree into original sentence exactly.

As a result, the new output will be:

Americanos NNP ROOT 2
 +-- Two CD num 0
 +-- iced JJ amod 1
 +-- , , punct 3
 +-- lattes NNS conj 6
 |   +-- two CD num 4
 |   +-- plain JJ amod 5
 +-- and CC cc 7
 +-- lattes NNS conj 10
 |   +-- two CD num 8
 |   +-- vanilla NN amod 9
 +-- . . punct 11