### PR TITLE
Remove erroneous comment from resnet_v2.py

### DIFF
--- a/slim/nets/resnet_v2.py
+++ b/slim/nets/resnet_v2.py
@@ -25,8 +25,6 @@ introduced by:
 
 The key difference of the full preactivation 'v2' variant compared to the
 'v1' variant in [1] is the use of batch normalization before every weight layer.
-Another difference is that 'v2' ResNets do not include an activation function in
-the main pathway. Also see [2; Fig. 4e].
 
 Typical use:
 


### PR DESCRIPTION
The comment is incorrect because the identity pathway actually includes a batch norm and a ReLU (the figure in the paper is actually also incorrect). For reference, see the [slim code](https://github.com/tensorflow/models/blob/master/slim/nets/resnet_v2.py#L90) and the [code from the v2 paper](https://github.com/KaimingHe/resnet-1k-layers/blob/master/resnet-pre-act.lua#L64).