### PR TITLE
Updated concat_v2 to concat for 1.0 compatibility

### DIFF
--- a/im2txt/im2txt/show_and_tell_model.py
+++ b/im2txt/im2txt/show_and_tell_model.py
@@ -264,7 +264,7 @@ class ShowAndTellModel(object):
       if self.mode == "inference":
         # In inference mode, use concatenated states for convenient feeding and
         # fetching.
-        tf.concat_v2(initial_state, 1, name="initial_state")
+        tf.concat(initial_state, 1, name="initial_state")
 
         # Placeholder for feeding a batch of concatenated states.
         state_feed = tf.placeholder(dtype=tf.float32,
@@ -278,7 +278,7 @@ class ShowAndTellModel(object):
             state=state_tuple)
 
         # Concatentate the resulting state.
-        tf.concat_v2(state_tuple, 1, name="state")
+        tf.concat(state_tuple, 1, name="state")
       else:
         # Run the batch of sequence embeddings through the LSTM.
         sequence_length = tf.reduce_sum(self.input_mask, 1)


### PR DESCRIPTION
Updated concat_v2 to concat for version 1.0 compatibility for breaking changes introduced in version 1.0
"tf.concat now takes arguments in reversed order and with different keywords. In particular we now match NumPy order as tf.concat(values, axis, name)"