### PR TITLE
Fixed confusing wording

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -664,7 +664,7 @@ bazel-bin/inception/build_image_data \
 ```
 
 where the `$OUTPUT_DIRECTORY` is the location of the sharded `TFRecords`. The
-`$LABELS_FILE` will be a text file that is outputted by the script that provides
+`$LABELS_FILE` will be a text file that is read by the script that provides
 a list of all of the labels. For instance, in the case flowers data set, the
 `$LABELS_FILE` contained the following data:
 


### PR DESCRIPTION
The script actually reads $LABEL_FILE and strips out the text, which it uses to label and find image files in their respective sub directories.