### PR TITLE
Shape fix for LFADS tf.case statements

### DIFF
--- a/lfads/README.md
+++ b/lfads/README.md
@@ -7,7 +7,7 @@ This code implements the model from the paper "[LFADS - Latent Factor Analysis v
 
 The code is written in Python 2.7.6. You will also need:
 
-* **TensorFlow** version 1.2.1 ([install](http://tflearn.org/installation/)) -
+* **TensorFlow** version 1.2.1 ([install](https://www.tensorflow.org/install/)) -
 * **NumPy, SciPy, Matplotlib** ([install SciPy stack](https://www.scipy.org/install.html), contains all of them)
 * **h5py** ([install](https://pypi.python.org/pypi/h5py))
 

--- a/lfads/README.md
+++ b/lfads/README.md
@@ -7,9 +7,7 @@ This code implements the model from the paper "[LFADS - Latent Factor Analysis v
 
 The code is written in Python 2.7.6. You will also need:
 
-* **TensorFlow** version 1.1 ([install](http://tflearn.org/installation/)) -
-  there is an incompatibility with LFADS and TF v1.2, which we are in the
-  process of resolving
+* **TensorFlow** version 1.2.1 ([install](http://tflearn.org/installation/)) -
 * **NumPy, SciPy, Matplotlib** ([install SciPy stack](https://www.scipy.org/install.html), contains all of them)
 * **h5py** ([install](https://pypi.python.org/pypi/h5py))
 

--- a/lfads/lfads.py
+++ b/lfads/lfads.py
@@ -432,11 +432,15 @@ class LFADS(object):
     pf_pairs_out_fac_Ws = zip(preds, fns_out_fac_Ws)
     pf_pairs_out_fac_bs = zip(preds, fns_out_fac_bs)
 
-    case_default = lambda: tf.constant([-8675309.0])
-    this_in_fac_W = tf.case(pf_pairs_in_fac_Ws, case_default, exclusive=True)
-    this_in_fac_b = tf.case(pf_pairs_in_fac_bs, case_default, exclusive=True)
-    this_out_fac_W = tf.case(pf_pairs_out_fac_Ws, case_default, exclusive=True)
-    this_out_fac_b = tf.case(pf_pairs_out_fac_bs, case_default, exclusive=True)
+    def _case_with_no_default(pairs):
+      def _default_value_fn():
+        with tf.control_dependencies([tf.Assert(False, ["Reached default"])]):
+          return tf.identity(pairs[0][1]())
+      return tf.case(pairs, _default_value_fn, exclusive=True)
+    this_in_fac_W = _case_with_no_default(pf_pairs_in_fac_Ws)
+    this_in_fac_b = _case_with_no_default(pf_pairs_in_fac_bs)
+    this_out_fac_W = _case_with_no_default(pf_pairs_out_fac_Ws)
+    this_out_fac_b = _case_with_no_default(pf_pairs_out_fac_bs)
 
     # External inputs (not changing by dataset, by definition).
     if hps.ext_input_dim > 0:


### PR DESCRIPTION
The default tf.case (which, judging by its value, has no model significance) previously had shape [1], which did not match the other cases. This caused shape inference errors when building gradients, since downstream Tensors had their shape information refined to shapes incompatible with [1].

The model works for me in TensorFlow 1.2.1 after this PR.