### PR TITLE
Implemented LRN for AlexNet tutorial

### DIFF
--- a/tutorials/image/alexnet/alexnet_benchmark.py
+++ b/tutorials/image/alexnet/alexnet_benchmark.py
@@ -73,11 +73,18 @@ def inference(images):
     print_activations(conv1)
     parameters += [kernel, biases]
 
-  # lrn1
-  # TODO(shlens, jiayq): Add a GPU version of local response normalization.
+
+  with tf.name_scope('lrn1') as scope:
+    lrn1 = tf.nn.local_response_normalization(
+      conv1,
+      alpha=1e-04,
+      beta=0.75,
+      depth_radius=5,
+      bias=2.0
+    )
 
   # pool1
-  pool1 = tf.nn.max_pool(conv1,
+  pool1 = tf.nn.max_pool(lrn1,
                          ksize=[1, 3, 3, 1],
                          strides=[1, 2, 2, 1],
                          padding='VALID',
@@ -96,8 +103,18 @@ def inference(images):
     parameters += [kernel, biases]
   print_activations(conv2)
 
+
+  with tf.name_scope('lrn2') as scope:
+    lrn2 = tf.nn.local_response_normalization(
+      conv2,
+      alpha=1e-04,
+      beta=0.75,
+      depth_radius=5,
+      bias=2.0
+    )
+
   # pool2
-  pool2 = tf.nn.max_pool(conv2,
+  pool2 = tf.nn.max_pool(lrn2,
                          ksize=[1, 3, 3, 1],
                          strides=[1, 2, 2, 1],
                          padding='VALID',

--- a/tutorials/image/alexnet/alexnet_benchmark.py
+++ b/tutorials/image/alexnet/alexnet_benchmark.py
@@ -75,13 +75,11 @@ def inference(images):
 
 
   with tf.name_scope('lrn1') as scope:
-    lrn1 = tf.nn.local_response_normalization(
-      conv1,
-      alpha=1e-04,
-      beta=0.75,
-      depth_radius=5,
-      bias=2.0
-    )
+    lrn1 = tf.nn.local_response_normalization(conv1,
+                                              alpha=1e-4,
+                                              beta=0.75,
+                                              depth_radius=5,
+                                              bias=2.0)
 
   # pool1
   pool1 = tf.nn.max_pool(lrn1,
@@ -105,13 +103,11 @@ def inference(images):
 
 
   with tf.name_scope('lrn2') as scope:
-    lrn2 = tf.nn.local_response_normalization(
-      conv2,
-      alpha=1e-04,
-      beta=0.75,
-      depth_radius=5,
-      bias=2.0
-    )
+    lrn2 = tf.nn.local_response_normalization(conv2,
+                                              alpha=1e-4,
+                                              beta=0.75,
+                                              depth_radius=5,
+                                              bias=2.0)
 
   # pool2
   pool2 = tf.nn.max_pool(lrn2,

--- a/tutorials/image/alexnet/alexnet_benchmark.py
+++ b/tutorials/image/alexnet/alexnet_benchmark.py
@@ -73,7 +73,7 @@ def inference(images):
     print_activations(conv1)
     parameters += [kernel, biases]
 
-
+  # lrn1
   with tf.name_scope('lrn1') as scope:
     lrn1 = tf.nn.local_response_normalization(conv1,
                                               alpha=1e-4,
@@ -101,7 +101,7 @@ def inference(images):
     parameters += [kernel, biases]
   print_activations(conv2)
 
-
+  # lrn2
   with tf.name_scope('lrn2') as scope:
     lrn2 = tf.nn.local_response_normalization(conv2,
                                               alpha=1e-4,

--- a/tutorials/image/alexnet/alexnet_benchmark.py
+++ b/tutorials/image/alexnet/alexnet_benchmark.py
@@ -78,7 +78,7 @@ def inference(images):
     lrn1 = tf.nn.local_response_normalization(conv1,
                                               alpha=1e-4,
                                               beta=0.75,
-                                              depth_radius=5,
+                                              depth_radius=2,
                                               bias=2.0)
 
   # pool1
@@ -106,7 +106,7 @@ def inference(images):
     lrn2 = tf.nn.local_response_normalization(conv2,
                                               alpha=1e-4,
                                               beta=0.75,
-                                              depth_radius=5,
+                                              depth_radius=2,
                                               bias=2.0)
 
   # pool2


### PR DESCRIPTION
A TODO was stated for adding LRN - Pending GPU support.
LRN was implemented by tensorflow/tensorflow@35df3ed43edabbc4ad1b2439bbc7de8917026d6e

Hyper-parameters taken from http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks
Additionally the location and architecture linking of the LRN layers was taken from Section 3.5 of the above paper, as best as can be deciphered.

Note: Individual CLA has been submitted, appropriately linking this GitHub Account.