### PR TITLE
Fix link to make image show up in mobilenet_v1.md

### DIFF
--- a/slim/nets/mobilenet_v1.md
+++ b/slim/nets/mobilenet_v1.md
@@ -4,7 +4,7 @@
 
 MobileNets trade off between latency, size and accuracy while comparing favorably with popular models from the literature.
 
-![alt text](https://github.com/tensorflow/models/tree/master/slim/nets/mobilenet_v1.png, "MobileNet Graph")
+![alt text](mobilenet_v1.png "MobileNet Graph")
 
 # Pre-trained Models
 


### PR DESCRIPTION
There was an extra comma so the image didn't show up. Also change to use a relative link for the image instead.