### PR TITLE
Fix unrecognized arguments

### DIFF
--- a/tutorials/image/cifar10/cifar10.py
+++ b/tutorials/image/cifar10/cifar10.py
@@ -58,7 +58,7 @@ parser.add_argument('--data_dir', type=str, default='/tmp/cifar10_data',
 parser.add_argument('--use_fp16', type=bool, default=False,
                     help='Train the model using fp16.')
 
-FLAGS = parser.parse_args()
+FLAGS, _ = parser.parse_known_args()
 
 # Global constants describing the CIFAR-10 data set.
 IMAGE_SIZE = cifar10_input.IMAGE_SIZE


### PR DESCRIPTION
Fix unrecognized arguments when run with arguments defined in cifar10_train or cifar10_eval