### PR TITLE
Add a message to the README to use TensorFlow 1.0 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This repository contains machine learning models implemented in
 [TensorFlow](https://tensorflow.org). The models are maintained by their
-respective authors.
+respective authors. To propose a model for inclusion, please submit a pull
+request.
 
-To propose a model for inclusion please submit a pull request.
+Currently, the models are compatible with TensorFlow 1.0 or later. If you are
+running TensorFlow 0.12 or earlier, please upgrade your installation.
 
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ respective authors. To propose a model for inclusion, please submit a pull
 request.
 
 Currently, the models are compatible with TensorFlow 1.0 or later. If you are
-running TensorFlow 0.12 or earlier, please upgrade your installation.
+running TensorFlow 0.12 or earlier, please
+[upgrade your installation](https://www.tensorflow.org/install).
 
 
 ## Models


### PR DESCRIPTION
We've been getting lots of issues submitted where users can't run function calls in the models because they aren't on TF 1.0. This should alleviate that.