### PR TITLE
Use more reasonable default argument values in visualization. (Issue 2754)

### DIFF
--- a/research/object_detection/eval_util.py
+++ b/research/object_detection/eval_util.py
@@ -60,7 +60,7 @@ def visualize_detection_results(result_dict,
                                 export_dir='',
                                 agnostic_mode=False,
                                 show_groundtruth=False,
-                                min_score_thresh=.5,
+                                min_score_thresh=.0,
                                 max_num_predictions=20):
   """Visualizes detection results and writes visualizations to image summaries.
 

--- a/research/object_detection/evaluator.py
+++ b/research/object_detection/evaluator.py
@@ -177,7 +177,7 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
           categories=categories,
           summary_dir=eval_dir,
           export_dir=eval_config.visualization_export_dir,
-          show_groundtruth=eval_config.visualization_export_dir)
+          show_groundtruth=true)
     return result_dict
 
   variables_to_restore = tf.global_variables()

--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -391,7 +391,7 @@ def visualize_boxes_and_labels_on_image_array(image,
                                               keypoints=None,
                                               use_normalized_coordinates=False,
                                               max_boxes_to_draw=20,
-                                              min_score_thresh=.5,
+                                              min_score_thresh=.0,
                                               agnostic_mode=False,
                                               line_thickness=4):
   """Overlay labeled boxes on an image with formatted scores and label names.


### PR DESCRIPTION
- Set default value for "min_score_thresh" to 0 in object detection visualization.
- Draw groundtruth bounding box by default.