### PR TITLE
Fixed calls to concat and convolution2d in adversarial crypto model

### DIFF
--- a/adversarial_crypto/train_eval.py
+++ b/adversarial_crypto/train_eval.py
@@ -128,13 +128,13 @@ class AdversarialCrypto(object):
     """
 
     if key is not None:
-      combined_message = tf.concat(1, [message, key])
+      combined_message = tf.concat([message, key], 1)
     else:
       combined_message = message
 
     # Ensure that all variables created are in the specified collection.
     with tf.contrib.framework.arg_scope(
-        [tf.contrib.layers.fully_connected, tf.contrib.layers.convolution],
+        [tf.contrib.layers.fully_connected, tf.contrib.layers.convolution2d],
         variables_collections=[collection]):
 
       fc = tf.contrib.layers.fully_connected(
@@ -147,13 +147,13 @@ class AdversarialCrypto(object):
       # and then squeezing it back down).
       fc = tf.expand_dims(fc, 2)
       # 2,1 -> 1,2
-      conv = tf.contrib.layers.convolution(
+      conv = tf.contrib.layers.convolution2d(
           fc, 2, 2, 2, 'SAME', activation_fn=tf.nn.sigmoid)
       # 1,2 -> 1, 2
-      conv = tf.contrib.layers.convolution(
+      conv = tf.contrib.layers.convolution2d(
           conv, 2, 1, 1, 'SAME', activation_fn=tf.nn.sigmoid)
       # 1,2 -> 1, 1
-      conv = tf.contrib.layers.convolution(
+      conv = tf.contrib.layers.convolution2d(
           conv, 1, 1, 1, 'SAME', activation_fn=tf.nn.tanh)
       conv = tf.squeeze(conv, 2)
       return conv


### PR DESCRIPTION
When attempting to run the adversarial crypto model, I got the following errors:

```
line 302, in _AssertCompatible
    (dtype.name, repr(mismatch), type(mismatch).__name__))
TypeError: Expected int32, got list containing Tensors of type '_Message' instead.
```

```
line 126, in model
    [tf.contrib.layers.fully_connected, tf.contrib.layers.convolution],
AttributeError: 'module' object has no attribute 'convolution'
```

It appears that the arguments for tf.concat were in the opposite order of the API documentation, and that the convolution2d method was called as convolution. I have corrected both of these issues in this pull request.