### PR TITLE
Make object detection's installation instruction more obvious

### DIFF
--- a/object_detection/README.md
+++ b/object_detection/README.md
@@ -31,13 +31,15 @@ https://scholar.googleusercontent.com/scholar.bib?q=info:l291WsrB-hQJ:scholar.go
 
 ## Table of contents
 
+Before You Start:
+* <a href='g3doc/installation.md'>Installation</a><br>
+
 Quick Start:
 * <a href='object_detection_tutorial.ipynb'>
       Quick Start: Jupyter notebook for off-the-shelf inference</a><br>
 * <a href="g3doc/running_pets.md">Quick Start: Training a pet detector</a><br>
 
 Setup:
-* <a href='g3doc/installation.md'>Installation</a><br>
 * <a href='g3doc/configuring_jobs.md'>
       Configuring an object detection pipeline</a><br>
 * <a href='g3doc/preparing_inputs.md'>Preparing inputs</a><br>

--- a/object_detection/object_detection_tutorial.ipynb
+++ b/object_detection/object_detection_tutorial.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Object Detection Demo\n",
-    "Welcome to the object detection inference walkthrough!  This notebook will walk you step by step through the process of using a pre-trained model to detect objects in an image."
+    "Welcome to the object detection inference walkthrough!  This notebook will walk you step by step through the process of using a pre-trained model to detect objects in an image. Make sure to follow the [installation instructions](https://github.com/tensorflow/models/blob/master/object_detection/g3doc/installation.md) before you start."
    ]
   },
   {
@@ -96,7 +96,7 @@
     "\n",
     "Any model exported using the `export_inference_graph.py` tool can be loaded here simply by changing `PATH_TO_CKPT` to point to a new .pb file.  \n",
     "\n",
-    "By default we use an \"SSD with Mobilenet\" model here. See the [detection model zoo](g3doc/detection_model_zoo.md) for a list of other models that can be run out-of-the-box with varying speeds and accuracies."
+    "By default we use an \"SSD with Mobilenet\" model here. See the [detection model zoo](https://github.com/tensorflow/models/blob/master/object_detection/g3doc/detection_model_zoo.md) for a list of other models that can be run out-of-the-box with varying speeds and accuracies."
    ]
   },
   {


### PR DESCRIPTION
A lot of people (including me!) seemed to miss the [installation instruction](https://github.com/tensorflow/models/blob/master/object_detection/g3doc/installation.md), especially the Protobuf compilation step, when trying out the [tutorial](https://github.com/tensorflow/models/blob/master/object_detection/object_detection_tutorial.ipynb) or other files for the first time. I hope this would make the tutorial clearer and avoid future confusion.

Related issues: #1562, #1591, #1595, #1604