### PR TITLE
Fixed broken paths in object_detection/protos

### DIFF
--- a/research/object_detection/protos/anchor_generator.proto
+++ b/research/object_detection/protos/anchor_generator.proto
@@ -2,8 +2,8 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/grid_anchor_generator.proto";
-import "object_detection/protos/ssd_anchor_generator.proto";
+import "research/object_detection/protos/grid_anchor_generator.proto";
+import "research/object_detection/protos/ssd_anchor_generator.proto";
 
 // Configuration proto for the anchor generator to use in the object detection
 // pipeline. See core/anchor_generator.py for details.

--- a/research/object_detection/protos/box_coder.proto
+++ b/research/object_detection/protos/box_coder.proto
@@ -2,9 +2,9 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/faster_rcnn_box_coder.proto";
-import "object_detection/protos/mean_stddev_box_coder.proto";
-import "object_detection/protos/square_box_coder.proto";
+import "research/object_detection/protos/faster_rcnn_box_coder.proto";
+import "research/object_detection/protos/mean_stddev_box_coder.proto";
+import "research/object_detection/protos/square_box_coder.proto";
 
 // Configuration proto for the box coder to be used in the object detection
 // pipeline. See core/box_coder.py for details.

--- a/research/object_detection/protos/box_predictor.proto
+++ b/research/object_detection/protos/box_predictor.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/hyperparams.proto";
+import "research/object_detection/protos/hyperparams.proto";
 
 
 // Configuration proto for box predictor. See core/box_predictor.py for details.

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -2,12 +2,12 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/anchor_generator.proto";
-import "object_detection/protos/box_predictor.proto";
-import "object_detection/protos/hyperparams.proto";
-import "object_detection/protos/image_resizer.proto";
-import "object_detection/protos/losses.proto";
-import "object_detection/protos/post_processing.proto";
+import "research/object_detection/protos/anchor_generator.proto";
+import "research/object_detection/protos/box_predictor.proto";
+import "research/object_detection/protos/hyperparams.proto";
+import "research/object_detection/protos/image_resizer.proto";
+import "research/object_detection/protos/losses.proto";
+import "research/object_detection/protos/post_processing.proto";
 
 // Configuration for Faster R-CNN models.
 // See meta_architectures/faster_rcnn_meta_arch.py and models/model_builder.py

--- a/research/object_detection/protos/matcher.proto
+++ b/research/object_detection/protos/matcher.proto
@@ -2,8 +2,8 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/argmax_matcher.proto";
-import "object_detection/protos/bipartite_matcher.proto";
+import "research/object_detection/protos/argmax_matcher.proto";
+import "research/object_detection/protos/bipartite_matcher.proto";
 
 // Configuration proto for the matcher to be used in the object detection
 // pipeline. See core/matcher.py for details.

--- a/research/object_detection/protos/model.proto
+++ b/research/object_detection/protos/model.proto
@@ -2,8 +2,8 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/faster_rcnn.proto";
-import "object_detection/protos/ssd.proto";
+import "research/object_detection/protos/faster_rcnn.proto";
+import "research/object_detection/protos/ssd.proto";
 
 // Top level configuration for DetectionModels.
 message DetectionModel {

--- a/research/object_detection/protos/pipeline.proto
+++ b/research/object_detection/protos/pipeline.proto
@@ -2,10 +2,10 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/eval.proto";
-import "object_detection/protos/input_reader.proto";
-import "object_detection/protos/model.proto";
-import "object_detection/protos/train.proto";
+import "research/object_detection/protos/eval.proto";
+import "research/object_detection/protos/input_reader.proto";
+import "research/object_detection/protos/model.proto";
+import "research/object_detection/protos/train.proto";
 
 // Convenience message for configuring a training and eval pipeline. Allows all
 // of the pipeline parameters to be configured from one file.

--- a/research/object_detection/protos/ssd.proto
+++ b/research/object_detection/protos/ssd.proto
@@ -1,15 +1,15 @@
 syntax = "proto2";
 package object_detection.protos;
 
-import "object_detection/protos/anchor_generator.proto";
-import "object_detection/protos/box_coder.proto";
-import "object_detection/protos/box_predictor.proto";
-import "object_detection/protos/hyperparams.proto";
-import "object_detection/protos/image_resizer.proto";
-import "object_detection/protos/matcher.proto";
-import "object_detection/protos/losses.proto";
-import "object_detection/protos/post_processing.proto";
-import "object_detection/protos/region_similarity_calculator.proto";
+import "research/object_detection/protos/anchor_generator.proto";
+import "research/object_detection/protos/box_coder.proto";
+import "research/object_detection/protos/box_predictor.proto";
+import "research/object_detection/protos/hyperparams.proto";
+import "research/object_detection/protos/image_resizer.proto";
+import "research/object_detection/protos/matcher.proto";
+import "research/object_detection/protos/losses.proto";
+import "research/object_detection/protos/post_processing.proto";
+import "research/object_detection/protos/region_similarity_calculator.proto";
 
 // Configuration for Single Shot Detection (SSD) models.
 message Ssd {

--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -2,8 +2,8 @@ syntax = "proto2";
 
 package object_detection.protos;
 
-import "object_detection/protos/optimizer.proto";
-import "object_detection/protos/preprocessor.proto";
+import "research/object_detection/protos/optimizer.proto";
+import "research/object_detection/protos/preprocessor.proto";
 
 // Message for configuring DetectionModel training jobs (train.py).
 message TrainConfig {


### PR DESCRIPTION
Modified the paths for imported modules in object_detection, following the restructuring for the repository.

Without this commit, running this command fails:
$ protoc research/object_detection/protos/*.proto --python_out=.