### PR TITLE
Do not skip download if image file already exists

### DIFF
--- a/im2txt/im2txt/data/download_and_preprocess_mscoco.sh
+++ b/im2txt/im2txt/data/download_and_preprocess_mscoco.sh
@@ -47,13 +47,8 @@ WORK_DIR="$0.runfiles/im2txt/im2txt"
 function download_and_unzip() {
   local BASE_URL=${1}
   local FILENAME=${2}
-
-  if [ ! -f ${FILENAME} ]; then
-    echo "Downloading ${FILENAME} to $(pwd)"
-    wget -nd -c "${BASE_URL}/${FILENAME}"
-  else
-    echo "Skipping download of ${FILENAME}"
-  fi
+  echo "Downloading ${FILENAME} to $(pwd)"
+  wget -nd -c "${BASE_URL}/${FILENAME}"
   echo "Unzipping ${FILENAME}"
   ${UNZIP} ${FILENAME}
 }


### PR DESCRIPTION
As the script uses the '-c' flag with wget, it allows wget to continue downloading from where the previous download stopped. By skipping the download all-together when the file already exists it renders this flag meaningless, and would render the script broken if a previous download has failed before finishing.