### PR TITLE
README.md warning on extra background class added by build_image_data.py

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -658,7 +658,6 @@ Each entry of the `TFRecord` is a serialized `tf.Example` protocol buffer. A
 complete list of information contained in the `tf.Example` is described in the
 comments of `build_image_data.py`.
 
-
 To run `build_image_data.py`, you can run the following command line:
 
 ```shell

--- a/inception/README.md
+++ b/inception/README.md
@@ -634,9 +634,10 @@ reside within `$TRAIN_DIR` and `$VALIDATION_DIR` arranged as such:
   $VALIDATION_DIR/cat/cat.JPG
   ...
 ```
-**NOTE**: This script will append an extra background class indexed at 0. Using the
-example above, the corresponding class labels generated from `build_image_data.py`
-will be as follows:
+**NOTE**: This script will append an extra background class indexed at 0, so
+your class labels will range from 0 to num_labels. Using the example above, the
+corresponding class labels generated from `build_image_data.py` will be as
+follows:
 ```shell
 0
 1 dog

--- a/inception/README.md
+++ b/inception/README.md
@@ -24,7 +24,7 @@ model architecture.
 
 ## Description of Code
 
-NOTE: For the most part, you will find a newer version of this code at [models/slim](https://github.com/tensorflow/models/tree/master/slim). In particular:
+**NOTE**: For the most part, you will find a newer version of this code at [models/slim](https://github.com/tensorflow/models/tree/master/slim). In particular:
 
 *   `inception_train.py` and `imagenet_train.py` should no longer be used. The slim editions for running on multiple GPUs are the current best examples.
 *   `inception_distributed_train.py` and `imagenet_distributed_train.py` are still valid examples of distributed training.
@@ -60,11 +60,6 @@ For more details about TensorFlow-Slim, please see the [Slim README]
 subsequent research.
 
 ## Getting Started
-
-**NOTE** Before doing anything, we first need to build TensorFlow from source,
-and installed as a PIP package. Please follow the instructions at [Installing
-From Source]
-(https://www.tensorflow.org/install/install_sources).
 
 Before you run the training script for the first time, you will need to download
 and convert the ImageNet data to native TFRecord format. The TFRecord format
@@ -639,9 +634,9 @@ reside within `$TRAIN_DIR` and `$VALIDATION_DIR` arranged as such:
   $VALIDATION_DIR/cat/cat.JPG
   ...
 ```
-**NOTE** This script will append an extra background class indexed at 0, so your
-class labels will range from [0, num_labels]. Using the example above, the
-corresponding class labels generated from `build_image_data.py` will be as follows:
+**NOTE**: This script will append an extra background class indexed at 0. Using the
+example above, the corresponding class labels generated from `build_image_data.py`
+will be as follows:
 ```shell
 0
 1 dog

--- a/inception/README.md
+++ b/inception/README.md
@@ -674,8 +674,8 @@ bazel-bin/inception/build_image_data \
   --validation_directory="${VALIDATION_DIR}" \
   --output_directory="${OUTPUT_DIRECTORY}" \
   --labels_file="${LABELS_FILE}" \
-  --train_shards=128 \
-  --validation_shards=24 \
+  --train_shards=24 \
+  --validation_shards=8 \
   --num_threads=8
 ```
 

--- a/inception/README.md
+++ b/inception/README.md
@@ -639,6 +639,14 @@ reside within `$TRAIN_DIR` and `$VALIDATION_DIR` arranged as such:
   $VALIDATION_DIR/cat/cat.JPG
   ...
 ```
+**NOTE** This script will append an extra background class indexed at 0, so your
+class labels will range from [0, num_labels]. Using the example above, the
+corresponding class labels generated from `build_image_data.py` will be as follows:
+```shell
+0
+1 dog
+2 cat
+```
 
 Each sub-directory in `$TRAIN_DIR` and `$VALIDATION_DIR` corresponds to a unique
 label for the images that reside within that sub-directory. The images may be
@@ -649,6 +657,7 @@ Once the data is arranged in this directory structure, we can run
 Each entry of the `TFRecord` is a serialized `tf.Example` protocol buffer. A
 complete list of information contained in the `tf.Example` is described in the
 comments of `build_image_data.py`.
+
 
 To run `build_image_data.py`, you can run the following command line:
 

--- a/inception/README.md
+++ b/inception/README.md
@@ -668,8 +668,8 @@ bazel-bin/inception/build_image_data \
   --validation_directory="${VALIDATION_DIR}" \
   --output_directory="${OUTPUT_DIRECTORY}" \
   --labels_file="${LABELS_FILE}" \
-  --train_shards=24 \
-  --validation_shards=8 \
+  --train_shards=128 \
+  --validation_shards=24 \
   --num_threads=8
 ```
 
@@ -694,20 +694,20 @@ class.
 After running this script produces files that look like the following:
 
 ```shell
-  $TRAIN_DIR/train-00000-of-00024
-  $TRAIN_DIR/train-00001-of-00024
+  $TRAIN_DIR/train-00000-of-00128
+  $TRAIN_DIR/train-00001-of-00128
   ...
-  $TRAIN_DIR/train-00023-of-00024
+  $TRAIN_DIR/train-00127-of-00128
 
 and
 
-  $VALIDATION_DIR/validation-00000-of-00008
-  $VALIDATION_DIR/validation-00001-of-00008
+  $VALIDATION_DIR/validation-00000-of-00024
+  $VALIDATION_DIR/validation-00001-of-00024
   ...
-  $VALIDATION_DIR/validation-00007-of-00008
+  $VALIDATION_DIR/validation-00023-of-00024
 ```
 
-where 24 and 8 are the number of shards specified for each dataset,
+where 128 and 24 are the number of shards specified for each dataset,
 respectively. Generally speaking, we aim for selecting the number of shards such
 that roughly 1024 images reside in each shard. Once this data set is built, you
 are ready to train or fine-tune an Inception model on this data set.


### PR DESCRIPTION
This cost me many hours of debugging when my network failed to converge when applying `build_image_data.py` to a new dataset. Turns out I didn't read the `build_image_data.py` comments carefully and missed the part about the background class being labeled 0. The [one_hot_encoding](https://github.com/tensorflow/models/blob/master/slim/train_image_classifier.py#L455) in train_image_classifier does not take into account of out-of-range inputs. Therefore in my 3 classes dataset, my labels of `[3 2 2 1]` are converted to these one hot labels:
```
[[0 0 0]
 [0 0 1]
 [0 0 1]
 [0 1 0]]
```
The NN will always classify class 3 as 'wrong'. I fixed this by changing [label_index](https://github.com/tensorflow/models/blob/master/inception/inception/data/build_image_data.py#L375) to 0 so my classes will now numerate `[0,2]`. (alternatively can add `tf.subtract(labels, 1)`). 

Additionally, I think that the background class is unnecessary since the script is referred to quite often in the README as a general data converter to TFRecords. The background class seems to be a relic of the ImageNet dataset that does not generalize well to other types of data. In any case, I hope this addition will emphasize this nuance to future README readers.

Fix shell script to match example.