### PR TITLE
Duplicate vocabulary name

### DIFF
--- a/tutorials/rnn/translate/data_utils.py
+++ b/tutorials/rnn/translate/data_utils.py
@@ -300,8 +300,8 @@ def prepare_data(data_dir, from_train_path, to_train_path, from_dev_path, to_dev
         (6) path to the "to language" vocabulary file.
     """
   # Create vocabularies of the appropriate sizes.
-  to_vocab_path = os.path.join(data_dir, "vocab%d" % to_vocabulary_size)
-  from_vocab_path = os.path.join(data_dir, "vocab%d" % from_vocabulary_size)
+  to_vocab_path = os.path.join(data_dir, "vocab%d.to" % to_vocabulary_size)
+  from_vocab_path = os.path.join(data_dir, "vocab%d.from" % from_vocabulary_size)
   create_vocabulary(to_vocab_path, to_train_path , to_vocabulary_size, tokenizer)
   create_vocabulary(from_vocab_path, from_train_path , from_vocabulary_size, tokenizer)
 

--- a/tutorials/rnn/translate/data_utils.py
+++ b/tutorials/rnn/translate/data_utils.py
@@ -300,8 +300,8 @@ def prepare_data(data_dir, from_train_path, to_train_path, from_dev_path, to_dev
         (6) path to the "to language" vocabulary file.
     """
   # Create vocabularies of the appropriate sizes.
-  to_vocab_path = os.path.join(data_dir, "vocab%d.to" % to_vocabulary_size)
-  from_vocab_path = os.path.join(data_dir, "vocab%d.from" % from_vocabulary_size)
+  to_vocab_path = os.path.join(data_dir, "to-vocab%d" % to_vocabulary_size)
+  from_vocab_path = os.path.join(data_dir, "from-vocab%d" % from_vocabulary_size)
   create_vocabulary(to_vocab_path, to_train_path , to_vocabulary_size, tokenizer)
   create_vocabulary(from_vocab_path, from_train_path , from_vocabulary_size, tokenizer)
 


### PR DESCRIPTION
The to vocabulary shares the same name with the from one, can not be loaded when decoding.