### PR TITLE
Update DenoisingAutoencoder.py

### DIFF
--- a/autoencoder/autoencoder_models/DenoisingAutoencoder.py
+++ b/autoencoder/autoencoder_models/DenoisingAutoencoder.py
@@ -13,7 +13,7 @@ class AdditiveGaussianNoiseAutoencoder(object):
 
         # model
         self.x = tf.placeholder(tf.float32, [None, self.n_input])
-        self.hidden = self.transfer(tf.add(tf.matmul(self.x + scale * tf.random_normal((n_input,)),
+        self.hidden = self.transfer(tf.add(tf.matmul(self.x + self.scale * tf.random_normal((n_input,)),
                 self.weights['w1']),
                 self.weights['b1']))
         self.reconstruction = tf.add(tf.matmul(self.hidden, self.weights['w2']), self.weights['b2'])


### PR DESCRIPTION
For the denoising autoencoder, I think it should be 'self.scale' not 'scale' in the graph. If not ,I think it unnecessary to fefine placeholder of scale because it is not connected wtih any node.