### PR TITLE
Update word2vec.py in tutorials/embedding to Tensorflow v1.0

### DIFF
--- a/tutorials/embedding/word2vec.py
+++ b/tutorials/embedding/word2vec.py
@@ -246,7 +246,7 @@ class Word2Vec(object):
     sampled_b = tf.nn.embedding_lookup(sm_b, sampled_ids)
 
     # True logits: [batch_size, 1]
-    true_logits = tf.reduce_sum(tf.mul(example_emb, true_w), 1) + true_b
+    true_logits = tf.reduce_sum(tf.multiply(example_emb, true_w), 1) + true_b
 
     # Sampled logits: [batch_size, num_sampled]
     # We replicate sampled noise labels for all examples in the batch


### PR DESCRIPTION
Updated method calls in line 249 of word2vec.py in tutorials/embedding to be compatible with Tensorflow v1.0