### PR TITLE
InceptionV1 has inconsistent naming in Mixed_5b

### DIFF
--- a/slim/nets/inception_v1.py
+++ b/slim/nets/inception_v1.py
@@ -218,7 +218,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 320, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0a_3x3')
+            branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')


### PR DESCRIPTION
This could be made into just a comment instead, because as it stands it could **break loading of the existing checkpoint** (if done by name).

I noticed this because I was creating an equivalent Keras version, which generated the 'inception blocks' via a subroutine, making the naming completely uniform.


