### PR TITLE
Word2vec can now be run if the users compile the ops on their own

### DIFF
--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -26,7 +26,7 @@ TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
 g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2
 ```
 
-(If you want to know what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)).
+(For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)).
 Then run using:
 
 ```shell

--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -21,11 +21,12 @@ rm source-archive.zip
 
 You will need to compile the ops as follows:
 
-``` shell
+```shell
 TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
 g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2
 ```
 
+(If you want to know what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)).
 Then run using:
 
 ```shell

--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -9,7 +9,7 @@ tutorials. Brief instructions are below.
 
 * [Word2Vec Tutorial](http://tensorflow.org/tutorials/word2vec)
 
-To download the example text and evaluation data:
+Assuming you have cloned the git repository, navigate into this directory. To download the example text and evaluation data:
 
 ```shell
 wget http://mattmahoney.net/dc/text8.zip -O text8.zip
@@ -19,21 +19,17 @@ unzip -p source-archive.zip  word2vec/trunk/questions-words.txt > questions-word
 rm source-archive.zip
 ```
 
-Assuming you have cloned the git repository, navigate into this directory and
-run using:
+You will need to compile the ops as follows:
 
-```shell
-cd models/tutorials/embedding
-python word2vec_optimized.py \
-  --train_data=text8 \
-  --eval_data=questions-words.txt \
-  --save_path=/tmp/
+``` shell
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2
 ```
 
-To run the code from sources using bazel:
+Then run using:
 
 ```shell
-bazel run -c opt models/tutorials/embedding/word2vec_optimized -- \
+python word2vec_optimized.py \
   --train_data=text8 \
   --eval_data=questions-words.txt \
   --save_path=/tmp/

--- a/tutorials/embedding/__init__.py
+++ b/tutorials/embedding/__init__.py
@@ -17,5 +17,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-import gen_word2vec

--- a/tutorials/embedding/word2vec.py
+++ b/tutorials/embedding/word2vec.py
@@ -42,7 +42,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import numpy as np
 import tensorflow as tf
 
-word2vec = tf.load_op_library(os.path.dirname(os.path.realpath(__file__)) + '/word2vec_ops.so')
+word2vec = tf.load_op_library(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'word2vec_ops.so'))
 
 flags = tf.app.flags
 

--- a/tutorials/embedding/word2vec.py
+++ b/tutorials/embedding/word2vec.py
@@ -42,7 +42,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import numpy as np
 import tensorflow as tf
 
-import gen_word2vec as word2vec
+word2vec = tf.load_op_library(os.path.dirname(os.path.realpath(__file__)) + '/word2vec_ops.so')
 
 flags = tf.app.flags
 

--- a/tutorials/embedding/word2vec_optimized.py
+++ b/tutorials/embedding/word2vec_optimized.py
@@ -41,7 +41,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import numpy as np
 import tensorflow as tf
 
-word2vec = tf.load_op_library(os.path.dirname(os.path.realpath(__file__)) + '/word2vec_ops.so')
+word2vec = tf.load_op_library(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'word2vec_ops.so'))
 
 flags = tf.app.flags
 

--- a/tutorials/embedding/word2vec_optimized.py
+++ b/tutorials/embedding/word2vec_optimized.py
@@ -41,7 +41,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import numpy as np
 import tensorflow as tf
 
-import gen_word2vec as word2vec
+word2vec = tf.load_op_library(os.path.dirname(os.path.realpath(__file__)) + '/word2vec_ops.so')
 
 flags = tf.app.flags
 


### PR DESCRIPTION
It doesn't seem possible to get this code to run using bazel unfortunately. I believe this is because when bazel calls `load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")`, it's unable to continue recursively loading within the TensorFlow repo, even after adding the TensorFlow repo into this repo's WORKSPACE file. This prevents us from being able to use `tf_gen_op_wrapper_py` and import the ops as needed.

I was finally able to get this model working by following the [TensorFlow tutorial for adding a new op](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library) and instructing the users to compile the ops on their own before running.

Unfortunately, this results in the Python code having to load word2vec_ops.so, which is not ideal and not cross-platform friendly. If you have other ideas for how to solve this, definitely let me know.