### PR TITLE
Start fixing Neural GPU's RNN baseline

### DIFF
--- a/neural_gpu/neural_gpu.py
+++ b/neural_gpu/neural_gpu.py
@@ -478,8 +478,10 @@ class NeuralGPU(object):
         # This is just for running a baseline RNN seq2seq model.
         if do_rnn:
           self.after_enc_step.append(step)  # Not meaningful here, but needed.
-          lstm_cell = tf.contrib.rnn.BasicLSTMCell(height * nmaps)
-          cell = tf.contrib.rnn.MultiRNNCell([lstm_cell] * nconvs)
+          def lstm_cell():
+            return tf.contrib.rnn.BasicLSTMCell(height * nmaps)
+          cell = tf.contrib.rnn.MultiRNNCell(
+              [lstm_cell() for _ in range(nconvs)])
           with tf.variable_scope("encoder"):
             encoder_outputs, encoder_state = tf.nn.dynamic_rnn(
                 cell, tf.reshape(step, [batch_size, length, height * nmaps]),


### PR DESCRIPTION
Running `python neural_gpu_trainer.py --problem bmul --rnn_baseline=True` fails with:

`ValueError: Attempt to reuse RNNCell <tensorflow.contrib.rnn.python.ops.core_rnn_cell_impl.BasicLSTMCell object at 0x7f5ae993d190> with a different variable scope than its first use.  First use of cell was with scope 'encoder/rnn/multi_rnn_cell/cell_0/basic_lstm_cell', this attempt is with scope 'encoder/rnn/multi_rnn_cell/cell_1/basic_lstm_cell'.  Please create a new instance of the cell if you would like it to use a different set of weights.  If before you were using: MultiRNNCell([BasicLSTMCell(...)] * num_layers), change to: MultiRNNCell([BasicLSTMCell(...) for _ in range(num_layers)]).  If before you were using the same cell instance as both the forward and reverse cell of a bidirectional RNN, simply create two instances (one for forward, one for reverse).  In May 2017, we will start transitioning this cell's behavior to use existing stored weights, if any, when it is called with scope=None (which can lead to silent model degradation, so this error will remain until then.)`

This is the first part of a fix for this, fixing the MultiRNNCell parameters.

However, there's a second bug which I don't fix here - the same instances are still used in the forward and reverse cells, so this error goes, but is replaced by:

`ValueError: Attempt to reuse RNNCell <tensorflow.contrib.rnn.python.ops.core_rnn_cell_impl.BasicLSTMCell object at 0x7f7584639050> with a different variable scope than its first use.  First use of cell was with scope 'encoder/rnn/multi_rnn_cell/cell_0/basic_lstm_cell', this attempt is with scope 'decoder/multi_rnn_cell/cell_0/basic_lstm_cell'.  Please create a new instance of the cell if you would like it to use a different set of weights.  If before you were using: MultiRNNCell([BasicLSTMCell(...)] * num_layers), change to: MultiRNNCell([BasicLSTMCell(...) for _ in range(num_layers)]).  If before you were using the same cell instance as both the forward and reverse cell of a bidirectional RNN, simply create two instances (one for forward, one for reverse).  In May 2017, we will start transitioning this cell's behavior to use existing stored weights, if any, when it is called with scope=None (which can lead to silent model degradation, so this error will remain until then.)`

Someone who knows the code better will need to fix that second part too to get it actually working again.