### PR TITLE
[Issue 11184] Filter out OSX hidden files while converting flowers dataset.

### DIFF
--- a/slim/datasets/download_and_convert_flowers.py
+++ b/slim/datasets/download_and_convert_flowers.py
@@ -51,7 +51,7 @@ _NUM_SHARDS = 5
 
 # Python regex that matches names of image files in the archive.
 # Used for filtering out extra hidden files that can appear on OSX.
-_FILE_NAME_REGEX = re.compile(r".+\.(?:jpg|JPG)$")
+_FILE_NAME_REGEX = re.compile(r"[^\.].+\.(?:jpg|JPG)$")
 
 class ImageReader(object):
   """Helper class that provides TensorFlow image coding utilities."""

--- a/slim/datasets/download_and_convert_flowers.py
+++ b/slim/datasets/download_and_convert_flowers.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 import math
 import os
 import random
+import re
 import sys
 
 import tensorflow as tf
@@ -48,6 +49,9 @@ _RANDOM_SEED = 0
 # The number of shards per dataset split.
 _NUM_SHARDS = 5
 
+# Python regex that matches names of image files in the archive.
+# Used for filtering out extra hidden files that can appear on OSX.
+_FILE_NAME_REGEX = re.compile(r".+\.(?:jpg|JPG)$")
 
 class ImageReader(object):
   """Helper class that provides TensorFlow image coding utilities."""
@@ -92,8 +96,9 @@ def _get_filenames_and_classes(dataset_dir):
   photo_filenames = []
   for directory in directories:
     for filename in os.listdir(directory):
-      path = os.path.join(directory, filename)
-      photo_filenames.append(path)
+      if (_FILE_NAME_REGEX.match(filename)):
+        path = os.path.join(directory, filename)
+        photo_filenames.append(path)
 
   return photo_filenames, sorted(class_names)
 


### PR DESCRIPTION
As described in https://github.com/tensorflow/tensorflow/issues/11184 , the script `download_and_convert_flowers.py` could attempt to convert the hidden image index file `.DS_Store` that OSX creates whenever a user opens a Finder window on a directory containing images (for example, because the user was monitoring the status of the script's target directory). This patch adds some filename filtering to the script to prevent the script from picking up .DS_Store. It also prevents the script from picking up any other hidden files (at least for files that are hidden because their names start with ".") or non-JPEG files that might appear in the temporary directory.