### PR TITLE
Slim: 3217920L --> 3217920 (drop the trailing L)

### DIFF
--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -165,7 +165,7 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_13_depthwise': [batch_size, 7, 7, 1024],
                         'Conv2d_13_pointwise': [batch_size, 7, 7, 1024]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
@@ -209,7 +209,7 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_13_depthwise': [batch_size, 14, 14, 1024],
                         'Conv2d_13_pointwise': [batch_size, 14, 14, 1024]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
@@ -253,7 +253,7 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_13_depthwise': [batch_size, 28, 28, 1024],
                         'Conv2d_13_pointwise': [batch_size, 28, 28, 1024]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
@@ -296,7 +296,7 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_13_depthwise': [batch_size, 4, 4, 768],
                         'Conv2d_13_pointwise': [batch_size, 4, 4, 768]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)

--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -310,7 +310,7 @@ class MobilenetV1Test(tf.test.TestCase):
       mobilenet_v1.mobilenet_v1_base(inputs)
       total_params, _ = slim.model_analyzer.analyze_vars(
           slim.get_model_variables())
-      self.assertAlmostEqual(3217920L, total_params)
+      self.assertAlmostEqual(3217920, total_params)
 
   def testBuildEndPointsWithDepthMultiplierLessThanOne(self):
     batch_size = 5


### PR DESCRIPTION
Replaces #2183  Python 2.7 no longer needs the trailing L and Python 3 treats it as a Syntax Error.