### PR TITLE
DOC: Disambiguate folder to build bazel for slim

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -195,6 +195,7 @@ you will not need to interact with the script again.
 DATA_DIR=$HOME/imagenet-data
 
 # build the preprocessing script.
+cd tensorflow-models
 bazel build slim/download_and_preprocess_imagenet
 
 # run it


### PR DESCRIPTION
Add a `cd` command in the instructions for downloading and converting imagenet. This lets users unfamiliar with bazel (which is most of them) know they shouldn't be in the slim folder when running the command. The directory is different for these instructions compared with the [instructions in the inception folder](inception#getting-started), which the slim README also [links to and tells you to follow](slim#downloading-and-converting-to-tfrecord-format).

I have written the instruction in the same manner as the [instructions for installation in the inception folder](inception#getting-started).