### PR TITLE
Remove unused import in slim dataset script

### DIFF
--- a/slim/datasets/build_imagenet_data.py
+++ b/slim/datasets/build_imagenet_data.py
@@ -92,7 +92,6 @@ import random
 import sys
 import threading
 
-import google3
 import numpy as np
 import tensorflow as tf
 


### PR DESCRIPTION
I was having issues running build_imagenet_data.py due to an unresolved dependency 'google3'.
Here, google3 is imported but never used, so this patch removes that import statement.