### PR TITLE
Update eval_image_classifier.py default batch_size from 100 to 50 to avoid bug.

### DIFF
--- a/research/slim/eval_image_classifier.py
+++ b/research/slim/eval_image_classifier.py
@@ -28,7 +28,7 @@ from preprocessing import preprocessing_factory
 slim = tf.contrib.slim
 
 tf.app.flags.DEFINE_integer(
-    'batch_size', 100, 'The number of samples in each batch.')
+    'batch_size', 50, 'The number of samples in each batch.')
 
 tf.app.flags.DEFINE_integer(
     'max_num_batches', None,


### PR DESCRIPTION
Right now the large NASNet-A model, when evaluated with the default batch_size of 100, runs into a bug. This change will allow the NASNet-A model to work with the default values. See #2778 for details.