### PR TITLE
Make object_detection/core/batcher.py Python3 compatible

### DIFF
--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -81,7 +81,7 @@ class BatchQueue(object):
         {key: tensor.get_shape() for key, tensor in tensor_dict.items()})
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
-        {(key, 'runtime_shapes'): tf.shape(tensor)
+        {key + '.runtime_shapes': tf.shape(tensor)
          for key, tensor in tensor_dict.items()})
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)
@@ -112,8 +112,8 @@ class BatchQueue(object):
     for key, batched_tensor in batched_tensors.items():
       unbatched_tensor_list = tf.unstack(batched_tensor)
       for i, unbatched_tensor in enumerate(unbatched_tensor_list):
-        if isinstance(key, tuple) and key[1] == 'runtime_shapes':
-          shapes[(key[0], i)] = unbatched_tensor
+        if 'runtime_shapes' in key:
+          shapes[(key.split('.')[0], i)] = unbatched_tensor
         else:
           tensors[(key, i)] = unbatched_tensor
 


### PR DESCRIPTION
As described in https://github.com/tensorflow/models/pull/1610#issuecomment-310883904, the previous PR https://github.com/tensorflow/models/pull/1593 is not compatible with `master` branch.

Problem comes from that `str` and `tuple` object in the same container cannot be sorted in Python3.
- So my solution is to make `tuple` key merged into one single `str` and make them separated by defined character.
- (also  another solution for that https://github.com/tensorflow/tensorflow/pull/11039)