### PR TITLE
Fixed the device specification for dequeue

### DIFF
--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -451,7 +451,8 @@ def main(_):
     ####################
     def clone_fn(batch_queue):
       """Allows data parallelism by creating multiple clones of network_fn."""
-      images, labels = batch_queue.dequeue()
+      with tf.device(deploy_config.inputs_device()):
+        images, labels = batch_queue.dequeue()
       logits, end_points = network_fn(images)
 
       #############################


### PR DESCRIPTION
This patch assigns dequeue node to inputs_device. And nolonger shows
"Ignoring device specification /device:GPU:X for node
'clone_X/fifo_queue_Dequeue'" message.