### PR TITLE
Remove comment that TensorFlow must be built from source.

### DIFF
--- a/im2txt/README.md
+++ b/im2txt/README.md
@@ -119,9 +119,7 @@ approximately 10 times slower.
 First ensure that you have installed the following required packages:
 
 * **Bazel** ([instructions](http://bazel.io/docs/install.html)).
-* **TensorFlow** ([instructions](https://www.tensorflow.org/versions/master/get_started/os_setup.html#installing-from-sources)).
-    * Note: the model currently requires TensorFlow built from source because it
-      uses features added after release r0.10.
+* **TensorFlow** ([instructions](https://www.tensorflow.org/versions/master/get_started/os_setup.html)).
 * **NumPy** ([instructions](http://www.scipy.org/install.html)).
 * **Natural Language Toolkit (NLTK)**:
     * First install NLTK ([instructions](http://www.nltk.org/install.html)).


### PR DESCRIPTION
Unnecessary now that TensorFlow 0.11.0 is officially out of RC.