### PR TITLE
Prevent analogy() from printing spurious "unknown"

### DIFF
--- a/tutorials/embedding/word2vec.py
+++ b/tutorials/embedding/word2vec.py
@@ -482,7 +482,7 @@ class Word2Vec(object):
     for c in [self._id2word[i] for i in idx[0, :]]:
       if c not in [w0, w1, w2]:
         print(c)
-        break
+        return
     print("unknown")
 
   def nearby(self, words, num=20):


### PR DESCRIPTION
Example word2vec code was break-ing instead of returning when candidate was found, making the "unknown" error message show regardless.