### PR TITLE
output more meaningful error messages

### DIFF
--- a/inception/inception/data/build_image_data.py
+++ b/inception/inception/data/build_image_data.py
@@ -263,11 +263,10 @@ def _process_image_files_batch(coder, thread_index, ranges, name, filenames,
 
       try:
         image_buffer, height, width = _process_image(filename, coder)
-      except Exception, e:
-        print (e)
-        print ('SKIPPED. Unexpected eror while decoding %s' % filename)
+      except Exception as e:
+        print(e)
+        print('SKIPPED: Unexpected eror while decoding %s.' % filename)
         continue
-
 
       example = _convert_to_example(filename, image_buffer, label,
                                     text, height, width)

--- a/inception/inception/data/build_image_data.py
+++ b/inception/inception/data/build_image_data.py
@@ -208,7 +208,11 @@ def _process_image(filename, coder):
     image_data = coder.png_to_jpeg(image_data)
 
   # Decode the RGB JPEG.
-  image = coder.decode_jpeg(image_data)
+  try:
+    image = coder.decode_jpeg(image_data)
+  except:
+    print('Unexpected eror while decoding %s' % filename)
+    raise
 
   # Check that image converted to RGB
   assert len(image.shape) == 3

--- a/inception/inception/data/build_image_data.py
+++ b/inception/inception/data/build_image_data.py
@@ -208,11 +208,7 @@ def _process_image(filename, coder):
     image_data = coder.png_to_jpeg(image_data)
 
   # Decode the RGB JPEG.
-  try:
-    image = coder.decode_jpeg(image_data)
-  except:
-    print('Unexpected eror while decoding %s' % filename)
-    raise
+  image = coder.decode_jpeg(image_data)
 
   # Check that image converted to RGB
   assert len(image.shape) == 3
@@ -265,7 +261,13 @@ def _process_image_files_batch(coder, thread_index, ranges, name, filenames,
       label = labels[i]
       text = texts[i]
 
-      image_buffer, height, width = _process_image(filename, coder)
+      try:
+        image_buffer, height, width = _process_image(filename, coder)
+      except Exception, e:
+        print (e)
+        print ('SKIPPED. Unexpected eror while decoding %s' % filename)
+        continue
+
 
       example = _convert_to_example(filename, image_buffer, label,
                                     text, height, width)


### PR DESCRIPTION
I use this script to create TFRecord file for other image datasets. Sometimes these datasets have corrupted JPEG files. Printing file names help pinpoint corrupted files.

Also, the exception bubbles up to the thread that is looping over JPEG files and causes the TFRecord shard to be halted prematurely. The thread is also stuck in limbo. Skipping corrupted files allows the thread to continue to execute to completion.