### PR TITLE
Update directories in preparing_inputs.md

### DIFF
--- a/object_detection/README.md
+++ b/object_detection/README.md
@@ -35,7 +35,7 @@ Before You Start:
 * <a href='g3doc/installation.md'>Installation</a><br>
 
 Quick Start:
-* <a href='object_detection_tutorial.ipynb'>
+* <a href='g3doc/running_notebook.md'>
       Quick Start: Jupyter notebook for off-the-shelf inference</a><br>
 * <a href="g3doc/running_pets.md">Quick Start: Training a pet detector</a><br>
 

--- a/object_detection/README.md
+++ b/object_detection/README.md
@@ -35,7 +35,7 @@ Before You Start:
 * <a href='g3doc/installation.md'>Installation</a><br>
 
 Quick Start:
-* <a href='g3doc/running_notebook.md'>
+* <a href='object_detection_tutorial.ipynb'>
       Quick Start: Jupyter notebook for off-the-shelf inference</a><br>
 * <a href="g3doc/running_pets.md">Quick Start: Training a pet detector</a><br>
 

--- a/object_detection/g3doc/preparing_inputs.md
+++ b/object_detection/g3doc/preparing_inputs.md
@@ -8,38 +8,45 @@ TFRecords.
 ## Generating the PASCAL VOC TFRecord files.
 
 The raw 2012 PASCAL VOC data set can be downloaded
-[here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar).
+[here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar),
+or by using the command below.
 Extract the tar file and run the `create_pascal_tf_record` script:
 
 ```bash
-# From tensorflow/models/object_detection
+# From tensorflow/models
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar
 tar -xvf VOCtrainval_11-May-2012.tar
-python create_pascal_tf_record.py --data_dir=VOCdevkit \
-    --year=VOC2012 --set=train --output_path=pascal_train.record
-python create_pascal_tf_record.py --data_dir=VOCdevkit \
-    --year=VOC2012 --set=val --output_path=pascal_val.record
+python object_detection/create_pascal_tf_record.py \
+    --label_map_path=object_detection/data/pascal_label_map.pbtxt \
+    --data_dir=VOCdevkit --year=VOC2012 --set=train \
+    --output_path=pascal_train.record
+python object_detection/create_pascal_tf_record.py \
+    --label_map_path=object_detection/data/pascal_label_map.pbtxt \
+    --data_dir=VOCdevkit --year=VOC2012 --set=val \
+    --output_path=pascal_val.record
 ```
 
 You should end up with two TFRecord files named `pascal_train.record` and
-`pascal_val.record` in the `tensorflow/models/object_detection` directory.
-
-The label map for the PASCAL VOC data set can be found at
-`data/pascal_label_map.pbtxt`.
+`pascal_val.record` in the `tensorflow/models` directory.
 
 ## Generating the Oxford-IIIT Pet TFRecord files.
 
 The Oxford-IIIT Pet data set can be downloaded from
-[their website](http://www.robots.ox.ac.uk/~vgg/data/pets/). Extract the tar
-file and run the `create_pet_tf_record` script to generate TFRecords.
+[their website](http://www.robots.ox.ac.uk/~vgg/data/pets/), or by using the
+command below. Extract the tar file and run the `create_pet_tf_record` script
+to generate TFRecords.
 
 ```bash
-# From tensorflow/models/object_detection
+# From tensorflow/models
+wget http://www.robots.ox.ac.uk/~vgg/data/pets/data/images.tar.gz
+wget http://www.robots.ox.ac.uk/~vgg/data/pets/data/annotations.tar.gz
 tar -xvf annotations.tar.gz
 tar -xvf images.tar.gz
-python create_pet_tf_record.py --data_dir=`pwd` --output_dir=`pwd`
+python object_detection/create_pet_tf_record.py \
+    --label_map_path=object_detection/data/pet_label_map.pbtxt \
+    --data_dir=`pwd` \
+    --output_dir=`pwd`
 ```
 
 You should end up with two TFRecord files named `pet_train.record` and
-`pet_val.record` in the `tensorflow/models/object_detection` directory.
-
-The label map for the Pet dataset can be found at `data/pet_label_map.pbtxt`.
+`pet_val.record` in the `tensorflow/models` directory.

--- a/object_detection/g3doc/preparing_inputs.md
+++ b/object_detection/g3doc/preparing_inputs.md
@@ -7,10 +7,10 @@ TFRecords.
 
 ## Generating the PASCAL VOC TFRecord files.
 
-The raw 2012 PASCAL VOC data set can be downloaded
-[here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar),
-or by using the command below.
-Extract the tar file and run the `create_pascal_tf_record` script:
+The raw 2012 PASCAL VOC data set is located
+[here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar).
+To download, extract and convert it to TFRecords, run the following commands
+below:
 
 ```bash
 # From tensorflow/models
@@ -29,12 +29,15 @@ python object_detection/create_pascal_tf_record.py \
 You should end up with two TFRecord files named `pascal_train.record` and
 `pascal_val.record` in the `tensorflow/models` directory.
 
+The label map for the PASCAL VOC data set can be found at
+`object_detection/data/pascal_label_map.pbtxt`.
+
 ## Generating the Oxford-IIIT Pet TFRecord files.
 
-The Oxford-IIIT Pet data set can be downloaded from
-[their website](http://www.robots.ox.ac.uk/~vgg/data/pets/), or by using the
-command below. Extract the tar file and run the `create_pet_tf_record` script
-to generate TFRecords.
+The Oxford-IIIT Pet data set is located on
+[their website](http://www.robots.ox.ac.uk/~vgg/data/pets/).
+To download, extract and convert it to TFRecrods, run the following commands
+below:
 
 ```bash
 # From tensorflow/models
@@ -50,3 +53,6 @@ python object_detection/create_pet_tf_record.py \
 
 You should end up with two TFRecord files named `pet_train.record` and
 `pet_val.record` in the `tensorflow/models` directory.
+
+The label map for the Pet dataset can be found at
+`object_detection/data/pet_label_map.pbtxt`.

--- a/object_detection/g3doc/running_locally.md
+++ b/object_detection/g3doc/running_locally.md
@@ -77,5 +77,5 @@ tensorboard --logdir=${PATH_TO_MODEL_DIRECTORY}
 ```
 
 where `${PATH_TO_MODEL_DIRECTORY}` points to the directory that contains the
-train and eval directories. Please note it make take Tensorboard a couple
+train and eval directories. Please note it may take Tensorboard a couple
 minutes to populate with data.


### PR DESCRIPTION
Like #1893, the directories to run from should be the root of the git directory, i.e. `tensorflow/models`. This PR is fixing `preparing_inputs.md` for consistency.

However, now that we run `create_pet_tf_record.py` from the root directory, this introduces some complication. Now we need to specify the flag `--label_map_path=object_detection/data/pet_label_map.pbtxt`, because its default value is `data/pet_label_map.pbtxt` (see [here](https://github.com/tensorflow/models/blob/master/object_detection/create_pet_tf_record.py#L45)). This makes sense because the file is in the `object_detection` directory, and if the script is run from there, the default value will work fine.

But does it make sense to edit the default value to `object_detection/data/pet_label_map.pbtxt` so that it's cleaner in the tutorials (but then it wouldn't be the relative path from the file itself)?

@derekjchow Could you please take a look? Thank you!