### PR TITLE
Add default parameters for visualize_detection_results

### DIFF
--- a/object_detection/evaluator.py
+++ b/object_detection/evaluator.py
@@ -170,7 +170,9 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
           result_dict, tag, global_step, categories=categories,
           summary_dir=eval_dir,
           export_dir=eval_config.visualization_export_dir,
-          show_groundtruth=eval_config.visualization_export_dir)
+          show_groundtruth=eval_config.visualization_export_dir,
+          min_score_thresh=eval_config.min_score_thresh,
+          max_num_predictions=eval_config.max_num_predictions)
     return result_dict
 
   def _process_aggregated_results(result_lists):

--- a/object_detection/protos/eval.proto
+++ b/object_detection/protos/eval.proto
@@ -44,4 +44,10 @@ message EvalConfig {
 
   // Whether to evaluate instance masks.
   optional bool eval_instance_masks = 12 [default=false];
+
+  // Minimum score threshold for a box to be visualized
+  optional float min_score_thresh = 13 [default = 0.5];
+
+  // Maximum number of detections to visualize
+  optional uint32 max_num_predictions = 14 [default=20];
 }


### PR DESCRIPTION
To configure **min_score_thresh** and **max_num_predictions** from **eval_config** of config file, it needs to add those variables into **eval.proto** and add default params into **eval_util.visualize_detection_results()** from **evaluator.py**. 
Those default values are .5(for **min_score_thresh**) and 20(for  **max_num_predictions**) which are for default values of **eval_util.visualize_detection_results()** as below. 

```
def visualize_detection_results(result_dict,
                                tag,
                                global_step,
                                categories,
                                summary_dir='',
                                export_dir='',
                                agnostic_mode=False,
                                show_groundtruth=False,
                                min_score_thresh=.5,
                                max_num_predictions=20):
```