### PR TITLE
Fix path in TF-slim README

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -78,7 +78,7 @@ To verify that this has worked, execute the following commands; it should run
 without raising any errors.
 
 ```
-cd $HOME/workspace/slim
+cd $HOME/workspace/models/slim
 python -c "from nets import cifarnet; mynet = cifarnet.cifarnet"
 ```
 


### PR DESCRIPTION
The instructions to install the TF-slim library clones the repository to `$HOME/workspace/models`. This PR fixes the path in the following instruction to change into the `models/slim` directory.
