### PR TITLE
Change the default rnn_mode for ptb_word_lm.py to BLOCK so that it works with TF1.4

### DIFF
--- a/tutorials/rnn/ptb/ptb_word_lm.py
+++ b/tutorials/rnn/ptb/ptb_word_lm.py
@@ -331,7 +331,7 @@ class SmallConfig(object):
   lr_decay = 0.5
   batch_size = 20
   vocab_size = 10000
-  rnn_mode = CUDNN
+  rnn_mode = BLOCK
 
 
 class MediumConfig(object):


### PR DESCRIPTION
Currently the command given at the bottom of https://www.tensorflow.org/tutorials/recurrent will fail with TF1.4, since the tf.contrib.cudnn_rnn API has changed.

cc @k-w-w, @bignamehyp