### PR TITLE
Fixing evaluation config

### DIFF
--- a/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_pets.config
+++ b/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_pets.config
@@ -133,4 +133,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/faster_rcnn_resnet101_pets.config
+++ b/object_detection/samples/configs/faster_rcnn_resnet101_pets.config
@@ -131,4 +131,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/faster_rcnn_resnet101_voc07.config
+++ b/object_detection/samples/configs/faster_rcnn_resnet101_voc07.config
@@ -132,4 +132,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pascal_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pascal_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/faster_rcnn_resnet152_pets.config
+++ b/object_detection/samples/configs/faster_rcnn_resnet152_pets.config
@@ -131,4 +131,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/faster_rcnn_resnet50_pets.config
+++ b/object_detection/samples/configs/faster_rcnn_resnet50_pets.config
@@ -131,4 +131,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/rfcn_resnet101_pets.config
+++ b/object_detection/samples/configs/rfcn_resnet101_pets.config
@@ -128,4 +128,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/ssd_inception_v2_pets.config
+++ b/object_detection/samples/configs/ssd_inception_v2_pets.config
@@ -177,4 +177,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }

--- a/object_detection/samples/configs/ssd_mobilenet_v1_pets.config
+++ b/object_detection/samples/configs/ssd_mobilenet_v1_pets.config
@@ -183,4 +183,6 @@ eval_input_reader: {
     input_path: "PATH_TO_BE_CONFIGURED/pet_val.record"
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
 }


### PR DESCRIPTION
During evaluation, should not shuffle and num_reader should be 1. Or only (num_examples / num_reader) distinct samples are evaluated. 