### PR TITLE
Added README to tutorials/ recommending to the user to install TensorFlow from source

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,3 @@
+# Tutorial Models
+
+This repository contains models referenced to from the [TensorFlow tutorials](https://www.tensorflow.org/tutorials/). We recommend [installing TensorFlow from source](https://www.tensorflow.org/get_started/os_setup#installing_from_sources) using the current master version rather than the r0.12 release before running these models.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,3 +1,3 @@
 # Tutorial Models
 
-This repository contains models referenced to from the [TensorFlow tutorials](https://www.tensorflow.org/tutorials/). We recommend [installing TensorFlow from source](https://www.tensorflow.org/get_started/os_setup#installing_from_sources) using the current master version rather than the r0.12 release before running these models.
+This repository contains models referenced to from the [TensorFlow tutorials](https://www.tensorflow.org/tutorials/). We recommend installing TensorFlow from the [nightly builds](https://github.com/tensorflow/tensorflow#installation) rather than the r0.12 release before running these models.


### PR DESCRIPTION
The tutorial models currently have code that is not compatible with the r0.12 release of TensorFlow due to breaking API changes.