### PR TITLE
Fix division changing dtype to float in python3

### DIFF
--- a/compression/encoder.py
+++ b/compression/encoder.py
@@ -92,7 +92,7 @@ def main(_):
   int_codes = np.asarray([x.astype(np.int8) for x in results])
 
   # Convert int codes to binary.
-  int_codes = (int_codes + 1)/2
+  int_codes = (int_codes + 1)//2
   export = np.packbits(int_codes.reshape(-1))
 
   output = io.BytesIO()


### PR DESCRIPTION
Running the compression encoder example in python3 causes the error:
`TypeError: Expected an input array of integer or boolean data type`

`int_codes` is divided by 2, but in python3 this converts it from an `int8` to `float64` array.

I am running the gpu version of tensorflow on Windows 10.