### PR TITLE
Fix POS tagging score of Ling et al.(2005)

### DIFF
--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -44,7 +44,7 @@ Parsey McParseface is also state-of-the-art for part-of-speech (POS) tagging
 
 Model                                                                      | News  | Web   | Questions
 -------------------------------------------------------------------------- | :---: | :---: | :-------:
-[Ling et al. (2015)](http://www.cs.cmu.edu/~lingwang/papers/emnlp2015.pdf) | 97.78 | 94.03 | 96.18
+[Ling et al. (2015)](http://www.cs.cmu.edu/~lingwang/papers/emnlp2015.pdf) | 97.44 | 94.03 | 96.18
 [Andor et al. (2016)](http://arxiv.org/abs/1603.06042)*                    | 97.77 | 94.80 | 96.86
 Parsey McParseface                                                         | 97.52 | 94.24 | 96.45
 


### PR DESCRIPTION
For English News Corpus,
[Ling et al. (2015)](http://www.cs.cmu.edu/~lingwang/papers/emnlp2015.pdf)'s score is 
97.78 -> 97.44 (lower than SyntaxNet and Parsey Mcparseface)
according to [Andor et al. (2016)](http://arxiv.org/abs/1603.06042).