### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/research/attention_ocr/python/datasets/__init__.py
+++ b/research/attention_ocr/python/datasets/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2017 The TensorFlow Authors All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import fsns
-import fsns_test
+from . import fsns
+from . import fsns_test
 
 __all__ = [fsns, fsns_test]

--- a/research/attention_ocr/python/datasets/fsns_test.py
+++ b/research/attention_ocr/python/datasets/fsns_test.py
@@ -14,14 +14,15 @@
 # ==============================================================================
 
 """Tests for FSNS datasets module."""
+from __future__ import absolute_import
 
 import collections
 import os
 import tensorflow as tf
 from tensorflow.contrib import slim
 
-import fsns
-import unittest_utils
+from . import fsns
+from . import unittest_utils
 
 FLAGS = tf.flags.FLAGS
 

--- a/research/attention_ocr/python/datasets/unittest_utils_test.py
+++ b/research/attention_ocr/python/datasets/unittest_utils_test.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 
 """Tests for unittest_utils."""
+from __future__ import absolute_import
 import StringIO
 
 import numpy as np
 from PIL import Image as PILImage
 import tensorflow as tf
 
-import unittest_utils
+from . import unittest_utils
 
 
 class UnittestUtilsTest(tf.test.TestCase):

--- a/research/attention_ocr/python/demo_inference.py
+++ b/research/attention_ocr/python/demo_inference.py
@@ -15,6 +15,7 @@ python demo_inference.py --batch_size=32 \
   --checkpoint=model.ckpt-399731\
   --image_path_pattern=./datasets/data/fsns/temp/fsns_train_%02d.png
 """
+from __future__ import print_function
 import numpy as np
 import PIL.Image
 

--- a/research/cognitive_mapping_and_planning/scripts/script_distill.py
+++ b/research/cognitive_mapping_and_planning/scripts/script_distill.py
@@ -26,6 +26,7 @@ blaze build --define=ION_GFX_OGLES20=1 -c opt --copt=-mavx --config=cuda_clang \
   --config_name 'v0+train' --gfs_user robot-intelligence-gpu
 
 """
+from __future__ import print_function
 import sys, os, numpy as np
 import copy
 import argparse, pprint

--- a/research/cognitive_mapping_and_planning/scripts/script_env_vis.py
+++ b/research/cognitive_mapping_and_planning/scripts/script_env_vis.py
@@ -17,6 +17,7 @@
 PYTHONPATH='.' PYOPENGL_PLATFORM=egl python scripts/script_env_vis.py \
   --dataset_name sbpd --building_name area3
 """
+from __future__ import print_function
 import sys
 import numpy as np
 import matplotlib
@@ -90,7 +91,7 @@ def walk_through(b):
 
   root = tk.Tk()
   image = b.render_nodes(b.task.nodes[[current_node],:])[0]
-  print image.shape
+  print(image.shape)
   image = image.astype(np.uint8)
   im = Image.fromarray(image)
   im = ImageTk.PhotoImage(im)

--- a/research/cognitive_mapping_and_planning/scripts/script_plot_trajectory.py
+++ b/research/cognitive_mapping_and_planning/scripts/script_plot_trajectory.py
@@ -24,6 +24,7 @@ to plot the view points.
       --imset test --alsologtostderr --base_dir output --out_dir vis
 
 """
+from __future__ import print_function
 import os, sys, numpy as np, copy
 import matplotlib
 matplotlib.use("Agg")
@@ -265,7 +266,7 @@ def plot_trajectory_first_person(dt, orig_maps, out_dir):
     tmp_file_name = 'tmp.mp4'
     line_ani.save(tmp_file_name, writer=writer, savefig_kwargs={'facecolor':'black'})
     out_file_name = os.path.join(out_dir, 'vis_{:04d}.mp4'.format(i))
-    print out_file_name
+    print(out_file_name)
 
     if fu.exists(out_file_name):
       gfile.Remove(out_file_name)
@@ -318,7 +319,7 @@ def plot_trajectory(dt, hardness, orig_maps, out_dir):
     ax.set_ylim([xy1[1], xy2[1]])
     
     file_name = os.path.join(out_dir, 'trajectory_{:04d}.png'.format(i))
-    print file_name
+    print(file_name)
     with fu.fopen(file_name, 'w') as f: 
       plt.savefig(f)
     plt.close(fig)

--- a/research/cognitive_mapping_and_planning/src/utils.py
+++ b/research/cognitive_mapping_and_planning/src/utils.py
@@ -15,6 +15,7 @@
 
 r"""Generaly Utilities.
 """
+from __future__ import print_function
 
 import numpy as np, cPickle, os, time
 import src.file_utils as fu
@@ -93,12 +94,12 @@ def tic_toc_print(interval, string):
   global tic_toc_print_time_old
   if 'tic_toc_print_time_old' not in globals():
     tic_toc_print_time_old = time.time()
-    print string
+    print(string)
   else:
     new_time = time.time()
     if new_time - tic_toc_print_time_old > interval:
       tic_toc_print_time_old = new_time;
-      print string
+      print(string)
 
 def mkdir_if_missing(output_dir):
   if not fu.exists(output_dir):

--- a/research/compression/entropy_coder/all_models/all_models_test.py
+++ b/research/compression/entropy_coder/all_models/all_models_test.py
@@ -14,11 +14,13 @@
 # ==============================================================================
 
 """Basic test of all registered models."""
+from __future__ import print_function
+from __future__ import absolute_import
 
 import tensorflow as tf
 
 # pylint: disable=unused-import
-import all_models
+from . import all_models
 # pylint: enable=unused-import
 from entropy_coder.model import model_factory
 

--- a/research/compression/entropy_coder/core/entropy_coder_single.py
+++ b/research/compression/entropy_coder/core/entropy_coder_single.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Compute the additional compression ratio after entropy coding."""
+from __future__ import print_function
 
 import io
 import os
@@ -58,7 +59,7 @@ def main(_):
   #iteration = FLAGS.iteration
 
   if not tf.gfile.Exists(FLAGS.input_codes):
-    print '\nInput codes not found.\n'
+    print('\nInput codes not found.\n')
     return
 
   with tf.gfile.FastGFile(FLAGS.input_codes, 'rb') as code_file:

--- a/research/compression/entropy_coder/core/entropy_coder_train.py
+++ b/research/compression/entropy_coder/core/entropy_coder_train.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Train an entropy coder model."""
+from __future__ import print_function
 
 import time
 
@@ -171,7 +172,7 @@ def train():
               'code_length': model.average_code_length
           }
           np_tensors = sess.run(tf_tensors, feed_dict=feed_dict)
-          print np_tensors['code_length']
+          print(np_tensors['code_length'])
 
       sv.Stop()
 

--- a/research/compression/entropy_coder/lib/blocks.py
+++ b/research/compression/entropy_coder/lib/blocks.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2017 The TensorFlow Authors All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +14,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from block_base import *
-from block_util import *
-from blocks_binarizer import *
-from blocks_entropy_coding import *
-from blocks_lstm import *
-from blocks_masked_conv2d import *
-from blocks_masked_conv2d_lstm import *
-from blocks_operator import *
-from blocks_std import *
+from .block_base import *
+from .block_util import *
+from .blocks_binarizer import *
+from .blocks_entropy_coding import *
+from .blocks_lstm import *
+from .blocks_masked_conv2d import *
+from .blocks_masked_conv2d_lstm import *
+from .blocks_operator import *
+from .blocks_std import *

--- a/research/compression/entropy_coder/lib/blocks_entropy_coding.py
+++ b/research/compression/entropy_coder/lib/blocks_entropy_coding.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 """Set of blocks related to entropy coding."""
+from __future__ import absolute_import
 
 import math
 
 import tensorflow as tf
 
-import block_base
+from . import block_base
 
 # pylint does not recognize block_base.BlockBase.__call__().
 # pylint: disable=not-callable

--- a/research/compression/entropy_coder/lib/blocks_entropy_coding_test.py
+++ b/research/compression/entropy_coder/lib/blocks_entropy_coding_test.py
@@ -17,13 +17,14 @@
 
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 import math
 
 import numpy as np
 import tensorflow as tf
 
-import blocks_entropy_coding
+from . import blocks_entropy_coding
 
 
 class BlocksEntropyCodingTest(tf.test.TestCase):

