### PR TITLE
Removed deprecated op

### DIFF
--- a/tutorials/embedding/word2vec.py
+++ b/tutorials/embedding/word2vec.py
@@ -365,7 +365,7 @@ class Word2Vec(object):
       self._word2id[w] = i
     true_logits, sampled_logits = self.forward(examples, labels)
     loss = self.nce_loss(true_logits, sampled_logits)
-    tf.scalar_summary("NCE loss", loss)
+    tf.summary.scalar("NCE loss", loss)
     self._loss = loss
     self.optimize(loss)
 


### PR DESCRIPTION
Remove the deprecated `scalar_summary` and use `summary.scalar` instead. 

The current program gets the following warning:
> WARNING:tensorflow:
build_graph.: scalar_summary (from tensorflow.python.ops.logging_ops) is deprecated and will be removed after 2016-11-30.
Instructions for updating:
Please switch to tf.summary.scalar. Note that tf.summary.scalar uses the node name instead of the tag. This means that TensorFlow will automatically de-duplicate summary names based on the scope they are created in. Also, passing a tensor or list of tags to a scalar summary op is no longer supported.
