### PR TITLE
modification to resnet_model.py and resnet_main.py

### DIFF
--- a/resnet/resnet_main.py
+++ b/resnet/resnet_main.py
@@ -198,7 +198,11 @@ def main(_):
                              use_bottleneck=False,
                              weight_decay_rate=0.0002,
                              relu_leakiness=0.1,
-                             optimizer='mom')
+                             optimizer='mom',
+                             keep_prob=0.9,
+                             dropout_identity=False,
+                             dropout_conv=True
+                             )
 
   with tf.device(dev):
     if FLAGS.mode == 'train':

--- a/resnet/resnet_main.py
+++ b/resnet/resnet_main.py
@@ -201,7 +201,7 @@ def main(_):
                              optimizer='mom',
                              keep_prob=0.9,
                              dropout_identity=False,
-                             dropout_conv=True
+                             dropout_conv=False
                              )
 
   with tf.device(dev):

--- a/resnet/resnet_model.py
+++ b/resnet/resnet_model.py
@@ -32,7 +32,7 @@ from tensorflow.python.training import moving_averages
 HParams = namedtuple('HParams',
                      'batch_size, num_classes, min_lrn_rate, lrn_rate, '
                      'num_residual_units, use_bottleneck, weight_decay_rate, '
-                     'relu_leakiness, optimizer')
+                     'relu_leakiness, optimizer, keep_prob, dropout_identity, dropout_conv ')
 
 
 class ResNet(object):
@@ -212,6 +212,21 @@ class ResNet(object):
       x = self._batch_norm('bn2', x)
       x = self._relu(x, self.hps.relu_leakiness)
       x = self._conv('conv2', x, 3, out_filter, out_filter, [1, 1, 1, 1])
+
+    """Dropout Layer"""
+    if self.hps.dropout_identity:
+        if self.mode == 'train':
+            with tf.variable_scope('Dropout'):
+                orig_x = tf.nn.dropout(orig_x, self.hps.keep_prob)
+        else:
+            orig_x *= self.hps.keep_prob
+
+    if self.hps.dropout_conv:
+        if self.mode == 'train':
+            with tf.variable_scope('Dropout'):
+                x = tf.nn.dropout(x, self.hps.keep_prob)
+        else:
+            x *= self.hps.keep_prob
 
     with tf.variable_scope('sub_add'):
       if in_filter != out_filter:

--- a/resnet/resnet_model.py
+++ b/resnet/resnet_model.py
@@ -149,7 +149,8 @@ class ResNet(object):
   def _batch_norm(self, name, x):
     """Batch normalization."""
     with tf.variable_scope(name):
-      params_shape = [x.get_shape()[-1]]
+      #params_shape = [x.get_shape()[-1]]
+      params_shape = x.get_shape()[1:]
 
       beta = tf.get_variable(
           'beta', params_shape, tf.float32,
@@ -159,7 +160,7 @@ class ResNet(object):
           initializer=tf.constant_initializer(1.0, tf.float32))
 
       if self.mode == 'train':
-        mean, variance = tf.nn.moments(x, [0, 1, 2], name='moments')
+        mean, variance = tf.nn.moments(x, [0], name='moments')
 
         moving_mean = tf.get_variable(
             'moving_mean', params_shape, tf.float32,


### PR DESCRIPTION
resnet_model.py:
- Replaced _batch_norm function with tf.layers.batch_normalization
It was also one of TODOs as code comment.

- resnet_model.py, resnet_main.py
Added hyperparameter options for dropout on identity and conv branch going to addition block with residual cell. As also noted in Wide Resnet Paper (https://arxiv.org/pdf/1605.07146.pdf) that dropout was found to be counter-productive on the identity branch. Authors recommend to implement it between conv layers instead. in my experiment however dropout on conv branch just before the addition actually improves test accuracy (92.98 in ~70.0k steps, keep_prob=0.9). I thought it could useful for other explorers.