### PR TITLE
Inception v3: fix variable initialization

### DIFF
--- a/inception/inception/inception_train.py
+++ b/inception/inception/inception_train.py
@@ -220,7 +220,7 @@ def train(dataset):
     # Number of classes in the Dataset label set plus 1.
     # Label 0 is reserved for an (unused) background class.
     num_classes = dataset.num_classes() + 1
-    
+
      # Split the batch of images and labels for towers.
     images_splits = tf.split(0, FLAGS.num_gpus, images)
     labels_splits = tf.split(0, FLAGS.num_gpus, labels)
@@ -305,7 +305,8 @@ def train(dataset):
     summary_op = tf.merge_summary(summaries)
 
     # Build an initialization operation to run below.
-    init = tf.initialize_all_variables()
+    init = tf.group(tf.initialize_all_variables(),
+                    tf.initialize_local_variables())
 
     # Start running operations on the Graph. allow_soft_placement must be set to
     # True to build towers on GPU, as some of the ops do not have GPU


### PR DESCRIPTION
This PR is highly related to this issue: https://github.com/tensorflow/tensorflow/issues/3168

To summarize, there appears to be a regression since r0.9 which makes the initialization of some variables of the input_producer fail (or more specifically, calling `tf.initialize_all_variables()` do not include these variables). To include the variables of the input_producer (apparently the ones responsible for the epoch count) you also need to call `tf.initialize_local_variables()`.

I am using part of the `inception/inception/inception_train.py` `train` function, and stumble on the same error.
## PR Content

Fixes aforementioned issue by adding to the `init_op` the initialization of local variables.
## Environment info

Operating System: Ubuntu 16.04
Installed version of CUDA and cuDNN: Cuda 7.5 and CuDnn 5.0

```
guillaume@xxxxxxx:~$ ls -l /usr/local/cuda/lib*/libcud*
-rw-r--r-- 1 root root   322936 Aug 15  2015 /usr/local/cuda/lib64/libcudadevrt.a
lrwxrwxrwx 1 root root       16 Aug 15  2015 /usr/local/cuda/lib64/libcudart.so -> libcudart.so.7.5
lrwxrwxrwx 1 root root       19 Aug 15  2015 /usr/local/cuda/lib64/libcudart.so.7.5 -> libcudart.so.7.5.18
-rwxr-xr-x 1 root root   383336 Aug 15  2015 /usr/local/cuda/lib64/libcudart.so.7.5.18
-rw-r--r-- 1 root root   720192 Aug 15  2015 /usr/local/cuda/lib64/libcudart_static.a
-rwxr-xr-x 1 root root 61453024 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn.so
-rwxr-xr-x 1 root root 61453024 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn.so.4
-rwxr-xr-x 1 root root 61453024 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn.so.4.0.7
-rwxr-xr-x 1 root root 59909104 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn.so.5
-rwxr-xr-x 1 root root 59909104 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn.so.5.0.5
-rw-r--r-- 1 root root 62025862 Aug  2 10:41 /usr/local/cuda/lib64/libcudnn_static.a
```
## Log

