### PR TITLE
Fix the CODEOWNERS file syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,43 +1,43 @@
-official/* @nealwu @k-w-w
-research/adversarial_crypto/* @dave-andersen
-research/adversarial_text/* @rsepassi
-research/adv_imagenet_models/* @AlexeyKurakin
-research/attention_ocr/* @alexgorban
-research/audioset/* @plakal @dpwe
-research/autoencoders/* @snurkabill
-research/cognitive_mapping_and_planning/* @s-gupta
-research/compression/* @nmjohn
-research/delf/* @andrefaraujo
-research/differential_privacy/* @panyx0718
-research/domain_adaptation/* @bousmalis @dmrd
-research/gan/* @joel-shor
-research/im2txt/* @cshallue
-research/inception/* @shlens @vincentvanhoucke
-research/learned_optimizer/* @olganw @nirum
-research/learning_to_remember_rare_events/* @lukaszkaiser @ofirnachum
-research/lfads/* @jazcollins @susillo
-research/lm_1b/* @oriolvinyals @panyx0718
-research/namignizer/* @knathanieltucker
-research/neural_gpu/* @lukaszkaiser
-research/neural_programmer/* @arvind2505
-research/next_frame_prediction/* @panyx0718
-research/object_detection/* @jch1 @tombstone @derekjchow @jesu9 @dreamdragon
-research/pcl_rl/* @ofirnachum
-research/ptn/* @xcyan @arkanath @hellojas @honglaklee
-research/real_nvp/* @laurent-dinh
-research/rebar/* @gjtucker
-research/resnet/* @panyx0718
-research/skip_thoughts/* @cshallue
-research/slim/* @sguada @nathansilberman
-research/street/* @theraysmith
-research/swivel/* @waterson
-research/syntaxnet/* @calberti @andorardo @bogatyy @markomernick
-research/tcn/* @coreylynch @sermanet
-research/textsum/* @panyx0718 @peterjliu
-research/transformer/* @daviddao
-research/video_prediction/* @cbfinn
-research/fivo/* @dieterichlawson
-samples/* @MarkDaoust
-tutorials/embedding/* @zffchen78 @a-dai
-tutorials/image/* @sherrym @shlens
-tutorials/rnn/* @lukaszkaiser @ebrevdo
+/official/ @nealwu @k-w-w
+/research/adversarial_crypto/ @dave-andersen
+/research/adversarial_text/ @rsepassi
+/research/adv_imagenet_models/ @AlexeyKurakin
+/research/attention_ocr/ @alexgorban
+/research/audioset/ @plakal @dpwe
+/research/autoencoders/ @snurkabill
+/research/cognitive_mapping_and_planning/ @s-gupta
+/research/compression/ @nmjohn
+/research/delf/ @andrefaraujo
+/research/differential_privacy/ @panyx0718
+/research/domain_adaptation/ @bousmalis @dmrd
+/research/gan/ @joel-shor
+/research/im2txt/ @cshallue
+/research/inception/ @shlens @vincentvanhoucke
+/research/learned_optimizer/ @olganw @nirum
+/research/learning_to_remember_rare_events/ @lukaszkaiser @ofirnachum
+/research/lfads/ @jazcollins @susillo
+/research/lm_1b/ @oriolvinyals @panyx0718
+/research/namignizer/ @knathanieltucker
+/research/neural_gpu/ @lukaszkaiser
+/research/neural_programmer/ @arvind2505
+/research/next_frame_prediction/ @panyx0718
+/research/object_detection/ @jch1 @tombstone @derekjchow @jesu9 @dreamdragon
+/research/pcl_rl/ @ofirnachum
+/research/ptn/ @xcyan @arkanath @hellojas @honglaklee
+/research/real_nvp/ @laurent-dinh
+/research/rebar/ @gjtucker
+/research/resnet/ @panyx0718
+/research/skip_thoughts/ @cshallue
+/research/slim/ @sguada @nathansilberman
+/research/street/ @theraysmith
+/research/swivel/ @waterson
+/research/syntaxnet/ @calberti @andorardo @bogatyy @markomernick
+/research/tcn/ @coreylynch @sermanet
+/research/textsum/ @panyx0718 @peterjliu
+/research/transformer/ @daviddao
+/research/video_prediction/ @cbfinn
+/research/fivo/ @dieterichlawson
+/samples/ @MarkDaoust
+/tutorials/embedding/ @zffchen78 @a-dai
+/tutorials/image/ @sherrym @shlens
+/tutorials/rnn/ @lukaszkaiser @ebrevdo


### PR DESCRIPTION
See https://help.github.com/articles/about-codeowners/ for details on CODEOWNERS syntax.

In particular we should change from this pattern:
```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com

# In this example, @octocat owns any file in an apps directory
# anywhere in your repository.
apps/ @octocat
```

to this pattern:
```
# In this example, @doctocat owns any files in the build/logs
# directory at the root of the repository and any of its
# subdirectories.
/build/logs/ @doctocat
```