### PR TITLE
Modifications for exporting other MobileNet graphs

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -349,8 +349,14 @@ $ python export_inference_graph.py \
 $ python export_inference_graph.py \
   --alsologtostderr \
   --model_name=mobilenet_v1 \
-  --image_size=224 \
   --output_file=/tmp/mobilenet_v1_224.pb
+
+$ python export_inference_graph.py \
+  --alsologtostderr \
+  --model_name=mobilenet_v1 \
+  --override_default_image_size=true \
+  --default_image_size=192 \
+  --output_file=/tmp/mobilenet_v1_192.pb
 ```
 
 ## Freezing the exported Graph

--- a/slim/export_inference_graph.py
+++ b/slim/export_inference_graph.py
@@ -73,6 +73,11 @@ tf.app.flags.DEFINE_boolean(
     'is_training', False,
     'Whether to save out a training-focused version of the model.')
 
+tf.app.flags.DEFINE_boolean(
+    'override_default_image_size', False,
+    'use image size specified by default_image_size even when the model does '
+    'define it')
+
 tf.app.flags.DEFINE_integer(
     'default_image_size', 224,
     'The image size to use if the model does not define it.')
@@ -107,7 +112,10 @@ def main(_):
         num_classes=(dataset.num_classes - FLAGS.labels_offset),
         is_training=FLAGS.is_training)
     if hasattr(network_fn, 'default_image_size'):
-      image_size = network_fn.default_image_size
+      if FLAGS.override_default_image_size:
+        image_size = FLAGS.default_image_size
+      else:
+        image_size = network_fn.default_image_size
     else:
       image_size = FLAGS.default_image_size
     placeholder = tf.placeholder(name='input', dtype=tf.float32,

--- a/slim/nets/mobilenet_v1.py
+++ b/slim/nets/mobilenet_v1.py
@@ -332,6 +332,55 @@ def mobilenet_v1(inputs,
         end_points['Predictions'] = prediction_fn(logits, scope='Predictions')
   return logits, end_points
 
+def mobilenet_v1_075(inputs,
+                 num_classes=1000,
+                 dropout_keep_prob=0.999,
+                 is_training=True,
+                 min_depth=8,
+                 depth_multiplier=0.75,
+                 conv_defs=None,
+                 prediction_fn=tf.contrib.layers.softmax,
+                 spatial_squeeze=True,
+                 reuse=None,
+                 scope='MobilenetV1'):
+
+  mobilenet_v1(inputs, num_classes, dropout_keep_prob, is_training, min_depth,
+               depth_multiplier, conv_defs, prediction_fn, spatial_squeeze,
+               reuse, scope)
+
+def mobilenet_v1_050(inputs,
+                 num_classes=1001,
+                 dropout_keep_prob=0.999,
+                 is_training=True,
+                 min_depth=8,
+                 depth_multiplier=0.50,
+                 conv_defs=None,
+                 prediction_fn=tf.contrib.layers.softmax,
+                 spatial_squeeze=True,
+                 reuse=None,
+                 scope='MobilenetV1'):
+
+  mobilenet_v1(inputs, num_classes, dropout_keep_prob, is_training, min_depth,
+               depth_multiplier, conv_defs, prediction_fn, spatial_squeeze,
+               reuse, scope)
+
+def mobilenet_v1_025(inputs,
+                 num_classes=1001,
+                 dropout_keep_prob=0.999,
+                 is_training=True,
+                 min_depth=8,
+                 depth_multiplier=0.25,
+                 conv_defs=None,
+                 prediction_fn=tf.contrib.layers.softmax,
+                 spatial_squeeze=True,
+                 reuse=None,
+                 scope='MobilenetV1'):
+
+  mobilenet_v1(inputs, num_classes, dropout_keep_prob, is_training, min_depth,
+               depth_multiplier, conv_defs, prediction_fn, spatial_squeeze,
+               reuse, scope)
+
+
 mobilenet_v1.default_image_size = 224
 
 

--- a/slim/nets/nets_factory.py
+++ b/slim/nets/nets_factory.py
@@ -54,6 +54,9 @@ networks_map = {'alexnet_v2': alexnet.alexnet_v2,
                 'resnet_v2_152': resnet_v2.resnet_v2_152,
                 'resnet_v2_200': resnet_v2.resnet_v2_200,
                 'mobilenet_v1': mobilenet_v1.mobilenet_v1,
+                'mobilenet_v1_0.75': mobilenet_v1.mobilenet_v1_075,
+                'mobilenet_v1_0.50': mobilenet_v1.mobilenet_v1_050,
+                'mobilenet_v1_0.25': mobilenet_v1.mobilenet_v1_025,
                }
 
 arg_scopes_map = {'alexnet_v2': alexnet.alexnet_v2_arg_scope,
@@ -78,6 +81,9 @@ arg_scopes_map = {'alexnet_v2': alexnet.alexnet_v2_arg_scope,
                   'resnet_v2_152': resnet_v2.resnet_arg_scope,
                   'resnet_v2_200': resnet_v2.resnet_arg_scope,
                   'mobilenet_v1': mobilenet_v1.mobilenet_v1_arg_scope,
+                  'mobilenet_v1_0.75': mobilenet_v1.mobilenet_v1_arg_scope,
+                  'mobilenet_v1_0.50': mobilenet_v1.mobilenet_v1_arg_scope,
+                  'mobilenet_v1_0.25': mobilenet_v1.mobilenet_v1_arg_scope,
                  }
 
 


### PR DESCRIPTION
MobileNet has two hyperparameters. One is the input image size,
the other is the depth multiplier. Some modifications are needed
so that we can use export_inference_graph.py to export all the
graphs for current available MobileNet Models.

1. --override_default_image_size=true: allowing changing image size to
   192, 160, and 128
2. mobilenet_v1_0.75, mobilenet_v1_0.5, and mobilenet_v1_0.25 for depth
   multipler = 0.75, 0.5, and 0.25