### PR TITLE
Update protobuf version dependency

### DIFF
--- a/syntaxnet/README.md
+++ b/syntaxnet/README.md
@@ -77,7 +77,7 @@ source. You'll need to install:
     *   `brew install swig` on OSX
 *   protocol buffers, with a version supported by TensorFlow:
     *   check your protobuf version with `pip freeze | grep protobuf`
-    *   upgrade to a supported version with `pip install -U protobuf==3.0.0b2`
+    *   upgrade to a supported version with `pip install -U protobuf==3.3.0`
 *   mock, the testing package:
     *   `pip install mock`
 *   asciitree, to draw parse trees on the console for the demo:


### PR DESCRIPTION
Updates protobuf version as previous (3.0.0b2) was no longer compatible and resulted in failing bazel tests during setup process.