### PR TITLE
Update deprecated function

### DIFF
--- a/neural_programmer/parameters.py
+++ b/neural_programmer/parameters.py
@@ -72,7 +72,7 @@ class Parameters:
         self.RandomUniformInit([1, embedding_dims]))
     params["break_conditional"] = tf.Variable(
         self.RandomUniformInit([2 * embedding_dims, embedding_dims]))
-    init = tf.initialize_all_variables()
+    init = tf.global_variables_initializer()
     return params, global_step, init
 
   def RandomUniformInit(self, shape):


### PR DESCRIPTION
Update based on the error message:
 WARNING:tensorflow:From ./neural_programmer/parameters.py:75 in parameters.: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.