### PR TITLE
Fix compatibility for object_detection/core/batcher.py

### DIFF
--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -84,7 +84,7 @@ class BatchQueue(object):
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
         {(key + rt_shape_str): tf.shape(tensor)
-         for key, tensor in tensor_dict.iteritems()})
+         for key, tensor in tensor_dict.items()})
 
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)


### PR DESCRIPTION
iteritems -> items

I've tried Pets Dataset tutorial locally (not using GCP) with Python 3.6.0.
https://github.com/tensorflow/models/blob/master/object_detection/g3doc/running_pets.md

And I got error like below.
```
AttributeError: ‘dict’ object has no attribute ‘iteritems’
```