### PR TITLE
[mnist]: Updates

### DIFF
--- a/official/mnist/README.md
+++ b/official/mnist/README.md
@@ -21,6 +21,13 @@ python mnist.py
 The model will begin training and will automatically evaluate itself on the
 validation data.
 
+Illustrative unittests and benchmarks can be run with:
+
+```
+python mnist_test.py
+python mnist_test.py --benchmarks=.
+```
+
 ## Exporting the model
 
 You can export the model into Tensorflow [SavedModel](https://www.tensorflow.org/programmers_guide/saved_model) format by using the argument `--export_dir`:

--- a/official/mnist/README.md
+++ b/official/mnist/README.md
@@ -21,7 +21,7 @@ python mnist.py
 The model will begin training and will automatically evaluate itself on the
 validation data.
 
-Illustrative unittests and benchmarks can be run with:
+Illustrative unit tests and benchmarks can be run with:
 
 ```
 python mnist_test.py

--- a/official/mnist/README.md
+++ b/official/mnist/README.md
@@ -33,7 +33,7 @@ python mnist_test.py --benchmarks=.
 You can export the model into Tensorflow [SavedModel](https://www.tensorflow.org/programmers_guide/saved_model) format by using the argument `--export_dir`:
 
 ```
-python mnist.py --export_dir /tmp/mnist_saved_model 
+python mnist.py --export_dir /tmp/mnist_saved_model
 ```
 
 The SavedModel will be saved in a timestamped directory under `/tmp/mnist_saved_model/` (e.g. `/tmp/mnist_saved_model/1513630966/`).
@@ -42,7 +42,7 @@ The SavedModel will be saved in a timestamped directory under `/tmp/mnist_saved_
 Use [`saved_model_cli`](https://www.tensorflow.org/programmers_guide/saved_model#cli_to_inspect_and_execute_savedmodel) to inspect and execute the SavedModel.
 
 ```
-saved_model_cli run --dir /tmp/mnist_saved_model/TIMESTAMP --tag_set serve --signature_def classify --inputs image_raw=examples.npy
+saved_model_cli run --dir /tmp/mnist_saved_model/TIMESTAMP --tag_set serve --signature_def classify --inputs image=examples.npy
 ```
 
 `examples.npy` contains the data from `example5.png` and `example3.png` in a numpy array, in that order. The array values are normalized to values between 0 and 1.

--- a/official/mnist/mnist.py
+++ b/official/mnist/mnist.py
@@ -100,7 +100,7 @@ class Model(object):
         64, 5, padding='same', data_format=data_format, activation=tf.nn.relu)
     self.fc1 = tf.layers.Dense(1024, activation=tf.nn.relu)
     self.fc2 = tf.layers.Dense(10)
-    self.dropout = tf.layers.Dropout(0.5)
+    self.dropout = tf.layers.Dropout(0.4)
     self.max_pool2d = tf.layers.MaxPooling2D(
         (2, 2), (2, 2), padding='same', data_format=data_format)
 

--- a/official/mnist/mnist_test.py
+++ b/official/mnist/mnist_test.py
@@ -18,52 +18,76 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+import time
 
 import mnist
 
-tf.logging.set_verbosity(tf.logging.ERROR)
+BATCH_SIZE = 100
 
 
-class BaseTest(tf.test.TestCase):
+def dummy_input_fn():
+  image = tf.random_uniform([BATCH_SIZE, 784])
+  labels = tf.random_uniform([BATCH_SIZE], maxval=9, dtype=tf.int32)
+  return image, tf.one_hot(labels, 10)
 
-  def input_fn(self):
-    features = tf.random_uniform([55000, 784])
-    labels = tf.random_uniform([55000], maxval=9, dtype=tf.int32)
-    return features, tf.one_hot(labels, 10)
 
-  def mnist_model_fn_helper(self, mode):
-    features, labels = self.input_fn()
-    image_count = features.shape[0]
-    spec = mnist.mnist_model_fn(
-        features, labels, mode, {'data_format': 'channels_last'})
+def make_estimator():
+  data_format = 'channels_last'
+  if tf.test.is_built_with_cuda():
+    data_format = 'channels_first'
+  return tf.estimator.Estimator(
+      model_fn=mnist.model_fn, params={
+          'data_format': data_format
+      })
 
-    predictions = spec.predictions
-    self.assertAllEqual(predictions['probabilities'].shape, (image_count, 10))
-    self.assertEqual(predictions['probabilities'].dtype, tf.float32)
-    self.assertAllEqual(predictions['classes'].shape, (image_count,))
-    self.assertEqual(predictions['classes'].dtype, tf.int64)
 
-    if mode != tf.estimator.ModeKeys.PREDICT:
-      loss = spec.loss
-      self.assertAllEqual(loss.shape, ())
-      self.assertEqual(loss.dtype, tf.float32)
+class Tests(tf.test.TestCase):
 
-    if mode == tf.estimator.ModeKeys.EVAL:
-      eval_metric_ops = spec.eval_metric_ops
-      self.assertAllEqual(eval_metric_ops['accuracy'][0].shape, ())
-      self.assertAllEqual(eval_metric_ops['accuracy'][1].shape, ())
-      self.assertEqual(eval_metric_ops['accuracy'][0].dtype, tf.float32)
-      self.assertEqual(eval_metric_ops['accuracy'][1].dtype, tf.float32)
+  def test_mnist(self):
+    classifier = make_estimator()
+    classifier.train(input_fn=dummy_input_fn, steps=2)
+    eval_results = classifier.evaluate(input_fn=dummy_input_fn, steps=1)
 
-  def test_mnist_model_fn_train_mode(self):
-    self.mnist_model_fn_helper(tf.estimator.ModeKeys.TRAIN)
+    loss = eval_results['loss']
+    global_step = eval_results['global_step']
+    accuracy = eval_results['accuracy']
+    self.assertEqual(loss.shape, ())
+    self.assertEqual(2, global_step)
+    self.assertEqual(accuracy.shape, ())
 
-  def test_mnist_model_fn_eval_mode(self):
-    self.mnist_model_fn_helper(tf.estimator.ModeKeys.EVAL)
+    input_fn = lambda: tf.random_uniform([3, 784])
+    predictions_generator = classifier.predict(input_fn)
+    for i in range(3):
+      predictions = next(predictions_generator)
+      self.assertEqual(predictions['probabilities'].shape, (10,))
+      self.assertEqual(predictions['classes'].shape, ())
 
-  def test_mnist_model_fn_predict_mode(self):
-    self.mnist_model_fn_helper(tf.estimator.ModeKeys.PREDICT)
+
+class Benchmarks(tf.test.Benchmark):
+
+  def benchmark_train_step_time(self):
+    classifier = make_estimator()
+    # Run one step to warmup any use of the GPU.
+    classifier.train(input_fn=dummy_input_fn, steps=1)
+
+    have_gpu = tf.test.is_gpu_available()
+    num_steps = 1000 if have_gpu else 100
+    name = 'train_step_time_%s' % ('gpu' if have_gpu else 'cpu')
+
+    start = time.time()
+    classifier.train(input_fn=dummy_input_fn, steps=num_steps)
+    end = time.time()
+
+    wall_time = (end - start) / num_steps
+    self.report_benchmark(
+        iters=num_steps,
+        wall_time=wall_time,
+        name=name,
+        extras={
+            'examples_per_sec': BATCH_SIZE / wall_time
+        })
 
 
 if __name__ == '__main__':
+  tf.logging.set_verbosity(tf.logging.ERROR)
   tf.test.main()


### PR DESCRIPTION
- Use the object-oriented tf.layers API instead of the functional one.
  The object-oriented API is particularly useful when using the model
  with eager execution.
- Update unittest to train, evaluate, and predict using the model.
- Add a micro-benchmark for measuring step-time.
  The parameters (batch_size, num_steps etc.) have NOT been tuned,
  the purpose with this code is mostly to illustrate how model
  benchmarks may be written.

These changes are made as a step towards consolidating model definitions
for different TensorFlow features (like eager execution and support for
TPUs in
https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/eager/python/examples/mnist
and
https://github.com/tensorflow/tpu-demos/tree/master/cloud_tpu/models/mnist)

CC @martinwicke @jhseu @ispirmustafa 