### PR TITLE
Fix typos/style in object_detection's markdown docs

### DIFF
--- a/object_detection/g3doc/preparing_inputs.md
+++ b/object_detection/g3doc/preparing_inputs.md
@@ -11,7 +11,7 @@ The raw 2012 PASCAL VOC data set can be downloaded
 [here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar).
 Extract the tar file and run the `create_pascal_tf_record` script:
 
-```
+```bash
 # From tensorflow/models/object_detection
 tar -xvf VOCtrainval_11-May-2012.tar
 python create_pascal_tf_record.py --data_dir=VOCdevkit \
@@ -20,11 +20,11 @@ python create_pascal_tf_record.py --data_dir=VOCdevkit \
     --year=VOC2012 --set=val --output_path=pascal_val.record
 ```
 
-You should end up with two TFRecord files named pascal_train.record and
-pascal_val.record in the tensorflow/models/object_detection directory.
+You should end up with two TFRecord files named `pascal_train.record` and
+`pascal_val.record` in the `tensorflow/models/object_detection` directory.
 
 The label map for the PASCAL VOC data set can be found at
-data/pascal_label_map.pbtxt.
+`data/pascal_label_map.pbtxt`.
 
 ## Generation the Oxford-IIIT Pet TFRecord files.
 
@@ -32,14 +32,14 @@ The Oxford-IIIT Pet data set can be downloaded from
 [their website](http://www.robots.ox.ac.uk/~vgg/data/pets/). Extract the tar
 file and run the `create_pet_tf_record` script to generate TFRecords.
 
-```
+```bash
 # From tensorflow/models/object_detection
 tar -xvf annotations.tar.gz
 tar -xvf images.tar.gz
 python create_pet_tf_record.py --data_dir=`pwd` --output_dir=`pwd`
 ```
 
-You should end up with two TFRecord files named pet_train.record and
-pet_val.record in the tensorflow/models/object_detection directory.
+You should end up with two TFRecord files named `pet_train.record` and
+`pet_val.record` in the `tensorflow/models/object_detection` directory.
 
-The label map for the Pet dataset can be found at data/pet_label_map.pbtxt.
+The label map for the Pet dataset can be found at `data/pet_label_map.pbtxt`.

--- a/object_detection/g3doc/preparing_inputs.md
+++ b/object_detection/g3doc/preparing_inputs.md
@@ -16,7 +16,7 @@ Extract the tar file and run the `create_pascal_tf_record` script:
 tar -xvf VOCtrainval_11-May-2012.tar
 python create_pascal_tf_record.py --data_dir=VOCdevkit \
     --year=VOC2012 --set=train --output_path=pascal_train.record
-python create_pascal_tf_record.py --data_dir=/home/user/VOCdevkit \
+python create_pascal_tf_record.py --data_dir=VOCdevkit \
     --year=VOC2012 --set=val --output_path=pascal_val.record
 ```
 

--- a/object_detection/g3doc/running_pets.md
+++ b/object_detection/g3doc/running_pets.md
@@ -64,7 +64,7 @@ the tarballs, your object_detection directory should appear as follows:
 ```
 
 The Tensorflow Object Detection API expects data to be in the TFRecord format,
-so we'll now run the _create_pet_tf_record_ script to convert from the raw
+so we'll now run the `create_pet_tf_record` script to convert from the raw
 Oxford-IIIT Pet dataset into TFRecords. Run the following commands from the
 object_detection directory:
 
@@ -83,12 +83,12 @@ python object_detection/create_pet_tf_record.py \
 Note: It is normal to see some warnings when running this script. You may ignore
 them.
 
-Two TFRecord files named pet_train.record and pet_val.record should be generated
+Two TFRecord files named `pet_train.record` and `pet_val.record` should be generated
 in the object_detection/ directory.
 
 Now that the data has been generated, we'll need to upload it to Google Cloud
 Storage so the data can be accessed by ML Engine. Run the following command to
