### PR TITLE
Fix the error of "TypeError: ones_initializer() got multiple values for keyword argument 'dtype'".

### DIFF
--- a/inception/inception/slim/ops.py
+++ b/inception/inception/slim/ops.py
@@ -91,7 +91,7 @@ def batch_norm(inputs,
     if scale:
       gamma = variables.variable('gamma',
                                  params_shape,
-                                 initializer=tf.ones_initializer,
+                                 initializer=tf.ones_initializer(),
                                  trainable=trainable,
                                  restore=restore)
     # Create moving_mean and moving_variance add them to
@@ -105,7 +105,7 @@ def batch_norm(inputs,
                                      collections=moving_collections)
     moving_variance = variables.variable('moving_variance',
                                          params_shape,
-                                         initializer=tf.ones_initializer,
+                                         initializer=tf.ones_initializer(),
                                          trainable=False,
                                          restore=restore,
                                          collections=moving_collections)


### PR DESCRIPTION
Without the change, when I run the inception model with command 
  ```
  bazel-bin/inception/imagenet_train --num_gpus=1 --batch_size=32 --train_dir=/tmp/imagenet_train --data_dir=/tmp/imagenet-data
  ```
it would fail with the error
  ```
  Traceback (most recent call last):
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/imagenet_train.py", line 41, in <module>
    tf.app.run()
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 43, in run
    sys.exit(main(sys.argv[:1] + flags_passthrough))
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/imagenet_train.py", line 37, in main
    inception_train.train(dataset)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/inception_train.py", line 239, in train
    scope)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/inception_train.py", line 108, in _tower_loss
    scope=scope)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/inception_model.py", line 87, in inference
    scope=scope)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/inception_model.py", line 87, in inception_v3
    scope='conv0')
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/scopes.py", line 155, in func_with_args
    return func(*args, **current_args)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/ops.py", line 234, in conv2d
    outputs = batch_norm(conv, **batch_norm_params)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/scopes.py", line 155, in func_with_args
    return func(*args, **current_args)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/ops.py", line 111, in batch_norm
    collections=moving_collections)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/scopes.py", line 155, in func_with_args
    return func(*args, **current_args)
  File "/home/ubuntu/2nd/models/inception/bazel-bin/inception/imagenet_train.runfiles/inception/inception/slim/variables.py", line 289, in variable
    trainable=trainable, collections=collections)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 1024, in get_variable
    custom_getter=custom_getter)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 850, in get_variable
    custom_getter=custom_getter)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 346, in get_variable
    validate_shape=validate_shape)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 331, in _true_getter
    caching_device=caching_device, validate_shape=validate_shape)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 677, in _get_single_variable
    expected_shape=shape)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 224, in __init__
    expected_shape=expected_shape)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 327, in _init_from_args
    initial_value(), name="initial_value", dtype=dtype)
  File "/home/ubuntu/.local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 665, in <lambda>
    shape.as_list(), dtype=dtype, partition_info=partition_info)
TypeError: ones_initializer() got multiple values for keyword argument 'dtype'
  ```