### PR TITLE
correct order of argument for tf.image.resize_image_with_crop_or_pad

### DIFF
--- a/tutorials/image/cifar10/cifar10_input.py
+++ b/tutorials/image/cifar10/cifar10_input.py
@@ -237,7 +237,7 @@ def inputs(eval_data, data_dir, batch_size):
   # Image processing for evaluation.
   # Crop the central [height, width] of the image.
   resized_image = tf.image.resize_image_with_crop_or_pad(reshaped_image,
-                                                         width, height)
+                                                         height, width)
 
   # Subtract off the mean and divide by the variance of the pixels.
   float_image = tf.image.per_image_standardization(resized_image)


### PR DESCRIPTION
correct small mistake. I think it is better to change order for precise code.
https://github.com/tensorflow/models/blob/master/tutorials/image/cifar10/cifar10_input.py#L239

change order of arguments
[reshaped_image, width, height] -> [reshaped_image, height, width]

