### PR TITLE
Fixed the installation instructions URL

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Object Detection Demo\n",
-    "Welcome to the object detection inference walkthrough!  This notebook will walk you step by step through the process of using a pre-trained model to detect objects in an image. Make sure to follow the [installation instructions](https://github.com/tensorflow/models/blob/master/object_detection/g3doc/installation.md) before you start."
+    "Welcome to the object detection inference walkthrough!  This notebook will walk you step by step through the process of using a pre-trained model to detect objects in an image. Make sure to follow the [installation instructions](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/installation.md) before you start."
    ]
   },
   {


### PR DESCRIPTION
There is a broken link (maybe more than one) because of the move of the models into the research subdirectory.