### PR TITLE
Fix ValueError when processing bbox in XML annotation file

### DIFF
--- a/inception/inception/data/process_bounding_boxes.py
+++ b/inception/inception/data/process_bounding_boxes.py
@@ -102,7 +102,9 @@ def GetItem(name, root, index=0):
 
 
 def GetInt(name, root, index=0):
-  return int(GetItem(name, root, index))
+  #  In some XML annotation files, the point value are not int,  but float.
+  #  So adding a float function to avoid  ValueError.
+  return int(float(GetItem(name, root, index)))
 
 
 def FindNumberBoundingBoxes(root):


### PR DESCRIPTION
In some XML annotation files, point values [xmin, ymin, xmax, ymax] relative to bounding box are string type look like a float number. So if want to use int() convert those string to int. The program will raise an ValueError.Such as:
`ValueError: invalid literal for int() with base 10: '64.0994'`

So I fixed this bug by adding an float function before int function.