### PR TITLE
Remove `import google3` from slim nets.

### DIFF
--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import google3
 import numpy as np
 
 import tensorflow as tf

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 
 from math import log
 
-import google3
-
 import tensorflow as tf
 slim = tf.contrib.slim
 


### PR DESCRIPTION
@martinwicke @sguada Removes `import google3` from slim/nets, which is invalid in open source.