### PR TITLE
Add Python3-compatible comparison methods

### DIFF
--- a/im2txt/im2txt/inference_utils/caption_generator.py
+++ b/im2txt/im2txt/inference_utils/caption_generator.py
@@ -54,6 +54,14 @@ class Caption(object):
       return -1
     else:
       return 1
+    
+  def __lt__(self, other):
+    assert isinstance(other, Caption)
+    return self.score < other.score
+      
+  def __eq__(self, other):
+    assert isinstance(other, Caption)
+    return self.score == other.score
 
 
 class TopN(object):


### PR DESCRIPTION
Otherwise breaks with `TypeError: unorderable types: Caption() < Caption()` in Python 3.5