### PR TITLE
Update the embedding README to be compatible with Mac

### DIFF
--- a/tutorials/embedding/README.md
+++ b/tutorials/embedding/README.md
@@ -12,11 +12,11 @@ tutorials. Brief instructions are below.
 Assuming you have cloned the git repository, navigate into this directory. To download the example text and evaluation data:
 
 ```shell
-wget http://mattmahoney.net/dc/text8.zip -O text8.zip
+curl http://mattmahoney.net/dc/text8.zip > text8.zip
 unzip text8.zip
-wget https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/word2vec/source-archive.zip
+curl https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/word2vec/source-archive.zip > source-archive.zip
 unzip -p source-archive.zip  word2vec/trunk/questions-words.txt > questions-words.txt
-rm source-archive.zip
+rm text8.zip source-archive.zip
 ```
 
 You will need to compile the ops as follows:
@@ -25,6 +25,8 @@ You will need to compile the ops as follows:
 TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
 g++ -std=c++11 -shared word2vec_ops.cc word2vec_kernels.cc -o word2vec_ops.so -fPIC -I $TF_INC -O2 -D_GLIBCXX_USE_CXX11_ABI=0
 ```
+
+On Mac, add `-undefined dynamic_lookup` to the g++ command.
 
 (For an explanation of what this is doing, see the tutorial on [Adding a New Op to TensorFlow](https://www.tensorflow.org/how_tos/adding_an_op/#building_the_op_library). The flag `-D_GLIBCXX_USE_CXX11_ABI=0` is included to support newer versions of g++.)
 Then run using:


### PR DESCRIPTION
See https://github.com/tensorflow/models/issues/914

Tested this on my Macbook as well. Also changed the `wget` commands to `curl` since I think that should work on both Linux and Mac.