### PR TITLE
im2txt: make python3 compatible adding lt and eq

### DIFF
--- a/im2txt/im2txt/inference_utils/caption_generator.py
+++ b/im2txt/im2txt/inference_utils/caption_generator.py
@@ -54,6 +54,16 @@ class Caption(object):
       return -1
     else:
       return 1
+  
+  # for version 3 compatibility (__cmp__ is deprecated)
+  def __lt__(self, other):
+    assert isinstance(other, Caption)
+    return self.score < other.score
+  
+  # also for version 3 compatibility
+  def __eq__(self, other):
+    assert isinstance(other, Caption)
+    return self.score == other.score
 
 
 class TopN(object):

--- a/im2txt/im2txt/inference_utils/caption_generator.py
+++ b/im2txt/im2txt/inference_utils/caption_generator.py
@@ -55,12 +55,12 @@ class Caption(object):
     else:
       return 1
   
-  # for version 3 compatibility (__cmp__ is deprecated)
+  # For Python 3 compatibility (__cmp__ is deprecated).
   def __lt__(self, other):
     assert isinstance(other, Caption)
     return self.score < other.score
   
-  # also for version 3 compatibility
+  # Also for Python 3 compatibility.
   def __eq__(self, other):
     assert isinstance(other, Caption)
     return self.score == other.score


### PR DESCRIPTION
Fix of #839.

Class `Caption` is not comparable on Python3, because `cmp` is deprecated.

So I added `lt` and `eq`.

By the way, `xrange`is renamed to `range` on Python3, so I had to change them as well.

How do we make it both 2 and 3 compatible?