### PR TITLE
Attention OCR: from six.moves import xrange for Python 3

### DIFF
--- a/research/attention_ocr/python/model_test.py
+++ b/research/attention_ocr/python/model_test.py
@@ -16,7 +16,7 @@
 """Tests for the model."""
 
 import numpy as np
-from six import xrange
+from six.moves import xrange
 import string
 import tensorflow as tf
 from tensorflow.contrib import slim

--- a/research/attention_ocr/python/model_test.py
+++ b/research/attention_ocr/python/model_test.py
@@ -16,6 +16,7 @@
 """Tests for the model."""
 
 import numpy as np
+from six import xrange
 import string
 import tensorflow as tf
 from tensorflow.contrib import slim


### PR DESCRIPTION
Replaces #2117 

xrange() was removed from Python 3 in favor of range().

@wookayin Please review this change.