### PR TITLE
Obj_Det: From six.moves import integer_types, range

### DIFF
--- a/object_detection/exporter_test.py
+++ b/object_detection/exporter_test.py
@@ -23,11 +23,10 @@ from object_detection.builders import model_builder
 from object_detection.core import model
 from object_detection.protos import pipeline_pb2
 
-if six.PY2:
-  import mock  # pylint: disable=g-import-not-at-top
-else:
-  from unittest import mock  # pylint: disable=g-import-not-at-top
-
+try:
+  from unittest import mock
+except ImportError:
+  import mock
 
 class FakeModel(model.DetectionModel):
 

--- a/object_detection/exporter_test.py
+++ b/object_detection/exporter_test.py
@@ -16,7 +16,6 @@
 """Tests for object_detection.export_inference_graph."""
 import os
 import numpy as np
-import six
 import tensorflow as tf
 from object_detection import exporter
 from object_detection.builders import model_builder

--- a/object_detection/utils/np_box_list_ops.py
+++ b/object_detection/utils/np_box_list_ops.py
@@ -20,7 +20,7 @@ Example box operations that are supported:
   * IOU: pairwise intersection-over-union scores
 """
 
-from builtins import range
+from six.moves import range
 import numpy as np
 
 from object_detection.utils import np_box_list

--- a/object_detection/utils/np_box_list_ops.py
+++ b/object_detection/utils/np_box_list_ops.py
@@ -20,6 +20,7 @@ Example box operations that are supported:
   * IOU: pairwise intersection-over-union scores
 """
 
+from builtins import range
 import numpy as np
 
 from object_detection.utils import np_box_list
@@ -214,7 +215,7 @@ def non_max_suppression(boxlist,
   is_index_valid = np.full(num_boxes, 1, dtype=bool)
   selected_indices = []
   num_output = 0
-  for i in xrange(num_boxes):
+  for i in range(num_boxes):
     if num_output < max_output_size:
       if is_index_valid[i]:
         num_output += 1

--- a/object_detection/utils/np_box_list_ops.py
+++ b/object_detection/utils/np_box_list_ops.py
@@ -20,7 +20,6 @@ Example box operations that are supported:
   * IOU: pairwise intersection-over-union scores
 """
 
-from six.moves import range
 import numpy as np
 
 from object_detection.utils import np_box_list

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -16,6 +16,7 @@
 """A module for helper tensorflow ops."""
 import math
 import six
+
 import tensorflow as tf
 
 from object_detection.core import box_list

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -15,7 +15,7 @@
 
 """A module for helper tensorflow ops."""
 import math
-import six
+from past.builtins import long
 
 import tensorflow as tf
 
@@ -198,9 +198,9 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth, (int, long) if six.PY2 else int):
+  if depth < 0 or not isinstance(depth, (int, long)):
     raise ValueError('`depth` must be a non-negative integer.')
-  if left_pad < 0 or not isinstance(left_pad, (int, long) if six.PY2 else int):
+  if left_pad < 0 or not isinstance(left_pad, (int, long)):
     raise ValueError('`left_pad` must be a non-negative integer.')
   if depth == 0:
     return None

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -15,8 +15,7 @@
 
 """A module for helper tensorflow ops."""
 import math
-from past.builtins import long
-
+import six
 import tensorflow as tf
 
 from object_detection.core import box_list
@@ -198,9 +197,9 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth, (int, long)):
+  if depth < 0 or not isinstance(depth,  six.integer_types):
     raise ValueError('`depth` must be a non-negative integer.')
-  if left_pad < 0 or not isinstance(left_pad, (int, long)):
+  if left_pad < 0 or not isinstance(left_pad, six.integer_types):
     raise ValueError('`left_pad` must be a non-negative integer.')
   if depth == 0:
     return None

--- a/object_detection/utils/ops.py
+++ b/object_detection/utils/ops.py
@@ -197,7 +197,7 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth,  six.integer_types):
+  if depth < 0 or not isinstance(depth, six.integer_types):
     raise ValueError('`depth` must be a non-negative integer.')
   if left_pad < 0 or not isinstance(left_pad, six.integer_types):
     raise ValueError('`left_pad` must be a non-negative integer.')


### PR DESCRIPTION
* `xrange()` was removed in Python 3
* Also use six to define `long` in Python 3 in a way that works for linters

@derekjchow Your thoughts on these mods?