### PR TITLE
Fix import error in RNN ptb tutorial

### DIFF
--- a/tutorials/rnn/ptb/util.py
+++ b/tutorials/rnn/ptb/util.py
@@ -86,7 +86,7 @@ class UpdateCollection(object):
 
 
 def auto_parallel(metagraph, model):
-  from google3.third_party.tensorflow.python.grappler import tf_optimizer
+  from tensorflow.python.grappler import tf_optimizer
   rewriter_config = rewriter_config_pb2.RewriterConfig()
   rewriter_config.optimizers.append("autoparallel")
   rewriter_config.auto_parallel.enable = True


### PR DESCRIPTION
Tested on python2.7 tensorflow-gpu==1.2.0

```
python ptb_word_lm.py --data_path=simple-examples/data/ --model small --num_gpus=2
```

| config | epochs | train | valid | test | wps |
|-------|-----|-----|-----|-----|-----|
| small | 13 | 38.109 | 141.901 | 135.217 | 45k |


The tutorial can not run on python3, look like #1922 need to be reverted.