### PR TITLE
Change default visibility of the slim package to public.

### DIFF
--- a/slim/BUILD
+++ b/slim/BUILD
@@ -2,8 +2,7 @@
 #   Contains files for loading, training and evaluating TF-Slim-based models.
 
 package(default_visibility = [
-    ":internal",
-    "//domain_adaptation:__subpackages__",
+    "//visibility:public",
 ])
 
 licenses(["notice"])  # Apache 2.0


### PR DESCRIPTION
* We do this because we want rules outside of slim to be able to depend on it in order to pull in slim models.
