### PR TITLE
bugfix for rnn tutorial on Python3

### DIFF
--- a/tutorials/rnn/ptb/reader.py
+++ b/tutorials/rnn/ptb/reader.py
@@ -25,10 +25,14 @@ import sys
 
 import tensorflow as tf
 
+Py3 = sys.version_info[0] == 3
 
 def _read_words(filename):
   with tf.gfile.GFile(filename, "r") as f:
-    return f.read().decode("utf-8").replace("\n", "<eos>").split()
+    if Py3:
+      return f.read().replace("\n", "<eos>").split()
+    else:
+      return f.read().decode("utf-8").replace("\n", "<eos>").split()
 
 
 def _build_vocab(filename):


### PR DESCRIPTION
`str` object doesn't have `decode` method and so `tutorials/rnn/ptb/reader.py` doesn't work on Python3.

Actually we don't have to call `decode` method even if we use Python2 because the data used in the tutorial only include ascii characters.
I wrote the code which have `if` condition for `Py3` to apply this code to some texts include non-ascii characters.