### PR TITLE
object_detection docs: Fixed reference to directory in protobuff compilation instructions.

### DIFF
--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -45,11 +45,11 @@ sudo pip install matplotlib
 The Tensorflow Object Detection API uses Protobufs to configure model and
 training parameters. Before the framework can be used, the Protobuf libraries
 must be compiled. This should be done by running the following command from
-the tensorflow/models directory:
+the tensorflow/models/research directory:
 
 
 ``` bash
-# From tensorflow/models/
+# From tensorflow/models/research
 protoc object_detection/protos/*.proto --python_out=.
 ```
 


### PR DESCRIPTION
The installation instructions are missing the correct path to the Protobuff libraries following the move of models into the research folder.