### PR TITLE
comment out deps on "//tensorflow"

### DIFF
--- a/research/slim/BUILD
+++ b/research/slim/BUILD
@@ -13,7 +13,7 @@ py_library(
     name = "dataset_utils",
     srcs = ["datasets/dataset_utils.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -36,7 +36,7 @@ py_binary(
     srcs = ["datasets/build_imagenet_data.py"],
     deps = [
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -46,7 +46,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -55,7 +55,7 @@ py_library(
     srcs = ["datasets/download_and_convert_flowers.py"],
     deps = [
         ":dataset_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -65,7 +65,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -76,7 +76,7 @@ py_binary(
         ":download_and_convert_cifar10",
         ":download_and_convert_flowers",
         ":download_and_convert_mnist",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -85,7 +85,7 @@ py_binary(
     srcs = ["datasets/cifar10.py"],
     deps = [
         ":dataset_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -94,7 +94,7 @@ py_binary(
     srcs = ["datasets/flowers.py"],
     deps = [
         ":dataset_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -103,7 +103,7 @@ py_binary(
     srcs = ["datasets/imagenet.py"],
     deps = [
         ":dataset_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -112,7 +112,7 @@ py_binary(
     srcs = ["datasets/mnist.py"],
     deps = [
         ":dataset_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -131,7 +131,7 @@ py_library(
     name = "model_deploy",
     srcs = ["deployment/model_deploy.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -142,7 +142,7 @@ py_test(
     deps = [
         ":model_deploy",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -150,7 +150,7 @@ py_library(
     name = "cifarnet_preprocessing",
     srcs = ["preprocessing/cifarnet_preprocessing.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -158,8 +158,8 @@ py_library(
     name = "inception_preprocessing",
     srcs = ["preprocessing/inception_preprocessing.py"],
     deps = [
-        "//tensorflow",
-        "//tensorflow/python:control_flow_ops",
+        # "//tensorflow",
+        # "//tensorflow/python:control_flow_ops",
     ],
 )
 
@@ -167,7 +167,7 @@ py_library(
     name = "lenet_preprocessing",
     srcs = ["preprocessing/lenet_preprocessing.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -175,7 +175,7 @@ py_library(
     name = "vgg_preprocessing",
     srcs = ["preprocessing/vgg_preprocessing.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -187,7 +187,7 @@ py_library(
         ":inception_preprocessing",
         ":lenet_preprocessing",
         ":vgg_preprocessing",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -215,7 +215,9 @@ py_library(
     name = "alexnet",
     srcs = ["nets/alexnet.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -225,7 +227,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":alexnet",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -233,7 +235,7 @@ py_library(
     name = "cifarnet",
     srcs = ["nets/cifarnet.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -242,7 +244,7 @@ py_library(
     srcs = ["nets/cyclegan.py"],
     deps = [
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -253,7 +255,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":cyclegan",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -261,7 +263,7 @@ py_library(
     name = "dcgan",
     srcs = ["nets/dcgan.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -272,7 +274,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":dcgan",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -293,7 +295,9 @@ py_library(
     name = "inception_utils",
     srcs = ["nets/inception_utils.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_library(
@@ -302,7 +306,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":inception_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -312,7 +316,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":inception_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -322,7 +326,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":inception_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -332,7 +336,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":inception_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -340,7 +344,9 @@ py_library(
     name = "inception_resnet_v2",
     srcs = ["nets/inception_resnet_v2.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -352,7 +358,7 @@ py_test(
     deps = [
         ":inception",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -365,7 +371,7 @@ py_test(
     deps = [
         ":inception",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -378,7 +384,7 @@ py_test(
     deps = [
         ":inception",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -390,7 +396,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -402,7 +408,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -410,7 +416,7 @@ py_library(
     name = "lenet",
     srcs = ["nets/lenet.py"],
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -418,7 +424,9 @@ py_library(
     name = "mobilenet_v1",
     srcs = ["nets/mobilenet_v1.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -430,7 +438,7 @@ py_test(
     deps = [
         ":mobilenet_v1",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -439,7 +447,7 @@ py_library(
     srcs = ["nets/nasnet/nasnet_utils.py"],
     srcs_version = "PY2AND3",
     deps = [
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -449,7 +457,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":nasnet_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -460,7 +468,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":nasnet_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -472,7 +480,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":nasnet",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -480,7 +488,9 @@ py_library(
     name = "overfeat",
     srcs = ["nets/overfeat.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -490,7 +500,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":overfeat",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -498,7 +508,9 @@ py_library(
     name = "pix2pix",
     srcs = ["nets/pix2pix.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -507,7 +519,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":pix2pix",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -515,7 +527,9 @@ py_library(
     name = "resnet_utils",
     srcs = ["nets/resnet_utils.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_library(
@@ -524,7 +538,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":resnet_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -538,7 +552,7 @@ py_test(
         ":resnet_utils",
         ":resnet_v1",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -548,7 +562,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":resnet_utils",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -562,7 +576,7 @@ py_test(
         ":resnet_utils",
         ":resnet_v2",
         # "//numpy",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -570,7 +584,9 @@ py_library(
     name = "vgg",
     srcs = ["nets/vgg.py"],
     srcs_version = "PY2AND3",
-    deps = ["//tensorflow"],
+    deps = [
+        # "//tensorflow"
+    ],
 )
 
 py_test(
@@ -580,7 +596,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":vgg",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -589,7 +605,7 @@ py_library(
     srcs = ["nets/nets_factory.py"],
     deps = [
         ":nets",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -601,7 +617,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":nets_factory",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -613,7 +629,7 @@ py_binary(
         ":model_deploy",
         ":nets_factory",
         ":preprocessing_factory",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -624,7 +640,7 @@ py_binary(
         ":dataset_factory",
         ":nets_factory",
         ":preprocessing_factory",
-        "//tensorflow",
+        # "//tensorflow",
     ],
 )
 
@@ -634,8 +650,8 @@ py_binary(
     deps = [
         ":dataset_factory",
         ":nets_factory",
-        "//tensorflow",
-        "//tensorflow/python:platform",
+        # "//tensorflow",
+        # "//tensorflow/python:platform",
     ],
 )
 
@@ -649,7 +665,7 @@ py_test(
     ],
     deps = [
         ":export_inference_graph",
-        "//tensorflow",
-        "//tensorflow/python:platform",
+        # "//tensorflow",
+        # "//tensorflow/python:platform",
     ],
 )


### PR DESCRIPTION
There are several py_library(), py_binary() and py_test() claimed deps on "//tensorflow" explicitly. This causes the BUILD failed. This is discussed in the issue submitted earlier at [tensorflow/models 2571](https://github.com/tensorflow/models/issues/2571).

As my understanding, the `deps = [ "//tensorflow" ]` is looking for a directory tensorflow under the slim, which doesn't exist. Remove the deps fixed the issue, as long as the tensorflow is built and available.

Another approach might define the tensorflow library in workspace, by linking it to outside github repo? However, in this way, it could lead to replicated tensorflow modules?

Thank you.