### PR TITLE
Fix wrong base path from exporting_model.md

### DIFF
--- a/object_detection/g3doc/exporting_models.md
+++ b/object_detection/g3doc/exporting_models.md
@@ -8,7 +8,7 @@ graph proto. A checkpoint will typically consist of three files:
 * model.ckpt-${CHECKPOINT_NUMBER}.meta
 
 After you've identified a candidate checkpoint to export, run the following
-command from tensorflow/models/object_detection:
+command from tensorflow/models:
 
 ``` bash
 # From tensorflow/models


### PR DESCRIPTION
The base path for this should be `tensorflow/models` not `tensorflow/models/object_detection`