### PR TITLE
Refactor object detection tutorial to use recommended PIL to numpy conversion

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -194,27 +194,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Helper code"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def load_image_into_numpy_array(image):\n",
-    "  (im_width, im_height) = image.size\n",
-    "  return np.array(image.getdata()).reshape(\n",
-    "      (im_height, im_width, 3)).astype(np.uint8)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Detection"
    ]
   },
@@ -234,18 +213,8 @@
     "TEST_IMAGE_PATHS = [ os.path.join(PATH_TO_TEST_IMAGES_DIR, 'image{}.jpg'.format(i)) for i in range(1, 3) ]\n",
     "\n",
     "# Size, in inches, of the output images.\n",
-    "IMAGE_SIZE = (12, 8)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
+    "IMAGE_SIZE = (12, 8)\n",
+    "\n",
     "with detection_graph.as_default():\n",
     "  with tf.Session(graph=detection_graph) as sess:\n",
     "    # Definite input and output Tensors for detection_graph\n",
@@ -261,7 +230,7 @@
     "      image = Image.open(image_path)\n",
     "      # the array based representation of the image will be used later in order to prepare the\n",
     "      # result image with boxes and labels on it.\n",
-    "      image_np = load_image_into_numpy_array(image)\n",
+    "      image_np = np.array(image)\n",
     "      # Expand dimensions since the model expects images to have shape: [1, None, None, 3]\n",
     "      image_np_expanded = np.expand_dims(image_np, axis=0)\n",
     "      # Actual detection.\n",

--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -213,8 +213,18 @@
     "TEST_IMAGE_PATHS = [ os.path.join(PATH_TO_TEST_IMAGES_DIR, 'image{}.jpg'.format(i)) for i in range(1, 3) ]\n",
     "\n",
     "# Size, in inches, of the output images.\n",
-    "IMAGE_SIZE = (12, 8)\n",
-    "\n",
+    "IMAGE_SIZE = (12, 8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
     "with detection_graph.as_default():\n",
     "  with tf.Session(graph=detection_graph) as sess:\n",
     "    # Definite input and output Tensors for detection_graph\n",


### PR DESCRIPTION
This PR simplifies the object detection tutorial a little by removing the helper function for converting PIL/Pillow images to numpy arrays by using the numpy array interface on the PIL.Image object (introduced PIL 1.1.6). Which seems to be the preferred method for converting between the two [1] [2].

[1] [https://stackoverflow.com/a/384926](https://stackoverflow.com/a/384926)
[2] [http://effbot.org/zone/pil-changes-116.htm](http://effbot.org/zone/pil-changes-116.htm)