### PR TITLE
Fix invalid default_visibility specification.

### DIFF
--- a/research/slim/BUILD
+++ b/research/slim/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Contains files for loading, training and evaluating TF-Slim-based models.
 
-package(default_visibility = [":public"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
Without this change, Bazel will draw an error.
