### PR TITLE
correct parser_trainer_test.sh for recent bazel

### DIFF
--- a/syntaxnet/syntaxnet/parser_trainer_test.sh
+++ b/syntaxnet/syntaxnet/parser_trainer_test.sh
@@ -22,7 +22,7 @@
 
 set -eux
 
-BINDIR=$TEST_SRCDIR/syntaxnet
+BINDIR=$TEST_SRCDIR/$TEST_WORKSPACE/syntaxnet
 CONTEXT=$BINDIR/testdata/context.pbtxt
 TMP_DIR=/tmp/syntaxnet-output
 


### PR DESCRIPTION
Without this, the parser_trainer_test.sh errors out because the testdata/context.pbtxt file is not where the script thinks it is.
