### PR TITLE
Revert "fixed a bug in sampled_loss(), made compatible for 0.12.0"

### DIFF
--- a/tutorials/rnn/translate/seq2seq_model.py
+++ b/tutorials/rnn/translate/seq2seq_model.py
@@ -100,7 +100,7 @@ class Seq2SeqModel(object):
       b = tf.get_variable("proj_b", [self.target_vocab_size], dtype=dtype)
       output_projection = (w, b)
 
-      def sampled_loss(inputs, labels):
+      def sampled_loss(labels, inputs):
         labels = tf.reshape(labels, [-1, 1])
         # We need to compute the sampled_softmax_loss using 32bit floats to
         # avoid numerical instabilities.


### PR DESCRIPTION
Reverts tensorflow/models#982
See discussions in https://github.com/tensorflow/models/issues/1221, https://github.com/tensorflow/models/issues/836, https://github.com/tensorflow/tensorflow/issues/8505, and https://github.com/tensorflow/models/issues/1220