### PR TITLE
Fix augmentation bugs

### DIFF
--- a/object_detection/core/preprocessor.py
+++ b/object_detection/core/preprocessor.py
@@ -1441,7 +1441,7 @@ def subtract_channel_mean(image, means=None):
       raise ValueError('Input must be of size [height, width, channels]')
     if len(means) != image.get_shape()[-1]:
       raise ValueError('len(means) must match the number of channels')
-    return tf.subtract(image, tf.constant([v for v in means]))
+    return tf.subtract(image, tf.constant([m for m in means]))
 
 
 def one_hot_encoding(labels, num_classes=None):

--- a/object_detection/core/preprocessor.py
+++ b/object_detection/core/preprocessor.py
@@ -1246,7 +1246,6 @@ def random_resize_method(image, target_size):
   Returns:
     resized image.
   """
-
   resized_image = _apply_with_random_selector(
       image,
       lambda x, method: tf.image.resize_images(x, target_size, method),
@@ -1442,7 +1441,7 @@ def subtract_channel_mean(image, means=None):
       raise ValueError('Input must be of size [height, width, channels]')
     if len(means) != image.get_shape()[-1]:
       raise ValueError('len(means) must match the number of channels')
-    return image - [[means]]
+    return tf.subtract(image, tf.constant([v for v in means]))
 
 
 def one_hot_encoding(labels, num_classes=None):

--- a/object_detection/protos/preprocessor.proto
+++ b/object_detection/protos/preprocessor.proto
@@ -195,8 +195,8 @@ message RandomBlackPatches {
 
 // Randomly resizes the image up to [target_height, target_width].
 message RandomResizeMethod {
-  optional float target_height = 1;
-  optional float target_width = 2;
+  optional int32 target_height = 1;
+  optional int32 target_width = 2;
 }
 
 // Scales boxes from normalized coordinates to pixel coordinates.


### PR DESCRIPTION
1. For random_resize_method, float height / width would cause errors becuase tf.image.resize_images require a int32 Tensor for parameter size. 
2. For subtract_channel_mean, tf.constant could not accept a protobuf field. 