### PR TITLE
Slim: Add tf.device(/job:ps/task:0) block to global_step

### DIFF
--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -395,7 +395,8 @@ def main(_):
 
     # Create global_step
     with tf.device(deploy_config.variables_device()):
-      global_step = slim.create_global_step()
+      with tf.device("/job:ps/task:0"):
+        global_step = slim.create_global_step()
 
     ######################
     # Select the dataset #


### PR DESCRIPTION
To solve [issue #1419](https://github.com/tensorflow/models/issues/1419) there we get the exception:
`ValueError: When using replicas, all Variables must have their device set: name: "global_step"`
For when using multiple worker replicas, i.e. running distributed TensorFlow.

Solved with the accepted answer from: http://stackoverflow.com/questions/38793718/distributed-tensorflow-valueerror-when-when-using-replicas-all-variables-mus