### PR TITLE
update inception v3 model works with the latest tensorflow API

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -540,7 +540,7 @@ the flowers data set with the following command.
 bazel build inception/flowers_train
 
 # Path to the downloaded Inception-v3 model.
-MODEL_PATH="${INCEPTION_MODEL_DIR}/model.ckpt-157585"
+MODEL_PATH="${INCEPTION_MODEL_DIR}/"
 
 # Directory where the flowers data resides.
 FLOWERS_DATA_DIR=/tmp/flowers-data/

--- a/inception/inception/slim/ops.py
+++ b/inception/inception/slim/ops.py
@@ -91,7 +91,7 @@ def batch_norm(inputs,
     if scale:
       gamma = variables.variable('gamma',
                                  params_shape,
-                                 initializer=tf.ones_initializer,
+                                 initializer=tf.ones_initializer(),
                                  trainable=trainable,
                                  restore=restore)
     # Create moving_mean and moving_variance add them to
@@ -105,7 +105,7 @@ def batch_norm(inputs,
                                      collections=moving_collections)
     moving_variance = variables.variable('moving_variance',
                                          params_shape,
-                                         initializer=tf.ones_initializer,
+                                         initializer=tf.ones_initializer(),
                                          trainable=False,
                                          restore=restore,
                                          collections=moving_collections)

--- a/inception/inception/slim/variables.py
+++ b/inception/inception/slim/variables.py
@@ -275,8 +275,8 @@ def variable(name, shape=None, dtype=tf.float32, initializer=None,
   """
   collections = list(collections or [])
 
-  # Make sure variables are added to tf.GraphKeys.VARIABLES and MODEL_VARIABLES
-  collections += [tf.GraphKeys.VARIABLES, MODEL_VARIABLES]
+  # Make sure variables are added to tf.GraphKeys.GLOBAL_VARIABLES and MODEL_VARIABLES
+  collections += [tf.GraphKeys.GLOBAL_VARIABLES, MODEL_VARIABLES]
   # Add to VARIABLES_TO_RESTORE if necessary
   if restore:
     collections.append(VARIABLES_TO_RESTORE)


### PR DESCRIPTION
The '--pretrained_model_checkpoint_path' specify the file of a checkpoint and the new checkpoint V2 is not support read from file. 
Because of the changes to tf.all_variables() and tf.GraphKeys, the collection name is changed and the necessary parameters in checkpoint cannot be saved in training process which cause checkpoint not able to be read to continue training. 