### PR TITLE
Fix the problem that all the words become UNK

### DIFF
--- a/tutorials/rnn/translate/data_utils.py
+++ b/tutorials/rnn/translate/data_utils.py
@@ -177,7 +177,7 @@ def initialize_vocabulary(vocabulary_path):
     rev_vocab = []
     with gfile.GFile(vocabulary_path, mode="rb") as f:
       rev_vocab.extend(f.readlines())
-    rev_vocab = [line.strip() for line in rev_vocab]
+    rev_vocab = [tf.compat.as_bytes(line).strip() for line in rev_vocab]
     vocab = dict([(x, y) for (y, x) in enumerate(rev_vocab)])
     return vocab, rev_vocab
   else:


### PR DESCRIPTION
All the words became `_UNK` since the keys of `vocab` were in `str` type.
The problem occurred in Python 3.5