### PR TITLE
Add back six dependency and change pbtxt files to reflect new way of …

### DIFF
--- a/object_detection/data/pascal_label_map.pbtxt
+++ b/object_detection/data/pascal_label_map.pbtxt
@@ -1,9 +1,4 @@
 item {
-  id: 0
-  name: 'none_of_the_above'
-}
-
-item {
   id: 1
   name: 'aeroplane'
 }

--- a/object_detection/data/pet_label_map.pbtxt
+++ b/object_detection/data/pet_label_map.pbtxt
@@ -1,9 +1,4 @@
 item {
-  id: 0
-  name: 'none_of_the_above'
-}
-
-item {
   id: 1
   name: 'Abyssinian'
 }

--- a/object_detection/utils/visualization_utils.py
+++ b/object_detection/utils/visualization_utils.py
@@ -25,8 +25,8 @@ import PIL.Image as Image
 import PIL.ImageColor as ImageColor
 import PIL.ImageDraw as ImageDraw
 import PIL.ImageFont as ImageFont
-import tensorflow as tf
 import six
+import tensorflow as tf
 
 
 _TITLE_LEFT_MARGIN = 10

--- a/object_detection/utils/visualization_utils.py
+++ b/object_detection/utils/visualization_utils.py
@@ -26,6 +26,7 @@ import PIL.ImageColor as ImageColor
 import PIL.ImageDraw as ImageDraw
 import PIL.ImageFont as ImageFont
 import tensorflow as tf
+import six
 
 
 _TITLE_LEFT_MARGIN = 10


### PR DESCRIPTION
…using own data to train object recognition models.


Six was erroneously removed when it is still used in the file.  Running /object_detection/eval.py will give an error and not run because of this.  

Also, this commit (https://github.com/tensorflow/models/commit/88a05515fcc13d6a6fb8224b5c4465414d0d53c2) created the function _validate_label_map in object_detection/utils/label_map_util.py which makes sure that label_map ids are greater than zero, but in the two object detection examples (the pets and pascal datasets) still use items with an id of zero.  I haven't run these examples, but this will give an error if you have items of id 0 like in these two instances.