### PR TITLE
Update nasnet_utils.py

### DIFF
--- a/research/slim/nets/nasnet/nasnet_utils.py
+++ b/research/slim/nets/nasnet/nasnet_utils.py
@@ -411,7 +411,7 @@ class NasNetABaseCell(object):
         tf.summary.scalar('layer_ratio', layer_ratio)
       drop_path_keep_prob = 1 - layer_ratio * (1 - drop_path_keep_prob)
       # Decrease the keep probability over time
-      current_step = tf.cast(tf.contrib.framework.get_or_create_global_step(),
+      current_step = tf.cast(tf.train.get_or_create_global_step(),
                              tf.float32)
       drop_path_burn_in_steps = self._total_training_steps
       current_ratio = (


### PR DESCRIPTION
Fix warning message (tf version 1.4.0): 
```
WARNING:tensorflow:From nasnet_utils.py:414: get_or_create_global_step (from tensorflow.contrib.framework.python.ops.variables) is deprecated and will be removed in a future version.
Instructions for updating:
Please switch to tf.train.get_or_create_global_step
```