### PR TITLE
python 3.x compatibility

### DIFF
--- a/tutorials/rnn/ptb/reader.py
+++ b/tutorials/rnn/ptb/reader.py
@@ -27,7 +27,7 @@ import tensorflow as tf
 
 
 def _read_words(filename):
-  with tf.gfile.GFile(filename, "r") as f:
+  with tf.gfile.GFile(filename, "rb") as f:
     return f.read().decode("utf-8").replace("\n", "<eos>").split()
 
 


### PR DESCRIPTION
On default, GFile.read() returns a python string which would depend on the python version. Set GFile to bytes mode and the function will work on both python 2.x and 3.x.