### PR TITLE
BUG: Fix inception imagenet download script

### DIFF
--- a/research/inception/inception/data/download_imagenet.sh
+++ b/research/inception/inception/data/download_imagenet.sh
@@ -43,7 +43,7 @@ SYNSETS_FILE="${2:-./synsets.txt}"
 
 echo "Saving downloaded files to $OUTDIR"
 mkdir -p "${OUTDIR}"
-CURRENT_DIR=$(pwd)
+INITIAL_DIR=$(pwd)
 BBOX_DIR="${OUTDIR}bounding_boxes"
 mkdir -p "${BBOX_DIR}"
 cd "${OUTDIR}"
@@ -102,4 +102,4 @@ while read SYNSET; do
   rm -f "${SYNSET}.tar"
 
   echo "Finished processing: ${SYNSET}"
-done < "${SYNSETS_FILE}"
+done < "${INITIAL_DIR}/${SYNSETS_FILE}"

--- a/research/slim/datasets/download_imagenet.sh
+++ b/research/slim/datasets/download_imagenet.sh
@@ -43,7 +43,7 @@ SYNSETS_FILE="${2:-./synsets.txt}"
 
 echo "Saving downloaded files to $OUTDIR"
 mkdir -p "${OUTDIR}"
-CURRENT_DIR=$(pwd)
+INITIAL_DIR=$(pwd)
 BBOX_DIR="${OUTDIR}bounding_boxes"
 mkdir -p "${BBOX_DIR}"
 cd "${OUTDIR}"
@@ -96,4 +96,4 @@ while read SYNSET; do
   rm -f "${SYNSET}.tar"
 
   echo "Finished processing: ${SYNSET}"
-done < "${SYNSETS_FILE}"
+done < "${INITIAL_DIR}/${SYNSETS_FILE}"


### PR DESCRIPTION
In [`download_imagenet.sh`](inception/inception/data/download_imagenet.sh), the path to the `$SYNSETS_FILE` resource (`imagenet_2012_validation_synset_labels.txt`) was not working due to a `cd` earlier in the script.

This is fixed by prepending the initial directory path to the path to the resource file (`$SYNSETS_FILE`) when we try to access it.

Fixes #682.