### PR TITLE
Align `object_detection` docs with the parameters' names from model freezing script

### DIFF
--- a/object_detection/g3doc/running_pets.md
+++ b/object_detection/g3doc/running_pets.md
@@ -296,11 +296,12 @@ gsutil cp gs://${YOUR_GCS_BUCKET}/train/model.ckpt-${CHECKPOINT_NUMBER}.* .
 python object_detection/export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path object_detection/samples/configs/faster_rcnn_resnet101_pets.config \
-    --checkpoint_path model.ckpt-${CHECKPOINT_NUMBER} \
-    --inference_graph_path output_inference_graph.pb
+    --trained_checkpoint_prefix model.ckpt-${CHECKPOINT_NUMBER} \
+    --output_directory output_graph_directory
 ```
 
-Afterwards, you should see a graph named `output_inference_graph.pb`.
+Afterwards, you should see a graph named `frozen_inference_graph.pb` in
+`output_graph_directory`.
 
 ## What's Next
 


### PR DESCRIPTION
There is a discrepancy between parameters' names: see https://github.com/tensorflow/models/blob/master/object_detection/export_inference_graph.py#L77-L86 and https://github.com/tensorflow/models/blob/master/object_detection/g3doc/running_pets.md#exporting-the-tensorflow-graph .