### PR TITLE
Remove the erroneous comment from resnet_v2.py again

### DIFF
--- a/slim/nets/resnet_v2.py
+++ b/slim/nets/resnet_v2.py
@@ -25,8 +25,6 @@ introduced by:
 
 The key difference of the full preactivation 'v2' variant compared to the
 'v1' variant in [1] is the use of batch normalization before every weight layer.
-Another difference is that 'v2' ResNets do not include an activation function in
-the main pathway. Also see [2; Fig. 4e].
 
 Typical use:
 


### PR DESCRIPTION
Was removed in https://github.com/tensorflow/models/commit/ad975cb283dc6b907e29ce4957f48ee02fbc33cc#diff-9fa9cd89690d39b6eaf98c9c0ed7dfa8 and then unintentionally added back in https://github.com/tensorflow/models/pull/1559