### PR TITLE
Make the WORK_DIR in download script absolute

### DIFF
--- a/inception/inception/data/download_and_preprocess_imagenet.sh
+++ b/inception/inception/data/download_and_preprocess_imagenet.sh
@@ -58,7 +58,7 @@ DATA_DIR="${1%/}"
 SCRATCH_DIR="${DATA_DIR}/raw-data/"
 mkdir -p "${DATA_DIR}"
 mkdir -p "${SCRATCH_DIR}"
-WORK_DIR="$0.runfiles/inception/inception"
+WORK_DIR="$(pwd)/$0.runfiles/inception/inception"
 
 # Download the ImageNet data.
 LABELS_FILE="${WORK_DIR}/data/imagenet_lsvrc_2015_synsets.txt"


### PR DESCRIPTION
If `WORK_DIR` is not absolute, the `download_imagenet.sh` shell might not be able to locate synsets.txt