### PR TITLE
Removed an error-causing parameter

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -392,8 +392,7 @@ bazel-bin/tensorflow/examples/label_image/label_image \
   --graph=/tmp/frozen_inception_v3.pb \
   --labels=/tmp/imagenet_slim_labels.txt \
   --input_mean=0 \
-  --input_std=255 \
-  --logtostderr
+  --input_std=255
 ```
 
 


### PR DESCRIPTION
--logtostderr causes the following error: E tensorflow/examples/label_image/main.cc:319] Unknown argument --logtostderr