### PR TITLE
no need for django and flask in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,14 +49,6 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
 # Scrapy stuff:
 .scrapy
 


### PR DESCRIPTION
you have copied and pasted from [Python .gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore) without filtering the useless lines

there is no need for flask and django .gitignore code

this is not a django or flask project