### PR TITLE
fix #2470 : Create imagenet sub-dir only if does not exist

### DIFF
--- a/research/inception/inception/data/download_imagenet.sh
+++ b/research/inception/inception/data/download_imagenet.sh
@@ -39,7 +39,7 @@ END
 fi
 
 OUTDIR="${1:-./imagenet-data}"
-SYNSETS_FILE="${2:-./synsets.txt}"
+SYNSETS_FILE="$PWD/${2:-./synsets.txt}"
 
 echo "Saving downloaded files to $OUTDIR"
 mkdir -p "${OUTDIR}"

--- a/research/inception/inception/data/preprocess_imagenet_validation_data.py
+++ b/research/inception/inception/data/preprocess_imagenet_validation_data.py
@@ -69,7 +69,8 @@ if __name__ == '__main__':
   # Make all sub-directories in the validation data dir.
   for label in unique_labels:
     labeled_data_dir = os.path.join(data_dir, label)
-    os.makedirs(labeled_data_dir)
+    if not os.path.exists(labeled_data_dir):
+      os.makedirs(labeled_data_dir)
 
   # Move all of the image to the appropriate sub-directory.
   for i in range(len(labels)):


### PR DESCRIPTION
The imagenet download and preprocess script failed due to some bug in bazel file path parsing system. If I re-run the imagenet download and preprocess script, it throws an error saying-

OSError: [Errno 17] File exists:
because some of the dataset was previously extracted.

Ideally the script should only try to create a directory if it does not exist.

My commit fixes just this problem and has just one line of code added.