### PR TITLE
Fix linkage of UnpackSparseFeatures op so kernel is registered

### DIFF
--- a/syntaxnet/syntaxnet/BUILD
+++ b/syntaxnet/syntaxnet/BUILD
@@ -389,6 +389,7 @@ cc_library(
         ":sparse_proto",
         ":utils",
     ],
+    alwayslink = 1,
 )
 
 cc_library(


### PR DESCRIPTION
When using parser_ops_cc as a dependency from an external project, all of the sub-dependencies (that provide OpKernel implementations) need to have alwayslink=1 or the OpKernel's won't be register.  I believe all of them do, except for "UnpackSparseFeatures". Without this an error like, e.g:

```
F tensorflow_serving/example/mnist_inference.cc:215] Check failed: ::tensorflow::Status::OK() == (bundle_factory->CreateSessionBundle(bundle_path, &bundle)) (OK vs. Invalid argument: No OpKernel was registered to support Op 'UnpackSparseFeatures' with these attrs
     [[Node: evaluation/while/UnpackSparseFeatures_2 = UnpackSparseFeatures[](evaluation/while/feature_2)]])
```

Will be generated when running the compiled output.