### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/cognitive_mapping_and_planning/datasets/nav_env.py
+++ b/cognitive_mapping_and_planning/datasets/nav_env.py
@@ -336,6 +336,7 @@ class Building(GridWorld):
                category_list=None, small=False, flip=False, logdir=None,
                building_loader=None):
 
+    GridWorld.__init__(self)
     self.restrict_to_largest_cc = True
     self.robot = robot
     self.env = env

--- a/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
+++ b/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
@@ -132,7 +132,8 @@ def _add_summaries(m, summary_mode, arop_full_summary_iters):
                                      m.input_tensors, scope_name=scope_name)
     m.summary_ops = {summary_mode: s_ops}
 
-def visit_count_fc(visit_count, last_visit, embed_neurons, wt_decay, fc_dropout):
+def visit_count_fc(visit_count, last_visit, embed_neurons, wt_decay, fc_dropout,
+                   is_training):
   with tf.variable_scope('embed_visit_count'):
     visit_count = tf.reshape(visit_count, shape=[-1])
     last_visit = tf.reshape(last_visit, shape=[-1])

--- a/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
+++ b/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
@@ -196,7 +196,6 @@ def combine_setup(name, combine_type, embed_img, embed_goal, num_img_neuorons=No
     elif combine_type == 'goalonly':
       out = embed_goal
     else:
-      logging.fatal('Undefined combine_type: %s', combine_type)
       raise ValueError('Undefined combine_type: %s', combine_type)
   return out
 

--- a/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
+++ b/cognitive_mapping_and_planning/tfcode/vision_baseline_lstm.py
@@ -196,6 +196,7 @@ def combine_setup(name, combine_type, embed_img, embed_goal, num_img_neuorons=No
       out = embed_goal
     else:
       logging.fatal('Undefined combine_type: %s', combine_type)
+      raise ValueError('Undefined combine_type: %s', combine_type)
   return out
 
 

--- a/domain_adaptation/domain_separation/dsn_train.py
+++ b/domain_adaptation/domain_separation/dsn_train.py
@@ -181,18 +181,18 @@ def main(_):
         # 1000 is the maximum number of labelled target samples that exists in
         # the datasets.
         target_semi_images, target_semi_labels = provide_batch_fn()(
-          FLAGS.target_labeled_dataset, 'train', FLAGS.dataset_dir,
-          FLAGS.num_readers, FLAGS.batch_size, FLAGS.num_preprocessing_threads)
+            FLAGS.target_labeled_dataset, 'train', FLAGS.dataset_dir,
+            FLAGS.num_readers, FLAGS.batch_size, FLAGS.num_preprocessing_threads)
 
         # Calculate the proportion of source domain samples in the semi-
         # supervised setting, so that the proportion is set accordingly in the
         # batches.
         proportion = float(source_labels['num_train_samples']) / (
-          source_labels['num_train_samples'] +
-          target_semi_labels['num_train_samples'])
+            source_labels['num_train_samples'] +
+            target_semi_labels['num_train_samples'])
 
         rnd_tensor = tf.random_uniform(
-          (target_semi_images.get_shape().as_list()[0],))
+            (target_semi_images.get_shape().as_list()[0],))
 
         domain_selection_mask = rnd_tensor < proportion
         source_images = tf.where(domain_selection_mask, source_images,

--- a/domain_adaptation/domain_separation/dsn_train.py
+++ b/domain_adaptation/domain_separation/dsn_train.py
@@ -181,17 +181,18 @@ def main(_):
         # 1000 is the maximum number of labelled target samples that exists in
         # the datasets.
         target_semi_images, target_semi_labels = provide_batch_fn()(
-            FLAGS.target_labeled_dataset, 'train', FLAGS.batch_size)
+          FLAGS.target_labeled_dataset, 'train', FLAGS.dataset_dir,
+          FLAGS.num_readers, FLAGS.batch_size, FLAGS.num_preprocessing_threads)
 
         # Calculate the proportion of source domain samples in the semi-
         # supervised setting, so that the proportion is set accordingly in the
         # batches.
         proportion = float(source_labels['num_train_samples']) / (
-            source_labels['num_train_samples'] +
-            target_semi_labels['num_train_samples'])
+          source_labels['num_train_samples'] +
+          target_semi_labels['num_train_samples'])
 
         rnd_tensor = tf.random_uniform(
-            (target_semi_images.get_shape().as_list()[0],))
+          (target_semi_images.get_shape().as_list()[0],))
 
         domain_selection_mask = rnd_tensor < proportion
         source_images = tf.where(domain_selection_mask, source_images,

--- a/lfads/lfads.py
+++ b/lfads/lfads.py
@@ -773,8 +773,8 @@ class LFADS(object):
     self.nll_bound_vae = tf.constant(0.0)
     self.nll_bound_iwae = tf.constant(0.0) # for eval with IWAE cost.
     if kind in ["train", "posterior_sample_and_average"]:
-      kl_cost_g0_b = 0.0
-      kl_cost_co_b = 0.0
+      kl_cost_g0_b = tf.zeros_like(batch_size, dtype=tf.float32)
+      kl_cost_co_b = tf.zeros_like(batch_size, dtype=tf.float32)
       if ic_dim > 0:
         g0_priors = [self.prior_zs_g0]
         g0_posts = [self.posterior_zs_g0]

--- a/lfads/lfads.py
+++ b/lfads/lfads.py
@@ -423,7 +423,6 @@ class LFADS(object):
           assert False, "NIY"
 
         preds[d] = tf.equal(tf.constant(name), self.dataName)
-        data_dim = hps.dataset_dims[name]
         fns_out_fac_Ws[d] = makelambda(out_fac_W)
         fns_out_fac_bs[d] =  makelambda(out_fac_b)
 
@@ -769,8 +768,6 @@ class LFADS(object):
     # Variational Lower Bound on posterior, p(z|x), plus reconstruction cost.
     # KL and reconstruction costs are normalized only by batch size, not by
     # dimension, or by time steps.
-    kl_cost_g0_b = tf.zeros_like(batch_size, dtype=tf.float32)
-    kl_cost_co_b = tf.zeros_like(batch_size, dtype=tf.float32)
     self.kl_cost = tf.constant(0.0) # VAE KL cost
     self.recon_cost = tf.constant(0.0) # VAE reconstruction cost
     self.nll_bound_vae = tf.constant(0.0)

--- a/lfads/plot_lfads.py
+++ b/lfads/plot_lfads.py
@@ -181,6 +181,8 @@ def plot_lfads_timeseries(data_bxtxn, model_vals, ext_input_bxtxi=None,
     means_nxt = params_nxt
   elif output_dist == 'gaussian': # (means+vars) x time
     means_nxt = np.vsplit(params_nxt,2)[0] # get means
+  else:
+    raise ValueError("output_dist '{}' not implemented.".format(output_dist))
 
   plt.subplot(nrows,2,11+subplot_cidx)
   plt.imshow(data_nxt, aspect='auto', interpolation='nearest')

--- a/lfads/plot_lfads.py
+++ b/lfads/plot_lfads.py
@@ -138,8 +138,7 @@ def plot_lfads_timeseries(data_bxtxn, model_vals, ext_input_bxtxi=None,
     plot_time_series(means-stds, bidx, n_to_plot=n_to_plot, scale=scale,
                      color='c')
   else:
-    assert 'NIY'
-
+    raise ValueError("output_dist '{}' not implemented.".format(output_dist))
 
   if truth_bxtxn is not None:
     plot_time_series(truth_bxtxn, bidx, n_to_plot=n_to_plot, color='k',
@@ -182,8 +181,6 @@ def plot_lfads_timeseries(data_bxtxn, model_vals, ext_input_bxtxi=None,
     means_nxt = params_nxt
   elif output_dist == 'gaussian': # (means+vars) x time
     means_nxt = np.vsplit(params_nxt,2)[0] # get means
-  else:
-    assert "NIY"
 
   plt.subplot(nrows,2,11+subplot_cidx)
   plt.imshow(data_nxt, aspect='auto', interpolation='nearest')

--- a/lfads/utils.py
+++ b/lfads/utils.py
@@ -174,9 +174,8 @@ def write_data(data_fname, data_dict, use_json=False, compression=None):
     os.makedirs(dir_name)
 
   if use_json:
-    the_file = open(data_fname,'w')
-    json.dump(data_dict, the_file)
-    the_file.close()
+    with open(data_fname,'w') as the_file:
+        json.dump(data_dict, the_file)
   else:
     try:
       with h5py.File(data_fname, 'w') as hf:

--- a/neural_gpu/neural_gpu.py
+++ b/neural_gpu/neural_gpu.py
@@ -234,8 +234,8 @@ def reorder_beam(beam_size, batch_size, beam_val, output, is_first,
     which_beam = top_beam_idx[:, i] / beam_size  # [batch]
     which_beam = which_beam * batch_size + tf.range(batch_size)
     reordered[0].append(tf.gather(output, which_beam))
-    for i, t in enumerate(tensors_to_reorder):
-      reordered[i + 1].append(tf.gather(t, which_beam))
+    for j, t in enumerate(tensors_to_reorder):
+      reordered[j + 1].append(tf.gather(t, which_beam))
   new_tensors = [tf.concat(axis=0, values=t) for t in reordered]
   top_out_idx = tf.concat(axis=0, values=top_out_idx)
   return (top_beam, new_tensors[0], top_out_idx, new_tensors[1:])

--- a/neural_gpu/neural_gpu_trainer.py
+++ b/neural_gpu/neural_gpu_trainer.py
@@ -652,7 +652,6 @@ def train():
    (train_set, dev_set, en_vocab_path, fr_vocab_path), sv, sess) = initialize()
   with sess.as_default():
     quant_op = model.quantize_op
-    max_cur_length = min(min_length + 3, max_length)
     prev_acc_perp = [1000000 for _ in xrange(5)]
     prev_seq_err = 1.0
     is_chief = FLAGS.task < 1

--- a/neural_gpu/program_utils.py
+++ b/neural_gpu/program_utils.py
@@ -111,7 +111,6 @@ f_sum = Function("sum", [ListType("Int")], "Int")
 def plus_one(x): return x + 1
 def minus_one(x): return x - 1
 def times_two(x): return x * 2
-def neg(x): return x * (-1)
 def div_two(x): return int(x/2)
 def sq(x): return x**2 
 def times_three(x): return x * 3

--- a/neural_programmer/model.py
+++ b/neural_programmer/model.py
@@ -502,10 +502,6 @@ class Graph():
         self.data_type)  #running sum of the hidden states of the model
     output = tf.cast(tf.fill([self.batch_size, 1], 0.0),
                      self.data_type)  #output of the model
-    correct = tf.cast(
-        tf.fill([1], 0.0), self.data_type
-    )  #to compute accuracy, returns number of correct examples for this batch
-    total_error = 0.0
     prev_select_1 = tf.zeros_like(select)
     self.create_summary_embeddings()
     self.get_column_hidden_vectors()
@@ -567,6 +563,7 @@ class Graph():
     self.scalar_output = output
     error = self.error_computation()
     cond = tf.less(error, 0.0001, name="cond")
+    #to compute accuracy, returns number of correct examples for this batch
     correct_add = tf.where(
         cond, tf.fill(tf.shape(cond), 1.0), tf.fill(tf.shape(cond), 0.0))
     correct = tf.reduce_sum(correct_add)

--- a/real_nvp/lsun_formatting.py
+++ b/real_nvp/lsun_formatting.py
@@ -75,7 +75,6 @@ def main():
         image_raw = numpy.array(Image.open(os.path.join(fn_root, img_fn)))
         rows = image_raw.shape[0]
         cols = image_raw.shape[1]
-        depth = image_raw.shape[2]
         downscale = min(rows / 96., cols / 96.)
         image_raw = skimage.transform.pyramid_reduce(image_raw, downscale)
         image_raw *= 255.

--- a/street/python/nn_ops.py
+++ b/street/python/nn_ops.py
@@ -103,7 +103,6 @@ def _variable_lstm_shape(op):
   state_shape = op.inputs[1].get_shape().with_rank(2)
   memory_shape = op.inputs[2].get_shape().with_rank(2)
   w_m_m_shape = op.inputs[3].get_shape().with_rank(3)
-  batch_size = input_shape[0].merge_with(state_shape[0])
   batch_size = input_shape[0].merge_with(memory_shape[0])
   seq_len = input_shape[1]
   gate_num = input_shape[2].merge_with(w_m_m_shape[1])


### PR DESCRIPTION
This PR fixes issues flagged by lgtm.com code queries. Some are minors and some should fix errors or unintentional code behaviour.

I think the suggested fixes make sense but someone more familiar with the code base and what was the initial intention may suggest an alternative way. In particular there seem to be many `if` `elif` blocks that look like they could throw errors due to non initialised variables.

The standard lgtm engineering analytics highlights dependencies, vulnerabilities and currently flag [184 alerts](https://lgtm.com/projects/g/tensorflow/models/alerts/) but you can investigate further by writing [your own custom queries](https://lgtm.com/docs/ql/about-ql) to explore your code base.

I personally find lgtm alerts most useful when using [PR integration](https://lgtm.com/docs/lgtm/config/pr-integration) as it allows to check and deal with potential issues before they find their way into master - for instance several of the alerts fixed by this PR were introduced in recent commits (notably 5b9d9097cc255becef4b5460c4b951c143d7a380 and 3a65897989c4711c2b0d8544a1a8a455ac654cec).

Full disclosure: I work on lgtm.com (and play with tensorflow), hence my interest!

Hope that helps, any question please ask.