### PR TITLE
fix exporter api

### DIFF
--- a/object_detection/exporter.py
+++ b/object_detection/exporter.py
@@ -290,8 +290,7 @@ def _write_graph_and_checkpoint(inference_graph_def,
   with tf.Graph().as_default():
     tf.import_graph_def(inference_graph_def, name='')
     with session.Session() as sess:
-      saver = saver_lib.Saver(saver_def=input_saver_def,
-                              save_relative_paths=True)
+      saver = saver_lib.Saver(saver_def=input_saver_def)
       saver.restore(sess, trained_checkpoint_prefix)
       saver.save(sess, model_path)
 


### PR DESCRIPTION
Removing the extra argument `save_relative_paths` in the exporter API function call. 

------
```Traceback (most recent call last):
  File "object_detection/export_inference_graph.py", line 106, in <module>
    tf.app.run()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "object_detection/export_inference_graph.py", line 102, in main
    FLAGS.output_directory)
  File "/home/ubuntu/yixuan-li/object_detection/exporter.py", line 376, in export_inference_graph
    optimize_graph, output_collection_name)
  File "/home/ubuntu/yixuan-li/object_detection/exporter.py", line 336, in _export_inference_graph
    trained_checkpoint_prefix=trained_checkpoint_prefix)
  File "/home/ubuntu/yixuan-li/object_detection/exporter.py", line 294, in _write_graph_and_checkpoint
    save_relative_paths=True)
TypeError: __init__() got an unexpected keyword argument 'save_relative_paths'
```