### PR TITLE
SyntaxNet does not compile, because isnan is unknown.

### DIFF
--- a/syntaxnet/dragnn/core/beam.h
+++ b/syntaxnet/dragnn/core/beam.h
@@ -2,6 +2,7 @@
 #define NLP_SAFT_OPENSOURCE_DRAGNN_CORE_BEAM_H_
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <vector>
 
@@ -112,7 +113,7 @@ class Beam {
             CHECK_LT(matrix_idx, matrix_length)
                 << "Matrix index out of bounds!";
             const double score_delta = transition_matrix[matrix_idx];
-            CHECK(!isnan(score_delta));
+            CHECK(!std::isnan(score_delta));
             candidate.source_idx = beam_idx;
             candidate.action = action_idx;
             candidate.resulting_score = state->GetScore() + score_delta;


### PR DESCRIPTION
SyntaxNet does not compile with gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4). This leads to the error in #1194.

Including `cmath` and using the `std` namespace for `isnan` solves this problem.