### PR TITLE
Convert RepeatedScalarContainer to a list of floats

### DIFF
--- a/object_detection/core/preprocessor.py
+++ b/object_detection/core/preprocessor.py
@@ -1442,6 +1442,7 @@ def subtract_channel_mean(image, means=None):
       raise ValueError('Input must be of size [height, width, channels]')
     if len(means) != image.get_shape()[-1]:
       raise ValueError('len(means) must match the number of channels')
+    means = map(float, means)
     return image - [[means]]
 
 


### PR DESCRIPTION
Convert `means` parameter of `subtract_channel_mean` function from type `RepeatedScalarContainer` to a list of floats.

Fix `TypeError: Expected float32, got <google.protobuf.pyext._message.RepeatedScalarContainer object at 0x7fb7e6d65618> of type 'RepeatedScalarContainer' instead.`