### PR TITLE
Fixes bug #2140, that prevents running the perspective transformer net

### DIFF
--- a/ptn/.gitignore
+++ b/ptn/.gitignore
@@ -5,5 +5,4 @@ bazel-out
 bazel-genfiles
 bazel-ptn
 bazel-testlogs
-WORKSPACE
 *.pyc


### PR DESCRIPTION
Fixes bug #2140. Adds bazel workspace file to enable running perspective transformer networks.

