### PR TITLE
Fixed bug test failed on parser_trainer_test

### DIFF
--- a/syntaxnet/syntaxnet/parser_trainer_test.sh
+++ b/syntaxnet/syntaxnet/parser_trainer_test.sh
@@ -22,7 +22,7 @@
 
 set -eux
 
-BINDIR=$TEST_SRCDIR/syntaxnet
+BINDIR=$TEST_SRCDIR/$TEST_WORKSPACE/syntaxnet
 CONTEXT=$BINDIR/testdata/context.pbtxt
 TMP_DIR=/tmp/syntaxnet-output
 


### PR DESCRIPTION
Fixed bug file not found "/syntaxnet/bazel-out/local-opt/bin/syntaxnet/parser_trainer_test.runfiles/syntaxnet/parser_trainer: No such file or directory"
