### PR TITLE
Change 'iteritems' to 'items' to make it runnnable with Python3

### DIFF
--- a/object_detection/utils/visualization_utils.py
+++ b/object_detection/utils/visualization_utils.py
@@ -395,7 +395,7 @@ def visualize_boxes_and_labels_on_image_array(image,
               classes[i] % len(STANDARD_COLORS)]
 
   # Draw all boxes onto image.
-  for box, color in box_to_color_map.iteritems():
+  for box, color in box_to_color_map.items():
     ymin, xmin, ymax, xmax = box
     if instance_masks is not None:
       draw_mask_on_image_array(


### PR DESCRIPTION
I found that object_detection_tutorial.ipynb couldn't run on Python3 due to iteritems function. This change will make it run without problem.