-copy the files into your GCS bucket (substituting ${YOUR_GCS_BUCKET}):
+copy the files into your GCS bucket (substituting `${YOUR_GCS_BUCKET}`):
 
 ``` bash
 # From tensorflow/models/
@@ -109,7 +109,7 @@ parameters to initialize our new model.
 
 Download our [COCO-pretrained Faster R-CNN with Resnet-101
 model](http://storage.googleapis.com/download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_coco_11_06_2017.tar.gz).
-Unzip the contents of the folder and copy the model.ckpt* files into your GCS
+Unzip the contents of the folder and copy the `model.ckpt*` files into your GCS
 Bucket.
 
 ``` bash
@@ -134,7 +134,7 @@ text editor.
 
 We'll need to configure some paths in order for the template to work. Search the
 file for instances of `PATH_TO_BE_CONFIGURED` and replace them with the
-appropriate value (typically "gs://${YOUR_GCS_BUCKET}/data/"). Afterwards
+appropriate value (typically `gs://${YOUR_GCS_BUCKET}/data/`). Afterwards
 upload your edited file onto GCS, making note of the path it was uploaded to
 (we'll need it when starting the training/eval jobs).
 
@@ -171,7 +171,7 @@ the following:
 ```
 
 You can inspect your bucket using the [Google Cloud Storage
-browser](pantheon.corp.google.com/storage).
+browser](https://console.cloud.google.com/storage/browser).
 
 ## Starting Training and Evaluation Jobs on Google Cloud ML Engine
 
@@ -194,7 +194,7 @@ and `slim/dist/slim-0.1.tar.gz`.
 
 For running the training Cloud ML job, we'll configure the cluster to use 10
 training jobs (1 master + 9 workers) and three parameters servers. The
-configuration file can be found at object_detection/samples/cloud/cloud.yml.
+configuration file can be found at `object_detection/samples/cloud/cloud.yml`.
 
 To start training, execute the following command from the tensorflow/models/
 directory:
@@ -233,7 +233,7 @@ submit training` command is correct. ML Engine does not distinguish between
 training and evaluation jobs.
 
 Users can monitor and stop training and evaluation jobs on the [ML Engine
-Dasboard](https://console.cloud.google.com/mlengine/jobs).
+Dashboard](https://console.cloud.google.com/mlengine/jobs).
 
 ## Monitoring Progress with Tensorboard
 
@@ -263,15 +263,15 @@ Note: It takes roughly 10 minutes for a job to get started on ML Engine, and
 roughly an hour for the system to evaluate the validation dataset. It may take
 some time to populate the dashboards. If you do not see any entries after half
 an hour, check the logs from the [ML Engine
-Dasboard](https://pantheon.corp.google.com/mlengine/jobs).
+Dashboard](https://console.cloud.google.com/mlengine/jobs).
 
 ## Exporting the Tensorflow Graph
 
 After your model has been trained, you should export it to a Tensorflow
 graph proto. First, you need to identify a candidate checkpoint to export. You
 can search your bucket using the [Google Cloud Storage
-Browser](https://pantheon.corp.google.com/storage/browser). The file should be
-stored under ${YOUR_GCS_BUCKET}/train. The checkpoint will typically consist of
+Browser](https://console.cloud.google.com/storage/browser). The file should be
+stored under `${YOUR_GCS_BUCKET}/train`. The checkpoint will typically consist of
 three files:
 
 * model.ckpt-${CHECKPOINT_NUMBER}.data-00000-of-00001,
@@ -291,7 +291,7 @@ python object_detection/export_inference_graph \
     --inference_graph_path output_inference_graph.pb
 ```
 
-Afterwards, you should see a graph named output_inference_graph.pb.
+Afterwards, you should see a graph named `output_inference_graph.pb`.
 
 ## What's Next
 

--- a/object_detection/g3doc/running_pets.md
+++ b/object_detection/g3doc/running_pets.md
@@ -284,7 +284,7 @@ command from `tensorflow/models/object_detection`:
 ``` bash
 # From tensorflow/models
 gsutil cp gs://${YOUR_GCS_BUCKET}/train/model.ckpt-${CHECKPOINT_NUMBER}.* .
-python object_detection/export_inference_graph \
+python object_detection/export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path object_detection/samples/configs/faster_rcnn_resnet101_pets.config \
     --checkpoint_path model.ckpt-${CHECKPOINT_NUMBER} \

--- a/object_detection/g3doc/running_pets.md
+++ b/object_detection/g3doc/running_pets.md
@@ -51,8 +51,8 @@ dataset for Oxford-IIIT Pets lives
 [here](http://www.robots.ox.ac.uk/~vgg/data/pets/). You will need to download
 both the image dataset [`images.tar.gz`](http://www.robots.ox.ac.uk/~vgg/data/pets/data/images.tar.gz)
 and the groundtruth data [`annotations.tar.gz`](http://www.robots.ox.ac.uk/~vgg/data/pets/data/annotations.tar.gz)
-to the tensorflow/models directory. This may take some time. After downloading
-the tarballs, your object_detection directory should appear as follows:
+to the `tensorflow/models` directory. This may take some time. After downloading
+the tarballs, your `object_detection` directory should appear as follows:
 
 ```lang-none
 + object_detection/
@@ -66,7 +66,7 @@ the tarballs, your object_detection directory should appear as follows:
 The Tensorflow Object Detection API expects data to be in the TFRecord format,
 so we'll now run the `create_pet_tf_record` script to convert from the raw
 Oxford-IIIT Pet dataset into TFRecords. Run the following commands from the
-object_detection directory:
+`object_detection` directory:
 
 ``` bash
 # From tensorflow/models/
@@ -84,7 +84,7 @@ Note: It is normal to see some warnings when running this script. You may ignore
 them.
 
 Two TFRecord files named `pet_train.record` and `pet_val.record` should be generated
-in the object_detection/ directory.
+in the `object_detection` directory.
 
 Now that the data has been generated, we'll need to upload it to Google Cloud
 Storage so the data can be accessed by ML Engine. Run the following command to
@@ -127,7 +127,7 @@ In the Tensorflow Object Detection API, the model parameters, training
 parameters and eval parameters are all defined by a config file. More details
 can be found [here](configuring_jobs.md). For this tutorial, we will use some
 predefined templates provided with the source code. In the
-object_detection/samples/configs folder, there are skeleton object_detection
+`object_detection/samples/configs` folder, there are skeleton object_detection
 configuration files. We will use `faster_rcnn_resnet101_pets.config` as a
 starting point for configuring the pipeline. Open the file with your favourite
 text editor.
@@ -181,7 +181,7 @@ Before we can start a job on Google Cloud ML Engine, we must:
 2. Write a cluster configuration for our Google Cloud ML job.
 
 To package the Tensorflow Object Detection code, run the following commands from
-the tensorflow/models/ directory:
+the `tensorflow/models/` directory:
 
 ``` bash
 # From tensorflow/models/
@@ -196,7 +196,7 @@ For running the training Cloud ML job, we'll configure the cluster to use 10
 training jobs (1 master + 9 workers) and three parameters servers. The
 configuration file can be found at `object_detection/samples/cloud/cloud.yml`.
 
-To start training, execute the following command from the tensorflow/models/
+To start training, execute the following command from the `tensorflow/models/`
 directory:
 
 ``` bash
@@ -274,12 +274,12 @@ Browser](https://console.cloud.google.com/storage/browser). The file should be
 stored under `${YOUR_GCS_BUCKET}/train`. The checkpoint will typically consist of
 three files:
 
-* model.ckpt-${CHECKPOINT_NUMBER}.data-00000-of-00001,
-* model.ckpt-${CHECKPOINT_NUMBER}.index
-* model.ckpt-${CHECKPOINT_NUMBER}.meta
+* `model.ckpt-${CHECKPOINT_NUMBER}.data-00000-of-00001`
+* `model.ckpt-${CHECKPOINT_NUMBER}.index`
+* `model.ckpt-${CHECKPOINT_NUMBER}.meta`
 
 After you've identified a candidate checkpoint to export, run the following
-command from tensorflow/models/object_detection:
+command from `tensorflow/models/object_detection`:
 
 ``` bash
 # From tensorflow/models


### PR DESCRIPTION
- `preparing_inputs.md`: The second `--data_dir` flag for preparing PASCAL VOC dataset is incorrect and inconsistent with the first one.
- `running_pets.md`: Fix typos and wrong links.
- Both: Fix styles, especially `inline code` for file/directory names to improve readability.