### PR TITLE
Remove dated Bazel docs in syntaxnet

### DIFF
--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -81,21 +81,6 @@ source. You'll need to install:
 *   pip (python package manager)
     * `apt-get install python-pip` on Ubuntu
     * `brew` installs pip along with python on OSX
-*   bazel:
-    *   **versions 0.3.0 - 0.3.1*
-    *   follow the instructions [here](http://bazel.io/docs/install.html)
-    *   Alternately, Download bazel <.deb> from
-        [https://github.com/bazelbuild/bazel/releases]
-        (https://github.com/bazelbuild/bazel/releases) for your system
-        configuration.
-    *   Install it using the command: sudo dpkg -i <.deb file>
-    *   Check for the bazel version by typing: bazel version
-*   swig:
-    *   `apt-get install swig` on Ubuntu
-    *   `brew install swig` on OSX
-*   protocol buffers, with a version supported by TensorFlow:
-    *   check your protobuf version with `pip freeze | grep protobuf`
-    *   upgrade to a supported version with `pip install -U protobuf==3.0.0b2`
 *   asciitree, to draw parse trees on the console for the demo:
     *   `pip install asciitree`
 *   numpy, package for scientific computing:


### PR DESCRIPTION
This documentation seems to have fallen out of date. I don't see any evidence that syntaxnet requires an older version of Bazel than TensorFlow uses. If it legitimately does, that's a separate bug. It's probably better to remove this documentation so it doesn't drift from the official ones.

Fixes #657 