### PR TITLE
Removed rmsprop_momentum flag, use --momentum flag

### DIFF
--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -118,8 +118,6 @@ tf.app.flags.DEFINE_float(
     'momentum', 0.9,
     'The momentum for the MomentumOptimizer and RMSPropOptimizer.')
 
-tf.app.flags.DEFINE_float('rmsprop_momentum', 0.9, 'Momentum.')
-
 tf.app.flags.DEFINE_float('rmsprop_decay', 0.9, 'Decay term for RMSProp.')
 
 #######################
@@ -304,7 +302,7 @@ def _configure_optimizer(learning_rate):
     optimizer = tf.train.RMSPropOptimizer(
         learning_rate,
         decay=FLAGS.rmsprop_decay,
-        momentum=FLAGS.rmsprop_momentum,
+        momentum=FLAGS.momentum,
         epsilon=FLAGS.opt_epsilon)
   elif FLAGS.optimizer == 'sgd':
     optimizer = tf.train.GradientDescentOptimizer(learning_rate)


### PR DESCRIPTION
The flag description for the momentum flag states that it is 
> The momentum for the MomentumOptimizer and RMSPropOptimizer

however its not actually used in the RMSPropOptimizer.  Instead, a separate
`--rmsprop_momentum` flag was used.  This deletes that flag for
correctness of the `--momentum` flag description and simplicity.  
It was not referenced anywhere else in the repo.