### PR TITLE
Fix typo of g3doc

### DIFF
--- a/object_detection/g3doc/exporting_models.md
+++ b/object_detection/g3doc/exporting_models.md
@@ -12,7 +12,7 @@ command from tensorflow/models/object_detection:
 
 ``` bash
 # From tensorflow/models
-python object_detection/export_inference_graph \
+python object_detection/export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path ${PIPELINE_CONFIG_PATH} \
     --trained_checkpoint_prefix ${TRAIN_PATH} \


### PR DESCRIPTION
Fixed typo of `object_detection/g3doc/exporting_models.md`

