### PR TITLE
SYNSETS contains the full path and does not need pwd prepended.

### DIFF
--- a/inception/inception/data/download_imagenet.sh
+++ b/inception/inception/data/download_imagenet.sh
@@ -40,7 +40,6 @@ fi
 
 OUTDIR="${1:-./imagenet-data}"
 SYNSETS_FILE="${2:-./synsets.txt}"
-SYNSETS_FILE="${PWD}/${SYNSETS_FILE}"
 
 echo "Saving downloaded files to $OUTDIR"
 mkdir -p "${OUTDIR}"


### PR DESCRIPTION
Tested on GCE with ubuntu 16.04. Mirrors change 157536266.