### PR TITLE
Do not perform averaging of the cost.

### DIFF
--- a/resnet/resnet_model.py
+++ b/resnet/resnet_model.py
@@ -122,10 +122,7 @@ class ResNet(object):
       self.cost = tf.reduce_mean(xent, name='xent')
       self.cost += self._decay()
 
-      moving_avg = tf.train.ExponentialMovingAverage(
-          0.99, num_updates=self.global_step, name='moving_avg')
-      self._extra_train_ops.append(moving_avg.apply([self.cost]))
-      tf.scalar_summary('cost', moving_avg.average(self.cost))
+      tf.scalar_summary('cost', self.cost)
 
   def _build_train_op(self):
     """Build training specific ops for the graph."""


### PR DESCRIPTION
The moving average object was shared between training and evaluation. As a result, the cost during evaluation was averaged with the training cost. This affects only objective, not precision.