### PR TITLE
Uncomments code dependent on `tf.summary.text`

### DIFF
--- a/research/attention_ocr/python/model.py
+++ b/research/attention_ocr/python/model.py
@@ -496,13 +496,12 @@ class Model(object):
       return '%s/%s' % (prefix, label)
 
     max_outputs = 4
-    # TODO(gorban): uncomment, when tf.summary.text released.
-    # charset_mapper = CharsetMapper(charset)
-    # pr_text = charset_mapper.get_text(
-    #     endpoints.predicted_chars[:max_outputs,:])
-    # tf.summary.text(sname('text/pr'), pr_text)
-    # gt_text = charset_mapper.get_text(data.labels[:max_outputs,:])
-    # tf.summary.text(sname('text/gt'), gt_text)
+    charset_mapper = CharsetMapper(charset)
+    pr_text = charset_mapper.get_text(
+        endpoints.predicted_chars[:max_outputs,:])
+    tf.summary.text(sname('text/pr'), pr_text)
+    gt_text = charset_mapper.get_text(data.labels[:max_outputs,:])
+    tf.summary.text(sname('text/gt'), gt_text)
     tf.summary.image(sname('image'), data.images, max_outputs=max_outputs)
 
     if is_training:


### PR DESCRIPTION
We can use `tf.summary.text` since [TensorFlow 1.2.0](https://github.com/tensorflow/tensorflow/releases/tag/v1.2.0), 

I found this text very useful during training, so it may help others too.

