### PR TITLE
Add PARAMS definition to shell snippets in syntaxnet/README

### DIFF
--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -549,6 +549,7 @@ Once you have the pre-trained locally normalized model, a globally normalized
 parsing model can now be trained with the following command:
 
 ```shell
+PARAMS=200x200-0.08-4400-0.85-4
 bazel-bin/syntaxnet/parser_trainer \
   --arg_prefix=brain_parser \
   --batch_size=8 \

--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -476,6 +476,7 @@ Once the tagged datasets are available, a locally normalized dependency parsing
 model can be trained with the following command:
 
 ```shell
+PARAMS=128-0.08-3600-0.9-0
 bazel-bin/syntaxnet/parser_trainer \
   --arg_prefix=brain_parser \
   --batch_size=32 \


### PR DESCRIPTION
A couple of shell snippets uses the `$PARAMS` variable, but the snippet does not include the `PARAMS` definition, as the previous snippets.