### PR TITLE
Update syntaxnet/tensorflow submodule

### DIFF
--- a/syntaxnet/WORKSPACE
+++ b/syntaxnet/WORKSPACE
@@ -23,3 +23,8 @@ tf_workspace(path_prefix="", tf_repo_name="org_tensorflow")
 # Test that Bazel is up-to-date.
 load("@org_tensorflow//tensorflow:workspace.bzl", "check_version")
 check_version("0.4.2")
+
+bind(
+    name = "protobuf",
+    actual = "@protobuf_archive//:protobuf",
+)

--- a/syntaxnet/dragnn/tensorflow_ops.bzl
+++ b/syntaxnet/dragnn/tensorflow_ops.bzl
@@ -659,7 +659,7 @@ def cc_header_only_library(name, deps=[], **kwargs):
 
 def tf_custom_op_library_additional_deps():
   return [
-      "@protobuf//:protobuf",
+      "@protobuf_archive//:protobuf",
       "//third_party/eigen3",
       "@org_tensorflow//tensorflow/core:framework_headers_lib",
   ]

--- a/syntaxnet/syntaxnet/BUILD
+++ b/syntaxnet/syntaxnet/BUILD
@@ -79,7 +79,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_googlesource_code_re2//:re2",
-        "@protobuf//:protobuf",
+        "@protobuf_archive//:protobuf",
         "@org_tensorflow//third_party/eigen3",
     ] + select({
         "//conditions:default": [

--- a/syntaxnet/syntaxnet/BUILD
+++ b/syntaxnet/syntaxnet/BUILD
@@ -110,7 +110,6 @@ cc_library(
     srcs = ["test_main.cc"],
     linkopts = ["-lm"],
     deps = [
-        "//external:gtest",
         "@org_tensorflow//tensorflow/core:lib",
         "@org_tensorflow//tensorflow/core:test",
         "@org_tensorflow//tensorflow/core:testlib",

--- a/syntaxnet/syntaxnet/syntaxnet.bzl
+++ b/syntaxnet/syntaxnet/syntaxnet.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
-load("@protobuf//:protobuf.bzl", "cc_proto_library")
-load("@protobuf//:protobuf.bzl", "py_proto_library")
+load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
+load("@protobuf_archive//:protobuf.bzl", "py_proto_library")
 
 
 def if_cuda(if_true, if_false = []):
@@ -43,9 +43,9 @@ def tf_proto_library(name, srcs=[], has_services=False,
   cc_proto_library(name=name,
                    srcs=srcs,
                    deps=deps,
-                   cc_libs = ["@protobuf//:protobuf"],
-                   protoc="@protobuf//:protoc",
-                   default_runtime="@protobuf//:protobuf",
+                   cc_libs = ["@protobuf_archive//:protobuf"],
+                   protoc="@protobuf_archive//:protoc",
+                   default_runtime="@protobuf_archive//:protobuf",
                    testonly=testonly,
                    visibility=visibility,)
 
@@ -54,8 +54,8 @@ def tf_proto_library_py(name, srcs=[], deps=[], visibility=None, testonly=0):
                    srcs=srcs,
                    srcs_version = "PY2AND3",
                    deps=deps,
-                   default_runtime="@protobuf//:protobuf_python",
-                   protoc="@protobuf//:protoc",
+                   default_runtime="@protobuf_archive//:protobuf_python",
+                   protoc="@protobuf_archive//:protoc",
                    visibility=visibility,
                    testonly=testonly,)
 


### PR DESCRIPTION
Should fix tests that fail due to incompatibility with the old version of tensorflow that uses an old version of rules_closure.