### PR TITLE
Revert "Use open() instead of tf.gfile.FastGFile()"

### DIFF
--- a/im2txt/im2txt/data/build_mscoco_data.py
+++ b/im2txt/im2txt/data/build_mscoco_data.py
@@ -210,7 +210,7 @@ def _to_sequence_example(image, decoder, vocab):
   Returns:
     A SequenceExample proto.
   """
-  with open(image.filename, "r") as f:
+  with tf.gfile.FastGFile(image.filename, "r") as f:
     encoded_image = f.read()
 
   try:

--- a/inception/inception/data/build_image_data.py
+++ b/inception/inception/data/build_image_data.py
@@ -199,7 +199,7 @@ def _process_image(filename, coder):
     width: integer, image width in pixels.
   """
   # Read the image file.
-  with open(filename, 'r') as f:
+  with tf.gfile.FastGFile(filename, 'r') as f:
     image_data = f.read()
 
   # Convert any PNG to JPEG's for consistency.

--- a/inception/inception/data/build_imagenet_data.py
+++ b/inception/inception/data/build_imagenet_data.py
@@ -313,7 +313,7 @@ def _process_image(filename, coder):
     width: integer, image width in pixels.
   """
   # Read the image file.
-  with open(filename, 'r') as f:
+  with tf.gfile.FastGFile(filename, 'r') as f:
     image_data = f.read()
 
   # Clean the dirty data.


### PR DESCRIPTION
PTAL @rohan100jain 

This reverts commit c6a4f783080c5310ce0e3244daa31af57df12def.

Fixed tensorflow/tensorflow#4981
