### PR TITLE
Added -D_GLIBCXX_USE_CXX11_ABI=0 to support g++ version 5 for word2vec

### DIFF
--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -26,7 +26,7 @@ TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
 g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2 -D_GLIBCXX_USE_CXX11_ABI=0
 ```
 
-(For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)). The flag `-D_GLIBCXX_USE_CXX11_ABI=0` is included to support newer versions of g++.
+(For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library). The flag `-D_GLIBCXX_USE_CXX11_ABI=0` is included to support newer versions of g++.)
 Then run using:
 
 ```shell

--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -23,10 +23,10 @@ You will need to compile the ops as follows:
 
 ```shell
 TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
-g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2
+g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2 -D_GLIBCXX_USE_CXX11_ABI=0
 ```
 
-(For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)).
+(For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library)). The flag `-D_GLIBCXX_USE_CXX11_ABI=0` is included to support newer versions of g++.
 Then run using:
 
 ```shell


### PR DESCRIPTION
Fixes the issues brought up in https://github.com/tensorflow/models/pull/802