### PR TITLE
Fix indentation in obj detection tutorial

### DIFF
--- a/object_detection/object_detection_tutorial.ipynb
+++ b/object_detection/object_detection_tutorial.ipynb
@@ -140,9 +140,9 @@
     "opener.retrieve(DOWNLOAD_BASE + MODEL_FILE, MODEL_FILE)\n",
     "tar_file = tarfile.open(MODEL_FILE)\n",
     "for file in tar_file.getmembers():\n",
-    "    file_name = os.path.basename(file.name)\n",
-    "    if 'frozen_inference_graph.pb' in file_name:\n",
-    "        tar_file.extract(file, os.getcwd())"
+    "  file_name = os.path.basename(file.name)\n",
+    "  if 'frozen_inference_graph.pb' in file_name:\n",
+    "    tar_file.extract(file, os.getcwd())"
    ]
   },
   {
@@ -162,11 +162,11 @@
    "source": [
     "detection_graph = tf.Graph()\n",
     "with detection_graph.as_default():\n",
-    "    od_graph_def = tf.GraphDef()\n",
-    "    with tf.gfile.GFile(PATH_TO_CKPT, 'rb') as fid:\n",
-    "        serialized_graph = fid.read()\n",
-    "        od_graph_def.ParseFromString(serialized_graph)\n",
-    "        tf.import_graph_def(od_graph_def, name='')"
+    "  od_graph_def = tf.GraphDef()\n",
+    "  with tf.gfile.GFile(PATH_TO_CKPT, 'rb') as fid:\n",
+    "    serialized_graph = fid.read()\n",
+    "    od_graph_def.ParseFromString(serialized_graph)\n",
+    "    tf.import_graph_def(od_graph_def, name='')"
    ]
   },
   {

--- a/object_detection/utils/label_map_util.py
+++ b/object_detection/utils/label_map_util.py
@@ -75,7 +75,7 @@ def convert_label_map_to_categories(label_map,
       list is created with max_num_classes categories.
     max_num_classes: maximum number of (consecutive) label indices to include.
     use_display_name: (boolean) choose whether to load 'display_name' field
-      as category name.  If False of if the display_name field does not exist,
+      as category name.  If False or if the display_name field does not exist,
       uses 'name' field as category names instead.
   Returns:
     categories: a list of dictionaries representing all possible categories.


### PR DESCRIPTION
Make the indentation in python code blocks consistent by changing 4 spaces to 2 spaces. (Some are already correct.)