### PR TITLE
fix issue #1858

### DIFF
--- a/tutorials/rnn/ptb/reader.py
+++ b/tutorials/rnn/ptb/reader.py
@@ -28,10 +28,7 @@ import tensorflow as tf
 
 def _read_words(filename):
   with tf.gfile.GFile(filename, "r") as f:
-    if sys.version_info[0] >= 3:
-      return f.read().replace("\n", "<eos>").split()
-    else:
-      return f.read().decode("utf-8").replace("\n", "<eos>").split()
+    return f.read().decode("utf-8").replace("\n", "<eos>").split()
 
 
 def _build_vocab(filename):


### PR DESCRIPTION
In reader.py, GFile returns an object of type bytes independently from the Python version. Therefore, the object must be decoded as string in any case. Removed the check of Python version