### PR TITLE
correct the percentage logs in slim_walkthrough.ipynb

### DIFF
--- a/slim/slim_walkthrough.ipynb
+++ b/slim/slim_walkthrough.ipynb
@@ -849,7 +849,7 @@
     "    names = imagenet.create_readable_names_for_imagenet_labels()\n",
     "    for i in range(5):\n",
     "        index = sorted_inds[i]\n",
-    "        print('Probability %0.2f%% => [%s]' % (probabilities[index]*100, names[index]))"
+    "        print('Probability %0.2f%% => [%s]' % (probabilities[index] * 100, names[index]))"
    ]
   },
   {
@@ -944,7 +944,7 @@
     "    for i in range(5):\n",
     "        index = sorted_inds[i]\n",
     "        # Shift the index of a class name by one. \n",
-    "        print('Probability %0.2f%% => [%s]' % (probabilities[index]*100, names[index+1]))"
+    "        print('Probability %0.2f%% => [%s]' % (probabilities[index] * 100, names[index+1]))"
    ]
   },
   {

--- a/slim/slim_walkthrough.ipynb
+++ b/slim/slim_walkthrough.ipynb
@@ -849,7 +849,7 @@
     "    names = imagenet.create_readable_names_for_imagenet_labels()\n",
     "    for i in range(5):\n",
     "        index = sorted_inds[i]\n",
-    "        print('Probability %0.2f%% => [%s]' % (probabilities[index], names[index]))"
+    "        print('Probability %0.2f%% => [%s]' % (probabilities[index]*100, names[index]))"
    ]
   },
   {
@@ -944,7 +944,7 @@
     "    for i in range(5):\n",
     "        index = sorted_inds[i]\n",
     "        # Shift the index of a class name by one. \n",
-    "        print('Probability %0.2f%% => [%s]' % (probabilities[index], names[index+1]))"
+    "        print('Probability %0.2f%% => [%s]' % (probabilities[index]*100, names[index+1]))"
    ]
   },
   {


### PR DESCRIPTION
Correct the format of the percentages in slim_walkthrough.ipynb.
The probability is shown as percentage thus should be scaled correctly.