### PR TITLE
Attention OCR: Add missing is_training to batch_norm and dropout

### DIFF
--- a/research/attention_ocr/python/model.py
+++ b/research/attention_ocr/python/model.py
@@ -201,9 +201,11 @@ class Model(object):
     with tf.variable_scope('conv_tower_fn/INCE'):
       if reuse:
         tf.get_variable_scope().reuse_variables()
-      with slim.arg_scope(inception.inception_v3_arg_scope()):
-        net, _ = inception.inception_v3_base(
-            images, final_endpoint=mparams.final_endpoint)
+      with slim.arg_scope(
+        [slim.batch_norm, slim.dropout], is_training=is_training):  
+          with slim.arg_scope(inception.inception_v3_arg_scope()):
+            net, _ = inception.inception_v3_base(
+                images, final_endpoint=mparams.final_endpoint)
       return net
 
   def _create_lstm_inputs(self, net):


### PR DESCRIPTION
In the current implementation the inception_v3_base was not using is_training variable somehow. So the model mistakenly used batch normalization and dropout for inference time.