### PR TITLE
Update dockerfile to allow notebook to run

### DIFF
--- a/syntaxnet/Dockerfile
+++ b/syntaxnet/Dockerfile
@@ -89,4 +89,4 @@ EXPOSE 8888
 COPY examples $SYNTAXNETDIR/syntaxnet/examples
 # Todo: Move this earlier in the file (don't want to invalidate caches for now).
 
-CMD /bin/bash -c "bazel-bin/dragnn/tools/oss_notebook_launcher notebook --debug --notebook-dir=/opt/tensorflow/syntaxnet/examples"
+CMD /bin/bash -c "bazel-bin/dragnn/tools/oss_notebook_launcher notebook --debug --notebook-dir=/opt/tensorflow/syntaxnet/examples --allow-root"


### PR DESCRIPTION
Without this change, users get an error message `[C 17:30:11.563 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.` that will cause the `docker run` to exit with status code 1.