### PR TITLE
updated path to im2txt directory in readme

### DIFF
--- a/research/im2txt/README.md
+++ b/research/im2txt/README.md
@@ -145,7 +145,7 @@ available space for storing the downloaded and processed data.
 MSCOCO_DIR="${HOME}/im2txt/data/mscoco"
 
 # Build the preprocessing script.
-cd tensorflow-models/im2txt
+cd research/im2txt
 bazel build //im2txt:download_and_preprocess_mscoco
 
 # Run the preprocessing script.
@@ -212,7 +212,7 @@ INCEPTION_CHECKPOINT="${HOME}/im2txt/data/inception_v3.ckpt"
 MODEL_DIR="${HOME}/im2txt/model"
 
 # Build the model.
-cd tensorflow-models/im2txt
+cd research/im2txt
 bazel build -c opt //im2txt/...
 
 # Run the training script.
@@ -306,7 +306,7 @@ VOCAB_FILE="${HOME}/im2txt/data/mscoco/word_counts.txt"
 IMAGE_FILE="${HOME}/im2txt/data/mscoco/raw-data/val2014/COCO_val2014_000000224477.jpg"
 
 # Build the inference binary.
-cd tensorflow-models/im2txt
+cd research/im2txt
 bazel build -c opt //im2txt:run_inference
 
 # Ignore GPU devices (only necessary if your GPU is currently memory

--- a/research/im2txt/README.md
+++ b/research/im2txt/README.md
@@ -119,8 +119,8 @@ First ensure that you have installed the following required packages:
 * **NumPy** ([instructions](http://www.scipy.org/install.html))
 * **Natural Language Toolkit (NLTK)**:
     * First install NLTK ([instructions](http://www.nltk.org/install.html))
-    * Then install the NLTK data ([instructions](http://www.nltk.org/data.html))
-
+    * Then install the NLTK data package "punkt" ([instructions](http://www.nltk.org/data.html))
+* **Unzip**
 ### Prepare the Training Data
 
 To train the model you will need to provide training data in native TFRecord


### PR DESCRIPTION
The current readme refers to a directory tensorflow-models which is not in the current directory structure 