### PR TITLE
Fix `Segmentation Fault` when loading very big corpus file

### DIFF
--- a/tutorials/embedding/word2vec_kernels.cc
+++ b/tutorials/embedding/word2vec_kernels.cc
@@ -128,7 +128,7 @@ class SkipgramWord2vecOp : public OpKernel {
   random::SimplePhilox rng_ GUARDED_BY(mu_);
   int32 current_epoch_ GUARDED_BY(mu_) = -1;
   int64 total_words_processed_ GUARDED_BY(mu_) = 0;
-  int32 example_pos_ GUARDED_BY(mu_);
+  int64 example_pos_ GUARDED_BY(mu_);
   int32 label_pos_ GUARDED_BY(mu_);
   int32 label_limit_ GUARDED_BY(mu_);
 


### PR DESCRIPTION
example_pos_ is the cursor to current position when reading the corpus file. When corpus file is very big, the corpus_size_ may bigger than max of int32, then example_pos_ became negative, and cause `corpus_[example_pos_]` to `Segmentation Fault`.