### PR TITLE
Compatibility with tensorflow master

### DIFF
--- a/syntaxnet/WORKSPACE
+++ b/syntaxnet/WORKSPACE
@@ -14,11 +14,11 @@ check_version("0.2.0")
 
 bind(
     name = "libssl",
-    actual = "@boringssl_git//:ssl",
+    actual = "@ts_boringssl_git//:ssl",
 )
 
 git_repository(
-    name = "boringssl_git",
+    name = "ts_boringssl_git",
     commit = "436432d849b83ab90f18773e4ae1c7a8f148f48d",
     init_submodules = True,
     remote = "https://github.com/mdsteele/boringssl-bazel.git",
@@ -26,11 +26,11 @@ git_repository(
 
 bind(
     name = "zlib",
-    actual = "@zlib_archive//:zlib",
+    actual = "@ts_zlib_archive//:zlib",
 )
 
 new_http_archive(
-    name = "zlib_archive",
+    name = "ts_zlib_archive",
     build_file = "zlib.BUILD",
     sha256 = "879d73d8cd4d155f31c1f04838ecd567d34bebda780156f0e82a20721b3973d5",
     strip_prefix = "zlib-1.2.8",

--- a/syntaxnet/WORKSPACE
+++ b/syntaxnet/WORKSPACE
@@ -1,13 +1,13 @@
 local_repository(
-  name = "tf",
+  name = "org_tensorflow",
   path = __workspace_dir__ + "/tensorflow",
 )
 
 load('//tensorflow/tensorflow:workspace.bzl', 'tf_workspace')
-tf_workspace("tensorflow/", "@tf")
+tf_workspace("tensorflow/", "@org_tensorflow")
 
 # Specify the minimum required Bazel version.
-load("@tf//tensorflow:tensorflow.bzl", "check_version")
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "check_version")
 check_version("0.2.0")
 
 # ===== gRPC dependencies =====

--- a/syntaxnet/syntaxnet/BUILD
+++ b/syntaxnet/syntaxnet/BUILD
@@ -77,15 +77,15 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@re2//:re2",
-        "@tf//google/protobuf",
-        "@tf//third_party/eigen3",
+        "@protobuf//:protobuf",
+        "@org_tensorflow//third_party/eigen3",
     ] + select({
         "//conditions:default": [
-            "@tf//tensorflow/core:framework",
-            "@tf//tensorflow/core:lib",
+            "@org_tensorflow//tensorflow/core:framework",
+            "@org_tensorflow//tensorflow/core:lib",
         ],
-        "@tf//tensorflow:darwin": [
-            "@tf//tensorflow/core:framework_headers_lib",
+        "@org_tensorflow//tensorflow:darwin": [
+            "@org_tensorflow//tensorflow/core:framework_headers_lib",
         ],
     }),
 )
@@ -108,8 +108,8 @@ cc_library(
     srcs = ["test_main.cc"],
     linkopts = ["-lm"],
     deps = [
-        "@tf//tensorflow/core:lib",
-        "@tf//tensorflow/core:testlib",
+        "@org_tensorflow//tensorflow/core:lib",
+        "@org_tensorflow//tensorflow/core:testlib",
         "//external:gtest",
     ],
 )
@@ -408,7 +408,7 @@ cc_binary(
     name = "parser_ops.so",
     linkopts = select({
         "//conditions:default": ["-lm"],
-        "@tf//tensorflow:darwin": [],
+        "@org_tensorflow//tensorflow:darwin": [],
     }),
     linkshared = 1,
     linkstatic = 1,
@@ -518,8 +518,8 @@ py_library(
     name = "graph_builder",
     srcs = ["graph_builder.py"],
     deps = [
-        "@tf//tensorflow:tensorflow_py",
-        "@tf//tensorflow/core:protos_all_py",
+        "@org_tensorflow//tensorflow:tensorflow_py",
+        "@org_tensorflow//tensorflow/core:protos_all_py",
         ":load_parser_ops_py",
         ":parser_ops",
     ],

--- a/syntaxnet/syntaxnet/reader_ops.cc
+++ b/syntaxnet/syntaxnet/reader_ops.cc
@@ -514,19 +514,16 @@ class WordEmbeddingInitializer : public OpKernel {
   static tensorflow::Status CopyToTmpPath(const string &source_path,
                                           string *tmp_path) {
     // Opens source file.
-    tensorflow::RandomAccessFile *source_file;
+    std::unique_ptr<tensorflow::RandomAccessFile> source_file;
     TF_RETURN_IF_ERROR(tensorflow::Env::Default()->NewRandomAccessFile(
         source_path, &source_file));
-    std::unique_ptr<tensorflow::RandomAccessFile> source_file_deleter(
-        source_file);
 
     // Creates destination file.
-    tensorflow::WritableFile *target_file;
+    std::unique_ptr<tensorflow::WritableFile> target_file;
     *tmp_path = tensorflow::strings::Printf(
         "/tmp/%d.%lld", getpid(), tensorflow::Env::Default()->NowMicros());
     TF_RETURN_IF_ERROR(
         tensorflow::Env::Default()->NewWritableFile(*tmp_path, &target_file));
-    std::unique_ptr<tensorflow::WritableFile> target_file_deleter(target_file);
 
     // Performs copy.
     tensorflow::Status s;

--- a/syntaxnet/syntaxnet/sentence_features.cc
+++ b/syntaxnet/syntaxnet/sentence_features.cc
@@ -120,9 +120,9 @@ string AffixTableFeature::WorkspaceName() const {
 static AffixTable *CreateAffixTable(const string &filename,
                                     AffixTable::Type type) {
   AffixTable *affix_table = new AffixTable(type, 1);
-  tensorflow::RandomAccessFile *file;
+  std::unique_ptr<tensorflow::RandomAccessFile> file;
   TF_CHECK_OK(tensorflow::Env::Default()->NewRandomAccessFile(filename, &file));
-  ProtoRecordReader reader(file);
+  ProtoRecordReader reader(file.release());
   affix_table->Read(&reader);
   return affix_table;
 }

--- a/syntaxnet/syntaxnet/syntaxnet.bzl
+++ b/syntaxnet/syntaxnet/syntaxnet.bzl
@@ -15,7 +15,14 @@
 
 load("@protobuf//:protobuf.bzl", "cc_proto_library")
 load("@protobuf//:protobuf.bzl", "py_proto_library")
-load("@org_tensorflow//third_party/gpus/cuda:build_defs.bzl", "if_cuda")
+
+def if_cuda(if_true, if_false = []):
+    """Shorthand for select()'ing on whether we're building with CUDA."""
+    return select({
+        "@org_tensorflow//third_party/gpus/cuda:using_nvcc": if_true,
+        "@org_tensorflow//third_party/gpus/cuda:using_gcudacc": if_true,
+        "//conditions:default": if_false
+    })
 
 def tf_copts():
   return (["-fno-exceptions", "-DEIGEN_AVOID_STL_ARRAY",] +

--- a/syntaxnet/syntaxnet/syntaxnet.bzl
+++ b/syntaxnet/syntaxnet/syntaxnet.bzl
@@ -13,26 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
-load("@tf//google/protobuf:protobuf.bzl", "cc_proto_library")
-load("@tf//google/protobuf:protobuf.bzl", "py_proto_library")
-
-def if_cuda(if_true, if_false = []):
-    """Shorthand for select()'ing on whether we're building with CUDA.
-
-    Returns a select statement which evaluates to if_true if we're building
-    with CUDA enabled.  Otherwise, the select statement evaluates to if_false.
-
-    """
-    return select({
-        "@tf//third_party/gpus/cuda:using_nvcc": if_true,
-        "@tf//third_party/gpus/cuda:using_gcudacc": if_true,
-        "//conditions:default": if_false
-    })
+load("@protobuf//:protobuf.bzl", "cc_proto_library")
+load("@protobuf//:protobuf.bzl", "py_proto_library")
+load("@org_tensorflow//third_party/gpus/cuda:build_defs.bzl", "if_cuda")
 
 def tf_copts():
   return (["-fno-exceptions", "-DEIGEN_AVOID_STL_ARRAY",] +
           if_cuda(["-DGOOGLE_CUDA=1"]) +
-          select({"@tf//tensorflow:darwin": [],
+          select({"@org_tensorflow//tensorflow:darwin": [],
                   "//conditions:default": ["-pthread"]}))
 
 def tf_proto_library(name, srcs=[], has_services=False,
@@ -47,9 +35,9 @@ def tf_proto_library(name, srcs=[], has_services=False,
   cc_proto_library(name=name,
                    srcs=srcs,
                    deps=deps,
-                   cc_libs = ["@tf//google/protobuf:protobuf"],
-                   protoc="@tf//google/protobuf:protoc",
-                   default_runtime="@tf//google/protobuf:protobuf",
+                   cc_libs = ["@protobuf//:protobuf"],
+                   protoc="@protobuf//:protoc",
+                   default_runtime="@protobuf//:protobuf",
                    testonly=testonly,
                    visibility=visibility,)
 
@@ -58,8 +46,8 @@ def tf_proto_library_py(name, srcs=[], deps=[], visibility=None, testonly=0):
                    srcs=srcs,
                    srcs_version = "PY2AND3",
                    deps=deps,
-                   default_runtime="@tf//google/protobuf:protobuf_python",
-                   protoc="@tf//google/protobuf:protoc",
+                   default_runtime="@protobuf//:protobuf_python",
+                   protoc="@protobuf//:protoc",
                    visibility=visibility,
                    testonly=testonly,)
 
@@ -72,7 +60,7 @@ def tf_gen_op_libs(op_lib_names):
     native.cc_library(name=n + "_op_lib",
                       copts=tf_copts(),
                       srcs=["ops/" + n + ".cc"],
-                      deps=(["@tf//tensorflow/core:framework"]),
+                      deps=(["@org_tensorflow//tensorflow/core:framework"]),
                       visibility=["//visibility:public"],
                       alwayslink=1,
                       linkstatic=1,)
@@ -89,8 +77,8 @@ def tf_gen_op_wrapper_py(name, out=None, hidden=[], visibility=None, deps=[],
       linkopts = ["-lm"],
       copts = tf_copts(),
       linkstatic = 1,   # Faster to link this one-time-use binary dynamically
-      deps = (["@tf//tensorflow/core:framework",
-               "@tf//tensorflow/python:python_op_gen_main"] + deps),
+      deps = (["@org_tensorflow//tensorflow/core:framework",
+               "@org_tensorflow//tensorflow/python:python_op_gen_main"] + deps),
   )
 
   # Invoke the previous cc_binary to generate a python file.
@@ -110,5 +98,5 @@ def tf_gen_op_wrapper_py(name, out=None, hidden=[], visibility=None, deps=[],
                     srcs_version="PY2AND3",
                     visibility=visibility,
                     deps=[
-                        "@tf//tensorflow/python:framework_for_generated_wrappers",
+                        "@org_tensorflow//tensorflow/python:framework_for_generated_wrappers",
                     ],)

--- a/syntaxnet/util/utf8/BUILD
+++ b/syntaxnet/util/utf8/BUILD
@@ -27,7 +27,7 @@ cc_test(
         "unicodetext_unittest.cc",
     ],
     deps = [
-        "@tf//tensorflow/core:testlib",
+        "@org_tensorflow//tensorflow/core:testlib",
         ":unicodetext",
     ],
 )


### PR DESCRIPTION
This PR is for syntaxnet.

The motivation of these changes are to make syntaxnet usable inside other WORKSPACEs that use up-to-date tensorflow (e.g. TF Serving)

This PR fixes some naming issues and is required for compatibility with tensorflow master (0ef58dc5c571d4c6ca1564bc27fc0c5db23cbd01 as I write this). I have NOT updated the actual tensorflow submodule with this PR because I don't know anything about release schedules or anything, but if this is merged, TF submodule should be updated.

In particular, protobuf was moved from a submodule to an external repository in TF. Also, the canonical repo name changed from @tf to @org_tensorflow.

Finally, there are some repo naming conflicts between syntaxnet and TF for external dependencies (boringssl and zlib) so prefix the names to make them unique.

P.S. @googlebot : I have signed a Company CLA, company name is COBITE, INC. "I signed it!"