### PR TITLE
Add github-account owner to `tensorflow/models/gan` CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,7 @@ research/compression/* @nmjohn
 research/delf/* @andrefaraujo
 research/differential_privacy/* @panyx0718
 research/domain_adaptation/* @bousmalis @ddohan
+research/gan/* @joel-shor
 research/im2txt/* @cshallue
 research/inception/* @shlens @vincentvanhoucke
 research/learned_optimizer/* @olganw @nirum


### PR DESCRIPTION
@nealwu @martinwicke  Add my github account to CODEOWNERS.

Note: I think some of the entries in CODEOWNERS are `@google` email addresses and some are github accounts. It might make sense to standardize at some point.