### PR TITLE
Slim: 3217920L --> 3217920 (drop the trailing L)

### DIFF
--- a/slim/nets/mobilenet_v1_test.py
+++ b/slim/nets/mobilenet_v1_test.py
@@ -297,7 +297,7 @@ class MobilenetV1Test(tf.test.TestCase):
       mobilenet_v1.mobilenet_v1_base(inputs)
       total_params, _ = slim.model_analyzer.analyze_vars(
           slim.get_model_variables())
-      self.assertAlmostEqual(3217920L, total_params)
+      self.assertAlmostEqual(3217920, total_params)
 
   def testBuildEndPointsWithDepthMultiplierLessThanOne(self):
     batch_size = 5


### PR DESCRIPTION
Python 2.7 no longer needs the trailing L and Python 3 treats it as a Syntax Error.