### PR TITLE
Fix warning 'Summary name /clone_loss is illegal'

### DIFF
--- a/slim/deployment/model_deploy.py
+++ b/slim/deployment/model_deploy.py
@@ -230,7 +230,7 @@ def _gather_clone_loss(clone, num_clones, regularization_losses):
       sum_loss = tf.add_n(all_losses)
   # Add the summaries out of the clone device block.
   if clone_loss is not None:
-    tf.summary.scalar(clone.scope + '/clone_loss', clone_loss)
+    tf.summary.scalar(clone.scope + 'clone_loss', clone_loss)
   if regularization_loss is not None:
     tf.summary.scalar('regularization_loss', regularization_loss)
   return sum_loss


### PR DESCRIPTION
When clone.scope is empty a warning(info) like below occurs.
```
INFO:tensorflow:Summary name /clone_loss is illegal; using clone_loss instead.
```

Since '/' is contained in clone.scope, removed it from '/clone_loss' string.