### PR TITLE
stack outputs instead of concat outputs

### DIFF
--- a/tutorials/rnn/ptb/ptb_word_lm.py
+++ b/tutorials/rnn/ptb/ptb_word_lm.py
@@ -157,7 +157,7 @@ class PTBModel(object):
         (cell_output, state) = cell(inputs[:, time_step, :], state)
         outputs.append(cell_output)
 
-    output = tf.reshape(tf.concat(axis=1, values=outputs), [-1, size])
+    output = tf.reshape(tf.stack(axis=1, values=outputs), [-1, size])
     softmax_w = tf.get_variable(
         "softmax_w", [size, vocab_size], dtype=data_type())
     softmax_b = tf.get_variable("softmax_b", [vocab_size], dtype=data_type())


### PR DESCRIPTION
`outputs` is a list of `num_steps` tensors, each shaped `(batch_size, size)`. 

It makes more sense to stack them to a `(batch_size, num_steps, size)` tensor, instead of concatenating them to a `(batch_size, size*num_steps)` tensor, although it makes no difference to the result.