### PR TITLE
Naming consistency pascal_voc_ -> pascal_

### DIFF
--- a/object_detection/samples/configs/faster_rcnn_resnet101_voc07.config
+++ b/object_detection/samples/configs/faster_rcnn_resnet101_voc07.config
@@ -118,9 +118,9 @@ train_config: {
 
 train_input_reader: {
   tf_record_input_reader {
-    input_path: "PATH_TO_BE_CONFIGURED/pascal_voc_train.record"
+    input_path: "PATH_TO_BE_CONFIGURED/pascal_train.record"
   }
-  label_map_path: "PATH_TO_BE_CONFIGURED/pascal_voc_label_map.pbtxt"
+  label_map_path: "PATH_TO_BE_CONFIGURED/pascal_label_map.pbtxt"
 }
 
 eval_config: {
@@ -129,7 +129,7 @@ eval_config: {
 
 eval_input_reader: {
   tf_record_input_reader {
-    input_path: "PATH_TO_BE_CONFIGURED/pascal_voc_val.record"
+    input_path: "PATH_TO_BE_CONFIGURED/pascal_val.record"
   }
-  label_map_path: "PATH_TO_BE_CONFIGURED/pascal_voc_label_map.pbtxt"
+  label_map_path: "PATH_TO_BE_CONFIGURED/pascal_label_map.pbtxt"
 }


### PR DESCRIPTION
- pascal_voc_train.record, 
- pascal_voc_val.record, 
- pascal_voc_label_map.pbxt

**naming is not consistent with:**

- Default label map filename for VOC (object_detection/data/pascal_label_map.pbtxt), and
- Preparing input documentation markdown file: 
https://github.com/tensorflow/models/blob/master/object_detection/g3doc/preparing_inputs.md


