### PR TITLE
fix eval_training_data bug

### DIFF
--- a/research/object_detection/eval.py
+++ b/research/object_detection/eval.py
@@ -103,7 +103,10 @@ def main(unused_argv):
 
   model_config = configs['model']
   eval_config = configs['eval_config']
-  input_config = configs['eval_input_config']
+  if FLAGS.eval_training_data:
+    input_config = configs['train_input_config']
+  else:
+    input_config = configs['eval_input_config']
 
   model_fn = functools.partial(
       model_builder.build,


### PR DESCRIPTION
`eval_training_data` flag seems no effect.
Since no code handles `eval_training_data` flag, `input_config = configs['eval_input_config']` will be always executed, even though ‘eval_training_data’ is set to `Ture`.
When ‘eval_training_data’ is set to `Ture`, `input_config` should be `configs['train_input_config']`.
I fix the bug in pull request.