### PR TITLE
Change eval to session.run for namignizer

### DIFF
--- a/namignizer/names.py
+++ b/namignizer/names.py
@@ -122,7 +122,7 @@ def run_epoch(session, m, names, counts, epoch_size, eval_op, verbose=False):
         cost, _ = session.run([m.cost, eval_op],
                               {m.input_data: x,
                                m.targets: y,
-                               m.initial_state: m.initial_state.eval(),
+                               m.initial_state: session.run(m.initial_state),
                                m.weights: np.ones(m.batch_size * m.num_steps)})
         costs += cost
         iters += m.num_steps
@@ -201,7 +201,7 @@ def namignize(names, checkpoint_path, config):
             cost, loss, _ = session.run([m.cost, m.loss, tf.no_op()],
                                   {m.input_data: x,
                                    m.targets: y,
-                                   m.initial_state: m.initial_state.eval(),
+                                   m.initial_state: session.run(m.initial_state),
                                    m.weights: np.concatenate((
                                        np.ones(len(name)), np.zeros(m.batch_size * m.num_steps - len(name))))})
 
@@ -234,7 +234,7 @@ def namignator(checkpoint_path, config):
         activations, final_state, _ = session.run([m.activations, m.final_state, tf.no_op()],
                                                   {m.input_data: np.zeros((1, 1)),
                                                    m.targets: np.zeros((1, 1)),
-                                                   m.initial_state: m.initial_state.eval(),
+                                                   m.initial_state: session.run(m.initial_state),
                                                    m.weights: np.ones(1)})
 
         # sample from our softmax activations


### PR DESCRIPTION
# Description

I was getting the following error while trying to run **namignizer** model with `Python 2.7.12` and `TensorFlow 0.11.0`:
```
Traceback (most recent call last):
  File "names.py", line 257, in <module>
    train("data/SmallNames.txt", "model/namignizer", SmallConfig)
  File "names.py", line 171, in train
    verbose=True)
  File "names.py", line 125, in run_epoch
    m.initial_state: m.initial_state.eval(),
AttributeError: 'tuple' object has no attribute 'eval'
```
The problem was when doing `m.initial_state.eval()`. I changed it to `session.run(m.initial_state)` (which I guess makes more sense) and now it's working.

Thanks!