### PR TITLE
Fix the call to build_imagenet_data.py

### DIFF
--- a/inception/inception/data/download_and_preprocess_imagenet.sh
+++ b/inception/inception/data/download_and_preprocess_imagenet.sh
@@ -88,7 +88,7 @@ BOUNDING_BOX_DIR="${SCRATCH_DIR}bounding_boxes/"
 echo "Finished downloading and preprocessing the ImageNet data."
 
 # Build the TFRecords version of the ImageNet data.
-BUILD_SCRIPT="${WORK_DIR}/build_imagenet_data"
+BUILD_SCRIPT="${WORK_DIR}/build_imagenet_data.py"
 OUTPUT_DIRECTORY="${DATA_DIR}"
 IMAGENET_METADATA_FILE="${WORK_DIR}/data/imagenet_metadata.txt"
 


### PR DESCRIPTION
The Python extension is missing in the BUILD_SCRIPT string.