### PR TITLE
Variational Autoencoder generate() function fixed (z fed in rather th…

### DIFF
--- a/autoencoder/autoencoder_models/VariationalAutoencoder.py
+++ b/autoencoder/autoencoder_models/VariationalAutoencoder.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-import numpy as np
 
 class VariationalAutoencoder(object):
 
@@ -57,8 +56,8 @@ class VariationalAutoencoder(object):
 
     def generate(self, hidden = None):
         if hidden is None:
-            hidden = np.random.normal(size=self.weights["b1"])
-        return self.sess.run(self.reconstruction, feed_dict={self.z_mean: hidden})
+            hidden = self.sess.run(tf.random_normal([1, self.n_hidden]))
+        return self.sess.run(self.reconstruction, feed_dict={self.z: hidden})
 
     def reconstruct(self, X):
         return self.sess.run(self.reconstruction, feed_dict={self.x: X})


### PR DESCRIPTION
…an z_mean)

A follow on to a previous update to remove external dependencies from the autoencoder models, and to solve [the following issue](https://github.com/tensorflow/models/issues/1199#issuecomment-289022533). Below is a sample image created from the output of the generate function. 

![img1](https://cloud.githubusercontent.com/assets/10055613/24317626/0e566732-10c7-11e7-8a78-5690741c1180.png)