### PR TITLE
Remove obsolete README.

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Very simple implementations of some autoencoder variations


### PR DESCRIPTION
README file was introduced with autoencoder commit but today we have multiple models in repo. Should either be synced with README.md or be removed, I guess removing is preferred.

This is really a trivial change, just can't live with such tiny flaw :)

Ideally we should collect all trivial patches from thousands of open source projects and train a deep network model to submit trivial patches automatically <grin> 

Great project, thank you!