### PR TITLE
[slim] Fix a scope name typo in Inception_v1.py

### DIFF
--- a/slim/nets/inception_v1.py
+++ b/slim/nets/inception_v1.py
@@ -289,7 +289,7 @@ def inception_v1(inputs,
                         is_training=is_training):
       net, end_points = inception_v1_base(inputs, scope=scope)
       with tf.variable_scope('Logits'):
-        net = slim.avg_pool2d(net, [7, 7], stride=1, scope='MaxPool_0a_7x7')
+        net = slim.avg_pool2d(net, [7, 7], stride=1, scope='AvgPool_0a_7x7')
         net = slim.dropout(net,
                            dropout_keep_prob, scope='Dropout_0b')
         logits = slim.conv2d(net, num_classes, [1, 1], activation_fn=None,


### PR DESCRIPTION
The average pool is used but named 'MaxPool_0a_7x7'.
Change it to 'AvgPool_0a_7x7'.