### PR TITLE
Fix broken link in inception readme

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -479,7 +479,7 @@ your custom data set. Please see the associated options and assumptions behind
 this script by reading the comments section of [`build_image_data.py`]
 (inception/data/build_image_data.py). Also, if your custom data has a different 
 number of examples or classes, you need to change the appropriate values in
-[`imagenet_data.py`](imagenet_data.py).
+[`imagenet_data.py`](inception/imagenet_data.py).
 
 The second piece you will need is a trained Inception v3 image model. You have
 the option of either training one yourself (See [How to Train from Scratch]


### PR DESCRIPTION
This is to fix #529.

I wrote this script to check that there aren't any other broken links. In the future, this should possibly be added as a Bazel rule test or something, so we can catch problems like these in the future. 

```py
import os
import re
import sys

def find_markdown_files():
  for path, dirs, files in os.walk('.'):
    for f in files:
      if f.endswith('.md'):
        yield os.path.join(path, f)

for markdown in find_markdown_files():
  for m in re.finditer(r'\]\((.*?)[\s)]', open(markdown).read()):
    path = m.group(1)
    if path.startswith(('#', 'http')):
      continue
    if not os.path.exists(os.path.join(os.path.dirname(markdown), path)):
      print >>sys.stderr, "%s: %s" % (markdown, path)
```