### PR TITLE
Fix end point collection to return a dict

### DIFF
--- a/slim/nets/alexnet.py
+++ b/slim/nets/alexnet.py
@@ -117,7 +117,7 @@ def alexnet_v2(inputs,
                           scope='fc8')
 
       # Convert end_points_collection into a end_point dict.
-      end_points = dict(tf.get_collection(end_points_collection))
+      end_points = slim.utils.convert_collection_to_dict(end_points_collection)
       if spatial_squeeze:
         net = tf.squeeze(net, [1, 2], name='fc8/squeezed')
         end_points[sc.name + '/fc8'] = net

--- a/slim/nets/overfeat.py
+++ b/slim/nets/overfeat.py
@@ -110,7 +110,7 @@ def overfeat(inputs,
                           biases_initializer=tf.zeros_initializer,
                           scope='fc8')
       # Convert end_points_collection into a end_point dict.
-      end_points = dict(tf.get_collection(end_points_collection))
+      end_points = slim.utils.convert_collection_to_dict(end_points_collection)
       if spatial_squeeze:
         net = tf.squeeze(net, [1, 2], name='fc8/squeezed')
         end_points[sc.name + '/fc8'] = net

--- a/slim/nets/resnet_v1.py
+++ b/slim/nets/resnet_v1.py
@@ -198,7 +198,7 @@ def resnet_v1(inputs,
           net = slim.conv2d(net, num_classes, [1, 1], activation_fn=None,
                             normalizer_fn=None, scope='logits')
         # Convert end_points_collection into a dictionary of end_points.
-        end_points = dict(tf.get_collection(end_points_collection))
+        end_points = slim.utils.convert_collection_to_dict(end_points_collection)
         if num_classes is not None:
           end_points['predictions'] = slim.softmax(net, scope='predictions')
         return net, end_points

--- a/slim/nets/resnet_v2.py
+++ b/slim/nets/resnet_v2.py
@@ -207,7 +207,7 @@ def resnet_v2(inputs,
           net = slim.conv2d(net, num_classes, [1, 1], activation_fn=None,
                             normalizer_fn=None, scope='logits')
         # Convert end_points_collection into a dictionary of end_points.
-        end_points = dict(tf.get_collection(end_points_collection))
+        end_points = slim.utils.convert_collection_to_dict(end_points_collection)
         if num_classes is not None:
           end_points['predictions'] = slim.softmax(net, scope='predictions')
         return net, end_points

--- a/slim/nets/vgg.py
+++ b/slim/nets/vgg.py
@@ -114,7 +114,7 @@ def vgg_a(inputs,
                         normalizer_fn=None,
                         scope='fc8')
       # Convert end_points_collection into a end_point dict.
-      end_points = dict(tf.get_collection(end_points_collection))
+      end_points = slim.utils.convert_collection_to_dict(end_points_collection)
       if spatial_squeeze:
         net = tf.squeeze(net, [1, 2], name='fc8/squeezed')
         end_points[sc.name + '/fc8'] = net
@@ -173,7 +173,7 @@ def vgg_16(inputs,
                         normalizer_fn=None,
                         scope='fc8')
       # Convert end_points_collection into a end_point dict.
-      end_points = dict(tf.get_collection(end_points_collection))
+      end_points = slim.utils.convert_collection_to_dict(end_points_collection)
       if spatial_squeeze:
         net = tf.squeeze(net, [1, 2], name='fc8/squeezed')
         end_points[sc.name + '/fc8'] = net
@@ -232,7 +232,7 @@ def vgg_19(inputs,
                         normalizer_fn=None,
                         scope='fc8')
       # Convert end_points_collection into a end_point dict.
-      end_points = dict(tf.get_collection(end_points_collection))
+      end_points = slim.utils.convert_collection_to_dict(end_points_collection)
       if spatial_squeeze:
         net = tf.squeeze(net, [1, 2], name='fc8/squeezed')
         end_points[sc.name + '/fc8'] = net


### PR DESCRIPTION
Fixes the TF slim models to be compatible with the change in TF 0.11 (https://github.com/tensorflow/tensorflow/commit/5247ebbe24465563bdd4ef46f1cecc34f256f76b)

Otherwise, running vgg/alexnet etc models gives the following error:
```txt
end_points = dict(tf.get_collection(end_points_collection))
TypeError: cannot convert dictionary update sequence element #0 to a sequence
```