### PR TITLE
Import scipy.ndimage before tensorflow to fix jpeg load.

### DIFF
--- a/transformer/example.py
+++ b/transformer/example.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from scipy import ndimage
 import tensorflow as tf
 from spatial_transformer import transformer
-from scipy import ndimage
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
When importing tensorflow before scipi.ndimage and running the
example in a docker container, the following error is given:

```
 % python example.py
Traceback (most recent call last):
  File "example.py", line 25, in <module>
    im = im / 255.
TypeError: unsupported operand type(s) for /: 'instance' and 'float'
```
This only happens for 'cat.jpg'. When converting the image to a '.png'
file, the example runs as expected.

When swapping the imports around so that scipy.ndimage is imported
BEFORE tensorflow, both 'jpg' and 'png' files work.