### PR TITLE
Remove class id 0 from label maps

### DIFF
--- a/object_detection/data/pascal_label_map.pbtxt
+++ b/object_detection/data/pascal_label_map.pbtxt
@@ -1,9 +1,4 @@
 item {
-  id: 0
-  name: 'none_of_the_above'
-}
-
-item {
   id: 1
   name: 'aeroplane'
 }

--- a/object_detection/data/pet_label_map.pbtxt
+++ b/object_detection/data/pet_label_map.pbtxt
@@ -1,9 +1,4 @@
 item {
-  id: 0
-  name: 'none_of_the_above'
-}
-
-item {
   id: 1
   name: 'Abyssinian'
 }


### PR DESCRIPTION
From #1861, class id 0 are not allowed in label maps. This affects two
label maps in the object detection datasets, i.e. pets and PASCAL VOC.
(Related: #1906)

@derekjchow Could you please take a look?