### PR TITLE
Correct 3x3 convolutions to 5x5 convolutions

### DIFF
--- a/research/slim/nets/inception_v1.py
+++ b/research/slim/nets/inception_v1.py
@@ -89,7 +89,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 128, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 16, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 32, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 32, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 32, [1, 1], scope='Conv2d_0b_1x1')
@@ -107,7 +107,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 192, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 96, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 96, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
@@ -130,7 +130,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 208, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 16, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 48, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 48, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
@@ -148,7 +148,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 224, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 24, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 64, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
@@ -166,7 +166,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 256, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 24, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 64, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
@@ -184,7 +184,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 288, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 64, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
@@ -202,7 +202,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 320, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 128, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
@@ -225,7 +225,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 320, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0a_3x3')
+            branch_2 = slim.conv2d(branch_2, 128, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
@@ -243,7 +243,7 @@ def inception_v1_base(inputs,
             branch_1 = slim.conv2d(branch_1, 384, [3, 3], scope='Conv2d_0b_3x3')
           with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 48, [1, 1], scope='Conv2d_0a_1x1')
-            branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0b_3x3')
+            branch_2 = slim.conv2d(branch_2, 128, [5, 5], scope='Conv2d_0b_5x5')
           with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')

--- a/research/slim/nets/inception_v1_test.py
+++ b/research/slim/nets/inception_v1_test.py
@@ -114,7 +114,7 @@ class InceptionV1Test(tf.test.TestCase):
       inception.inception_v1_base(inputs)
     total_params, _ = slim.model_analyzer.analyze_vars(
         slim.get_model_variables())
-    self.assertAlmostEqual(5607184, total_params)
+    self.assertAlmostEqual(5988112, total_params)
 
   def testHalfSizeImages(self):
     batch_size = 5


### PR DESCRIPTION
Fixes #2545 

This PR corrects the 3x3 convolutions to 5x5 convolutions in Inception v1.

I have run the tests in `inception_v1_test.py` and ensured that they pass following these changes.