### PR TITLE
Removing syntaxnet-users@google.com from the SyntaxNet readme.

### DIFF
--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -594,7 +594,10 @@ and parse text in the wild.
 
 ## Contact
 
-To ask questions or report issues please contact syntaxnet-users@google.com.
+To ask questions or report issues please post on Stack Overflow with the tag
+[syntaxnet](http://stackoverflow.com/questions/tagged/syntaxnet)
+or open an issue on the tensorflow/models
+[issues tracker](https://github.com/tensorflow/models/issues).
 
 ## Credits
 


### PR DESCRIPTION
And replacing it with instructions to post to stackoverflow or on github issues.