--- a/research/compression/entropy_coder/lib/blocks_lstm.py
+++ b/research/compression/entropy_coder/lib/blocks_lstm.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 
 """Blocks of LSTM and its variants."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import block_base
-import block_util
-import blocks_std
+from . import block_base
+from . import block_util
+from . import blocks_std
 
 # pylint does not recognize block_base.BlockBase.__call__().
 # pylint: disable=not-callable

--- a/research/compression/entropy_coder/lib/blocks_lstm_test.py
+++ b/research/compression/entropy_coder/lib/blocks_lstm_test.py
@@ -15,13 +15,14 @@
 
 """Tests for LSTM tensorflow blocks."""
 from __future__ import division
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import block_base
-import blocks_std
-import blocks_lstm
+from . import block_base
+from . import blocks_std
+from . import blocks_lstm
 
 
 class BlocksLSTMTest(tf.test.TestCase):

--- a/research/compression/entropy_coder/lib/blocks_masked_conv2d.py
+++ b/research/compression/entropy_coder/lib/blocks_masked_conv2d.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 """Define some typical masked 2D convolutions."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import block_util
-import blocks_std
+from . import block_util
+from . import blocks_std
 
 # pylint does not recognize block_base.BlockBase.__call__().
 # pylint: disable=not-callable

--- a/research/compression/entropy_coder/lib/blocks_masked_conv2d_lstm.py
+++ b/research/compression/entropy_coder/lib/blocks_masked_conv2d_lstm.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 """Masked conv2d LSTM."""
+from __future__ import absolute_import
 
-import block_base
-import block_util
-import blocks_masked_conv2d
-import blocks_lstm
-import blocks_std
+from . import block_base
+from . import block_util
+from . import blocks_masked_conv2d
+from . import blocks_lstm
+from . import blocks_std
 
 # pylint: disable=not-callable
 

--- a/research/compression/entropy_coder/lib/blocks_masked_conv2d_test.py
+++ b/research/compression/entropy_coder/lib/blocks_masked_conv2d_test.py
@@ -17,11 +17,12 @@
 
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import blocks_masked_conv2d
+from . import blocks_masked_conv2d
 
 
 class MaskedConv2DTest(tf.test.TestCase):

--- a/research/compression/entropy_coder/lib/blocks_operator.py
+++ b/research/compression/entropy_coder/lib/blocks_operator.py
@@ -14,10 +14,11 @@
 # ==============================================================================
 
 """Common blocks which work as operators on other blocks."""
+from __future__ import absolute_import
 
 import tensorflow as tf
 
-import block_base
+from . import block_base
 
 # pylint: disable=not-callable
 

--- a/research/compression/entropy_coder/lib/blocks_operator_test.py
+++ b/research/compression/entropy_coder/lib/blocks_operator_test.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 """Tests of the block operators."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import block_base
-import blocks_operator
+from . import block_base
+from . import blocks_operator
 
 
 class AddOneBlock(block_base.BlockBase):

--- a/research/compression/entropy_coder/lib/blocks_std.py
+++ b/research/compression/entropy_coder/lib/blocks_std.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 
 """Basic blocks for building tensorflow models."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import block_base
-import block_util
+from . import block_base
+from . import block_util
 
 # pylint does not recognize block_base.BlockBase.__call__().
 # pylint: disable=not-callable

--- a/research/compression/entropy_coder/lib/blocks_std_test.py
+++ b/research/compression/entropy_coder/lib/blocks_std_test.py
@@ -17,6 +17,7 @@
 
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 import math
 import os
@@ -24,7 +25,7 @@ import os
 import numpy as np
 import tensorflow as tf
 
-import blocks_std
+from . import blocks_std
 
 
 def _NumpyConv2D(x, f, strides, padding, rate=1):

--- a/research/compression/image_encoder/decoder.py
+++ b/research/compression/image_encoder/decoder.py
@@ -21,6 +21,7 @@ Example usage:
 python decoder.py --input_codes=output_codes.pkl --iteration=15 \
 --output_directory=/tmp/compression_output/ --model=residual_gru.pb
 """
+from __future__ import print_function
 import io
 import os
 

--- a/research/compression/image_encoder/encoder.py
+++ b/research/compression/image_encoder/encoder.py
@@ -23,6 +23,7 @@ Example usage:
 python encoder.py --input_image=/your/image/here.png \
 --output_codes=output_codes.pkl --iteration=15 --model=residual_gru.pb
 """
+from __future__ import print_function
 import io
 import os
 

--- a/research/compression/image_encoder/msssim.py
+++ b/research/compression/image_encoder/msssim.py
@@ -21,6 +21,7 @@ Usage:
 
 python msssim.py --original_image=original.png --compared_image=distorted.png
 """
+from __future__ import print_function
 import numpy as np
 from scipy import signal
 from scipy.ndimage.filters import convolve

--- a/research/differential_privacy/multiple_teachers/analysis.py
+++ b/research/differential_privacy/multiple_teachers/analysis.py
@@ -38,6 +38,7 @@ python analysis.py
   --max_examples=1000
   --delta=1e-6
 """
+from __future__ import print_function
 import os
 import math
 import numpy as np
@@ -139,7 +140,7 @@ def logmgf_exact(q, priv_eps, l):
     try:
       log_t = math.log(t)
     except ValueError:
-      print "Got ValueError in math.log for values :" + str((q, priv_eps, l, t))
+      print("Got ValueError in math.log for values :" + str((q, priv_eps, l, t)))
       log_t = priv_eps * l
   else:
     log_t = priv_eps * l
@@ -171,7 +172,7 @@ def sens_at_k(counts, noise_eps, l, k):
   """
   counts_sorted = sorted(counts, reverse=True)
   if 0.5 * noise_eps * l > 1:
-    print "l too large to compute sensitivity"
+    print("l too large to compute sensitivity")
     return 0
   # Now we can assume that at k, gap remains positive
   # or we have reached the point where logmgf_exact is
@@ -268,8 +269,8 @@ def main(unused_argv):
   # Solving gives eps = (alpha - ln (delta))/l
   eps_list_nm = (total_log_mgf_nm - math.log(delta)) / l_list
 
-  print "Epsilons (Noisy Max): " + str(eps_list_nm)
-  print "Smoothed sensitivities (Noisy Max): " + str(total_ss_nm / l_list)
+  print("Epsilons (Noisy Max): " + str(eps_list_nm))
+  print("Smoothed sensitivities (Noisy Max): " + str(total_ss_nm / l_list))
 
   # If beta < eps / 2 ln (1/delta), then adding noise Lap(1) * 2 SS/eps
   # is eps,delta DP
@@ -280,12 +281,12 @@ def main(unused_argv):
   # Print the first one's scale
   ss_eps = 2.0 * beta * math.log(1/delta)
   ss_scale = 2.0 / ss_eps
-  print "To get an " + str(ss_eps) + "-DP estimate of epsilon, "
-  print "..add noise ~ " + str(ss_scale)
-  print "... times " + str(total_ss_nm / l_list)
-  print "Epsilon = " + str(min(eps_list_nm)) + "."
+  print("To get an " + str(ss_eps) + "-DP estimate of epsilon, ")
+  print("..add noise ~ " + str(ss_scale))
+  print("... times " + str(total_ss_nm / l_list))
+  print("Epsilon = " + str(min(eps_list_nm)) + ".")
   if min(eps_list_nm) == eps_list_nm[-1]:
-    print "Warning: May not have used enough values of l"
+    print("Warning: May not have used enough values of l")
 
   # Data independent bound, as mechanism is
   # 2*noise_eps DP.
@@ -294,7 +295,7 @@ def main(unused_argv):
       [logmgf_exact(1.0, 2.0 * noise_eps, l) for l in l_list])
 
   data_ind_eps_list = (data_ind_log_mgf - math.log(delta)) / l_list
-  print "Data independent bound = " + str(min(data_ind_eps_list)) + "."
+  print("Data independent bound = " + str(min(data_ind_eps_list)) + ".")
 
   return
 

--- a/research/differential_privacy/privacy_accountant/python/gaussian_moments.py
+++ b/research/differential_privacy/privacy_accountant/python/gaussian_moments.py
@@ -40,6 +40,7 @@ To verify that the I1 >= I2 (see comments in GaussianMomentsAccountant in
 accountant.py for the context), run the same loop above with verify=True
 passed to compute_log_moment.
 """
