### PR TITLE
Revert a change to imports which breaks the instructions given in the tutorial

### DIFF
--- a/tutorials/rnn/translate/__init__.py
+++ b/tutorials/rnn/translate/__init__.py
@@ -18,5 +18,5 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from . import data_utils
-from . import seq2seq_model
+import data_utils
+import seq2seq_model

--- a/tutorials/rnn/translate/seq2seq_model.py
+++ b/tutorials/rnn/translate/seq2seq_model.py
@@ -25,7 +25,7 @@ import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
-from . import data_utils
+import data_utils
 
 
 class Seq2SeqModel(object):


### PR DESCRIPTION
Reverts https://github.com/tensorflow/models/pull/1299.

See the tutorial at https://www.tensorflow.org/tutorials/seq2seq. Running `translate.py` as described results in the following error:

```
Traceback (most recent call last):
  File "translate.py", line 46, in <module>
    import seq2seq_model
  File "/usr/local/google/home/wun/Desktop/models/tutorials/rnn/translate/seq2seq_model.py", line 28, in <module>
    from . import data_utils
ValueError: Attempted relative import in non-package
```