### PR TITLE
Fixed Error in specifying the Output Directory

### DIFF
--- a/object_detection/g3doc/running_pets.md
+++ b/object_detection/g3doc/running_pets.md
@@ -84,7 +84,7 @@ Note: It is normal to see some warnings when running this script. You may ignore
 them.
 
 Two TFRecord files named `pet_train.record` and `pet_val.record` should be generated
-in the `object_detection` directory.
+in the `tensorflow/models` directory.
 
 Now that the data has been generated, we'll need to upload it to Google Cloud
 Storage so the data can be accessed by ML Engine. Run the following command to


### PR DESCRIPTION
When following the directory structure of the example, TFRecords generated from the Oxford Pet Dataset are stored in the pwd i.e `tensorflow/models` while the original file was specifying `object_detection` directory