### PR TITLE
tutorials/rnn/ptb: Small fix to make Python 3-compatible.

### DIFF
--- a/tutorials/rnn/ptb/ptb_word_lm.py
+++ b/tutorials/rnn/ptb/ptb_word_lm.py
@@ -252,7 +252,7 @@ class PTBModel(object):
       ops.update(lr=self._lr, new_lr=self._new_lr, lr_update=self._lr_update)
       if self._rnn_params:
         ops.update(rnn_params=self._rnn_params)
-    for name, op in ops.iteritems():
+    for name, op in ops.items():
       tf.add_to_collection(name, op)
     self._initial_state_name = util.with_prefix(self._name, "initial")
     self._final_state_name = util.with_prefix(self._name, "final")
@@ -484,7 +484,7 @@ def main(_):
                          input_=test_input)
 
     models = {"Train": m, "Valid": mvalid, "Test": mtest}
-    for name, model in models.iteritems():
+    for name, model in models.items():
       model.export_ops(name)
     metagraph = tf.train.export_meta_graph()
     if tf.__version__ < "1.1.0" and FLAGS.num_gpus > 1:


### PR DESCRIPTION
Replace dict.iteritems with dict.items.  In both cases the dict is
very small, so the optimization that `iteritems` provides on Python 2
doesn't matter.

With this fix, the model works smoothly for me on CPython 3.5.3.