### PR TITLE
Python3 dict.values() does not return a list

### DIFF
--- a/slim/eval_image_classifier.py
+++ b/slim/eval_image_classifier.py
@@ -183,7 +183,7 @@ def main(_):
         checkpoint_path=checkpoint_path,
         logdir=FLAGS.eval_dir,
         num_evals=num_batches,
-        eval_op=names_to_updates.values(),
+        eval_op=list(names_to_updates.values()),
         variables_to_restore=variables_to_restore)
 
 


### PR DESCRIPTION
Add a list wrapper will make it run properly in Python3 as well as Python2.