```
guillaume@xxxxxxx:~/finetuning$ python inception_v3.py 
I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcublas.so locally
I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcudnn.so locally
I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcufft.so locally
I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcuda.so.1 locally
I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcurand.so locally
I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:925] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
I tensorflow/core/common_runtime/gpu/gpu_init.cc:102] Found device 0 with properties: 
name: GRID K520
major: 3 minor: 0 memoryClockRate (GHz) 0.797
pciBusID 0000:00:03.0
Total memory: 4.00GiB
Free memory: 3.60GiB
I tensorflow/core/common_runtime/gpu/gpu_init.cc:126] DMA: 0 
I tensorflow/core/common_runtime/gpu/gpu_init.cc:136] 0:   Y 
I tensorflow/core/common_runtime/gpu/gpu_device.cc:839] Creating TensorFlow device (/gpu:0) -> (device: 0, name: GRID K520, pci bus id: 0000:00:03.0)
E tensorflow/core/client/tensor_c_api.cc:485] Attempting to use uninitialized value input/input_producer/limit_epochs/epochs
     [[Node: input/input_producer/limit_epochs/CountUpTo = CountUpTo[T=DT_INT64, _class=["loc:@input/input_producer/limit_epochs/epochs"], limit=100, _device="/job:localhost/replica:0/task:0/cpu:0"](input/input_producer/limit_epochs/epochs)]]
ERROR:tensorflow:Exception in QueueRunner: Attempting to use uninitialized value input/input_producer/limit_epochs/epochs
     [[Node: input/input_producer/limit_epochs/CountUpTo = CountUpTo[T=DT_INT64, _class=["loc:@input/input_producer/limit_epochs/epochs"], limit=100, _device="/job:localhost/replica:0/task:0/cpu:0"](input/input_producer/limit_epochs/epochs)]]
Caused by op u'input/input_producer/limit_epochs/CountUpTo', defined at:
  File "inception_v3.py", line 453, in <module>
    num_epochs=100, num_threads=4, initial_learning_rate=.01)
  File "inception_v3.py", line 63, in tf_train
    num_labels=num_labels, filename=filename)
  File "/home/guillaume/image_tagging/image_tagging/preprocessing/pipeline.py", line 44, in inputs
    [filename], num_epochs=num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 194, in string_input_producer
    summary_name="fraction_of_%d_full" % capacity)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 133, in input_producer
    input_tensor = limit_epochs(input_tensor, num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 84, in limit_epochs
    counter = epochs.count_up_to(num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 577, in count_up_to
    return state_ops.count_up_to(self._variable, limit=limit)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/ops/gen_state_ops.py", line 127, in count_up_to
    result = _op_def_lib.apply_op("CountUpTo", ref=ref, limit=limit, name=name)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.py", line 703, in apply_op
    op_def=op_def)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 2310, in create_op
    original_op=self._default_original_op, op_def=op_def)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1232, in __init__
    self._traceback = _extract_stack()

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/queue_runner.py", line 185, in _run
    sess.run(enqueue_op)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 382, in run
    run_metadata_ptr)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 655, in _run
    feed_dict_string, options, run_metadata)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 723, in _do_run
    target_list, options, run_metadata)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 743, in _do_call
    raise type(e)(node_def, op, message)
FailedPreconditionError: Attempting to use uninitialized value input/input_producer/limit_epochs/epochs
     [[Node: input/input_producer/limit_epochs/CountUpTo = CountUpTo[T=DT_INT64, _class=["loc:@input/input_producer/limit_epochs/epochs"], limit=100, _device="/job:localhost/replica:0/task:0/cpu:0"](input/input_producer/limit_epochs/epochs)]]
Caused by op u'input/input_producer/limit_epochs/CountUpTo', defined at:
  File "inception_v3.py", line 453, in <module>
    num_epochs=100, num_threads=4, initial_learning_rate=.01)
  File "inception_v3.py", line 63, in tf_train
    num_labels=num_labels, filename=filename)
  File "/home/guillaume/image_tagging/image_tagging/preprocessing/pipeline.py", line 44, in inputs
    [filename], num_epochs=num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 194, in string_input_producer
    summary_name="fraction_of_%d_full" % capacity)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 133, in input_producer
    input_tensor = limit_epochs(input_tensor, num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/training/input.py", line 84, in limit_epochs
    counter = epochs.count_up_to(num_epochs)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 577, in count_up_to
    return state_ops.count_up_to(self._variable, limit=limit)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/ops/gen_state_ops.py", line 127, in count_up_to
    result = _op_def_lib.apply_op("CountUpTo", ref=ref, limit=limit, name=name)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.py", line 703, in apply_op
    op_def=op_def)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 2310, in create_op
    original_op=self._default_original_op, op_def=op_def)
  File "/home/guillaume/.virtualenvs/tf/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1232, in __init__
    self._traceback = _extract_stack()
```
