### PR TITLE
Add autograd v1.1.13 dependency to manual install

### DIFF
--- a/research/syntaxnet/README.md
+++ b/research/syntaxnet/README.md
@@ -111,6 +111,8 @@ source. You'll need to install:
     *   `pip install asciitree`
 *   numpy, package for scientific computing:
     *   `pip install numpy`
+*   autograd 1.1.13, for automatic differentiation (not yet compatible with autograd v1.2 rewrite):
+    *   `pip install autograd==1.1.13`
 *   pygraphviz to visualize traces and parse trees:
     *   `apt-get install -y graphviz libgraphviz-dev`
     *   `pip install pygraphviz


### PR DESCRIPTION
New bulk component tests fail with the latest version of autograd (1.2), which was rewritten and no longer contains the `containers` module. They pass with v1.1.13, which is the latest pre-1.2 version available in pip.