### PR TITLE
Fix label_id_offset inconsistencies (obj detection)

### DIFF
--- a/object_detection/eval_util.py
+++ b/object_detection/eval_util.py
@@ -52,7 +52,7 @@ def write_metrics(metrics, global_step, summary_dir):
 
 def evaluate_detection_results_pascal_voc(result_lists,
                                           categories,
-                                          label_id_offset=0,
+                                          label_id_offset=1,
                                           iou_thres=0.5,
                                           corloc_summary=False):
   """Computes Pascal VOC detection metrics given groundtruth and detections.

--- a/object_detection/utils/label_map_util.py
+++ b/object_detection/utils/label_map_util.py
@@ -57,7 +57,8 @@ def create_category_index(categories):
 
 def convert_label_map_to_categories(label_map,
                                     max_num_classes,
-                                    use_display_name=True):
+                                    use_display_name=True,
+                                    label_id_offset=1):
   """Loads label map proto and returns categories list compatible with eval.
 
   This function loads a label map and returns a list of dicts, each of which
@@ -77,13 +78,13 @@ def convert_label_map_to_categories(label_map,
     use_display_name: (boolean) choose whether to load 'display_name' field
       as category name.  If False or if the display_name field does not exist,
       uses 'name' field as category names instead.
+    label_id_offset: an integer offset for the label space.
   Returns:
     categories: a list of dictionaries representing all possible categories.
   """
   categories = []
   list_of_ids_already_added = []
   if not label_map:
-    label_id_offset = 1
     for class_id in range(max_num_classes):
       categories.append({
           'id': class_id + label_id_offset,
@@ -99,7 +100,7 @@ def convert_label_map_to_categories(label_map,
       name = item.display_name
     else:
       name = item.name
-    if item.id not in list_of_ids_already_added:
+    if item.id - label_id_offset not in list_of_ids_already_added:
       list_of_ids_already_added.append(item.id)
       categories.append({'id': item.id, 'name': name})
   return categories

--- a/object_detection/utils/label_map_util.py
+++ b/object_detection/utils/label_map_util.py
@@ -92,7 +92,7 @@ def convert_label_map_to_categories(label_map,
       })
     return categories
   for item in label_map.item:
-    if not 0 < item.id <= max_num_classes:
+    if not 0 <= item.id - label_id_offset < max_num_classes:
       logging.info('Ignore item %d since it falls outside of requested '
                    'label range.', item.id)
       continue
@@ -100,7 +100,7 @@ def convert_label_map_to_categories(label_map,
       name = item.display_name
     else:
       name = item.name
-    if item.id - label_id_offset not in list_of_ids_already_added:
+    if item.id not in list_of_ids_already_added:
       list_of_ids_already_added.append(item.id)
       categories.append({'id': item.id, 'name': name})
   return categories


### PR DESCRIPTION
The ["using your own dataset" tutorial](https://github.com/tensorflow/models/blob/master/object_detection/g3doc/using_your_own_dataset.md) says "Label maps should always start from id 1." However, the current code still has some inconsistencies.

Right now, the default value for `label_id_offset` in `eval_util.py`'s [`evaluate_detection_results_pascal_voc` method](https://github.com/tensorflow/models/blob/master/object_detection/eval_util.py#L111-L125) is 0 (instead of 1). When I run an evaluation using a pre-trained model on the PASCAL VOC, for example, `num_classes` will be 21 instead of 20, giving me the following warning.

```bash
WARNING:root:The following classes have no ground truth examples: 0
```
Changing the default value of `label_id_offset` to 1 will fix it.

### Questions
Should the comment in L111 ("Pascal VOC evaluator assumes foreground index starts from zero.") also change from "zero" to "one"?

By the way, what is allowed as the `categories`?
- At least, the ids should start from 1. The `label_id_offset` can allow for other cases.
- Maybe they should also be in an increasing order and consecutive? I'm not sure whether anything will break if this condition is not satisfied (e.g. the label map is 1=cat1, 5=cat5, 3=cat3). It seems like some codes are making these assumptions?
If these should be satisfied, maybe some checks can be added in `label_map_util.py`'s [`_validate_label_map` method](https://github.com/tensorflow/models/blob/master/object_detection/utils/label_map_util.py#L25).

Possibly related issues: #1856, #1936 

@derekjchow Could you please take a look? Thank you!