### PR TITLE
syntaxnet: make data loader more robust to extra whitespace

### DIFF
--- a/research/syntaxnet/syntaxnet/text_formats.cc
+++ b/research/syntaxnet/syntaxnet/text_formats.cc
@@ -41,6 +41,7 @@ bool DoubleNewlineReadRecord(tensorflow::io::BufferedInputStream *buffer,
   while (!line.empty() && status.ok()) {
     tensorflow::strings::StrAppend(record, line, "\n");
     status = buffer->ReadLine(&line);
+    utils::RemoveWhitespaceContextStr(line);
   }
   return status.ok() || !record->empty();
 }
@@ -114,7 +115,9 @@ class CoNLLSyntaxFormat : public DocumentFormat {
     for (size_t i = 0; i < lines.size(); ++i) {
       // Split line into tab-separated fields.
       fields.clear();
-      fields = utils::Split(lines[i], '\t');
+      std::string line = lines[i];
+      utils::RemoveWhitespaceContextStr(line);
+      fields = utils::Split(line, '\t');
       if (fields.empty()) continue;
 
       // Skip comment lines.
@@ -141,6 +144,7 @@ class CoNLLSyntaxFormat : public DocumentFormat {
       // Check that the ids follow the expected format.
       const int id = utils::ParseUsing<int>(fields[0], 0, utils::ParseInt32);
       CHECK_EQ(expected_id++, id)
+          << "(Line " << i+1 << ": |" << line << "|) "
           << "Token ids start at 1 for each new sentence and increase by 1 "
           << "on each new token. Sentences are separated by an empty line.";
 

--- a/research/syntaxnet/syntaxnet/utils.cc
+++ b/research/syntaxnet/syntaxnet/utils.cc
@@ -169,6 +169,21 @@ size_t RemoveWhitespaceContext(tensorflow::StringPiece *text) {
   return RemoveLeadingWhitespace(text) + RemoveTrailingWhitespace(text);
 }
 
+void RemoveLeadingWhitespaceStr(std::string &text) {
+    text.erase(text.begin(), std::find_if(text.begin(), text.end(),
+            std::not1(std::ptr_fun<int, int>(std::isspace))));
+}
+
+void RemoveTrailingWhitespaceStr(std::string &text) {
+    text.erase(std::find_if(text.rbegin(), text.rend(),
+            std::not1(std::ptr_fun<int, int>(std::isspace))).base(), text.end());
+}
+
+void RemoveWhitespaceContextStr(std::string &text) {
+  RemoveTrailingWhitespaceStr(text);
+  RemoveLeadingWhitespaceStr(text);
+}
+
 namespace {
 // Lower-level versions of Get... that read directly from a character buffer
 // without any bounds checking.

--- a/research/syntaxnet/syntaxnet/utils.h
+++ b/research/syntaxnet/syntaxnet/utils.h
@@ -75,6 +75,12 @@ size_t RemoveTrailingWhitespace(tensorflow::StringPiece *text);
 
 size_t RemoveWhitespaceContext(tensorflow::StringPiece *text);
 
+void RemoveLeadingWhitespaceStr(std::string &text);
+
+void RemoveTrailingWhitespaceStr(std::string &text);
+
+void RemoveWhitespaceContextStr(std::string &text);
+
 uint32 Hash32(const char *data, size_t n, uint32 seed);
 
 // Deletes all the elements in an STL container and clears the container. This


### PR DESCRIPTION
The data loader was failing when I tried to load files containing extra whitespace in blank lines. I added trims to avoid this in the future. Let me know if there is an implementation of trim that I should be using; I added functions from stackoverflow to util (the existing ones are for tensorflow strings rather than `std::string`).

I also made the relevant error message more informative, printing the line number and line.