### PR TITLE
Transformer:  from six.moves import xrange for Python 3

### DIFF
--- a/research/transformer/spatial_transformer.py
+++ b/research/transformer/spatial_transformer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
 from six.moves import xrange
 import tensorflow as tf
 

--- a/research/transformer/spatial_transformer.py
+++ b/research/transformer/spatial_transformer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from six.moves import xrange
 import tensorflow as tf
 
 


### PR DESCRIPTION
xrange() was removed in Python 3 in favor of range()