### PR TITLE
Compression: from six.moves import xrange for Python 3

### DIFF
--- a/research/compression/entropy_coder/progressive/progressive.py
+++ b/research/compression/entropy_coder/progressive/progressive.py
@@ -18,7 +18,6 @@
 import json
 
 from six.moves import xrange
-
 import tensorflow as tf
 
 from entropy_coder.lib import blocks

--- a/research/compression/entropy_coder/progressive/progressive.py
+++ b/research/compression/entropy_coder/progressive/progressive.py
@@ -17,6 +17,8 @@
 
 import json
 
+from six.moves import xrange
+
 import tensorflow as tf
 
 from entropy_coder.lib import blocks


### PR DESCRIPTION
xrange() was removed in Python 3 in favor of range()