+from __future__ import print_function
 import math
 import sys
 
@@ -108,10 +109,10 @@ def compute_a(sigma, q, lmbd, verbose=False):
   a_lambda_exact = ((1.0 - q) * a_lambda_first_term_exact +
                     q * a_lambda_second_term_exact)
   if verbose:
-    print "A: by binomial expansion    {} = {} + {}".format(
+    print("A: by binomial expansion    {} = {} + {}".format(
         a_lambda_exact,
         (1.0 - q) * a_lambda_first_term_exact,
-        q * a_lambda_second_term_exact)
+        q * a_lambda_second_term_exact))
   return _to_np_float64(a_lambda_exact)
 
 
@@ -125,8 +126,8 @@ def compute_b(sigma, q, lmbd, verbose=False):
   b_fn = lambda z: (np.power(mu0(z) / mu(z), lmbd) -
                     np.power(mu(-z) / mu0(z), lmbd))
   if verbose:
-    print "M =", m
-    print "f(-M) = {} f(M) = {}".format(b_fn(-m), b_fn(m))
+    print("M =", m)
+    print("f(-M) = {} f(M) = {}".format(b_fn(-m), b_fn(m)))
     assert b_fn(-m) < 0 and b_fn(m) < 0
 
   b_lambda_int1_fn = lambda z: (mu0(z) *
@@ -140,9 +141,9 @@ def compute_b(sigma, q, lmbd, verbose=False):
   b_bound = a_lambda_m1 + b_int1 - b_int2
 
   if verbose:
-    print "B: by numerical integration", b_lambda
-    print "B must be no more than     ", b_bound
-  print b_lambda, b_bound
+    print("B: by numerical integration", b_lambda)
+    print("B must be no more than     ", b_bound)
+  print(b_lambda, b_bound)
   return _to_np_float64(b_lambda)
 
 
@@ -188,10 +189,10 @@ def compute_a_mp(sigma, q, lmbd, verbose=False):
   a_lambda_second_term = integral_inf_mp(a_lambda_second_term_fn)
 
   if verbose:
-    print "A: by numerical integration {} = {} + {}".format(
+    print("A: by numerical integration {} = {} + {}".format(
         a_lambda,
         (1 - q) * a_lambda_first_term,
-        q * a_lambda_second_term)
+        q * a_lambda_second_term))
 
   return _to_np_float64(a_lambda)
 
@@ -210,8 +211,8 @@ def compute_b_mp(sigma, q, lmbd, verbose=False):
   b_fn = lambda z: ((mu0(z) / mu(z)) ** lmbd_int -
                     (mu(-z) / mu0(z)) ** lmbd_int)
   if verbose:
-    print "M =", m
-    print "f(-M) = {} f(M) = {}".format(b_fn(-m), b_fn(m))
+    print("M =", m)
+    print("f(-M) = {} f(M) = {}".format(b_fn(-m), b_fn(m)))
     assert b_fn(-m) < 0 and b_fn(m) < 0
 
   b_lambda_int1_fn = lambda z: mu0(z) * (mu0(z) / mu(z)) ** lmbd_int
@@ -223,8 +224,8 @@ def compute_b_mp(sigma, q, lmbd, verbose=False):
   b_bound = a_lambda_m1 + b_int1 - b_int2
 
   if verbose:
-    print "B by numerical integration", b_lambda
-    print "B must be no more than    ", b_bound
+    print("B by numerical integration", b_lambda)
+    print("B must be no more than    ", b_bound)
   assert b_lambda < b_bound + 1e-5
   return _to_np_float64(b_lambda)
 

--- a/research/domain_adaptation/domain_separation/dsn.py
+++ b/research/domain_adaptation/domain_separation/dsn.py
@@ -23,13 +23,14 @@ Specifically, in this file we define the:
   - Reconstruction Loss Module
   - Task Loss Module
 """
+from __future__ import absolute_import
 from functools import partial
 
 import tensorflow as tf
 
-import losses
-import models
-import utils
+from . import losses
+from . import models
+from . import utils
 
 slim = tf.contrib.slim
 

--- a/research/domain_adaptation/domain_separation/dsn_test.py
+++ b/research/domain_adaptation/domain_separation/dsn_test.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for DSN model assembly functions."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
-import dsn
+from . import dsn
 
 
 class HelperFunctionsTest(tf.test.TestCase):

--- a/research/domain_adaptation/domain_separation/dsn_train.py
+++ b/research/domain_adaptation/domain_separation/dsn_train.py
@@ -15,11 +15,12 @@
 
 """Training for Domain Separation Networks (DSNs)."""
 from __future__ import division
+from __future__ import absolute_import
 
 import tensorflow as tf
 
 from domain_adaptation.datasets import dataset_factory
-import dsn
+from . import dsn
 
 slim = tf.contrib.slim
 FLAGS = tf.app.flags.FLAGS

--- a/research/domain_adaptation/domain_separation/grl_ops_test.py
+++ b/research/domain_adaptation/domain_separation/grl_ops_test.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 
 """Tests for grl_ops."""
+from __future__ import absolute_import
 
 #from models.domain_adaptation.domain_separation import grl_op_grads  # pylint: disable=unused-import
 #from models.domain_adaptation.domain_separation import grl_op_shapes  # pylint: disable=unused-import
 import tensorflow as tf
 
-import grl_op_grads
-import grl_ops
+from . import grl_op_grads
+from . import grl_ops
 
 FLAGS = tf.app.flags.FLAGS
 

--- a/research/domain_adaptation/domain_separation/losses.py
+++ b/research/domain_adaptation/domain_separation/losses.py
@@ -24,13 +24,14 @@ The following domain adaptation loss functions are defined:
 
 - Correlation Loss on a batch.
 """
+from __future__ import absolute_import
 from functools import partial
 import tensorflow as tf
 
-import grl_op_grads  # pylint: disable=unused-import
-import grl_op_shapes  # pylint: disable=unused-import
-import grl_ops
-import utils
+from . import grl_op_grads  # pylint: disable=unused-import
+from . import grl_op_shapes  # pylint: disable=unused-import
+from . import grl_ops
+from . import utils
 slim = tf.contrib.slim
 
 

--- a/research/domain_adaptation/domain_separation/losses_test.py
+++ b/research/domain_adaptation/domain_separation/losses_test.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for DSN losses."""
+from __future__ import absolute_import
 from functools import partial
 
 import numpy as np
 import tensorflow as tf
 
-import losses
-import utils
+from . import losses
+from . import utils
 
 
 def MaximumMeanDiscrepancySlow(x, y, sigmas):

--- a/research/domain_adaptation/domain_separation/models.py
+++ b/research/domain_adaptation/domain_separation/models.py
@@ -20,10 +20,11 @@ model.
 - private encoder (default_encoder)
 - decoder (large_decoder, gtsrb_decoder, small_decoder)
 """
+from __future__ import absolute_import
 import tensorflow as tf
 
 #from models.domain_adaptation.domain_separation
-import utils
+from . import utils
 
 slim = tf.contrib.slim
 

--- a/research/domain_adaptation/domain_separation/models_test.py
+++ b/research/domain_adaptation/domain_separation/models_test.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for DSN components."""
+from __future__ import absolute_import
 
 import numpy as np
 import tensorflow as tf
 
 #from models.domain_adaptation.domain_separation
-import models
+from . import models
 
 
 class SharedEncodersTest(tf.test.TestCase):

--- a/research/im2txt/im2txt/evaluate.py
+++ b/research/im2txt/im2txt/evaluate.py
@@ -143,7 +143,7 @@ def run_once(model, saver, summary_writer, summary_op):
           global_step=global_step,
           summary_writer=summary_writer,
           summary_op=summary_op)
-    except Exception, e:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
       tf.logging.error("Evaluation failed.")
       coord.request_stop(e)
 

--- a/research/lm_1b/data_utils.py
+++ b/research/lm_1b/data_utils.py
@@ -185,7 +185,7 @@ def get_batch(generator, batch_size, num_steps, max_word_length, pad=False):
       while cur_pos < num_steps:
         if cur_stream[i] is None or len(cur_stream[i][0]) <= 1:
           try:
-            cur_stream[i] = list(generator.next())
+            cur_stream[i] = list(next(generator))
           except StopIteration:
             # No more data, exhaust current streams and quit
             no_more_data = True

--- a/research/neural_gpu/neural_gpu.py
+++ b/research/neural_gpu/neural_gpu.py
@@ -500,8 +500,10 @@ class NeuralGPU(object):
             return tf.reduce_sum(encoder_outputs * tf.expand_dims(mask, 2), 1)
 
           with tf.variable_scope("decoder"):
-            def decoder_loop_fn((state, prev_cell_out, _), (cell_inp, cur_tgt)):
+            def decoder_loop_fn(xxx_todo_changeme, xxx_todo_changeme1):
               """Decoder loop function."""
+              (state, prev_cell_out, _) = xxx_todo_changeme
+              (cell_inp, cur_tgt) = xxx_todo_changeme1
               attn_q = tf.layers.dense(prev_cell_out, height * nmaps,
                                        name="attn_query")
               attn_res = attention_query(attn_q, tf.get_variable(

--- a/research/neural_gpu/neural_gpu.py
+++ b/research/neural_gpu/neural_gpu.py
@@ -500,10 +500,10 @@ class NeuralGPU(object):
             return tf.reduce_sum(encoder_outputs * tf.expand_dims(mask, 2), 1)
 
           with tf.variable_scope("decoder"):
-            def decoder_loop_fn(xxx_todo_changeme, xxx_todo_changeme1):
+            def decoder_loop_fn(state__prev_cell_out__ignore, cell_inp__cur_tgt):
               """Decoder loop function."""
-              (state, prev_cell_out, _) = xxx_todo_changeme
-              (cell_inp, cur_tgt) = xxx_todo_changeme1
+              (state, prev_cell_out, _) = state__prev_cell_out__ignore
+              (cell_inp, cur_tgt) = cell_inp__cur_tgt
               attn_q = tf.layers.dense(prev_cell_out, height * nmaps,
                                        name="attn_query")
               attn_res = attention_query(attn_q, tf.get_variable(

--- a/research/neural_gpu/neural_gpu_trainer.py
+++ b/research/neural_gpu/neural_gpu_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Neural GPU."""
+from __future__ import print_function
 
 import math
 import os
@@ -144,7 +145,7 @@ def read_data(source_path, target_path, buckets, max_size=None, print_out=True):
         while source and target and (not max_size or counter < max_size):
           counter += 1
           if counter % 100000 == 0 and print_out:
-            print "  reading data line %d" % counter
+            print("  reading data line %d" % counter)
             sys.stdout.flush()
           source_ids = [int(x) for x in source.split()]
           target_ids = [int(x) for x in target.split()]
@@ -188,7 +189,7 @@ def read_data_into_global(source_path, target_path, buckets,
   global_train_set["wmt"].append(data_set)
   train_total_size = calculate_buckets_scale(data_set, buckets, "wmt")
   if print_out:
-    print "  Finished global data reading (%d)." % train_total_size
+    print("  Finished global data reading (%d)." % train_total_size)
 
 
 def initialize(sess=None):
@@ -552,7 +553,7 @@ def score_beams_prog(beams, target, inp, history, print_out=False,
                 for h in history]
   tgt_set = set(target)
   if print_out:
-    print "target: ", tgt_prog
+    print("target: ", tgt_prog)
   inps, tgt_outs = [], []
   for i in xrange(3):
     ilist = [inp[i + 1, l] for l in xrange(inp.shape[1])]
@@ -566,11 +567,11 @@ def score_beams_prog(beams, target, inp, history, print_out=False,
       if len(olist) == 1:
         tgt_outs.append(olist[0])
       else:
-        print [program_utils.prog_vocab[x] for x in ilist if x > 0]
-        print olist
-        print tgt_prog
-        print program_utils.evaluate(tgt_prog, {"a": inps[-1]})
-        print "AAAAA"
+        print([program_utils.prog_vocab[x] for x in ilist if x > 0])
+        print(olist)
+        print(tgt_prog)
+        print(program_utils.evaluate(tgt_prog, {"a": inps[-1]}))
+        print("AAAAA")
         tgt_outs.append(olist[0])
   if not test_mode:
     for _ in xrange(7):
@@ -602,7 +603,7 @@ def score_beams_prog(beams, target, inp, history, print_out=False,
       best_prog = b_prog
       best_score = score
   if print_out:
-    print "best score: ", best_score, " best prog: ", best_prog
+    print("best score: ", best_score, " best prog: ", best_prog)
   return best, best_score
 
 
@@ -719,7 +720,7 @@ def train():
           inp = new_inp
           # If all results are great, stop (todo: not to wait for all?).
           if FLAGS.nprint > 1:
-            print scores
+            print(scores)
           if sum(scores) / float(len(scores)) >= 10.0:
             break
         # The final step with the true target.
@@ -735,7 +736,7 @@ def train():
         errors, total, seq_err = data.accuracy(
             inp, res, target, batch_size, 0, new_target, scores)
         if FLAGS.nprint > 1:
-          print "seq_err: ", seq_err
+          print("seq_err: ", seq_err)
         acc_total += total
         acc_errors += errors
         acc_seq_err += seq_err
@@ -944,8 +945,8 @@ def interactive():
     for v in tf.trainable_variables():
       shape = v.get_shape().as_list()
       total += mul(shape)
-      print (v.name, shape, mul(shape))
-    print total
+      print((v.name, shape, mul(shape)))
+    print(total)
     # Start interactive loop.
     sys.stdout.write("Input to Neural GPU Translation Model.\n")
     sys.stdout.write("> ")
@@ -960,7 +961,7 @@ def interactive():
             normalize_digits=FLAGS.normalize_digits)
       else:
         token_ids = wmt.sentence_to_token_ids(inpt, en_vocab)
-      print [rev_en_vocab[t] for t in token_ids]
+      print([rev_en_vocab[t] for t in token_ids])
       # Which bucket does it belong to?
       buckets = [b for b in xrange(len(data.bins))
                  if data.bins[b] >= max(len(token_ids), len(cures))]
@@ -986,12 +987,12 @@ def interactive():
               loss = loss[0] - (data.bins[bucket_id] * FLAGS.length_norm)
               outputs = [int(np.argmax(logit, axis=1))
                          for logit in output_logits]
-            print [rev_fr_vocab[t] for t in outputs]
-            print loss, data.bins[bucket_id]
-            print linearize(outputs, rev_fr_vocab)
+            print([rev_fr_vocab[t] for t in outputs])
+            print(loss, data.bins[bucket_id])
+            print(linearize(outputs, rev_fr_vocab))
             cures.append(outputs[gen_idx])
-            print cures
-            print linearize(cures, rev_fr_vocab)
+            print(cures)
+            print(linearize(cures, rev_fr_vocab))
           if FLAGS.simple_tokenizer:
             cur_out = outputs
             if wmt.EOS_ID in cur_out:
@@ -1002,11 +1003,11 @@ def interactive():
           if loss < result_cost:
             result = outputs
             result_cost = loss
-        print ("FINAL", result_cost)
-        print [rev_fr_vocab[t] for t in result]
-        print linearize(result, rev_fr_vocab)
+        print(("FINAL", result_cost))
+        print([rev_fr_vocab[t] for t in result])
+        print(linearize(result, rev_fr_vocab))
       else:
-        print "TOOO_LONG"
+        print("TOOO_LONG")
       sys.stdout.write("> ")
       sys.stdout.flush()
       inpt = sys.stdin.readline(), ""

--- a/research/neural_gpu/program_utils.py
+++ b/research/neural_gpu/program_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Utilities for generating program synthesis and evaluation data."""
+from __future__ import print_function
 
 import contextlib
 import sys
@@ -177,7 +178,7 @@ def evaluate(program_str, input_names_to_vals, default="ERROR"):
   with stdoutIO() as s:
     # pylint: disable=bare-except
     try:
-      exec exec_str + " print(out)"
+      exec(exec_str + " print(out)")
       return s.getvalue()[:-1]
     except:
       return default
@@ -290,7 +291,7 @@ class Program(object):
 
     with stdoutIO() as s:
       # pylint: disable=exec-used
-      exec inp_str + self.body + "; print(out)"
+      exec(inp_str + self.body + "; print(out)")
       # pylint: enable=exec-used
     return s.getvalue()[:-1]
 
@@ -412,11 +413,11 @@ def gen(max_len, how_many):
     else:
       outcomes_to_programs[outcome_str] = t.flat_str()
     if counter % 5000 == 0:
-      print "== proggen: tried: " + str(counter)
-      print "== proggen: kept:  " + str(len(outcomes_to_programs))
+      print("== proggen: tried: " + str(counter))
+      print("== proggen: kept:  " + str(len(outcomes_to_programs)))
 
     if counter % 250000 == 0 and save_prefix is not None:
-      print "saving..."
+      print("saving...")
       save_counter = 0
       progfilename = os.path.join(save_prefix, "prog_" + str(counter) + ".txt")
       iofilename = os.path.join(save_prefix, "io_" + str(counter) + ".txt")
@@ -431,7 +432,7 @@ def gen(max_len, how_many):
         for (o, p) in outcomes_to_programs.iteritems():
           save_counter += 1
           if save_counter % 500 == 0:
-            print "saving %d of %d" % (save_counter, len(outcomes_to_programs))
+            print("saving %d of %d" % (save_counter, len(outcomes_to_programs)))
           fp.write(p+"\n")
           fi.write(o+"\n")
           ftp.write(str(tokenize(p, tokens))+"\n")

--- a/research/neural_gpu/wmt_utils.py
+++ b/research/neural_gpu/wmt_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Utilities for downloading data from WMT, tokenizing, vocabularies."""
+from __future__ import print_function
 
 import gzip
 import os
@@ -53,20 +54,20 @@ _WMT_ENFR_DEV_URL = "http://www.statmt.org/wmt15/dev-v2.tgz"
 def maybe_download(directory, filename, url):
   """Download filename from url unless it's already in directory."""
   if not tf.gfile.Exists(directory):
-    print "Creating directory %s" % directory
+    print("Creating directory %s" % directory)
     os.mkdir(directory)
   filepath = os.path.join(directory, filename)
   if not tf.gfile.Exists(filepath):
-    print "Downloading %s to %s" % (url, filepath)
+    print("Downloading %s to %s" % (url, filepath))
     filepath, _ = urllib.request.urlretrieve(url, filepath)
     statinfo = os.stat(filepath)
-    print "Successfully downloaded", filename, statinfo.st_size, "bytes"
+    print("Successfully downloaded", filename, statinfo.st_size, "bytes")
   return filepath
 
 
 def gunzip_file(gz_path, new_path):
   """Unzips from gz_path into new_path."""
-  print "Unpacking %s to %s" % (gz_path, new_path)
+  print("Unpacking %s to %s" % (gz_path, new_path))
   with gzip.open(gz_path, "rb") as gz_file:
     with open(new_path, "wb") as new_file:
       for line in gz_file:
@@ -80,7 +81,7 @@ def get_wmt_enfr_train_set(directory):
           tf.gfile.Exists(train_path +".en")):
     corpus_file = maybe_download(directory, "training-giga-fren.tar",
                                  _WMT_ENFR_TRAIN_URL)
-    print "Extracting tar file %s" % corpus_file
+    print("Extracting tar file %s" % corpus_file)
     with tarfile.open(corpus_file, "r") as corpus_tar:
       corpus_tar.extractall(directory)
     gunzip_file(train_path + ".fr.gz", train_path + ".fr")
@@ -95,7 +96,7 @@ def get_wmt_enfr_dev_set(directory):
   if not (tf.gfile.Exists(dev_path + ".fr") and
           tf.gfile.Exists(dev_path + ".en")):
     dev_file = maybe_download(directory, "dev-v2.tgz", _WMT_ENFR_DEV_URL)
-    print "Extracting tgz file %s" % dev_file
+    print("Extracting tgz file %s" % dev_file)
     with tarfile.open(dev_file, "r:gz") as dev_tar:
       fr_dev_file = dev_tar.getmember("dev/" + dev_name + ".fr")
       en_dev_file = dev_tar.getmember("dev/" + dev_name + ".en")
@@ -206,7 +207,7 @@ def create_vocabulary(vocabulary_path, data_path, max_vocabulary_size,
     normalize_digits: Boolean; if true, all digits are replaced by 0s.
   """
   if not tf.gfile.Exists(vocabulary_path):
-    print "Creating vocabulary %s from data %s" % (vocabulary_path, data_path)
+    print("Creating vocabulary %s from data %s" % (vocabulary_path, data_path))
     vocab, chars = {}, {}
     for c in _PUNCTUATION:
       chars[c] = 1
@@ -218,7 +219,7 @@ def create_vocabulary(vocabulary_path, data_path, max_vocabulary_size,
         line = " ".join(line_in.split())
         counter += 1
         if counter % 100000 == 0:
-          print "  processing fr line %d" % counter
+          print("  processing fr line %d" % counter)
         for c in line:
           if c in chars:
             chars[c] += 1
@@ -240,7 +241,7 @@ def create_vocabulary(vocabulary_path, data_path, max_vocabulary_size,
         line = " ".join(line_in.split())
         counter += 1
         if counter % 100000 == 0:
-          print "  processing en line %d" % counter
+          print("  processing en line %d" % counter)
         for c in line:
           if c in chars:
             chars[c] += 1
@@ -371,7 +372,7 @@ def data_to_token_ids(data_path, target_path, vocabulary_path,
     normalize_digits: Boolean; if true, all digits are replaced by 0s.
   """
   if not tf.gfile.Exists(target_path):
-    print "Tokenizing data in %s" % data_path
+    print("Tokenizing data in %s" % data_path)
     vocab, _ = initialize_vocabulary(vocabulary_path)
     with tf.gfile.GFile(data_path, mode="rb") as data_file:
       with tf.gfile.GFile(target_path, mode="w") as tokens_file:
@@ -379,7 +380,7 @@ def data_to_token_ids(data_path, target_path, vocabulary_path,
         for line in data_file:
           counter += 1
           if counter % 100000 == 0:
-            print "  tokenizing line %d" % counter
+            print("  tokenizing line %d" % counter)
           token_ids = sentence_to_token_ids(line, vocab, tokenizer,
                                             normalize_digits)
           tokens_file.write(" ".join([str(tok) for tok in token_ids]) + "\n")

--- a/research/neural_programmer/data_utils.py
+++ b/research/neural_programmer/data_utils.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Functions for constructing vocabulary, converting the examples to integer format and building the required masks for batch computation Author: aneelakantan (Arvind Neelakantan)
 """
+from __future__ import print_function
 
 import copy
 import numbers
@@ -46,7 +47,7 @@ def construct_vocab(data, utility, add_word=False):
         if (isinstance(word, numbers.Number)):
           number_found += 1
         else:
-          if (not (utility.word_ids.has_key(word))):
+          if (not (word in utility.word_ids)):
             utility.words.append(word)
             utility.word_count[word] = 1
             utility.word_ids[word] = len(utility.word_ids)
@@ -58,7 +59,7 @@ def construct_vocab(data, utility, add_word=False):
           if (isinstance(word, numbers.Number)):
             number_found += 1
           else:
-            if (not (utility.word_ids.has_key(word))):
+            if (not (word in utility.word_ids)):
               utility.words.append(word)
               utility.word_count[word] = 1
               utility.word_ids[word] = len(utility.word_ids)
@@ -70,7 +71,7 @@ def construct_vocab(data, utility, add_word=False):
           if (isinstance(word, numbers.Number)):
             number_found += 1
           else:
-            if (not (utility.word_ids.has_key(word))):
+            if (not (word in utility.word_ids)):
               utility.words.append(word)
               utility.word_count[word] = 1
               utility.word_ids[word] = len(utility.word_ids)
@@ -80,7 +81,7 @@ def construct_vocab(data, utility, add_word=False):
 
 
 def word_lookup(word, utility):
-  if (utility.word_ids.has_key(word)):
+  if (word in utility.word_ids):
     return word
   else:
     return utility.unk_token
@@ -201,7 +202,7 @@ def get_max_entry(a):
   e = {}
   for w in a:
     if (w != "UNK, "):
-      if (e.has_key(w)):
+      if (w in e):
         e[w] += 1
       else:
         e[w] = 1
@@ -536,15 +537,15 @@ def add_special_words(utility):
   utility.reverse_word_ids[utility.word_ids[
       utility.entry_match_token]] = utility.entry_match_token
   utility.entry_match_token_id = utility.word_ids[utility.entry_match_token]
-  print "entry match token: ", utility.word_ids[
-      utility.entry_match_token], utility.entry_match_token_id
+  print("entry match token: ", utility.word_ids[
+      utility.entry_match_token], utility.entry_match_token_id)
   utility.words.append(utility.column_match_token)
   utility.word_ids[utility.column_match_token] = len(utility.word_ids)
   utility.reverse_word_ids[utility.word_ids[
       utility.column_match_token]] = utility.column_match_token
   utility.column_match_token_id = utility.word_ids[utility.column_match_token]
-  print "entry match token: ", utility.word_ids[
-      utility.column_match_token], utility.column_match_token_id
+  print("entry match token: ", utility.word_ids[
+      utility.column_match_token], utility.column_match_token_id)
   utility.words.append(utility.dummy_token)
   utility.word_ids[utility.dummy_token] = len(utility.word_ids)
   utility.reverse_word_ids[utility.word_ids[
@@ -559,7 +560,7 @@ def add_special_words(utility):
 def perform_word_cutoff(utility):
   if (utility.FLAGS.word_cutoff > 0):
     for word in utility.word_ids.keys():
-      if (utility.word_count.has_key(word) and utility.word_count[word] <
+      if (word in utility.word_count and utility.word_count[word] <
           utility.FLAGS.word_cutoff and word != utility.unk_token and
           word != utility.dummy_token and word != utility.entry_match_token and
           word != utility.column_match_token):

--- a/research/neural_programmer/model.py
+++ b/research/neural_programmer/model.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Author: aneelakantan (Arvind Neelakantan)
 """
+from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
@@ -545,7 +546,7 @@ class Graph():
     self.batch_log_prob = tf.zeros([self.batch_size], dtype=self.data_type)
     #Perform max_passes and at each  pass select operation and column
     for curr_pass in range(max_passes):
-      print "step: ", curr_pass
+      print("step: ", curr_pass)
       output, select, softmax, soft_softmax, column_softmax, soft_column_softmax = self.one_pass(
           select, question_embedding, hidden_vectors, hprev, prev_select_1,
           curr_pass)
@@ -636,7 +637,7 @@ class Graph():
     self.total_cost = self.compute_error() 
     optimize_params = self.params.values()
     optimize_names = self.params.keys()
-    print "optimize params ", optimize_names
+    print("optimize params ", optimize_names)
     if (self.utility.FLAGS.l2_regularizer > 0.0):
       reg_cost = 0.0
       for ind_param in self.params.keys():
@@ -645,7 +646,7 @@ class Graph():
     grads = tf.gradients(self.total_cost, optimize_params, name="gradients")
     grad_norm = 0.0
     for p, name in zip(grads, optimize_names):
-      print "grads: ", p, name
+      print("grads: ", p, name)
       if isinstance(p, tf.IndexedSlices):
         grad_norm += tf.reduce_sum(p.values * p.values)
       elif not (p == None):

--- a/research/neural_programmer/neural_programmer.py
+++ b/research/neural_programmer/neural_programmer.py
@@ -18,6 +18,7 @@ This file calls functions to load & pre-process data, construct the TF graph
 and performs training or evaluation as specified by the flag evaluator_job
 Author: aneelakantan (Arvind Neelakantan)
 """
+from __future__ import print_function
 import time
 from random import Random
 import numpy as np
@@ -113,9 +114,9 @@ def evaluate(sess, data, batch_size, graph, i):
                                                             graph))
     gc += ct * batch_size
     num_examples += batch_size
-  print "dev set accuracy   after ", i, " : ", gc / num_examples
-  print num_examples, len(data)
-  print "--------"
+  print("dev set accuracy   after ", i, " : ", gc / num_examples)
+  print(num_examples, len(data))
+  print("--------")
 
 
 def Train(graph, utility, batch_size, train_data, sess, model_dir,
@@ -142,9 +143,9 @@ def Train(graph, utility, batch_size, train_data, sess, model_dir,
     if (i > 0 and i % FLAGS.eval_cycle == 0):
       end = time.time()
       time_taken = end - start
-      print "step ", i, " ", time_taken, " seconds "
+      print("step ", i, " ", time_taken, " seconds ")
       start = end
-      print " printing train set loss: ", train_set_loss / utility.FLAGS.eval_cycle
+      print(" printing train set loss: ", train_set_loss / utility.FLAGS.eval_cycle)
       train_set_loss = 0.0
 
 
@@ -183,23 +184,23 @@ def master(train_data, dev_data, utility):
         file_list = sorted(selected_models.items(), key=lambda x: x[0])
         if (len(file_list) > 0):
           file_list = file_list[0:len(file_list) - 1]
-	print "list of models: ", file_list
+        print("list of models: ", file_list)
         for model_file in file_list:
           model_file = model_file[1]
-          print "restoring: ", model_file
+          print("restoring: ", model_file)
           saver.restore(sess, model_dir + "/" + model_file)
           model_step = int(
               model_file.split("_")[len(model_file.split("_")) - 1])
-          print "evaluating on dev ", model_file, model_step
+          print("evaluating on dev ", model_file, model_step)
           evaluate(sess, dev_data, batch_size, graph, model_step)
     else:
       ckpt = tf.train.get_checkpoint_state(model_dir)
-      print "model dir: ", model_dir
+      print("model dir: ", model_dir)
       if (not (tf.gfile.IsDirectory(utility.FLAGS.output_dir))):
-        print "create dir: ", utility.FLAGS.output_dir
+        print("create dir: ", utility.FLAGS.output_dir)
         tf.gfile.MkDir(utility.FLAGS.output_dir)
       if (not (tf.gfile.IsDirectory(model_dir))):
-        print "create dir: ", model_dir
+        print("create dir: ", model_dir)
         tf.gfile.MkDir(model_dir)
       Train(graph, utility, batch_size, train_data, sess, model_dir,
             saver)
@@ -225,10 +226,10 @@ def main(args):
   train_data = data_utils.complete_wiki_processing(train_data, utility, True)
   dev_data = data_utils.complete_wiki_processing(dev_data, utility, False)
   test_data = data_utils.complete_wiki_processing(test_data, utility, False)
-  print "# train examples ", len(train_data)
-  print "# dev examples ", len(dev_data)
-  print "# test examples ", len(test_data)
-  print "running open source"
+  print("# train examples ", len(train_data))
+  print("# dev examples ", len(dev_data))
+  print("# test examples ", len(test_data))
+  print("running open source")
   #construct TF graph and train or evaluate
   master(train_data, dev_data, utility)
 

--- a/research/neural_programmer/parameters.py
+++ b/research/neural_programmer/parameters.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Author: aneelakantan (Arvind Neelakantan)
 """
+from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
@@ -59,7 +60,7 @@ class Parameters:
       #Biases for the gates and cell
       for bias in ["i", "f", "c", "o"]:
         if (bias == "f"):
-          print "forget gate bias"
+          print("forget gate bias")
           params[key + "_" + bias] = tf.Variable(
               tf.random_uniform([embedding_dims], 1.0, 1.1, self.utility.
                                 tf_data_type[self.utility.FLAGS.data_type]))

--- a/research/neural_programmer/wiki_data.py
+++ b/research/neural_programmer/wiki_data.py
@@ -22,6 +22,7 @@ columns.
 lookup answer (or matrix) is also split into number and word lookup matrix
 Author: aneelakantan (Arvind Neelakantan)
 """
+from __future__ import print_function
 import math
 import os
 import re
@@ -56,7 +57,7 @@ def correct_unicode(string):
   #string = re.sub("[â€œâ€Â«Â»]", "\"", string)
   #string = re.sub("[â€¢â€ â€¡]", "", string)
   #string = re.sub("[â€â€‘â€“â€”]", "-", string)
-  string = re.sub(ur'[\u2E00-\uFFFF]', "", string)
+  string = re.sub(u'[\u2E00-\uFFFF]', "", string)
   string = re.sub("\\s+", " ", string).strip()
   return string
 
@@ -78,7 +79,7 @@ def full_normalize(string):
   # Remove trailing info in brackets
   string = re.sub("\[[^\]]*\]", "", string)
   # Remove most unicode characters in other languages
-  string = re.sub(ur'[\u007F-\uFFFF]', "", string.strip())
+  string = re.sub(u'[\u007F-\uFFFF]', "", string.strip())
   # Remove trailing info in parenthesis
   string = re.sub("\([^)]*\)$", "", string.strip())
   string = final_normalize(string)
@@ -269,12 +270,12 @@ class WikiQuestionGenerator(object):
           word = "score"
       if (is_number(word)):
         word = float(word)
-      if (not (self.annotated_word_reject.has_key(word))):
+      if (not (word in self.annotated_word_reject)):
         if (is_number(word) or is_date(word) or self.is_money(word)):
           sentence.append(word)
         else:
           word = full_normalize(word)
-          if (not (self.annotated_word_reject.has_key(word)) and
+          if (not (word in self.annotated_word_reject) and
               bool(re.search("[a-z0-9]", word, re.IGNORECASE))):
             m = re.search(",", word)
             sentence.append(word.replace(",", ""))
@@ -298,7 +299,7 @@ class WikiQuestionGenerator(object):
             question_id, question, target_canon, context)
         self.annotated_tables[context] = []
       counter += 1
-    print "Annotated examples loaded ", len(self.annotated_examples)
+    print("Annotated examples loaded ", len(self.annotated_examples))
     f.close()
 
   def is_number_column(self, a):
@@ -423,7 +424,7 @@ class WikiQuestionGenerator(object):
       lines = f.readlines()
       for line in lines:
         line = line.strip()
-        if (not (self.annotated_examples.has_key(line.split("\t")[0]))):
+        if (not (line.split("\t")[0] in self.annotated_examples)):
           continue
         if (len(line.split("\t")) == 4):
           line = line + "\t" * (5 - len(line.split("\t")))
@@ -431,7 +432,7 @@ class WikiQuestionGenerator(object):
             ice_bad_questions += 1
         (example_id, ans_index, ans_raw, process_answer,
          matched_cells) = line.split("\t")
-        if (ice.has_key(example_id)):
+        if (example_id in ice):
           ice[example_id].append(line.split("\t"))
         else:
           ice[example_id] = [line.split("\t")]

--- a/research/object_detection/utils/visualization_utils_test.py
+++ b/research/object_detection/utils/visualization_utils_test.py
@@ -19,6 +19,7 @@ Testing with visualization in the following colab:
 https://drive.google.com/a/google.com/file/d/0B5HnKS_hMsNARERpU3MtU3I5RFE/view?usp=sharing
 
 """
+from __future__ import print_function
 
 import os
 
@@ -145,7 +146,7 @@ class VisualizationUtilsTest(tf.test.TestCase):
         for i in range(images_with_boxes_np.shape[0]):
           img_name = 'image_' + str(i) + '.png'
           output_file = os.path.join(self.get_temp_dir(), img_name)
-          print 'Writing output image %d to %s' % (i, output_file)
+          print('Writing output image %d to %s' % (i, output_file))
           image_pil = Image.fromarray(images_with_boxes_np[i, ...])
           image_pil.save(output_file)
 

--- a/research/real_nvp/celeba_formatting.py
+++ b/research/real_nvp/celeba_formatting.py
@@ -29,6 +29,7 @@ python celeba_formatting.py \
     --set [SUBSET_INDEX]
 
 """
+from __future__ import print_function
 
 import os
 import os.path
@@ -70,7 +71,7 @@ def main():
     writer = tf.python_io.TFRecordWriter(file_out)
     for example_idx, img_fn in enumerate(img_fn_list):
         if example_idx % 1000 == 0:
-            print example_idx, "/", num_examples
+            print(example_idx, "/", num_examples)
         image_raw = scipy.ndimage.imread(os.path.join(fn_root, img_fn))
         rows = image_raw.shape[0]
         cols = image_raw.shape[1]

--- a/research/real_nvp/imnet_formatting.py
+++ b/research/real_nvp/imnet_formatting.py
@@ -33,6 +33,7 @@ do
 done
 
 """
+from __future__ import print_function
 
 import os
 import os.path
@@ -73,10 +74,10 @@ def main():
             file_out = "%s_%05d.tfrecords"
             file_out = file_out % (FLAGS.file_out,
                                    example_idx // n_examples_per_file)
-            print "Writing on:", file_out
+            print("Writing on:", file_out)
             writer = tf.python_io.TFRecordWriter(file_out)
         if example_idx % 1000 == 0:
-            print example_idx, "/", num_examples
+            print(example_idx, "/", num_examples)
         image_raw = scipy.ndimage.imread(os.path.join(fn_root, img_fn))
         rows = image_raw.shape[0]
         cols = image_raw.shape[1]

--- a/research/real_nvp/lsun_formatting.py
+++ b/research/real_nvp/lsun_formatting.py
@@ -29,6 +29,7 @@ python lsun_formatting.py \
     --fn_root [LSUN_FOLDER]
 
 """
+from __future__ import print_function
 
 import os
 import os.path
@@ -68,10 +69,10 @@ def main():
             file_out = "%s_%05d.tfrecords"
             file_out = file_out % (FLAGS.file_out,
                                    example_idx // n_examples_per_file)
-            print "Writing on:", file_out
+            print("Writing on:", file_out)
             writer = tf.python_io.TFRecordWriter(file_out)
         if example_idx % 1000 == 0:
-            print example_idx, "/", num_examples
+            print(example_idx, "/", num_examples)
         image_raw = numpy.array(Image.open(os.path.join(fn_root, img_fn)))
         rows = image_raw.shape[0]
         cols = image_raw.shape[1]

--- a/research/real_nvp/real_nvp_multiscale_dataset.py
+++ b/research/real_nvp/real_nvp_multiscale_dataset.py
@@ -22,6 +22,8 @@ $ python real_nvp_multiscale_dataset.py \
 --dataset imnet \
 --data_path [DATA_PATH]
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import time
 from datetime import datetime
@@ -32,7 +34,7 @@ import tensorflow as tf
 
 from tensorflow import gfile
 
-from real_nvp_utils import (
+from .real_nvp_utils import (
     batch_norm, batch_norm_log_diff, conv_layer,
     squeeze_2x2, squeeze_2x2_ordered, standard_normal_ll,
     standard_normal_sample, unsqueeze_2x2, variable_on_cpu)
@@ -1435,10 +1437,10 @@ class RealNVP(object):
             n_equal = int(n_equal)
             n_dash = bar_len - n_equal
             progress_bar = "[" + "=" * n_equal + "-" * n_dash + "]\r"
-            print progress_bar,
+            print(progress_bar, end=' ')
             cost = self.bit_per_dim.eval()
             eval_costs.append(cost)
-        print ""
+        print("")
         return float(numpy.mean(eval_costs))
 
 
@@ -1467,7 +1469,7 @@ def train_model(hps, logdir):
 
             ckpt_state = tf.train.get_checkpoint_state(logdir)
             if ckpt_state and ckpt_state.model_checkpoint_path:
-                print "Loading file %s" % ckpt_state.model_checkpoint_path
+                print("Loading file %s" % ckpt_state.model_checkpoint_path)
                 saver.restore(sess, ckpt_state.model_checkpoint_path)
 
             # Start the queue runners.
@@ -1499,8 +1501,8 @@ def train_model(hps, logdir):
                     format_str = ('%s: step %d, loss = %.2f '
                                   '(%.1f examples/sec; %.3f '
                                   'sec/batch)')
-                    print format_str % (datetime.now(), global_step_val, loss,
-                                        examples_per_sec, duration)
+                    print(format_str % (datetime.now(), global_step_val, loss,
+                                        examples_per_sec, duration))
 
                 if should_eval_summaries:
                     summary_str = outputs[-1]
@@ -1542,24 +1544,24 @@ def evaluate(hps, logdir, traindir, subset="valid", return_val=False):
                 while True:
                     ckpt_state = tf.train.get_checkpoint_state(traindir)
                     if not (ckpt_state and ckpt_state.model_checkpoint_path):
-                        print "No model to eval yet at %s" % traindir
+                        print("No model to eval yet at %s" % traindir)
                         time.sleep(30)
                         continue
-                    print "Loading file %s" % ckpt_state.model_checkpoint_path
+                    print("Loading file %s" % ckpt_state.model_checkpoint_path)
                     saver.restore(sess, ckpt_state.model_checkpoint_path)
 
                     current_step = tf.train.global_step(sess, eval_model.step)
                     if current_step == previous_global_step:
-                        print "Waiting for the checkpoint to be updated."
+                        print("Waiting for the checkpoint to be updated.")
                         time.sleep(30)
                         continue
                     previous_global_step = current_step
 
-                    print "Evaluating..."
+                    print("Evaluating...")
                     bit_per_dim = eval_model.eval_epoch(hps)
                     print ("Epoch: %d, %s -> %.3f bits/dim"
                            % (current_step, subset, bit_per_dim))
-                    print "Writing summary..."
+                    print("Writing summary...")
                     summary = tf.Summary()
                     summary.value.extend(
                         [tf.Summary.Value(
@@ -1597,7 +1599,7 @@ def sample_from_model(hps, logdir, traindir):
                     ckpt_state = tf.train.get_checkpoint_state(traindir)
                     if not (ckpt_state and ckpt_state.model_checkpoint_path):
                         if not initialized:
-                            print "No model to eval yet at %s" % traindir
+                            print("No model to eval yet at %s" % traindir)
                             time.sleep(30)
                             continue
                     else:
@@ -1607,7 +1609,7 @@ def sample_from_model(hps, logdir, traindir):
 
                     current_step = tf.train.global_step(sess, eval_model.step)
                     if current_step == previous_global_step:
-                        print "Waiting for the checkpoint to be updated."
+                        print("Waiting for the checkpoint to be updated.")
                         time.sleep(30)
                         continue
                     previous_global_step = current_step

--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -310,7 +310,7 @@ class MobilenetV1Test(tf.test.TestCase):
       mobilenet_v1.mobilenet_v1_base(inputs)
       total_params, _ = slim.model_analyzer.analyze_vars(
           slim.get_model_variables())
-      self.assertAlmostEqual(3217920L, total_params)
+      self.assertAlmostEqual(3217920, total_params)
 
   def testBuildEndPointsWithDepthMultiplierLessThanOne(self):
     batch_size = 5

--- a/research/street/python/fsns_urls.py
+++ b/research/street/python/fsns_urls.py
@@ -22,6 +22,7 @@ Aria2c is a powerful download manager which can download multiple files in
 parallel, re-try if encounter an error and continue previously unfinished
 downloads.
 """
+from __future__ import print_function
 
 import os
 

--- a/research/street/python/vgsl_model.py
+++ b/research/street/python/vgsl_model.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """String network description language to define network layouts."""
+from __future__ import print_function
 import re
 import time
 
@@ -170,7 +171,7 @@ def Eval(train_dir,
           _AddRateToSummary('Sequence error rate', rates.sequence_error, step,
                             sw)
           sw.flush()
-          print 'Error rates=', rates
+          print('Error rates=', rates)
         else:
           raise ValueError('Non-softmax decoder evaluation not implemented!')
       if eval_interval_secs:

--- a/research/swivel/prep.py
+++ b/research/swivel/prep.py
@@ -54,6 +54,7 @@ Options:
       The number of co-occurrences that are buffered; default 16M.
 
 """
+from __future__ import print_function
 
 import itertools
 import math
@@ -118,7 +119,7 @@ def create_vocabulary(lines):
   if not num_words:
     raise Exception('empty vocabulary')
 
-  print 'vocabulary contains %d tokens' % num_words
+  print('vocabulary contains %d tokens' % num_words)
 
   vocab = vocab[:num_words]
   return [tok for tok, n in vocab]
@@ -129,8 +130,8 @@ def write_vocab_and_sums(vocab, sums, vocab_filename, sums_filename):
   with open(os.path.join(FLAGS.output_dir, vocab_filename), 'w') as vocab_out:
     with open(os.path.join(FLAGS.output_dir, sums_filename), 'w') as sums_out:
       for tok, cnt in itertools.izip(vocab, sums):
-        print >> vocab_out, tok
-        print >> sums_out, cnt
+        print(tok, file=vocab_out)
+        print(cnt, file=sums_out)
 
 
 def compute_coocs(lines, vocab):
@@ -309,7 +310,7 @@ def main(_):
   write_vocab_and_sums(vocab, sums, 'row_vocab.txt', 'row_sums.txt')
   write_vocab_and_sums(vocab, sums, 'col_vocab.txt', 'col_sums.txt')
 
-  print 'done!'
+  print('done!')
 
 
 if __name__ == '__main__':

--- a/research/swivel/text2bin.py
+++ b/research/swivel/text2bin.py
@@ -39,6 +39,7 @@ row-wise (i.e., each line must correspond to the same embedding), and they must
 have the same number of columns (i.e., be the same dimension).
 
 """
+from __future__ import print_function
 
 from itertools import izip
 from getopt import GetoptError, getopt
@@ -49,8 +50,8 @@ import sys
 try:
   opts, args = getopt(
       sys.argv[1:], 'o:v:', ['output=', 'vocab='])
-except GetoptError, e:
-  print >> sys.stderr, e
+except GetoptError as e:
+  print(e, file=sys.stderr)
   sys.exit(2)
 
 opt_output = 'vecs.bin'
@@ -71,7 +72,7 @@ def go(fhs):
         if any(part[0] != token for part in parts[1:]):
           raise IOError('vector files must be aligned')
 
-        print >> vocab_out, token
+        print(token, file=vocab_out)
 
         vec = [sum(float(x) for x in xs) for xs in zip(*parts)[1:]]
         if not fmt:

--- a/research/syntaxnet/dragnn/python/graph_builder.py
+++ b/research/syntaxnet/dragnn/python/graph_builder.py
@@ -28,7 +28,7 @@ from syntaxnet.util import check
 
 try:
   tf.NotDifferentiable('ExtractFixedFeatures')
-except KeyError, e:
+except KeyError as e:
   logging.info(str(e))
 
 

--- a/research/syntaxnet/syntaxnet/conll2tree.py
+++ b/research/syntaxnet/syntaxnet/conll2tree.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """A program to generate ASCII trees from conll files."""
+from __future__ import print_function
 
 import collections
 import re
@@ -88,12 +89,12 @@ def main(unused_argv):
         sentence.ParseFromString(d)
         tr = asciitree.LeftAligned()
         d = to_dict(sentence)
-        print 'Input: %s' % sentence.text
-        print 'Parse:'
+        print('Input: %s' % sentence.text)
+        print('Parse:')
         tr_str = tr(d)
         pat = re.compile(r'\s*@\d+$')
         for tr_ln in tr_str.splitlines():
-          print pat.sub('', tr_ln)
+          print(pat.sub('', tr_ln))
 
       if finished:
         break

--- a/research/transformer/cluttered_mnist.py
+++ b/research/transformer/cluttered_mnist.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/research/video_prediction/prediction_train.py
+++ b/research/video_prediction/prediction_train.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Code for training the prediction model."""
+from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf

--- a/samples/outreach/blogs/blog_estimators_dataset.py
+++ b/samples/outreach/blogs/blog_estimators_dataset.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tutorials/image/cifar10_estimator/cifar10_main.py
+++ b/tutorials/image/cifar10_estimator/cifar10_main.py
@@ -27,15 +27,16 @@ http://www.cs.toronto.edu/~kriz/cifar.html
 """
 from __future__ import division
 from __future__ import print_function
+from __future__ import absolute_import
 
 import argparse
 import functools
 import itertools
 import os
 
-import cifar10
-import cifar10_model
-import cifar10_utils
+from . import cifar10
+from . import cifar10_model
+from . import cifar10_utils
 import numpy as np
 import six
 from six.moves import xrange  # pylint: disable=redefined-builtin

--- a/tutorials/image/cifar10_estimator/cifar10_model.py
+++ b/tutorials/image/cifar10_estimator/cifar10_model.py
@@ -15,10 +15,11 @@
 """Model class for Cifar10 Dataset."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import absolute_import
 
 import tensorflow as tf
 
-import model_base
+from . import model_base
 
 
 class ResNetCifar10(model_base.ResNet):


### PR DESCRIPTION
Another attempt at #2390 which has become out of date with all the changes across the codebase.

Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _definitely_ be much more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`
* See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py` # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`