### PR TITLE
Removed wrong parameter in another example

### DIFF
--- a/slim/export_inference_graph.py
+++ b/slim/export_inference_graph.py
@@ -48,8 +48,7 @@ bazel-bin/tensorflow/examples/label_image/label_image \
 --graph=/tmp/frozen_inception_v3.pb \
 --labels=/tmp/imagenet_slim_labels.txt \
 --input_mean=0 \
---input_std=255 \
---logtostderr
+--input_std=255
 
 """
 


### PR DESCRIPTION
Same as #1837, but this is an example in `slim/export_inference_graph.py` instead of `slim/README.md`.