### PR TITLE
Change deprecated all_variables to global_variables

### DIFF
--- a/object_detection/meta_architectures/ssd_meta_arch.py
+++ b/object_detection/meta_architectures/ssd_meta_arch.py
@@ -604,7 +604,7 @@ class SSDMetaArch(model.DetectionModel):
       the model graph.
     """
     variables_to_restore = {}
-    for variable in tf.all_variables():
+    for variable in tf.global_variables():
       if variable.op.name.startswith(self._extract_features_scope):
         var_name = variable.op.name
         if not from_detection_checkpoint:


### PR DESCRIPTION
Following the generated warning message, changed the deprecated `all_variables` to `global_variables` 
```
[...] all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Please use tf.global_variables instead.
```