### PR TITLE
inception: Added protocol flag when running distributed

### DIFF
--- a/inception/README.md
+++ b/inception/README.md
@@ -367,6 +367,13 @@ I tensorflow/core/distributed_runtime/rpc/grpc_channel.cc:206] Initialize HostPo
 I tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc:202] Started server with target: grpc://localhost:2222
 ```
 
+If you compiled TensorFlow (from v1.1-rc3) with VERBS support and you have the
+required device and IB verbs SW stack, you can specify --protocol='grpc+verbs'
+In order to use Verbs RDMA for Tensor passing between workers and ps.
+Need to add the the --protocol flag in all tasks (ps and workers).
+The default protocol is the TensorFlow default protocol of grpc.
+
+
 [Congratulations!](https://www.youtube.com/watch?v=9bZkp7q19f0) You are now
 training Inception in a distributed manner.
 

--- a/inception/inception/imagenet_distributed_train.py
+++ b/inception/inception/imagenet_distributed_train.py
@@ -45,7 +45,8 @@ def main(unused_args):
       {'ps': ps_hosts,
        'worker': worker_hosts},
       job_name=FLAGS.job_name,
-      task_index=FLAGS.task_id)
+      task_index=FLAGS.task_id,
+      protocol=FLAGS.protocol)
 
   if FLAGS.job_name == 'ps':
     # `ps` jobs wait for incoming connections from the workers.

--- a/inception/inception/inception_distributed_train.py
+++ b/inception/inception/inception_distributed_train.py
@@ -42,6 +42,9 @@ tf.app.flags.DEFINE_string('worker_hosts', '',
                            """Comma-separated list of hostname:port for the """
                            """worker jobs. e.g. """
                            """'machine1:2222,machine2:1111,machine2:2222'""")
+tf.app.flags.DEFINE_string('protocol', 'grpc',
+                           """Communication protocol to use in distributed """
+                           """execution (default grpc) """)
 
 tf.app.flags.DEFINE_string('train_dir', '/tmp/imagenet_train',
                            """Directory where to write event logs """


### PR DESCRIPTION
Default is TensorFlow default of 'grpc' communication protocol.
If TensorFlow was complied with Verbs support 'grpc+verbs' can be
used to accelerate the tensor passing communication.

@drpngx @junshi15 @bkovalev