### PR TITLE
Fix flags issue in cifar10 example

### DIFF
--- a/tutorials/image/cifar10/cifar10_eval.py
+++ b/tutorials/image/cifar10/cifar10_eval.py
@@ -43,24 +43,22 @@ import tensorflow as tf
 
 import cifar10
 
-parser = cifar10.parser
-
-parser.add_argument('--eval_dir', type=str, default='/tmp/cifar10_eval',
+tf.flags._global_parser.add_argument('--eval_dir', type=str, default='/tmp/cifar10_eval',
                     help='Directory where to write event logs.')
 
-parser.add_argument('--eval_data', type=str, default='test',
+tf.flags._global_parser.add_argument('--eval_data', type=str, default='test',
                     help='Either `test` or `train_eval`.')
 
-parser.add_argument('--checkpoint_dir', type=str, default='/tmp/cifar10_train',
+tf.flags._global_parser.add_argument('--checkpoint_dir', type=str, default='/tmp/cifar10_train',
                     help='Directory where to read model checkpoints.')
 
-parser.add_argument('--eval_interval_secs', type=int, default=60*5,
+tf.flags._global_parser.add_argument('--eval_interval_secs', type=int, default=60*5,
                     help='How often to run the eval.')
 
-parser.add_argument('--num_examples', type=int, default=10000,
+tf.flags._global_parser.add_argument('--num_examples', type=int, default=10000,
                     help='Number of examples to run.')
 
-parser.add_argument('--run_once', type=bool, default=False,
+tf.flags._global_parser.add_argument('--run_once', type=bool, default=False,
                     help='Whether to run eval only once.')
 
 
@@ -159,5 +157,5 @@ def main(argv=None):  # pylint: disable=unused-argument
 
 
 if __name__ == '__main__':
-  FLAGS = parser.parse_args()
+  FLAGS = tf.flags._global_parser.parse_args()
   tf.app.run()

--- a/tutorials/image/cifar10/cifar10_multi_gpu_train.py
+++ b/tutorials/image/cifar10/cifar10_multi_gpu_train.py
@@ -49,18 +49,16 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 import cifar10
 
-parser = cifar10.parser
-
-parser.add_argument('--train_dir', type=str, default='/tmp/cifar10_train',
+tf.flags._global_parser.add_argument('--train_dir', type=str, default='/tmp/cifar10_train',
                     help='Directory where to write event logs and checkpoint.')
 
-parser.add_argument('--max_steps', type=int, default=1000000,
+tf.flags._global_parser.add_argument('--max_steps', type=int, default=1000000,
                     help='Number of batches to run.')
 
-parser.add_argument('--num_gpus', type=int, default=1,
+tf.flags._global_parser.add_argument('--num_gpus', type=int, default=1,
                     help='How many GPUs to use.')
 
-parser.add_argument('--log_device_placement', type=bool, default=False,
+tf.flags._global_parser.add_argument('--log_device_placement', type=bool, default=False,
                     help='Whether to log device placement.')
 
 
@@ -276,5 +274,5 @@ def main(argv=None):  # pylint: disable=unused-argument
 
 
 if __name__ == '__main__':
-  FLAGS = parser.parse_args()
+  FLAGS = tf.flags._global_parser.parse_args()
   tf.app.run()

--- a/tutorials/image/cifar10/cifar10_train.py
+++ b/tutorials/image/cifar10/cifar10_train.py
@@ -43,20 +43,17 @@ import tensorflow as tf
 
 import cifar10
 
-parser = cifar10.parser
-
-parser.add_argument('--train_dir', type=str, default='/tmp/cifar10_train',
+tf.flags._global_parser.add_argument('--train_dir', type=str, default='/tmp/cifar10_train',
                     help='Directory where to write event logs and checkpoint.')
 
-parser.add_argument('--max_steps', type=int, default=1000000,
+tf.flags._global_parser.add_argument('--max_steps', type=int, default=1000000,
                     help='Number of batches to run.')
 
-parser.add_argument('--log_device_placement', type=bool, default=False,
+tf.flags._global_parser.add_argument('--log_device_placement', type=bool, default=False,
                     help='Whether to log device placement.')
 
-parser.add_argument('--log_frequency', type=int, default=10,
+tf.flags._global_parser.add_argument('--log_frequency', type=int, default=10,
                     help='How often to log results to the console.')
-
 
 def train():
   """Train CIFAR-10 for a number of steps."""
@@ -126,5 +123,5 @@ def main(argv=None):  # pylint: disable=unused-argument
 
 
 if __name__ == '__main__':
-  FLAGS = parser.parse_args()
+  FLAGS = tf.flags._global_parser.parse_args()
   tf.app.run()


### PR DESCRIPTION
The way flags were handled actually did not allow to pass the `--train_dir` parameter to the script `cifar10_train.py` because the flags were parsed in `cifar10.py` before this argument was added.

I use explicitly the `tf.flags._global_parser` as parser and I am able to pass both the `--train_dir` and the `--data_dir` parameters to the script `cifar10_train.py`.