### PR TITLE
Add option to configure max GPU memory fraction for training and evaluation in object_detection

### DIFF
--- a/object_detection/evaluator.py
+++ b/object_detection/evaluator.py
@@ -208,4 +208,5 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
           None),
       master=eval_config.eval_master,
       save_graph=eval_config.save_graph,
-      save_graph_dir=(eval_dir if eval_config.save_graph else ''))
+      save_graph_dir=(eval_dir if eval_config.save_graph else ''),
+      eval_config=eval_config)

--- a/object_detection/protos/eval.proto
+++ b/object_detection/protos/eval.proto
@@ -44,4 +44,7 @@ message EvalConfig {
 
   // Whether to evaluate instance masks.
   optional bool eval_instance_masks = 12 [default=false];
+
+  // Maximum fraction of GPU memory which may be allocated.
+  optional float per_process_gpu_memory_fraction = 13 [default=0];
 }

--- a/object_detection/protos/train.proto
+++ b/object_detection/protos/train.proto
@@ -61,4 +61,7 @@ message TrainConfig {
 
   // Maximum capacity of the queue used to prefetch assembled batches.
   optional int32 prefetch_queue_capacity = 16 [default=10];
+
+  // Maximum fraction of GPU memory which may be allocated.
+  optional float per_process_gpu_memory_fraction = 17 [default=0];
 }

--- a/object_detection/trainer.py
+++ b/object_detection/trainer.py
@@ -275,6 +275,9 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
     session_config = tf.ConfigProto(allow_soft_placement=True,
                                     log_device_placement=False)
 
+    # The max GPU memory fraction which may be allocated.
+    session_config.gpu_options.per_process_gpu_memory_fraction = train_config.per_process_gpu_memory_fraction
+
     # Save checkpoints regularly.
     keep_checkpoint_every_n_hours = train_config.keep_checkpoint_every_n_hours
     saver = tf.train.Saver(


### PR DESCRIPTION
**Subfolder**: object_detection
**Use Case**:
I want to follow the accuracy over time during training. I run train.py and eval.py at the same time. train.py is directly allocating all GPU VRAM so eval.py can't restore the graph anymore and results in OOM (since I use one GPU).

**Changed method definition**:
An additional parameter is added in eval_util.py (method repeated_checkpoint_run and run_checkpoint_once). If this is problematic then I would suggest leaving the config option for eval and only add the option to train.proto.

(Original [PR](https://github.com/tensorflow/models/pull/2318))