### PR TITLE
fix tutorials/rnn/ptb problems on 0.12.1

### DIFF
--- a/tutorials/rnn/ptb/ptb_word_lm.py
+++ b/tutorials/rnn/ptb/ptb_word_lm.py
@@ -108,12 +108,12 @@ class PTBModel(object):
     # Slightly better results can be obtained with forget gate biases
     # initialized to 1 but the hyperparameters of the model would need to be
     # different than reported in the paper.
-    lstm_cell = tf.contrib.rnn.BasicLSTMCell(
+    lstm_cell = tf.nn.rnn_cell.BasicLSTMCell(
         size, forget_bias=0.0, state_is_tuple=True)
     if is_training and config.keep_prob < 1:
-      lstm_cell = tf.contrib.rnn.DropoutWrapper(
+      lstm_cell = tf.nn.rnn_cell.DropoutWrapper(
           lstm_cell, output_keep_prob=config.keep_prob)
-    cell = tf.contrib.rnn.MultiRNNCell(
+    cell = tf.nn.rnn_cell.MultiRNNCell(
         [lstm_cell] * config.num_layers, state_is_tuple=True)
 
     self._initial_state = cell.zero_state(batch_size, data_type())
@@ -148,7 +148,7 @@ class PTBModel(object):
         "softmax_w", [size, vocab_size], dtype=data_type())
     softmax_b = tf.get_variable("softmax_b", [vocab_size], dtype=data_type())
     logits = tf.matmul(output, softmax_w) + softmax_b
-    loss = tf.contrib.legacy_seq2seq.sequence_loss_by_example(
+    loss = tf.nn.seq2seq.sequence_loss_by_example(
         [logits],
         [tf.reshape(input_.targets, [-1])],
         [tf.ones([batch_size * num_steps], dtype=data_type())])
@@ -331,14 +331,14 @@ def main(_):
       train_input = PTBInput(config=config, data=train_data, name="TrainInput")
       with tf.variable_scope("Model", reuse=None, initializer=initializer):
         m = PTBModel(is_training=True, config=config, input_=train_input)
-      tf.contrib.deprecated.scalar_summary("Training Loss", m.cost)
-      tf.contrib.deprecated.scalar_summary("Learning Rate", m.lr)
+      tf.summary.scalar("Training Loss", m.cost)
+      tf.summary.scalar("Learning Rate", m.lr)
 
     with tf.name_scope("Valid"):
       valid_input = PTBInput(config=config, data=valid_data, name="ValidInput")
       with tf.variable_scope("Model", reuse=True, initializer=initializer):
         mvalid = PTBModel(is_training=False, config=config, input_=valid_input)
-      tf.contrib.deprecated.scalar_summary("Validation Loss", mvalid.cost)
+      tf.summary.scalar("Validation Loss", mvalid.cost)
 
     with tf.name_scope("Test"):
       test_input = PTBInput(config=eval_config, data=test_data, name="TestInput")

--- a/tutorials/rnn/ptb/reader.py
+++ b/tutorials/rnn/ptb/reader.py
@@ -114,9 +114,9 @@ def ptb_producer(raw_data, batch_size, num_steps, name=None):
 
     i = tf.train.range_input_producer(epoch_size, shuffle=False).dequeue()
     x = tf.strided_slice(data, [0, i * num_steps],
-                         [batch_size, (i + 1) * num_steps])
+                         [batch_size, (i + 1) * num_steps], [1, 1])
     x.set_shape([batch_size, num_steps])
     y = tf.strided_slice(data, [0, i * num_steps + 1],
-                         [batch_size, (i + 1) * num_steps + 1])
+                         [batch_size, (i + 1) * num_steps + 1], [1, 1])
     y.set_shape([batch_size, num_steps])
     return x, y


### PR DESCRIPTION
tutorial/rnn/ptb is not working on TensorFlow 0.12.1

Evidences:

https://github.com/tensorflow/tensorflow/pull/6200#issuecomment-266135026 complains about `sequence_loss_by_example` been moved to `tf.nn.seq2seq.sequence_loss_by_example`
https://github.com/tensorflow/tensorflow/issues/6468 complains about `strided_slice() takes at least 4 arguments (3 given)`
https://github.com/tensorflow/tensorflow/issues/6432 complains about `MultiRNNCell` been moved to `tf.nn.rnn_cell`

And I also replaced deprecated `tf.contrib.deprecated.scalar_summary` with `tf.summary.scalar`.

It works now on 0.12.1.
