### PR TITLE
Update exporting models documentation

### DIFF
--- a/object_detection/g3doc/exporting_models.md
+++ b/object_detection/g3doc/exporting_models.md
@@ -12,11 +12,17 @@ command from tensorflow/models/object_detection:
 
 ``` bash
 # From tensorflow/models
-python object_detection/export_inference_graph \
+python object_detection/export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path ${PIPELINE_CONFIG_PATH} \
-    --checkpoint_path model.ckpt-${CHECKPOINT_NUMBER} \
-    --inference_graph_path output_inference_graph.pb
+    --trained_checkpoint_prefix model.ckpt-${CHECKPOINT_NUMBER} \
+    --output_directory ${EXPORTED_MODEL_PATH}
 ```
 
-Afterwards, you should see a graph named output_inference_graph.pb.
+The expected output would be in the directory `${EXPORTED_MODEL_PATH}` (which is created if it does not exist) with contents:
+
+* graph.pbtxt
+* model.ckpt.data-00000-of-00001
+* model.ckpt.info
+* model.ckpt.meta
+* frozen_inference_graph.pb


### PR DESCRIPTION
With the recent changes in `export_inference_graph.py`, this PR makes the exporting models documentation up-to-date.