### PR TITLE
change shell scripts for better compatibility with macOS and tf docker image

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -487,6 +487,7 @@ model like so:
 ```shell
 # location of where to place the Inception v3 model
 DATA_DIR=$HOME/inception-v3-model
+mkdir -p ${DATA_DIR}
 cd ${DATA_DIR}
 
 # download the Inception v3 model

--- a/inception/inception/data/download_and_preprocess_flowers.sh
+++ b/inception/inception/data/download_and_preprocess_flowers.sh
@@ -53,7 +53,7 @@ cd "${DATA_DIR}"
 TARBALL="flower_photos.tgz"
 if [ ! -f ${TARBALL} ]; then
   echo "Downloading flower data set."
-  wget -O ${TARBALL} "${DATA_URL}"
+  curl -o ${TARBALL} "${DATA_URL}"
 else
   echo "Skipping download of flower data."
 fi

--- a/inception/inception/data/download_and_preprocess_flowers_mac.sh
+++ b/inception/inception/data/download_and_preprocess_flowers_mac.sh
@@ -53,7 +53,7 @@ cd "${DATA_DIR}"
 TARBALL="flower_photos.tgz"
 if [ ! -f ${TARBALL} ]; then
   echo "Downloading flower data set."
-  wget -O ${TARBALL} "${DATA_URL}"
+  curl -o ${TARBALL} "${DATA_URL}"
 else
   echo "Skipping download of flower data."
 fi


### PR DESCRIPTION
I was going through the flower retraining example.

I needed to make these changes to the scripts, and to the sample code in the README, for them to work with the tensorflow/tensorflow:1.0.1-devel docker image, since it includes `curl` but not `wget`.

They would also be needed on stock Mac, which includes curl but not wget. This is especially relevant for the script intended to run only on a Mac.