### PR TITLE
changed the tune corpus variable name from dev to tune

### DIFF
--- a/syntaxnet/dragnn/conll2017/conll_parser_trainer.sh
+++ b/syntaxnet/dragnn/conll2017/conll_parser_trainer.sh
@@ -21,7 +21,7 @@ language=English
 output_dir=./trained-"$language"
 
 training_corpus=$1
-dev_corpus=$2
+tune_corpus=$2
 
 bazel build -c opt //dragnn/tools:trainer //dragnn/conll2017:make_parser_spec
 
@@ -35,6 +35,6 @@ bazel-bin/dragnn/tools/trainer \
   --dragnn_spec="$output_dir/parser_spec.textproto" \
   --resource_path="$output_dir/resources" \
   --training_corpus_path="$training_corpus" \
-  --tune_corpus_path="$dev_corpus" \
+  --tune_corpus_path="$tune_corpus" \
   --tensorboard_dir="$output_dir/tensorboard" \
   --checkpoint_filename="$output_dir/checkpoint.model"


### PR DESCRIPTION
The variable named as `tune_corpus` indicate that the treebank will be used to tune the params. While the original name `dev_corpus` suggests to use the development corpus that [should not be used for training proper](http://universaldependencies.org/conll17/data.html). One suggestion is to take 5% of the train corpus to make a tune corpus, that can be downloaded [here](https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-1990).