### PR TITLE
typo: replace uers's with user's

### DIFF
--- a/slim/slim_walkthrough.ipynb
+++ b/slim/slim_walkthrough.ipynb
@@ -253,7 +253,7 @@
     "    # Add the loss function to the graph.\n",
     "    loss = tf.losses.mean_squared_error(labels=targets, predictions=predictions)\n",
     "    \n",
-    "    # The total loss is the uers's loss plus any regularization losses.\n",
+    "    # The total loss is the user's loss plus any regularization losses.\n",
     "    total_loss = slim.losses.get_total_loss()\n",
     "\n",
     "    # Specify the optimizer and create the train op:\n",


### PR DESCRIPTION
Change this line to say "The total loss is the user's loss ..."

The total loss is the uers's loss plus any regularization losses.