### PR TITLE
add 'reuse' parameter to RNNCells to make code compatible with tensorflow master code

### DIFF
--- a/tutorials/rnn/ptb/ptb_word_lm.py
+++ b/tutorials/rnn/ptb/ptb_word_lm.py
@@ -110,7 +110,7 @@ class PTBModel(object):
     # different than reported in the paper.
     def lstm_cell():
       return tf.contrib.rnn.BasicLSTMCell(
-          size, forget_bias=0.0, state_is_tuple=True)
+          size, forget_bias=0.0, state_is_tuple=True, reuse=tf.get_variable_scope().reuse)
     attn_cell = lstm_cell
     if is_training and config.keep_prob < 1:
       def attn_cell():


### PR DESCRIPTION
To fix the issue mentioned in [#8191](https://github.com/tensorflow/tensorflow/issues/8191) caused by the [recent commit](https://github.com/tensorflow/tensorflow/commit/54d50ffec8df4f748694632dbe5ebde9971e2c9e) of TensorFlow master branch. As the commit message says:

> Make all RNNCells in tf.contrib.rnn act like tf.layers Layers, but with stricter semantics for no
w:
>
>    1. Upon first use of __call__, the used scope is stored in the cell. The RNNCell tries to create weights in that scope but if some are already set, an error is raised unless the RNNCell was constructed with argument reuse=True.
>
>    2. A subsequent use of __call__ of the same cell instance must be in the same scope.
>       If it is not, an error is raised.