### PR TITLE
fix exporting model doc for object detection

### DIFF
--- a/object_detection/g3doc/exporting_models.md
+++ b/object_detection/g3doc/exporting_models.md
@@ -15,8 +15,8 @@ command from tensorflow/models/object_detection:
 python object_detection/export_inference_graph \
     --input_type image_tensor \
     --pipeline_config_path ${PIPELINE_CONFIG_PATH} \
-    --checkpoint_path model.ckpt-${CHECKPOINT_NUMBER} \
-    --inference_graph_path output_inference_graph.pb
+    --trained_checkpoint_prefix ${TRAIN_PATH} \
+    --output_directory output_inference_graph.pb
 ```
 
 Afterwards, you should see a graph named output_inference_graph.pb.


### PR DESCRIPTION
see example usage in https://github.com/tensorflow/models/blob/master/object_detection/export_inference_graph.py#L51
issue https://github.com/tensorflow/models/issues/2329