### PR TITLE
Fix compatibility of object_detection for Python3

### DIFF
--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -78,11 +78,11 @@ class BatchQueue(object):
     """
     # Remember static shapes to set shapes of batched tensors.
     static_shapes = collections.OrderedDict(
-        {key: tensor.get_shape() for key, tensor in tensor_dict.iteritems()})
+        {key: tensor.get_shape() for key, tensor in tensor_dict.items()})
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
         {(key, 'runtime_shapes'): tf.shape(tensor)
-         for key, tensor in tensor_dict.iteritems()})
+         for key, tensor in tensor_dict.items()})
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)
     batched_tensors = tf.train.batch(
@@ -109,7 +109,7 @@ class BatchQueue(object):
     # Separate input tensors from tensors containing their runtime shapes.
     tensors = {}
     shapes = {}
-    for key, batched_tensor in batched_tensors.iteritems():
+    for key, batched_tensor in batched_tensors.items():
       unbatched_tensor_list = tf.unstack(batched_tensor)
       for i, unbatched_tensor in enumerate(unbatched_tensor_list):
         if isinstance(key, tuple) and key[1] == 'runtime_shapes':

--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -16,7 +16,6 @@
 """Provides functions to batch a dictionary of input tensors."""
 import collections
 
-import six
 import tensorflow as tf
 
 from object_detection.core import prefetcher
@@ -79,11 +78,11 @@ class BatchQueue(object):
     """
     # Remember static shapes to set shapes of batched tensors.
     static_shapes = collections.OrderedDict(
-        {key: tensor.get_shape() for key, tensor in six.iteritems(tensor_dict)})
+        {key: tensor.get_shape() for key, tensor in tensor_dict.items()})
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
         {(key, 'runtime_shapes'): tf.shape(tensor)
-         for key, tensor in six.iteritems(tensor_dict)})
+         for key, tensor in tensor_dict.items()})
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)
     batched_tensors = tf.train.batch(
@@ -110,7 +109,7 @@ class BatchQueue(object):
     # Separate input tensors from tensors containing their runtime shapes.
     tensors = {}
     shapes = {}
-    for key, batched_tensor in six.iteritems(batched_tensors):
+    for key, batched_tensor in batched_tensors.items():
       unbatched_tensor_list = tf.unstack(batched_tensor)
       for i, unbatched_tensor in enumerate(unbatched_tensor_list):
         if isinstance(key, tuple) and key[1] == 'runtime_shapes':

--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -16,6 +16,7 @@
 """Provides functions to batch a dictionary of input tensors."""
 import collections
 
+import six
 import tensorflow as tf
 
 from object_detection.core import prefetcher
@@ -78,11 +79,11 @@ class BatchQueue(object):
     """
     # Remember static shapes to set shapes of batched tensors.
     static_shapes = collections.OrderedDict(
-        {key: tensor.get_shape() for key, tensor in tensor_dict.items()})
+        {key: tensor.get_shape() for key, tensor in six.iteritems(tensor_dict)})
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
         {(key, 'runtime_shapes'): tf.shape(tensor)
-         for key, tensor in tensor_dict.items()})
+         for key, tensor in six.iteritems(tensor_dict)})
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)
     batched_tensors = tf.train.batch(
@@ -109,7 +110,7 @@ class BatchQueue(object):
     # Separate input tensors from tensors containing their runtime shapes.
     tensors = {}
     shapes = {}
-    for key, batched_tensor in batched_tensors.items():
+    for key, batched_tensor in six.iteritems(batched_tensors):
       unbatched_tensor_list = tf.unstack(batched_tensor)
       for i, unbatched_tensor in enumerate(unbatched_tensor_list):
         if isinstance(key, tuple) and key[1] == 'runtime_shapes':

--- a/object_detection/core/post_processing.py
+++ b/object_detection/core/post_processing.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Post-processing operations on detected boxes."""
+
 import tensorflow as tf
 
 from object_detection.core import box_list

--- a/object_detection/core/post_processing.py
+++ b/object_detection/core/post_processing.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 
 """Post-processing operations on detected boxes."""
-import six
-
 import tensorflow as tf
 
 from object_detection.core import box_list
@@ -132,7 +130,7 @@ def multiclass_non_max_suppression(boxes,
         boxlist_and_class_scores.add_field(fields.BoxListFields.masks,
                                            per_class_masks)
       if additional_fields is not None:
-        for key, tensor in six.iteritems(additional_fields):
+        for key, tensor in additional_fields.items():
           boxlist_and_class_scores.add_field(key, tensor)
       boxlist_filtered = box_list_ops.filter_greater_than(
           boxlist_and_class_scores, score_thresh)

--- a/object_detection/core/post_processing.py
+++ b/object_detection/core/post_processing.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Post-processing operations on detected boxes."""
+import six
 
 import tensorflow as tf
 
@@ -131,7 +132,7 @@ def multiclass_non_max_suppression(boxes,
         boxlist_and_class_scores.add_field(fields.BoxListFields.masks,
                                            per_class_masks)
       if additional_fields is not None:
-        for key, tensor in additional_fields.iteritems():
+        for key, tensor in six.iteritems(additional_fields):
           boxlist_and_class_scores.add_field(key, tensor)
       boxlist_filtered = box_list_ops.filter_greater_than(
           boxlist_and_class_scores, score_thresh)

--- a/object_detection/core/prefetcher.py
+++ b/object_detection/core/prefetcher.py
@@ -45,7 +45,7 @@ def prefetch(tensor_dict, capacity):
   Returns:
     a FIFO prefetcher queue
   """
-  names = tensor_dict.keys()
+  names = list(tensor_dict.keys())
   dtypes = [t.dtype for t in tensor_dict.values()]
   shapes = [t.get_shape() for t in tensor_dict.values()]
   prefetch_queue = tf.PaddingFIFOQueue(capacity, dtypes=dtypes,

--- a/object_detection/core/preprocessor_test.py
+++ b/object_detection/core/preprocessor_test.py
@@ -15,7 +15,11 @@
 
 """Tests for object_detection.core.preprocessor."""
 
-import mock
+import six
+if six.PY2:
+  import mock
+else:
+  from unittest import mock
 import numpy as np
 
 import tensorflow as tf

--- a/object_detection/core/preprocessor_test.py
+++ b/object_detection/core/preprocessor_test.py
@@ -15,17 +15,18 @@
 
 """Tests for object_detection.core.preprocessor."""
 
-import six
-if six.PY2:
-  import mock
-else:
-  from unittest import mock
 import numpy as np
+import six
 
 import tensorflow as tf
 
 from object_detection.core import preprocessor
 from object_detection.core import standard_fields as fields
+
+if six.PY2:
+  import mock # pylint: disable=g-import-not-at-top
+else:
+  from unittest import mock # pylint: disable=g-import-not-at-top
 
 
 class PreprocessorTest(tf.test.TestCase):

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -15,6 +15,7 @@
 
 """A module for helper tensorflow ops."""
 import math
+import six
 
 import tensorflow as tf
 
@@ -197,9 +198,9 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth, (int, long)):
+  if depth < 0 or not isinstance(depth, (int, long) if six.PY2 else int):
     raise ValueError('`depth` must be a non-negative integer.')
-  if left_pad < 0 or not isinstance(left_pad, (int, long)):
+  if left_pad < 0 or not isinstance(left_pad, (int, long) if six.PY2 else int):
     raise ValueError('`left_pad` must be a non-negative integer.')
   if depth == 0:
     return None

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -549,7 +549,7 @@ def position_sensitive_crop_regions(image,
       raise ValueError('crop_size should be divisible by num_spatial_bins')
 
     total_bins *= num_bins
-    bin_crop_size.append(crop_dim / num_bins)
+    bin_crop_size.append(crop_dim // num_bins)
 
   if not global_pool and bin_crop_size[0] != bin_crop_size[1]:
     raise ValueError('Only support square bin crop size for now.')


### PR DESCRIPTION
Modify these lines to make `object_detection/trainer_test.py` pass in Python 3.
- `items()` and `iteritems()` issue in `core/batcher.py` and `core/post_processing.py`
- `keys()` of `dict()` behaves different between Python 2 and 3, make it explicitly convert to list.
- Related to #1594. However, I think `six` is a better choice for checking Python version.
- Division behaves differently in `util/ops.py`.
- Python3 use `from unittest import mock` instead of Python2's `import mock`.