### PR TITLE
A script to generate a text file with FSNS URLs.

### DIFF
--- a/street/README.md
+++ b/street/README.md
@@ -79,6 +79,7 @@ Note that these datasets are very large. The approximate sizes are:
 *   Validation: 64 files of 40MB each.
 *   Test: 64 files of 50MB each.
 *   Testdata: some smaller data files of a few MB for testing.
+*   Total: ~158 Gb.
 
 Here is a list of the download paths:
 
@@ -99,9 +100,14 @@ https://download.tensorflow.org/data/fsns-20160927/validation/validation-00000-o
 https://download.tensorflow.org/data/fsns-20160927/validation/validation-00063-of-00064
 ```
 
-The above files need to be downloaded individually, as they are large and
-downloads are more likely to succeed with the individual files than with a
-single archive containing them all.
+All URLs are stored in the text file `python/fsns_urls.txt`, to download them in
+parallel:
+
+```
+aria2c -c -j 20 -i fsns_urls.txt
+```
+If you ctrl+c and re-execute the command it will continue the aborted download.
+
 
 ## Confidence Tests
 
@@ -256,4 +262,3 @@ defines a Tensor Flow graph that can be used to process images of variable sizes
 to output a 1-dimensional sequence, like a transcription/OCR problem, or a
 0-dimensional label, as for image identification problems. For more information
 see [vgslspecs](g3doc/vgslspecs.md)
-

--- a/street/python/fsns_urls.py
+++ b/street/python/fsns_urls.py
@@ -1,0 +1,49 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Creates a text file with URLs to download FSNS dataset using aria2c.
+
+The FSNS dataset has 640 files and takes 158Gb of the disk space. So it is
+highly recommended to use some kind of a download manager to download it.
+
+Aria2c is a powerful download manager which can download multiple files in
+parallel, re-try if encounter an error and continue previously unfinished
+downloads.
+"""
+
+import os
+
+_FSNS_BASE_URL  = 'http://download.tensorflow.org/data/fsns-20160927/'
+_SHARDS = {'test': 64, 'train': 512, 'validation':64}
+_OUTPUT_FILE = "fsns_urls.txt"
+_OUTPUT_DIR = "data/fsns"
+
+def fsns_paths():
+  paths = ['charset_size=134.txt']
+  for name, shards in _SHARDS.items():
+    for i in range(shards):
+      paths.append('%s/%s-%05d-of-%05d' % (name, name, i, shards))
+  return paths
+
+
+if __name__ == "__main__":
+  with open(_OUTPUT_FILE, "w") as f:
+    for path in fsns_paths():
+      url = _FSNS_BASE_URL + path
+      dst_path = os.path.join(_OUTPUT_DIR, path)
+      f.write("%s\n  out=%s\n" % (url, dst_path))
+  print("To download FSNS dataset execute:")
+  print("aria2c -c -j 20 -i %s" % _OUTPUT_FILE)
+  print("The downloaded FSNS dataset will be stored under %s" % _OUTPUT_DIR)

--- a/street/python/fsns_urls.txt
+++ b/street/python/fsns_urls.txt
@@ -1,0 +1,1282 @@
+http://download.tensorflow.org/data/fsns-20160927/charset_size=134.txt
+  out=data/fsns/charset_size=134.txt
+http://download.tensorflow.org/data/fsns-20160927/test/test-00000-of-00064
+  out=data/fsns/test/test-00000-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00001-of-00064
+  out=data/fsns/test/test-00001-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00002-of-00064
+  out=data/fsns/test/test-00002-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00003-of-00064
+  out=data/fsns/test/test-00003-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00004-of-00064
+  out=data/fsns/test/test-00004-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00005-of-00064
+  out=data/fsns/test/test-00005-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00006-of-00064
+  out=data/fsns/test/test-00006-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00007-of-00064
+  out=data/fsns/test/test-00007-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00008-of-00064
+  out=data/fsns/test/test-00008-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00009-of-00064
+  out=data/fsns/test/test-00009-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00010-of-00064
+  out=data/fsns/test/test-00010-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00011-of-00064
+  out=data/fsns/test/test-00011-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00012-of-00064
+  out=data/fsns/test/test-00012-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00013-of-00064
+  out=data/fsns/test/test-00013-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00014-of-00064
+  out=data/fsns/test/test-00014-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00015-of-00064
+  out=data/fsns/test/test-00015-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00016-of-00064
+  out=data/fsns/test/test-00016-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00017-of-00064
+  out=data/fsns/test/test-00017-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00018-of-00064
+  out=data/fsns/test/test-00018-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00019-of-00064
+  out=data/fsns/test/test-00019-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00020-of-00064
+  out=data/fsns/test/test-00020-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00021-of-00064
+  out=data/fsns/test/test-00021-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00022-of-00064
+  out=data/fsns/test/test-00022-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00023-of-00064
+  out=data/fsns/test/test-00023-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00024-of-00064
+  out=data/fsns/test/test-00024-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00025-of-00064
+  out=data/fsns/test/test-00025-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00026-of-00064
+  out=data/fsns/test/test-00026-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00027-of-00064
+  out=data/fsns/test/test-00027-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00028-of-00064
+  out=data/fsns/test/test-00028-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00029-of-00064
+  out=data/fsns/test/test-00029-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00030-of-00064
+  out=data/fsns/test/test-00030-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00031-of-00064
+  out=data/fsns/test/test-00031-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00032-of-00064
+  out=data/fsns/test/test-00032-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00033-of-00064
+  out=data/fsns/test/test-00033-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00034-of-00064
+  out=data/fsns/test/test-00034-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00035-of-00064
+  out=data/fsns/test/test-00035-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00036-of-00064
+  out=data/fsns/test/test-00036-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00037-of-00064
+  out=data/fsns/test/test-00037-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00038-of-00064
+  out=data/fsns/test/test-00038-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00039-of-00064
+  out=data/fsns/test/test-00039-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00040-of-00064
+  out=data/fsns/test/test-00040-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00041-of-00064
+  out=data/fsns/test/test-00041-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00042-of-00064
+  out=data/fsns/test/test-00042-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00043-of-00064
+  out=data/fsns/test/test-00043-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00044-of-00064
+  out=data/fsns/test/test-00044-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00045-of-00064
+  out=data/fsns/test/test-00045-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00046-of-00064
+  out=data/fsns/test/test-00046-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00047-of-00064
+  out=data/fsns/test/test-00047-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00048-of-00064
+  out=data/fsns/test/test-00048-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00049-of-00064
+  out=data/fsns/test/test-00049-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00050-of-00064
+  out=data/fsns/test/test-00050-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00051-of-00064
+  out=data/fsns/test/test-00051-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00052-of-00064
+  out=data/fsns/test/test-00052-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00053-of-00064
+  out=data/fsns/test/test-00053-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00054-of-00064
+  out=data/fsns/test/test-00054-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00055-of-00064
+  out=data/fsns/test/test-00055-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00056-of-00064
+  out=data/fsns/test/test-00056-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00057-of-00064
+  out=data/fsns/test/test-00057-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00058-of-00064
+  out=data/fsns/test/test-00058-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00059-of-00064
+  out=data/fsns/test/test-00059-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00060-of-00064
+  out=data/fsns/test/test-00060-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00061-of-00064
+  out=data/fsns/test/test-00061-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00062-of-00064
+  out=data/fsns/test/test-00062-of-00064
+http://download.tensorflow.org/data/fsns-20160927/test/test-00063-of-00064
+  out=data/fsns/test/test-00063-of-00064
+http://download.tensorflow.org/data/fsns-20160927/train/train-00000-of-00512
+  out=data/fsns/train/train-00000-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00001-of-00512
+  out=data/fsns/train/train-00001-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00002-of-00512
+  out=data/fsns/train/train-00002-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00003-of-00512
+  out=data/fsns/train/train-00003-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00004-of-00512
+  out=data/fsns/train/train-00004-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00005-of-00512
+  out=data/fsns/train/train-00005-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00006-of-00512
+  out=data/fsns/train/train-00006-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00007-of-00512
+  out=data/fsns/train/train-00007-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00008-of-00512
+  out=data/fsns/train/train-00008-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00009-of-00512
+  out=data/fsns/train/train-00009-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00010-of-00512
+  out=data/fsns/train/train-00010-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00011-of-00512
+  out=data/fsns/train/train-00011-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00012-of-00512
+  out=data/fsns/train/train-00012-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00013-of-00512
+  out=data/fsns/train/train-00013-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00014-of-00512
+  out=data/fsns/train/train-00014-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00015-of-00512
+  out=data/fsns/train/train-00015-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00016-of-00512
+  out=data/fsns/train/train-00016-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00017-of-00512
+  out=data/fsns/train/train-00017-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00018-of-00512
+  out=data/fsns/train/train-00018-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00019-of-00512
+  out=data/fsns/train/train-00019-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00020-of-00512
+  out=data/fsns/train/train-00020-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00021-of-00512
+  out=data/fsns/train/train-00021-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00022-of-00512
+  out=data/fsns/train/train-00022-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00023-of-00512
+  out=data/fsns/train/train-00023-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00024-of-00512
+  out=data/fsns/train/train-00024-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00025-of-00512
+  out=data/fsns/train/train-00025-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00026-of-00512
+  out=data/fsns/train/train-00026-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00027-of-00512
+  out=data/fsns/train/train-00027-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00028-of-00512
+  out=data/fsns/train/train-00028-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00029-of-00512
+  out=data/fsns/train/train-00029-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00030-of-00512
+  out=data/fsns/train/train-00030-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00031-of-00512
+  out=data/fsns/train/train-00031-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00032-of-00512
+  out=data/fsns/train/train-00032-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00033-of-00512
+  out=data/fsns/train/train-00033-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00034-of-00512
+  out=data/fsns/train/train-00034-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00035-of-00512
+  out=data/fsns/train/train-00035-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00036-of-00512
+  out=data/fsns/train/train-00036-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00037-of-00512
+  out=data/fsns/train/train-00037-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00038-of-00512
+  out=data/fsns/train/train-00038-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00039-of-00512
+  out=data/fsns/train/train-00039-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00040-of-00512
+  out=data/fsns/train/train-00040-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00041-of-00512
+  out=data/fsns/train/train-00041-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00042-of-00512
+  out=data/fsns/train/train-00042-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00043-of-00512
+  out=data/fsns/train/train-00043-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00044-of-00512
+  out=data/fsns/train/train-00044-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00045-of-00512
+  out=data/fsns/train/train-00045-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00046-of-00512
+  out=data/fsns/train/train-00046-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00047-of-00512
+  out=data/fsns/train/train-00047-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00048-of-00512
+  out=data/fsns/train/train-00048-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00049-of-00512
+  out=data/fsns/train/train-00049-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00050-of-00512
+  out=data/fsns/train/train-00050-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00051-of-00512
+  out=data/fsns/train/train-00051-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00052-of-00512
+  out=data/fsns/train/train-00052-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00053-of-00512
+  out=data/fsns/train/train-00053-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00054-of-00512
+  out=data/fsns/train/train-00054-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00055-of-00512
+  out=data/fsns/train/train-00055-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00056-of-00512
+  out=data/fsns/train/train-00056-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00057-of-00512
+  out=data/fsns/train/train-00057-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00058-of-00512
+  out=data/fsns/train/train-00058-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00059-of-00512
+  out=data/fsns/train/train-00059-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00060-of-00512
+  out=data/fsns/train/train-00060-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00061-of-00512
+  out=data/fsns/train/train-00061-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00062-of-00512
+  out=data/fsns/train/train-00062-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00063-of-00512
+  out=data/fsns/train/train-00063-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00064-of-00512
+  out=data/fsns/train/train-00064-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00065-of-00512
+  out=data/fsns/train/train-00065-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00066-of-00512
+  out=data/fsns/train/train-00066-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00067-of-00512
+  out=data/fsns/train/train-00067-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00068-of-00512
+  out=data/fsns/train/train-00068-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00069-of-00512
+  out=data/fsns/train/train-00069-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00070-of-00512
+  out=data/fsns/train/train-00070-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00071-of-00512
+  out=data/fsns/train/train-00071-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00072-of-00512
+  out=data/fsns/train/train-00072-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00073-of-00512
+  out=data/fsns/train/train-00073-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00074-of-00512
+  out=data/fsns/train/train-00074-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00075-of-00512
+  out=data/fsns/train/train-00075-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00076-of-00512
+  out=data/fsns/train/train-00076-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00077-of-00512
+  out=data/fsns/train/train-00077-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00078-of-00512
+  out=data/fsns/train/train-00078-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00079-of-00512
+  out=data/fsns/train/train-00079-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00080-of-00512
+  out=data/fsns/train/train-00080-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00081-of-00512
+  out=data/fsns/train/train-00081-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00082-of-00512
+  out=data/fsns/train/train-00082-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00083-of-00512
+  out=data/fsns/train/train-00083-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00084-of-00512
+  out=data/fsns/train/train-00084-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00085-of-00512
+  out=data/fsns/train/train-00085-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00086-of-00512
+  out=data/fsns/train/train-00086-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00087-of-00512
+  out=data/fsns/train/train-00087-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00088-of-00512
+  out=data/fsns/train/train-00088-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00089-of-00512
+  out=data/fsns/train/train-00089-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00090-of-00512
+  out=data/fsns/train/train-00090-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00091-of-00512
+  out=data/fsns/train/train-00091-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00092-of-00512
+  out=data/fsns/train/train-00092-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00093-of-00512
+  out=data/fsns/train/train-00093-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00094-of-00512
+  out=data/fsns/train/train-00094-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00095-of-00512
+  out=data/fsns/train/train-00095-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00096-of-00512
+  out=data/fsns/train/train-00096-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00097-of-00512
+  out=data/fsns/train/train-00097-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00098-of-00512
+  out=data/fsns/train/train-00098-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00099-of-00512
+  out=data/fsns/train/train-00099-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00100-of-00512
+  out=data/fsns/train/train-00100-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00101-of-00512
+  out=data/fsns/train/train-00101-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00102-of-00512
+  out=data/fsns/train/train-00102-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00103-of-00512
+  out=data/fsns/train/train-00103-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00104-of-00512
+  out=data/fsns/train/train-00104-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00105-of-00512
+  out=data/fsns/train/train-00105-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00106-of-00512
+  out=data/fsns/train/train-00106-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00107-of-00512
+  out=data/fsns/train/train-00107-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00108-of-00512
+  out=data/fsns/train/train-00108-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00109-of-00512
+  out=data/fsns/train/train-00109-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00110-of-00512
+  out=data/fsns/train/train-00110-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00111-of-00512
+  out=data/fsns/train/train-00111-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00112-of-00512
+  out=data/fsns/train/train-00112-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00113-of-00512
+  out=data/fsns/train/train-00113-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00114-of-00512
+  out=data/fsns/train/train-00114-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00115-of-00512
+  out=data/fsns/train/train-00115-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00116-of-00512
+  out=data/fsns/train/train-00116-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00117-of-00512
+  out=data/fsns/train/train-00117-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00118-of-00512
+  out=data/fsns/train/train-00118-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00119-of-00512
+  out=data/fsns/train/train-00119-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00120-of-00512
+  out=data/fsns/train/train-00120-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00121-of-00512
+  out=data/fsns/train/train-00121-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00122-of-00512
+  out=data/fsns/train/train-00122-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00123-of-00512
+  out=data/fsns/train/train-00123-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00124-of-00512
+  out=data/fsns/train/train-00124-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00125-of-00512
+  out=data/fsns/train/train-00125-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00126-of-00512
+  out=data/fsns/train/train-00126-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00127-of-00512
+  out=data/fsns/train/train-00127-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00128-of-00512
+  out=data/fsns/train/train-00128-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00129-of-00512
+  out=data/fsns/train/train-00129-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00130-of-00512
+  out=data/fsns/train/train-00130-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00131-of-00512
+  out=data/fsns/train/train-00131-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00132-of-00512
+  out=data/fsns/train/train-00132-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00133-of-00512
+  out=data/fsns/train/train-00133-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00134-of-00512
+  out=data/fsns/train/train-00134-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00135-of-00512
+  out=data/fsns/train/train-00135-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00136-of-00512
+  out=data/fsns/train/train-00136-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00137-of-00512
+  out=data/fsns/train/train-00137-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00138-of-00512
+  out=data/fsns/train/train-00138-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00139-of-00512
+  out=data/fsns/train/train-00139-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00140-of-00512
+  out=data/fsns/train/train-00140-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00141-of-00512
+  out=data/fsns/train/train-00141-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00142-of-00512
+  out=data/fsns/train/train-00142-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00143-of-00512
+  out=data/fsns/train/train-00143-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00144-of-00512
+  out=data/fsns/train/train-00144-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00145-of-00512
+  out=data/fsns/train/train-00145-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00146-of-00512
+  out=data/fsns/train/train-00146-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00147-of-00512
+  out=data/fsns/train/train-00147-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00148-of-00512
+  out=data/fsns/train/train-00148-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00149-of-00512
+  out=data/fsns/train/train-00149-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00150-of-00512
+  out=data/fsns/train/train-00150-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00151-of-00512
+  out=data/fsns/train/train-00151-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00152-of-00512
+  out=data/fsns/train/train-00152-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00153-of-00512
+  out=data/fsns/train/train-00153-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00154-of-00512
+  out=data/fsns/train/train-00154-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00155-of-00512
+  out=data/fsns/train/train-00155-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00156-of-00512
+  out=data/fsns/train/train-00156-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00157-of-00512
+  out=data/fsns/train/train-00157-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00158-of-00512
+  out=data/fsns/train/train-00158-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00159-of-00512
+  out=data/fsns/train/train-00159-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00160-of-00512
+  out=data/fsns/train/train-00160-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00161-of-00512
+  out=data/fsns/train/train-00161-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00162-of-00512
+  out=data/fsns/train/train-00162-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00163-of-00512
+  out=data/fsns/train/train-00163-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00164-of-00512
+  out=data/fsns/train/train-00164-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00165-of-00512
+  out=data/fsns/train/train-00165-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00166-of-00512
+  out=data/fsns/train/train-00166-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00167-of-00512
+  out=data/fsns/train/train-00167-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00168-of-00512
+  out=data/fsns/train/train-00168-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00169-of-00512
+  out=data/fsns/train/train-00169-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00170-of-00512
+  out=data/fsns/train/train-00170-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00171-of-00512
+  out=data/fsns/train/train-00171-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00172-of-00512
+  out=data/fsns/train/train-00172-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00173-of-00512
+  out=data/fsns/train/train-00173-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00174-of-00512
+  out=data/fsns/train/train-00174-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00175-of-00512
+  out=data/fsns/train/train-00175-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00176-of-00512
+  out=data/fsns/train/train-00176-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00177-of-00512
+  out=data/fsns/train/train-00177-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00178-of-00512
+  out=data/fsns/train/train-00178-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00179-of-00512
+  out=data/fsns/train/train-00179-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00180-of-00512
+  out=data/fsns/train/train-00180-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00181-of-00512
+  out=data/fsns/train/train-00181-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00182-of-00512
+  out=data/fsns/train/train-00182-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00183-of-00512
+  out=data/fsns/train/train-00183-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00184-of-00512
+  out=data/fsns/train/train-00184-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00185-of-00512
+  out=data/fsns/train/train-00185-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00186-of-00512
+  out=data/fsns/train/train-00186-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00187-of-00512
+  out=data/fsns/train/train-00187-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00188-of-00512
+  out=data/fsns/train/train-00188-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00189-of-00512
+  out=data/fsns/train/train-00189-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00190-of-00512
+  out=data/fsns/train/train-00190-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00191-of-00512
+  out=data/fsns/train/train-00191-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00192-of-00512
+  out=data/fsns/train/train-00192-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00193-of-00512
+  out=data/fsns/train/train-00193-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00194-of-00512
+  out=data/fsns/train/train-00194-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00195-of-00512
+  out=data/fsns/train/train-00195-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00196-of-00512
+  out=data/fsns/train/train-00196-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00197-of-00512
+  out=data/fsns/train/train-00197-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00198-of-00512
+  out=data/fsns/train/train-00198-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00199-of-00512
+  out=data/fsns/train/train-00199-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00200-of-00512
+  out=data/fsns/train/train-00200-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00201-of-00512
+  out=data/fsns/train/train-00201-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00202-of-00512
+  out=data/fsns/train/train-00202-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00203-of-00512
+  out=data/fsns/train/train-00203-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00204-of-00512
+  out=data/fsns/train/train-00204-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00205-of-00512
+  out=data/fsns/train/train-00205-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00206-of-00512
+  out=data/fsns/train/train-00206-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00207-of-00512
+  out=data/fsns/train/train-00207-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00208-of-00512
+  out=data/fsns/train/train-00208-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00209-of-00512
+  out=data/fsns/train/train-00209-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00210-of-00512
+  out=data/fsns/train/train-00210-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00211-of-00512
+  out=data/fsns/train/train-00211-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00212-of-00512
+  out=data/fsns/train/train-00212-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00213-of-00512
+  out=data/fsns/train/train-00213-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00214-of-00512
+  out=data/fsns/train/train-00214-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00215-of-00512
+  out=data/fsns/train/train-00215-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00216-of-00512
+  out=data/fsns/train/train-00216-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00217-of-00512
+  out=data/fsns/train/train-00217-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00218-of-00512
+  out=data/fsns/train/train-00218-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00219-of-00512
+  out=data/fsns/train/train-00219-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00220-of-00512
+  out=data/fsns/train/train-00220-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00221-of-00512
+  out=data/fsns/train/train-00221-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00222-of-00512
+  out=data/fsns/train/train-00222-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00223-of-00512
+  out=data/fsns/train/train-00223-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00224-of-00512
+  out=data/fsns/train/train-00224-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00225-of-00512
+  out=data/fsns/train/train-00225-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00226-of-00512
+  out=data/fsns/train/train-00226-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00227-of-00512
+  out=data/fsns/train/train-00227-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00228-of-00512
+  out=data/fsns/train/train-00228-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00229-of-00512
+  out=data/fsns/train/train-00229-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00230-of-00512
+  out=data/fsns/train/train-00230-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00231-of-00512
+  out=data/fsns/train/train-00231-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00232-of-00512
+  out=data/fsns/train/train-00232-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00233-of-00512
+  out=data/fsns/train/train-00233-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00234-of-00512
+  out=data/fsns/train/train-00234-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00235-of-00512
+  out=data/fsns/train/train-00235-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00236-of-00512
+  out=data/fsns/train/train-00236-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00237-of-00512
+  out=data/fsns/train/train-00237-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00238-of-00512
+  out=data/fsns/train/train-00238-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00239-of-00512
+  out=data/fsns/train/train-00239-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00240-of-00512
+  out=data/fsns/train/train-00240-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00241-of-00512
+  out=data/fsns/train/train-00241-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00242-of-00512
+  out=data/fsns/train/train-00242-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00243-of-00512
+  out=data/fsns/train/train-00243-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00244-of-00512
+  out=data/fsns/train/train-00244-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00245-of-00512
+  out=data/fsns/train/train-00245-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00246-of-00512
+  out=data/fsns/train/train-00246-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00247-of-00512
+  out=data/fsns/train/train-00247-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00248-of-00512
+  out=data/fsns/train/train-00248-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00249-of-00512
+  out=data/fsns/train/train-00249-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00250-of-00512
+  out=data/fsns/train/train-00250-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00251-of-00512
+  out=data/fsns/train/train-00251-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00252-of-00512
+  out=data/fsns/train/train-00252-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00253-of-00512
+  out=data/fsns/train/train-00253-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00254-of-00512
+  out=data/fsns/train/train-00254-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00255-of-00512
+  out=data/fsns/train/train-00255-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00256-of-00512
+  out=data/fsns/train/train-00256-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00257-of-00512
+  out=data/fsns/train/train-00257-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00258-of-00512
+  out=data/fsns/train/train-00258-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00259-of-00512
+  out=data/fsns/train/train-00259-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00260-of-00512
+  out=data/fsns/train/train-00260-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00261-of-00512
+  out=data/fsns/train/train-00261-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00262-of-00512
+  out=data/fsns/train/train-00262-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00263-of-00512
+  out=data/fsns/train/train-00263-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00264-of-00512
+  out=data/fsns/train/train-00264-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00265-of-00512
+  out=data/fsns/train/train-00265-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00266-of-00512
+  out=data/fsns/train/train-00266-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00267-of-00512
+  out=data/fsns/train/train-00267-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00268-of-00512
+  out=data/fsns/train/train-00268-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00269-of-00512
+  out=data/fsns/train/train-00269-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00270-of-00512
+  out=data/fsns/train/train-00270-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00271-of-00512
+  out=data/fsns/train/train-00271-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00272-of-00512
+  out=data/fsns/train/train-00272-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00273-of-00512
+  out=data/fsns/train/train-00273-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00274-of-00512
+  out=data/fsns/train/train-00274-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00275-of-00512
+  out=data/fsns/train/train-00275-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00276-of-00512
+  out=data/fsns/train/train-00276-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00277-of-00512
+  out=data/fsns/train/train-00277-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00278-of-00512
+  out=data/fsns/train/train-00278-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00279-of-00512
+  out=data/fsns/train/train-00279-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00280-of-00512
+  out=data/fsns/train/train-00280-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00281-of-00512
+  out=data/fsns/train/train-00281-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00282-of-00512
+  out=data/fsns/train/train-00282-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00283-of-00512
+  out=data/fsns/train/train-00283-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00284-of-00512
+  out=data/fsns/train/train-00284-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00285-of-00512
+  out=data/fsns/train/train-00285-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00286-of-00512
+  out=data/fsns/train/train-00286-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00287-of-00512
+  out=data/fsns/train/train-00287-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00288-of-00512
+  out=data/fsns/train/train-00288-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00289-of-00512
+  out=data/fsns/train/train-00289-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00290-of-00512
+  out=data/fsns/train/train-00290-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00291-of-00512
+  out=data/fsns/train/train-00291-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00292-of-00512
+  out=data/fsns/train/train-00292-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00293-of-00512
+  out=data/fsns/train/train-00293-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00294-of-00512
+  out=data/fsns/train/train-00294-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00295-of-00512
+  out=data/fsns/train/train-00295-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00296-of-00512
+  out=data/fsns/train/train-00296-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00297-of-00512
+  out=data/fsns/train/train-00297-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00298-of-00512
+  out=data/fsns/train/train-00298-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00299-of-00512
+  out=data/fsns/train/train-00299-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00300-of-00512
+  out=data/fsns/train/train-00300-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00301-of-00512
+  out=data/fsns/train/train-00301-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00302-of-00512
+  out=data/fsns/train/train-00302-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00303-of-00512
+  out=data/fsns/train/train-00303-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00304-of-00512
+  out=data/fsns/train/train-00304-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00305-of-00512
+  out=data/fsns/train/train-00305-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00306-of-00512
+  out=data/fsns/train/train-00306-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00307-of-00512
+  out=data/fsns/train/train-00307-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00308-of-00512
+  out=data/fsns/train/train-00308-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00309-of-00512
+  out=data/fsns/train/train-00309-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00310-of-00512
+  out=data/fsns/train/train-00310-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00311-of-00512
+  out=data/fsns/train/train-00311-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00312-of-00512
+  out=data/fsns/train/train-00312-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00313-of-00512
+  out=data/fsns/train/train-00313-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00314-of-00512
+  out=data/fsns/train/train-00314-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00315-of-00512
+  out=data/fsns/train/train-00315-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00316-of-00512
+  out=data/fsns/train/train-00316-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00317-of-00512
+  out=data/fsns/train/train-00317-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00318-of-00512
+  out=data/fsns/train/train-00318-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00319-of-00512
+  out=data/fsns/train/train-00319-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00320-of-00512
+  out=data/fsns/train/train-00320-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00321-of-00512
+  out=data/fsns/train/train-00321-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00322-of-00512
+  out=data/fsns/train/train-00322-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00323-of-00512
+  out=data/fsns/train/train-00323-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00324-of-00512
+  out=data/fsns/train/train-00324-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00325-of-00512
+  out=data/fsns/train/train-00325-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00326-of-00512
+  out=data/fsns/train/train-00326-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00327-of-00512
+  out=data/fsns/train/train-00327-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00328-of-00512
+  out=data/fsns/train/train-00328-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00329-of-00512
+  out=data/fsns/train/train-00329-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00330-of-00512
+  out=data/fsns/train/train-00330-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00331-of-00512
+  out=data/fsns/train/train-00331-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00332-of-00512
+  out=data/fsns/train/train-00332-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00333-of-00512
+  out=data/fsns/train/train-00333-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00334-of-00512
+  out=data/fsns/train/train-00334-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00335-of-00512
+  out=data/fsns/train/train-00335-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00336-of-00512
+  out=data/fsns/train/train-00336-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00337-of-00512
+  out=data/fsns/train/train-00337-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00338-of-00512
+  out=data/fsns/train/train-00338-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00339-of-00512
+  out=data/fsns/train/train-00339-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00340-of-00512
+  out=data/fsns/train/train-00340-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00341-of-00512
+  out=data/fsns/train/train-00341-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00342-of-00512
+  out=data/fsns/train/train-00342-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00343-of-00512
+  out=data/fsns/train/train-00343-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00344-of-00512
+  out=data/fsns/train/train-00344-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00345-of-00512
+  out=data/fsns/train/train-00345-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00346-of-00512
+  out=data/fsns/train/train-00346-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00347-of-00512
+  out=data/fsns/train/train-00347-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00348-of-00512
+  out=data/fsns/train/train-00348-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00349-of-00512
+  out=data/fsns/train/train-00349-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00350-of-00512
+  out=data/fsns/train/train-00350-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00351-of-00512
+  out=data/fsns/train/train-00351-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00352-of-00512
+  out=data/fsns/train/train-00352-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00353-of-00512
+  out=data/fsns/train/train-00353-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00354-of-00512
+  out=data/fsns/train/train-00354-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00355-of-00512
+  out=data/fsns/train/train-00355-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00356-of-00512
+  out=data/fsns/train/train-00356-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00357-of-00512
+  out=data/fsns/train/train-00357-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00358-of-00512
+  out=data/fsns/train/train-00358-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00359-of-00512
+  out=data/fsns/train/train-00359-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00360-of-00512
+  out=data/fsns/train/train-00360-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00361-of-00512
+  out=data/fsns/train/train-00361-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00362-of-00512
+  out=data/fsns/train/train-00362-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00363-of-00512
+  out=data/fsns/train/train-00363-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00364-of-00512
+  out=data/fsns/train/train-00364-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00365-of-00512
+  out=data/fsns/train/train-00365-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00366-of-00512
+  out=data/fsns/train/train-00366-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00367-of-00512
+  out=data/fsns/train/train-00367-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00368-of-00512
+  out=data/fsns/train/train-00368-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00369-of-00512
+  out=data/fsns/train/train-00369-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00370-of-00512
+  out=data/fsns/train/train-00370-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00371-of-00512
+  out=data/fsns/train/train-00371-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00372-of-00512
+  out=data/fsns/train/train-00372-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00373-of-00512
+  out=data/fsns/train/train-00373-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00374-of-00512
+  out=data/fsns/train/train-00374-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00375-of-00512
+  out=data/fsns/train/train-00375-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00376-of-00512
+  out=data/fsns/train/train-00376-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00377-of-00512
+  out=data/fsns/train/train-00377-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00378-of-00512
+  out=data/fsns/train/train-00378-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00379-of-00512
+  out=data/fsns/train/train-00379-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00380-of-00512
+  out=data/fsns/train/train-00380-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00381-of-00512
+  out=data/fsns/train/train-00381-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00382-of-00512
+  out=data/fsns/train/train-00382-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00383-of-00512
+  out=data/fsns/train/train-00383-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00384-of-00512
+  out=data/fsns/train/train-00384-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00385-of-00512
+  out=data/fsns/train/train-00385-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00386-of-00512
+  out=data/fsns/train/train-00386-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00387-of-00512
+  out=data/fsns/train/train-00387-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00388-of-00512
+  out=data/fsns/train/train-00388-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00389-of-00512
+  out=data/fsns/train/train-00389-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00390-of-00512
+  out=data/fsns/train/train-00390-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00391-of-00512
+  out=data/fsns/train/train-00391-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00392-of-00512
+  out=data/fsns/train/train-00392-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00393-of-00512
+  out=data/fsns/train/train-00393-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00394-of-00512
+  out=data/fsns/train/train-00394-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00395-of-00512
+  out=data/fsns/train/train-00395-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00396-of-00512
+  out=data/fsns/train/train-00396-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00397-of-00512
+  out=data/fsns/train/train-00397-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00398-of-00512
+  out=data/fsns/train/train-00398-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00399-of-00512
+  out=data/fsns/train/train-00399-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00400-of-00512
+  out=data/fsns/train/train-00400-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00401-of-00512
+  out=data/fsns/train/train-00401-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00402-of-00512
+  out=data/fsns/train/train-00402-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00403-of-00512
+  out=data/fsns/train/train-00403-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00404-of-00512
+  out=data/fsns/train/train-00404-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00405-of-00512
+  out=data/fsns/train/train-00405-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00406-of-00512
+  out=data/fsns/train/train-00406-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00407-of-00512
+  out=data/fsns/train/train-00407-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00408-of-00512
+  out=data/fsns/train/train-00408-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00409-of-00512
+  out=data/fsns/train/train-00409-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00410-of-00512
+  out=data/fsns/train/train-00410-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00411-of-00512
+  out=data/fsns/train/train-00411-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00412-of-00512
+  out=data/fsns/train/train-00412-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00413-of-00512
+  out=data/fsns/train/train-00413-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00414-of-00512
+  out=data/fsns/train/train-00414-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00415-of-00512
+  out=data/fsns/train/train-00415-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00416-of-00512
+  out=data/fsns/train/train-00416-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00417-of-00512
+  out=data/fsns/train/train-00417-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00418-of-00512
+  out=data/fsns/train/train-00418-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00419-of-00512
+  out=data/fsns/train/train-00419-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00420-of-00512
+  out=data/fsns/train/train-00420-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00421-of-00512
+  out=data/fsns/train/train-00421-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00422-of-00512
+  out=data/fsns/train/train-00422-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00423-of-00512
+  out=data/fsns/train/train-00423-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00424-of-00512
+  out=data/fsns/train/train-00424-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00425-of-00512
+  out=data/fsns/train/train-00425-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00426-of-00512
+  out=data/fsns/train/train-00426-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00427-of-00512
+  out=data/fsns/train/train-00427-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00428-of-00512
+  out=data/fsns/train/train-00428-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00429-of-00512
+  out=data/fsns/train/train-00429-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00430-of-00512
+  out=data/fsns/train/train-00430-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00431-of-00512
+  out=data/fsns/train/train-00431-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00432-of-00512
+  out=data/fsns/train/train-00432-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00433-of-00512
+  out=data/fsns/train/train-00433-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00434-of-00512
+  out=data/fsns/train/train-00434-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00435-of-00512
+  out=data/fsns/train/train-00435-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00436-of-00512
+  out=data/fsns/train/train-00436-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00437-of-00512
+  out=data/fsns/train/train-00437-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00438-of-00512
+  out=data/fsns/train/train-00438-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00439-of-00512
+  out=data/fsns/train/train-00439-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00440-of-00512
+  out=data/fsns/train/train-00440-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00441-of-00512
+  out=data/fsns/train/train-00441-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00442-of-00512
+  out=data/fsns/train/train-00442-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00443-of-00512
+  out=data/fsns/train/train-00443-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00444-of-00512
+  out=data/fsns/train/train-00444-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00445-of-00512
+  out=data/fsns/train/train-00445-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00446-of-00512
+  out=data/fsns/train/train-00446-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00447-of-00512
+  out=data/fsns/train/train-00447-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00448-of-00512
+  out=data/fsns/train/train-00448-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00449-of-00512
+  out=data/fsns/train/train-00449-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00450-of-00512
+  out=data/fsns/train/train-00450-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00451-of-00512
+  out=data/fsns/train/train-00451-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00452-of-00512
+  out=data/fsns/train/train-00452-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00453-of-00512
+  out=data/fsns/train/train-00453-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00454-of-00512
+  out=data/fsns/train/train-00454-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00455-of-00512
+  out=data/fsns/train/train-00455-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00456-of-00512
+  out=data/fsns/train/train-00456-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00457-of-00512
+  out=data/fsns/train/train-00457-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00458-of-00512
+  out=data/fsns/train/train-00458-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00459-of-00512
+  out=data/fsns/train/train-00459-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00460-of-00512
+  out=data/fsns/train/train-00460-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00461-of-00512
+  out=data/fsns/train/train-00461-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00462-of-00512
+  out=data/fsns/train/train-00462-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00463-of-00512
+  out=data/fsns/train/train-00463-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00464-of-00512
+  out=data/fsns/train/train-00464-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00465-of-00512
+  out=data/fsns/train/train-00465-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00466-of-00512
+  out=data/fsns/train/train-00466-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00467-of-00512
+  out=data/fsns/train/train-00467-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00468-of-00512
+  out=data/fsns/train/train-00468-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00469-of-00512
+  out=data/fsns/train/train-00469-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00470-of-00512
+  out=data/fsns/train/train-00470-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00471-of-00512
+  out=data/fsns/train/train-00471-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00472-of-00512
+  out=data/fsns/train/train-00472-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00473-of-00512
+  out=data/fsns/train/train-00473-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00474-of-00512
+  out=data/fsns/train/train-00474-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00475-of-00512
+  out=data/fsns/train/train-00475-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00476-of-00512
+  out=data/fsns/train/train-00476-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00477-of-00512
+  out=data/fsns/train/train-00477-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00478-of-00512
+  out=data/fsns/train/train-00478-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00479-of-00512
+  out=data/fsns/train/train-00479-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00480-of-00512
+  out=data/fsns/train/train-00480-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00481-of-00512
+  out=data/fsns/train/train-00481-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00482-of-00512
+  out=data/fsns/train/train-00482-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00483-of-00512
+  out=data/fsns/train/train-00483-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00484-of-00512
+  out=data/fsns/train/train-00484-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00485-of-00512
+  out=data/fsns/train/train-00485-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00486-of-00512
+  out=data/fsns/train/train-00486-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00487-of-00512
+  out=data/fsns/train/train-00487-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00488-of-00512
+  out=data/fsns/train/train-00488-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00489-of-00512
+  out=data/fsns/train/train-00489-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00490-of-00512
+  out=data/fsns/train/train-00490-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00491-of-00512
+  out=data/fsns/train/train-00491-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00492-of-00512
+  out=data/fsns/train/train-00492-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00493-of-00512
+  out=data/fsns/train/train-00493-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00494-of-00512
+  out=data/fsns/train/train-00494-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00495-of-00512
+  out=data/fsns/train/train-00495-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00496-of-00512
+  out=data/fsns/train/train-00496-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00497-of-00512
+  out=data/fsns/train/train-00497-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00498-of-00512
+  out=data/fsns/train/train-00498-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00499-of-00512
+  out=data/fsns/train/train-00499-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00500-of-00512
+  out=data/fsns/train/train-00500-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00501-of-00512
+  out=data/fsns/train/train-00501-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00502-of-00512
+  out=data/fsns/train/train-00502-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00503-of-00512
+  out=data/fsns/train/train-00503-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00504-of-00512
+  out=data/fsns/train/train-00504-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00505-of-00512
+  out=data/fsns/train/train-00505-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00506-of-00512
+  out=data/fsns/train/train-00506-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00507-of-00512
+  out=data/fsns/train/train-00507-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00508-of-00512
+  out=data/fsns/train/train-00508-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00509-of-00512
+  out=data/fsns/train/train-00509-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00510-of-00512
+  out=data/fsns/train/train-00510-of-00512
+http://download.tensorflow.org/data/fsns-20160927/train/train-00511-of-00512
+  out=data/fsns/train/train-00511-of-00512
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00000-of-00064
+  out=data/fsns/validation/validation-00000-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00001-of-00064
+  out=data/fsns/validation/validation-00001-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00002-of-00064
+  out=data/fsns/validation/validation-00002-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00003-of-00064
+  out=data/fsns/validation/validation-00003-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00004-of-00064
+  out=data/fsns/validation/validation-00004-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00005-of-00064
+  out=data/fsns/validation/validation-00005-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00006-of-00064
+  out=data/fsns/validation/validation-00006-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00007-of-00064
+  out=data/fsns/validation/validation-00007-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00008-of-00064
+  out=data/fsns/validation/validation-00008-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00009-of-00064
+  out=data/fsns/validation/validation-00009-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00010-of-00064
+  out=data/fsns/validation/validation-00010-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00011-of-00064
+  out=data/fsns/validation/validation-00011-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00012-of-00064
+  out=data/fsns/validation/validation-00012-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00013-of-00064
+  out=data/fsns/validation/validation-00013-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00014-of-00064
+  out=data/fsns/validation/validation-00014-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00015-of-00064
+  out=data/fsns/validation/validation-00015-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00016-of-00064
+  out=data/fsns/validation/validation-00016-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00017-of-00064
+  out=data/fsns/validation/validation-00017-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00018-of-00064
+  out=data/fsns/validation/validation-00018-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00019-of-00064
+  out=data/fsns/validation/validation-00019-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00020-of-00064
+  out=data/fsns/validation/validation-00020-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00021-of-00064
+  out=data/fsns/validation/validation-00021-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00022-of-00064
+  out=data/fsns/validation/validation-00022-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00023-of-00064
+  out=data/fsns/validation/validation-00023-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00024-of-00064
+  out=data/fsns/validation/validation-00024-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00025-of-00064
+  out=data/fsns/validation/validation-00025-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00026-of-00064
+  out=data/fsns/validation/validation-00026-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00027-of-00064
+  out=data/fsns/validation/validation-00027-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00028-of-00064
+  out=data/fsns/validation/validation-00028-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00029-of-00064
+  out=data/fsns/validation/validation-00029-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00030-of-00064
+  out=data/fsns/validation/validation-00030-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00031-of-00064
+  out=data/fsns/validation/validation-00031-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00032-of-00064
+  out=data/fsns/validation/validation-00032-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00033-of-00064
+  out=data/fsns/validation/validation-00033-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00034-of-00064
+  out=data/fsns/validation/validation-00034-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00035-of-00064
+  out=data/fsns/validation/validation-00035-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00036-of-00064
+  out=data/fsns/validation/validation-00036-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00037-of-00064
+  out=data/fsns/validation/validation-00037-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00038-of-00064
+  out=data/fsns/validation/validation-00038-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00039-of-00064
+  out=data/fsns/validation/validation-00039-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00040-of-00064
+  out=data/fsns/validation/validation-00040-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00041-of-00064
+  out=data/fsns/validation/validation-00041-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00042-of-00064
+  out=data/fsns/validation/validation-00042-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00043-of-00064
+  out=data/fsns/validation/validation-00043-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00044-of-00064
+  out=data/fsns/validation/validation-00044-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00045-of-00064
+  out=data/fsns/validation/validation-00045-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00046-of-00064
+  out=data/fsns/validation/validation-00046-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00047-of-00064
+  out=data/fsns/validation/validation-00047-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00048-of-00064
+  out=data/fsns/validation/validation-00048-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00049-of-00064
+  out=data/fsns/validation/validation-00049-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00050-of-00064
+  out=data/fsns/validation/validation-00050-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00051-of-00064
+  out=data/fsns/validation/validation-00051-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00052-of-00064
+  out=data/fsns/validation/validation-00052-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00053-of-00064
+  out=data/fsns/validation/validation-00053-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00054-of-00064
+  out=data/fsns/validation/validation-00054-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00055-of-00064
+  out=data/fsns/validation/validation-00055-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00056-of-00064
+  out=data/fsns/validation/validation-00056-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00057-of-00064
+  out=data/fsns/validation/validation-00057-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00058-of-00064
+  out=data/fsns/validation/validation-00058-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00059-of-00064
+  out=data/fsns/validation/validation-00059-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00060-of-00064
+  out=data/fsns/validation/validation-00060-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00061-of-00064
+  out=data/fsns/validation/validation-00061-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00062-of-00064
+  out=data/fsns/validation/validation-00062-of-00064
+http://download.tensorflow.org/data/fsns-20160927/validation/validation-00063-of-00064
+  out=data/fsns/validation/validation-00063-of-00064


### PR DESCRIPTION
Currently the FSNS dataset is distributed as a description how to generate URLs to download files. This change adds a simple script to generate a text file with all URLs which is compatible with aria2c download manager, which can download all files in parallel and supports multiple retries and continue an aborted download modes.