### PR TITLE
Typo in finetuning instructions

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -295,7 +295,7 @@ $ python train_image_classifier.py \
     --model_name=inception_v3 \
     --checkpoint_path=${CHECKPOINT_PATH} \
     --checkpoint_exclude_scopes=InceptionV3/Logits,InceptionV3/AuxLogits \
-    --trainable_scopes=InceptionV3/Logits,InceptionV3/AuxLogits/Logits
+    --trainable_scopes=InceptionV3/Logits,InceptionV3/AuxLogits
 ```
 
 

--- a/slim/README.md
+++ b/slim/README.md
@@ -294,7 +294,7 @@ $ python train_image_classifier.py \
     --dataset_split_name=train \
     --model_name=inception_v3 \
     --checkpoint_path=${CHECKPOINT_PATH} \
-    --checkpoint_exclude_scopes=InceptionV3/Logits,InceptionV3/AuxLogits/Logits \
+    --checkpoint_exclude_scopes=InceptionV3/Logits,InceptionV3/AuxLogits \
     --trainable_scopes=InceptionV3/Logits,InceptionV3/AuxLogits/Logits
 ```
 


### PR DESCRIPTION
I think all variables in the `/AuxLogits` scope need to be ignored for the model to be loaded for fine-tuning tasks
