### PR TITLE
Enables training the PTN decoder, fixes #2160

### DIFF
--- a/ptn/utils.py
+++ b/ptn/utils.py
@@ -20,6 +20,8 @@ from __future__ import division
 from __future__ import print_function
 
 import StringIO
+import matplotlib
+matplotlib.use('Agg')
 from matplotlib import pylab as p
 # axes3d is being used implictly for visualization.
 from mpl_toolkits.mplot3d import axes3d as p3  # pylint:disable=unused-import


### PR DESCRIPTION
Due to a matplotlib multi-threading issue, the decoder training crashed, see issue ##2160.
This PR should fix the issue.