### PR TITLE
Change split name in slim's export_inference_graph

### DIFF
--- a/slim/export_inference_graph.py
+++ b/slim/export_inference_graph.py
@@ -100,7 +100,7 @@ def main(_):
     raise ValueError('You must supply the path to save to with --output_file')
   tf.logging.set_verbosity(tf.logging.INFO)
   with tf.Graph().as_default() as graph:
-    dataset = dataset_factory.get_dataset(FLAGS.dataset_name, 'validation',
+    dataset = dataset_factory.get_dataset(FLAGS.dataset_name, 'train',
                                           FLAGS.dataset_dir)
     network_fn = nets_factory.get_network_fn(
         FLAGS.model_name,


### PR DESCRIPTION
Change the hard-coded split name in slim's [`export_inference_graph.py`](https://github.com/tensorflow/models/blob/master/slim/export_inference_graph.py) from "validation" to "train" to support the MNIST and CIFAR10 datasets.

The current code uses the "validation" split to `get_dataset` from `dataset_factory`. While the ImageNet and flowers datasets have "train" and "validation" splits, the MNIST and CIFAR10 datasets only have "train" and "test" splits. Therefore, using `export_inference_graph.py` with MNIST or CIFAR10 results in an error.

Since `dataset = dataset_factory.get_dataset(...)` is called just to get `dataset.num_classes` for the next line, the choice of split should not matter. I changed to "train" because it's the only split that exists for all four datasets.

@sguada