### PR TITLE
fixes bug #2157, loads the pretrained encoder to finetune the decoder

### DIFF
--- a/ptn/model_voxel_generation.py
+++ b/ptn/model_voxel_generation.py
@@ -129,8 +129,9 @@ class Im2Vox(object):
       var_list.extend(
           filter(is_trainable, tf.contrib.framework.get_model_variables(scope)))
 
+    model_path = tf.train.latest_checkpoint(self._params.init_model)
     init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
-        self._params.init_model, var_list)
+        model_path, var_list)
 
     def init_assign_function(sess):
       sess.run(init_assign_op, init_feed_dict)


### PR DESCRIPTION
 bug #2157 didn't load the pretrained decoder when training  the volumetric decoder. This patch loads the latest checkpoint model from the given folder.