### PR TITLE
fix slim evaluation in slim_walkthrough.ipynb

### DIFF
--- a/slim/slim_walkthrough.ipynb
+++ b/slim/slim_walkthrough.ipynb
@@ -149,9 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with tf.Graph().as_default():\n",
@@ -186,9 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def produce_batch(batch_size, noise=0.3):\n",
@@ -234,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The following snippet trains the regression model using a mean_squared_error loss.\n",
@@ -286,9 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with tf.Graph().as_default():\n",
@@ -336,9 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with tf.Graph().as_default():\n",
@@ -373,9 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with tf.Graph().as_default():\n",
@@ -387,19 +375,20 @@
     "      'Mean Squared Error': slim.metrics.streaming_mean_squared_error(predictions, targets),\n",
     "      'Mean Absolute Error': slim.metrics.streaming_mean_absolute_error(predictions, targets)\n",
     "    })\n",
+    "    \n",
+    "    checkpoint_path = tf.train.latest_checkpoint(ckpt_dir)\n",
+    "    # Single pass over data, because we call the evaluate_once().\n",
+    "    # If you want to loop the evaluation, take a look at evaluate_loop().\n",
+    "    metric_values = slim.evaluation.evaluate_once(\n",
+    "        master='',\n",
+    "        checkpoint_path=checkpoint_path,\n",
+    "        logdir=ckpt_dir,\n",
+    "        eval_op=names_to_update_nodes,\n",
+    "        final_op=names_to_value_nodes)\n",
     "\n",
-    "    # Make a session which restores the old graph parameters, and then run eval.\n",
-    "    sv = tf.train.Supervisor(logdir=ckpt_dir)\n",
-    "    with sv.managed_session() as sess:\n",
-    "        metric_values = slim.evaluation.evaluation(\n",
-    "            sess,\n",
-    "            num_evals=1, # Single pass over data\n",
-    "            eval_op=names_to_update_nodes.values(),\n",
-    "            final_op=names_to_value_nodes.values())\n",
-    "\n",
-    "    names_to_values = dict(zip(names_to_value_nodes.keys(), metric_values))\n",
-    "    for key, value in names_to_values.items():\n",
-    "      print('%s: %f' % (key, value))"
+    "    # metric_values is a dict returned, which contains {metric_key: metric_value}\n",
+    "    for metric_key, metric_value in metric_values.items():\n",
+    "        print('%s: %f' % (metric_key, metric_value))"
    ]
   },
   {
@@ -447,9 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import tensorflow as tf\n",
@@ -474,9 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import flowers\n",
@@ -553,9 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import tensorflow as tf\n",
@@ -588,7 +571,7 @@
     "print('\\nProbabilities:')\n",
     "print(probabilities)\n",
     "\n",
-    "print('\\nSumming across all classes (Should equal 1):')\n",
+    "print('\\nSumming across all classes (Should equal 1 but maybe a little more or less if you use GPU):')\n",
     "print(np.sum(probabilities, 1)) # Each row sums to 1"
    ]
   },
@@ -657,9 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import flowers\n",
@@ -712,9 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import flowers\n",
@@ -741,12 +720,11 @@
     "        master='',\n",
     "        checkpoint_path=checkpoint_path,\n",
     "        logdir=train_dir,\n",
-    "        eval_op=names_to_updates.values(),\n",
-    "        final_op=names_to_values.values())\n",
+    "        eval_op=names_to_updates,\n",
+    "        final_op=names_to_values)\n",
     "\n",
-    "    names_to_values = dict(zip(names_to_values.keys(), metric_values))\n",
-    "    for name in names_to_values:\n",
-    "        print('%s: %f' % (name, names_to_values[name]))\n"
+    "    for metric_key, metric_value in metric_values.items():\n",
+    "        print('%s: %f' % (metric_key, metric_value))"
    ]
   },
   {
@@ -777,9 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import dataset_utils\n",
@@ -808,9 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -873,9 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import dataset_utils\n",


### PR DESCRIPTION
1. Since the `slim.evaluation.evaluation()` has been removed from `evaluation.py` (see commits fafc8b7 in tensorflow), if we call slim.evaluation.evaluation() then will get: `TypeError: 'module' object is not callable`, so this should be modified to `slim.evaluation.evaluate_once()` and accordingly, some parameters modification.
2. The return value of `evaluate_once()` is a dict not a list, so the `for loop` which is to show the `metric_values` results should be modified.
3. Minors comments modification, such as explaining cannot get exact result of `1` suming the probabilities across all classes when run on GPU.