### PR TITLE
fixes #2626 as Tuple Parameter Unpacking is removed from Python 3

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -289,8 +289,9 @@ def draw_bounding_boxes_on_image_tensors(images,
       agnostic_mode=False,
       line_thickness=4)
 
-  def draw_boxes((image, boxes, classes, scores)):
+  def draw_boxes(image_boxes_classes_scores):
     """Draws boxes on image."""
+    (image, boxes, classes, scores) = image_boxes_classes_scores
     image_with_boxes = tf.py_func(visualize_boxes_fn,
                                   [image, boxes, classes, scores], tf.uint8)
     return image_with_boxes


### PR DESCRIPTION
Also fixes issue #2628 

Fix was done according to https://www.python.org/dev/peps/pep-3113/#transition-plan