### PR TITLE
resolving when there are no detections

### DIFF
--- a/object_detection/utils/per_image_evaluation.py
+++ b/object_detection/utils/per_image_evaluation.py
@@ -202,6 +202,8 @@ class PerImageEvaluation(object):
 
   def _remove_invalid_boxes(self, detected_boxes, detected_scores,
                             detected_class_labels):
+    if len(detected_boxes) == 0:
+      return (detected_boxes, detected_scores, detected_class_labels)
     valid_indices = np.logical_and(detected_boxes[:, 0] < detected_boxes[:, 2],
                                    detected_boxes[:, 1] < detected_boxes[:, 3])
     return (detected_boxes[valid_indices, :], detected_scores[valid_indices],


### PR DESCRIPTION
Remove_invalid_boxes breaks when the detected_boxes is empty. The fix checks if there is any detected_boxes as an input.