### PR TITLE
correct tf.summary.scalar illegal name `learning rate`

### DIFF
--- a/resnet/resnet_model.py
+++ b/resnet/resnet_model.py
@@ -128,7 +128,7 @@ class ResNet(object):
   def _build_train_op(self):
     """Build training specific ops for the graph."""
     self.lrn_rate = tf.constant(self.hps.lrn_rate, tf.float32)
-    tf.summary.scalar('learning rate', self.lrn_rate)
+    tf.summary.scalar('learning_rate', self.lrn_rate)
 
     trainable_variables = tf.trainable_variables()
     grads = tf.gradients(self.cost, trainable_variables)


### PR DESCRIPTION
Corrected issue listed below.

`INFO:tensorflow:Summary name learning rate is illegal; using learning_rate instead.`