### PR TITLE
adversarial_crypto: ac.eve_optimizer, ac.reset_eve_vars

### DIFF
--- a/adversarial_crypto/train_eval.py
+++ b/adversarial_crypto/train_eval.py
@@ -249,17 +249,17 @@ def train_and_evaluate():
 
     if train_until_thresh(s, ac):
       for _ in xrange(EVE_EXTRA_ROUNDS):
-        s.run(eve_optimizer)
+        s.run(ac.eve_optimizer)
       print('Loss after eve extra training:')
       doeval(s, ac, EVAL_BATCHES * 2, 0)
       for _ in xrange(NUMBER_OF_EVE_RESETS):
         print('Resetting Eve')
-        s.run(reset_eve_vars)
+        s.run(ac.reset_eve_vars)
         eve_counter = 0
         for _ in xrange(RETRAIN_EVE_LOOPS):
           for _ in xrange(RETRAIN_EVE_ITERS):
             eve_counter += 1
-            s.run(eve_optimizer)
+            s.run(ac.eve_optimizer)
           doeval(s, ac, EVAL_BATCHES, eve_counter)
         doeval(s, ac, EVAL_BATCHES, eve_counter)
 


### PR DESCRIPTION
* eve_optimizer --> ac.eve_optimizer
* reset_eve_vars --> ac.reset_eve_vars
* eve_optimizer --> ac.eve_optimizer

Why make these changes?  flake8 testing of https://github.com/tensorflow/models on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

```
./adversarial_crypto/train_eval.py:252:15: F821 undefined name 'eve_optimizer'
        s.run(eve_optimizer)
              ^

./adversarial_crypto/train_eval.py:257:15: F821 undefined name 'reset_eve_vars'
        s.run(reset_eve_vars)
              ^

./adversarial_crypto/train_eval.py:262:19: F821 undefined name 'eve_optimizer'
            s.run(eve_optimizer)
                  ^
```