### PR TITLE
Convert control_flow_ops.with_dependencies to tf.control_dependencies

### DIFF
--- a/inception/inception/slim/ops_test.py
+++ b/inception/inception/slim/ops_test.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.ops import control_flow_ops
-
 from inception.slim import ops
 from inception.slim import scopes
 from inception.slim import variables
@@ -602,7 +600,8 @@ class BatchNormTest(tf.test.TestCase):
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
-        output = control_flow_ops.with_dependencies([barrier], output)
+        with tf.control_dependencies([barrier]):
+          output = output
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -632,7 +631,8 @@ class BatchNormTest(tf.test.TestCase):
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
-        output = control_flow_ops.with_dependencies([barrier], output)
+        with tf.control_dependencies([barrier]):
+          output = output
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -666,7 +666,8 @@ class BatchNormTest(tf.test.TestCase):
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
-        output = control_flow_ops.with_dependencies([barrier], output)
+        with tf.control_dependencies([barrier]):
+          output = output
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]

--- a/inception/inception/slim/ops_test.py
+++ b/inception/inception/slim/ops_test.py
@@ -418,7 +418,7 @@ class DropoutTest(tf.test.TestCase):
     with self.test_session():
       images = tf.random_uniform((5, height, width, 3), seed=1)
       output = ops.dropout(images)
-      self.assertEquals(output.op.name, 'Dropout/dropout/mul_1')
+      self.assertEquals(output.op.name, 'Dropout/dropout/mul')
       output.get_shape().assert_is_compatible_with(images.get_shape())
 
   def testCreateDropoutNoTraining(self):
@@ -599,9 +599,7 @@ class BatchNormTest(tf.test.TestCase):
       output = ops.batch_norm(images, decay=0.1)
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
-        barrier = tf.no_op(name='gradient_barrier')
-        with tf.control_dependencies([barrier]):
-          output = tf.identity(output)
+        output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -630,9 +628,7 @@ class BatchNormTest(tf.test.TestCase):
       output = ops.batch_norm(images, decay=0.1, is_training=False)
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
-        barrier = tf.no_op(name='gradient_barrier')
-        with tf.control_dependencies([barrier]):
-          output = tf.identity(output)
+        output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -665,9 +661,7 @@ class BatchNormTest(tf.test.TestCase):
       output = ops.batch_norm(images, decay=0.1, is_training=False)
       update_ops = tf.get_collection(ops.UPDATE_OPS_COLLECTION)
       with tf.control_dependencies(update_ops):
-        barrier = tf.no_op(name='gradient_barrier')
-        with tf.control_dependencies([barrier]):
-          output = tf.identity(output)
+        output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]

--- a/inception/inception/slim/ops_test.py
+++ b/inception/inception/slim/ops_test.py
@@ -601,7 +601,7 @@ class BatchNormTest(tf.test.TestCase):
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
         with tf.control_dependencies([barrier]):
-          output = output
+          output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -632,7 +632,7 @@ class BatchNormTest(tf.test.TestCase):
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
         with tf.control_dependencies([barrier]):
-          output = output
+          output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]
@@ -667,7 +667,7 @@ class BatchNormTest(tf.test.TestCase):
       with tf.control_dependencies(update_ops):
         barrier = tf.no_op(name='gradient_barrier')
         with tf.control_dependencies([barrier]):
-          output = output
+          output = tf.identity(output)
       # Initialize all variables
       sess.run(tf.global_variables_initializer())
       moving_mean = variables.get_variables('BatchNorm/moving_mean')[0]

--- a/slim/deployment/model_deploy.py
+++ b/slim/deployment/model_deploy.py
@@ -379,7 +379,7 @@ def deploy(config,
 
         update_op = tf.group(*update_ops)
         with tf.control_dependencies([update_op]):
-          train_op = total_loss
+          train_op = tf.identity(total_loss, name='train_op')
     else:
       clones_losses = []
       regularization_losses = tf.get_collection(

--- a/slim/deployment/model_deploy.py
+++ b/slim/deployment/model_deploy.py
@@ -378,8 +378,8 @@ def deploy(config,
         update_ops.append(grad_updates)
 
         update_op = tf.group(*update_ops)
-        train_op = control_flow_ops.with_dependencies([update_op], total_loss,
-                                                      name='train_op')
+        with tf.control_dependencies([update_op]):
+          train_op = total_loss
     else:
       clones_losses = []
       regularization_losses = tf.get_collection(

--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -540,7 +540,7 @@ def main(_):
 
     update_op = tf.group(*update_ops)
     with tf.control_dependencies([update_op]):
-      train_tensor = total_loss
+      train_tensor = tf.identity(total_loss, name='train_op')
 
     # Add the summaries from the first clone. These contain the summaries
     # created by model_fn and either optimize_clones() or _gather_clone_loss().

--- a/slim/train_image_classifier.py
+++ b/slim/train_image_classifier.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from tensorflow.python.ops import control_flow_ops
 from datasets import dataset_factory
 from deployment import model_deploy
 from nets import nets_factory
@@ -540,8 +539,8 @@ def main(_):
     update_ops.append(grad_updates)
 
     update_op = tf.group(*update_ops)
-    train_tensor = control_flow_ops.with_dependencies([update_op], total_loss,
-                                                      name='train_op')
+    with tf.control_dependencies([update_op]):
+      train_tensor = total_loss
 
     # Add the summaries from the first clone. These contain the summaries
     # created by model_fn and either optimize_clones() or _gather_clone_loss().


### PR DESCRIPTION
Note: I found other instances of `control_flow_ops` but wasn't sure what to do with them. Examples: https://github.com/tensorflow/models/blob/master/slim/preprocessing/inception_preprocessing.py#L40 and https://github.com/tensorflow/models/blob/master/syntaxnet/syntaxnet/structured_graph_builder.py#L57.

Also, a few of the conversions turned out a bit strange. I ended up having a few lines that assigned a variable to itself (`output = output`), and I wasn't sure what to do with the calls that used the `name` argument of `control_flow_ops.with_dependencies()`.