### PR TITLE
Remove WARNING in calling function softmax_cross_entropy

### DIFF
--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -471,9 +471,9 @@ def main(_):
       if 'AuxLogits' in end_points:
         slim.losses.softmax_cross_entropy(
             end_points['AuxLogits'], labels,
-            label_smoothing=FLAGS.label_smoothing, weight=0.4, scope='aux_loss')
+            label_smoothing=FLAGS.label_smoothing, weights=0.4, scope='aux_loss')
       slim.losses.softmax_cross_entropy(
-          logits, labels, label_smoothing=FLAGS.label_smoothing, weight=1.0)
+          logits, labels, label_smoothing=FLAGS.label_smoothing, weights=1.0)
       return end_points
 
     # Gather initial summaries.


### PR DESCRIPTION
https://www.tensorflow.org/code/tensorflow/contrib/losses/python/losses/loss_ops.py was refactored and now when running script produces a WARNING.

```
WARNING:tensorflow:From train_image_classifier.py:477 in clone_fn.: calling softmax_cross_entropy (from tensorflow.contrib.losses.python.losses.loss_ops) with weight is deprecated and will be removed after 2016-11-25.
Instructions for updating:
`weight` is being deprecated, use `weights`
```