### PR TITLE
Fix a minor path error in slim instructions

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -78,7 +78,7 @@ To verify that this has worked, execute the following commands; it should run
 without raising any errors.
 
 ```
-cd $HOME/workspace/slim
+cd $HOME/workspace/models/slim
 python -c "from nets import cifarnet; mynet = cifarnet.cifarnet"
 ```
 


### PR DESCRIPTION
The slim README says that the command should run without raising errors, however the path is not the path in which slim is installed in.