### PR TITLE
Fixed broken ImageNet download

### DIFF
--- a/inception/inception/data/download_and_preprocess_imagenet.sh
+++ b/inception/inception/data/download_and_preprocess_imagenet.sh
@@ -58,7 +58,7 @@ DATA_DIR="${1%/}"
 SCRATCH_DIR="${DATA_DIR}/raw-data/"
 mkdir -p "${DATA_DIR}"
 mkdir -p "${SCRATCH_DIR}"
-WORK_DIR="$0.runfiles/inception/inception"
+WORK_DIR="$(pwd)/$0.runfiles/inception/inception"
 
 # Download the ImageNet data.
 LABELS_FILE="${WORK_DIR}/data/imagenet_lsvrc_2015_synsets.txt"


### PR DESCRIPTION
download_and_preprocess_imagenet.sh invokes download_imagenet.sh with incorrect WORK_DIR passed as argument. This breaks download_imagenet.sh with a file-not-found error.
It breaks because WORK_DIR is relative path, but should be fully qualified.