### PR TITLE
tf.image.resize_images() expects 'size' argument as a 1-D Tensor.

### DIFF
--- a/slim/preprocessing/inception_preprocessing.py
+++ b/slim/preprocessing/inception_preprocessing.py
@@ -212,7 +212,7 @@ def preprocess_for_train(image, height, width, bbox,
     num_resize_cases = 1 if fast_mode else 4
     distorted_image = apply_with_random_selector(
         distorted_image,
-        lambda x, method: tf.image.resize_images(x, height, width, method),
+        lambda x, method: tf.image.resize_images(x, [height, width], method),
         num_cases=num_resize_cases)
 
     tf.image_summary('cropped_resized_image',


### PR DESCRIPTION
The TF Slim [README](https://github.com/tensorflow/models/tree/master/slim) recommends installing TensorFlow from master. However, in master the tf.image.resize_images() arguments have changed. This makes it compatible with TensorFlow @ [current master](https://github.com/tensorflow/tensorflow/commit/49bb6cc491869bd291c8ff4115907d3601332af9)
