### PR TITLE
Add IoU Threshold to the Evaluation Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ ENV/
 
 **/pretrained_models/*
 **/*_pb2.py
+**/~/

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # PyCharm
 .idea/
+
+**/pretrained_models/*
+**/*_pb2.py

--- a/research/object_detection/data/unihall_label.pbtxt
+++ b/research/object_detection/data/unihall_label.pbtxt
@@ -1,0 +1,4 @@
+item {
+  id: 1
+  name: 'person'
+}

--- a/research/object_detection/eval_util.py
+++ b/research/object_detection/eval_util.py
@@ -27,28 +27,29 @@ from object_detection.core import standard_fields as fields
 from object_detection.utils import label_map_util
 from object_detection.utils import ops
 from object_detection.utils import visualization_utils as vis_utils
+import json
 
 slim = tf.contrib.slim
 
 
 def write_metrics(metrics, global_step, summary_dir):
-  """Write metrics to a summary directory.
+    """Write metrics to a summary directory.
 
-  Args:
-    metrics: A dictionary containing metric names and values.
-    global_step: Global step at which the metrics are computed.
-    summary_dir: Directory to write tensorflow summaries to.
-  """
-  logging.info('Writing metrics to tf summary.')
-  summary_writer = tf.summary.FileWriter(summary_dir)
-  for key in sorted(metrics):
-    summary = tf.Summary(value=[
-        tf.Summary.Value(tag=key, simple_value=metrics[key]),
-    ])
-    summary_writer.add_summary(summary, global_step)
-    logging.info('%s: %f', key, metrics[key])
-  summary_writer.close()
-  logging.info('Metrics written to tf summary.')
+    Args:
+      metrics: A dictionary containing metric names and values.
+      global_step: Global step at which the metrics are computed.
+      summary_dir: Directory to write tensorflow summaries to.
+    """
+    logging.info('Writing metrics to tf summary.')
+    summary_writer = tf.summary.FileWriter(summary_dir)
+    for key in sorted(metrics):
+        summary = tf.Summary(value=[
+            tf.Summary.Value(tag=key, simple_value=metrics[key]),
+        ])
+        summary_writer.add_summary(summary, global_step)
+        logging.info('%s: %f', key, metrics[key])
+    summary_writer.close()
+    logging.info('Metrics written to tf summary.')
 
 
 # TODO: Add tests.
@@ -62,110 +63,110 @@ def visualize_detection_results(result_dict,
                                 show_groundtruth=False,
                                 min_score_thresh=.5,
                                 max_num_predictions=20):
-  """Visualizes detection results and writes visualizations to image summaries.
+    """Visualizes detection results and writes visualizations to image summaries.
 
-  This function visualizes an image with its detected bounding boxes and writes
-  to image summaries which can be viewed on tensorboard.  It optionally also
-  writes images to a directory. In the case of missing entry in the label map,
-  unknown class name in the visualization is shown as "N/A".
+    This function visualizes an image with its detected bounding boxes and writes
+    to image summaries which can be viewed on tensorboard.  It optionally also
+    writes images to a directory. In the case of missing entry in the label map,
+    unknown class name in the visualization is shown as "N/A".
 
-  Args:
-    result_dict: a dictionary holding groundtruth and detection
-      data corresponding to each image being evaluated.  The following keys
-      are required:
-        'original_image': a numpy array representing the image with shape
-          [1, height, width, 3]
-        'detection_boxes': a numpy array of shape [N, 4]
-        'detection_scores': a numpy array of shape [N]
-        'detection_classes': a numpy array of shape [N]
-      The following keys are optional:
-        'groundtruth_boxes': a numpy array of shape [N, 4]
-        'groundtruth_keypoints': a numpy array of shape [N, num_keypoints, 2]
-      Detections are assumed to be provided in decreasing order of score and for
-      display, and we assume that scores are probabilities between 0 and 1.
-    tag: tensorboard tag (string) to associate with image.
-    global_step: global step at which the visualization are generated.
-    categories: a list of dictionaries representing all possible categories.
-      Each dict in this list has the following keys:
-          'id': (required) an integer id uniquely identifying this category
-          'name': (required) string representing category name
-            e.g., 'cat', 'dog', 'pizza'
-          'supercategory': (optional) string representing the supercategory
-            e.g., 'animal', 'vehicle', 'food', etc
-    summary_dir: the output directory to which the image summaries are written.
-    export_dir: the output directory to which images are written.  If this is
-      empty (default), then images are not exported.
-    agnostic_mode: boolean (default: False) controlling whether to evaluate in
-      class-agnostic mode or not.
-    show_groundtruth: boolean (default: False) controlling whether to show
-      groundtruth boxes in addition to detected boxes
-    min_score_thresh: minimum score threshold for a box to be visualized
-    max_num_predictions: maximum number of detections to visualize
-  Raises:
-    ValueError: if result_dict does not contain the expected keys (i.e.,
-      'original_image', 'detection_boxes', 'detection_scores',
-      'detection_classes')
-  """
-  if not set([
-      'original_image', 'detection_boxes', 'detection_scores',
-      'detection_classes'
-  ]).issubset(set(result_dict.keys())):
-    raise ValueError('result_dict does not contain all expected keys.')
-  if show_groundtruth and 'groundtruth_boxes' not in result_dict:
-    raise ValueError('If show_groundtruth is enabled, result_dict must contain '
-                     'groundtruth_boxes.')
-  logging.info('Creating detection visualizations.')
-  category_index = label_map_util.create_category_index(categories)
+    Args:
+      result_dict: a dictionary holding groundtruth and detection
+        data corresponding to each image being evaluated.  The following keys
+        are required:
+          'original_image': a numpy array representing the image with shape
+            [1, height, width, 3]
+          'detection_boxes': a numpy array of shape [N, 4]
+          'detection_scores': a numpy array of shape [N]
+          'detection_classes': a numpy array of shape [N]
+        The following keys are optional:
+          'groundtruth_boxes': a numpy array of shape [N, 4]
+          'groundtruth_keypoints': a numpy array of shape [N, num_keypoints, 2]
+        Detections are assumed to be provided in decreasing order of score and for
+        display, and we assume that scores are probabilities between 0 and 1.
+      tag: tensorboard tag (string) to associate with image.
+      global_step: global step at which the visualization are generated.
+      categories: a list of dictionaries representing all possible categories.
+        Each dict in this list has the following keys:
+            'id': (required) an integer id uniquely identifying this category
+            'name': (required) string representing category name
+              e.g., 'cat', 'dog', 'pizza'
+            'supercategory': (optional) string representing the supercategory
+              e.g., 'animal', 'vehicle', 'food', etc
+      summary_dir: the output directory to which the image summaries are written.
+      export_dir: the output directory to which images are written.  If this is
+        empty (default), then images are not exported.
+      agnostic_mode: boolean (default: False) controlling whether to evaluate in
+        class-agnostic mode or not.
+      show_groundtruth: boolean (default: False) controlling whether to show
+        groundtruth boxes in addition to detected boxes
+      min_score_thresh: minimum score threshold for a box to be visualized
+      max_num_predictions: maximum number of detections to visualize
+    Raises:
+      ValueError: if result_dict does not contain the expected keys (i.e.,
+        'original_image', 'detection_boxes', 'detection_scores',
+        'detection_classes')
+    """
+    if not set([
+        'original_image', 'detection_boxes', 'detection_scores',
+        'detection_classes'
+    ]).issubset(set(result_dict.keys())):
+        raise ValueError('result_dict does not contain all expected keys.')
+    if show_groundtruth and 'groundtruth_boxes' not in result_dict:
+        raise ValueError('If show_groundtruth is enabled, result_dict must contain '
+                         'groundtruth_boxes.')
+    logging.info('Creating detection visualizations.')
+    category_index = label_map_util.create_category_index(categories)
 
-  image = np.squeeze(result_dict['original_image'], axis=0)
-  detection_boxes = result_dict['detection_boxes']
-  detection_scores = result_dict['detection_scores']
-  detection_classes = np.int32((result_dict['detection_classes']))
-  detection_keypoints = result_dict.get('detection_keypoints', None)
-  detection_masks = result_dict.get('detection_masks', None)
+    image = np.squeeze(result_dict['original_image'], axis=0)
+    detection_boxes = result_dict['detection_boxes']
+    detection_scores = result_dict['detection_scores']
+    detection_classes = np.int32((result_dict['detection_classes']))
+    detection_keypoints = result_dict.get('detection_keypoints', None)
+    detection_masks = result_dict.get('detection_masks', None)
 
-  # Plot groundtruth underneath detections
-  if show_groundtruth:
-    groundtruth_boxes = result_dict['groundtruth_boxes']
-    groundtruth_keypoints = result_dict.get('groundtruth_keypoints', None)
+    # Plot groundtruth underneath detections
+    if show_groundtruth:
+        groundtruth_boxes = result_dict['groundtruth_boxes']
+        groundtruth_keypoints = result_dict.get('groundtruth_keypoints', None)
+        vis_utils.visualize_boxes_and_labels_on_image_array(
+            image,
+            groundtruth_boxes,
+            None,
+            None,
+            category_index,
+            keypoints=groundtruth_keypoints,
+            use_normalized_coordinates=False,
+            max_boxes_to_draw=None)
     vis_utils.visualize_boxes_and_labels_on_image_array(
         image,
-        groundtruth_boxes,
-        None,
-        None,
+        detection_boxes,
+        detection_classes,
+        detection_scores,
         category_index,
-        keypoints=groundtruth_keypoints,
+        instance_masks=detection_masks,
+        keypoints=detection_keypoints,
         use_normalized_coordinates=False,
-        max_boxes_to_draw=None)
-  vis_utils.visualize_boxes_and_labels_on_image_array(
-      image,
-      detection_boxes,
-      detection_classes,
-      detection_scores,
-      category_index,
-      instance_masks=detection_masks,
-      keypoints=detection_keypoints,
-      use_normalized_coordinates=False,
-      max_boxes_to_draw=max_num_predictions,
-      min_score_thresh=min_score_thresh,
-      agnostic_mode=agnostic_mode)
+        max_boxes_to_draw=max_num_predictions,
+        min_score_thresh=min_score_thresh,
+        agnostic_mode=agnostic_mode)
 
-  if export_dir:
-    export_path = os.path.join(export_dir, 'export-{}.png'.format(tag))
-    vis_utils.save_image_array_as_png(image, export_path)
+    if export_dir:
+        export_path = os.path.join(export_dir, 'export-{}.png'.format(tag))
+        vis_utils.save_image_array_as_png(image, export_path)
 
-  summary = tf.Summary(value=[
-      tf.Summary.Value(
-          tag=tag,
-          image=tf.Summary.Image(
-              encoded_image_string=vis_utils.encode_image_array_as_png_str(
-                  image)))
-  ])
-  summary_writer = tf.summary.FileWriter(summary_dir)
-  summary_writer.add_summary(summary, global_step)
-  summary_writer.close()
+    summary = tf.Summary(value=[
+        tf.Summary.Value(
+            tag=tag,
+            image=tf.Summary.Image(
+                encoded_image_string=vis_utils.encode_image_array_as_png_str(
+                    image)))
+    ])
+    summary_writer = tf.summary.FileWriter(summary_dir)
+    summary_writer.add_summary(summary, global_step)
+    summary_writer.close()
 
-  logging.info('Detection visualizations written to summary with tag %s.', tag)
+    logging.info('Detection visualizations written to summary with tag %s.', tag)
 
 
 def _run_checkpoint_once(tensor_dict,
@@ -178,114 +179,122 @@ def _run_checkpoint_once(tensor_dict,
                          master='',
                          save_graph=False,
                          save_graph_dir=''):
-  """Evaluates metrics defined in evaluators.
+    """Evaluates metrics defined in evaluators.
 
-  This function loads the latest checkpoint in checkpoint_dirs and evaluates
-  all metrics defined in evaluators. The metrics are processed in batch by the
-  batch_processor.
+    This function loads the latest checkpoint in checkpoint_dirs and evaluates
+    all metrics defined in evaluators. The metrics are processed in batch by the
+    batch_processor.
 
-  Args:
-    tensor_dict: a dictionary holding tensors representing a batch of detections
-      and corresponding groundtruth annotations.
-    evaluators: a list of object of type DetectionEvaluator to be used for
-      evaluation. Note that the metric names produced by different evaluators
-      must be unique.
-    batch_processor: a function taking four arguments:
-      1. tensor_dict: the same tensor_dict that is passed in as the first
-        argument to this function.
-      2. sess: a tensorflow session
-      3. batch_index: an integer representing the index of the batch amongst
-        all batches
-      By default, batch_processor is None, which defaults to running:
-        return sess.run(tensor_dict)
-      To skip an image, it suffices to return an empty dictionary in place of
-      result_dict.
-    checkpoint_dirs: list of directories to load into an EnsembleModel. If it
-      has only one directory, EnsembleModel will not be used --
-        a DetectionModel
-      will be instantiated directly. Not used if restore_fn is set.
-    variables_to_restore: None, or a dictionary mapping variable names found in
-      a checkpoint to model variables. The dictionary would normally be
-      generated by creating a tf.train.ExponentialMovingAverage object and
-      calling its variables_to_restore() method. Not used if restore_fn is set.
-    restore_fn: None, or a function that takes a tf.Session object and correctly
-      restores all necessary variables from the correct checkpoint file. If
-      None, attempts to restore from the first directory in checkpoint_dirs.
-    num_batches: the number of batches to use for evaluation.
-    master: the location of the Tensorflow session.
-    save_graph: whether or not the Tensorflow graph is stored as a pbtxt file.
-    save_graph_dir: where to store the Tensorflow graph on disk. If save_graph
-      is True this must be non-empty.
+    Args:
+      tensor_dict: a dictionary holding tensors representing a batch of detections
+        and corresponding groundtruth annotations.
+      evaluators: a list of object of type DetectionEvaluator to be used for
+        evaluation. Note that the metric names produced by different evaluators
+        must be unique.
+      batch_processor: a function taking four arguments:
+        1. tensor_dict: the same tensor_dict that is passed in as the first
+          argument to this function.
+        2. sess: a tensorflow session
+        3. batch_index: an integer representing the index of the batch amongst
+          all batches
+        By default, batch_processor is None, which defaults to running:
+          return sess.run(tensor_dict)
+        To skip an image, it suffices to return an empty dictionary in place of
+        result_dict.
+      checkpoint_dirs: list of directories to load into an EnsembleModel. If it
+        has only one directory, EnsembleModel will not be used --
+          a DetectionModel
+        will be instantiated directly. Not used if restore_fn is set.
+      variables_to_restore: None, or a dictionary mapping variable names found in
+        a checkpoint to model variables. The dictionary would normally be
+        generated by creating a tf.train.ExponentialMovingAverage object and
+        calling its variables_to_restore() method. Not used if restore_fn is set.
+      restore_fn: None, or a function that takes a tf.Session object and correctly
+        restores all necessary variables from the correct checkpoint file. If
+        None, attempts to restore from the first directory in checkpoint_dirs.
+      num_batches: the number of batches to use for evaluation.
+      master: the location of the Tensorflow session.
+      save_graph: whether or not the Tensorflow graph is stored as a pbtxt file.
+      save_graph_dir: where to store the Tensorflow graph on disk. If save_graph
+        is True this must be non-empty.
 
-  Returns:
-    global_step: the count of global steps.
-    all_evaluator_metrics: A dictionary containing metric names and values.
+    Returns:
+      global_step: the count of global steps.
+      all_evaluator_metrics: A dictionary containing metric names and values.
 
-  Raises:
-    ValueError: if restore_fn is None and checkpoint_dirs doesn't have at least
-      one element.
-    ValueError: if save_graph is True and save_graph_dir is not defined.
-  """
-  if save_graph and not save_graph_dir:
-    raise ValueError('`save_graph_dir` must be defined.')
-  sess = tf.Session(master, graph=tf.get_default_graph())
-  sess.run(tf.global_variables_initializer())
-  sess.run(tf.local_variables_initializer())
-  sess.run(tf.tables_initializer())
-  if restore_fn:
-    restore_fn(sess)
-  else:
-    if not checkpoint_dirs:
-      raise ValueError('`checkpoint_dirs` must have at least one entry.')
-    checkpoint_file = tf.train.latest_checkpoint(checkpoint_dirs[0])
-    saver = tf.train.Saver(variables_to_restore)
-    saver.restore(sess, checkpoint_file)
+    Raises:
+      ValueError: if restore_fn is None and checkpoint_dirs doesn't have at least
+        one element.
+      ValueError: if save_graph is True and save_graph_dir is not defined.
+    """
+    if save_graph and not save_graph_dir:
+        raise ValueError('`save_graph_dir` must be defined.')
+    sess = tf.Session(master, graph=tf.get_default_graph())
+    sess.run(tf.global_variables_initializer())
+    sess.run(tf.local_variables_initializer())
+    sess.run(tf.tables_initializer())
+    if restore_fn:
+        restore_fn(sess)
+    else:
+        if not checkpoint_dirs:
+            raise ValueError('`checkpoint_dirs` must have at least one entry.')
+        checkpoint_file = tf.train.latest_checkpoint(checkpoint_dirs[0])
+        saver = tf.train.Saver(variables_to_restore)
+        saver.restore(sess, checkpoint_file)
 
-  if save_graph:
-    tf.train.write_graph(sess.graph_def, save_graph_dir, 'eval.pbtxt')
+    if save_graph:
+        tf.train.write_graph(sess.graph_def, save_graph_dir, 'eval.pbtxt')
 
-  counters = {'skipped': 0, 'success': 0}
-  with tf.contrib.slim.queues.QueueRunners(sess):
-    try:
-      for batch in range(int(num_batches)):
-        if (batch + 1) % 100 == 0:
-          logging.info('Running eval ops batch %d/%d', batch + 1, num_batches)
-        if not batch_processor:
-          try:
-            result_dict = sess.run(tensor_dict)
-            counters['success'] += 1
-          except tf.errors.InvalidArgumentError:
-            logging.info('Skipping image')
-            counters['skipped'] += 1
-            result_dict = {}
-        else:
-          result_dict = batch_processor(tensor_dict, sess, batch, counters)
-        for evaluator in evaluators:
-          # TODO: Use image_id tensor once we fix the input data
-          # decoders to return correct image_id.
-          # TODO: result_dict contains batches of images, while
-          # add_single_ground_truth_image_info expects a single image. Fix
-          evaluator.add_single_ground_truth_image_info(
-              image_id=batch, groundtruth_dict=result_dict)
-          evaluator.add_single_detected_image_info(
-              image_id=batch, detections_dict=result_dict)
-      logging.info('Running eval batches done.')
-    except tf.errors.OutOfRangeError:
-      logging.info('Done evaluating -- epoch limit reached')
-    finally:
-      # When done, ask the threads to stop.
-      logging.info('# success: %d', counters['success'])
-      logging.info('# skipped: %d', counters['skipped'])
-      all_evaluator_metrics = {}
-      for evaluator in evaluators:
-        metrics = evaluator.evaluate()
-        evaluator.clear()
-        if any(key in all_evaluator_metrics for key in metrics):
-          raise ValueError('Metric names between evaluators must not collide.')
-        all_evaluator_metrics.update(metrics)
-      global_step = tf.train.global_step(sess, tf.train.get_global_step())
-  sess.close()
-  return (global_step, all_evaluator_metrics)
+    counters = {'skipped': 0, 'success': 0}
+    times = []
+    with tf.contrib.slim.queues.QueueRunners(sess):
+        try:
+            for batch in range(int(num_batches)):
+                if (batch + 1) % 100 == 0:
+                    logging.info('Running eval ops batch %d/%d', batch + 1, num_batches)
+                if not batch_processor:
+                    try:
+                        result_dict = sess.run(tensor_dict)
+                        counters['success'] += 1
+                    except tf.errors.InvalidArgumentError:
+                        logging.info('Skipping image')
+                        counters['skipped'] += 1
+                        result_dict = {}
+                else:
+                    result_dict = batch_processor(tensor_dict, sess, batch, counters)
+
+                if 'forward_pass_time' in result_dict:
+                    times.append(result_dict['forward_pass_time'])
+                for evaluator in evaluators:
+                    # TODO: Use image_id tensor once we fix the input data
+                    # decoders to return correct image_id.
+                    # TODO: result_dict contains batches of images, while
+                    # add_single_ground_truth_image_info expects a single image. Fix
+                    evaluator.add_single_ground_truth_image_info(
+                        image_id=batch, groundtruth_dict=result_dict)
+                    evaluator.add_single_detected_image_info(
+                        image_id=batch, detections_dict=result_dict)
+            logging.info('Running eval batches done.')
+        except tf.errors.OutOfRangeError:
+            logging.info('Done evaluating -- epoch limit reached')
+        finally:
+            # When done, ask the threads to stop.
+            logging.info('# success: %d', counters['success'])
+            logging.info('# skipped: %d', counters['skipped'])
+            all_evaluator_metrics = {}
+            for evaluator in evaluators:
+                metrics = evaluator.evaluate()
+                evaluator.clear()
+                if any(key in all_evaluator_metrics for key in metrics):
+                    raise ValueError('Metric names between evaluators must not collide.')
+                all_evaluator_metrics.update(metrics)
+            global_step = tf.train.global_step(sess, tf.train.get_global_step())
+    sess.close()
+
+    import numpy as np
+    times_arr = np.asarray(times, dtype=np.float32)
+    all_evaluator_metrics['forward_pass_times'] = times_arr
+    return (global_step, all_evaluator_metrics)
 
 
 # TODO: Add tests.
@@ -302,95 +311,110 @@ def repeated_checkpoint_run(tensor_dict,
                             master='',
                             save_graph=False,
                             save_graph_dir=''):
-  """Periodically evaluates desired tensors using checkpoint_dirs or restore_fn.
+    """Periodically evaluates desired tensors using checkpoint_dirs or restore_fn.
 
-  This function repeatedly loads a checkpoint and evaluates a desired
-  set of tensors (provided by tensor_dict) and hands the resulting numpy
-  arrays to a function result_processor which can be used to further
-  process/save/visualize the results.
+    This function repeatedly loads a checkpoint and evaluates a desired
+    set of tensors (provided by tensor_dict) and hands the resulting numpy
+    arrays to a function result_processor which can be used to further
+    process/save/visualize the results.
 
-  Args:
-    tensor_dict: a dictionary holding tensors representing a batch of detections
-      and corresponding groundtruth annotations.
-    summary_dir: a directory to write metrics summaries.
-    evaluators: a list of object of type DetectionEvaluator to be used for
-      evaluation. Note that the metric names produced by different evaluators
-      must be unique.
-    batch_processor: a function taking three arguments:
-      1. tensor_dict: the same tensor_dict that is passed in as the first
-        argument to this function.
-      2. sess: a tensorflow session
-      3. batch_index: an integer representing the index of the batch amongst
-        all batches
-      By default, batch_processor is None, which defaults to running:
-        return sess.run(tensor_dict)
-    checkpoint_dirs: list of directories to load into a DetectionModel or an
-      EnsembleModel if restore_fn isn't set. Also used to determine when to run
-      next evaluation. Must have at least one element.
-    variables_to_restore: None, or a dictionary mapping variable names found in
-      a checkpoint to model variables. The dictionary would normally be
-      generated by creating a tf.train.ExponentialMovingAverage object and
-      calling its variables_to_restore() method. Not used if restore_fn is set.
-    restore_fn: a function that takes a tf.Session object and correctly restores
-      all necessary variables from the correct checkpoint file.
-    num_batches: the number of batches to use for evaluation.
-    eval_interval_secs: the number of seconds between each evaluation run.
-    max_number_of_evaluations: the max number of iterations of the evaluation.
-      If the value is left as None the evaluation continues indefinitely.
-    master: the location of the Tensorflow session.
-    save_graph: whether or not the Tensorflow graph is saved as a pbtxt file.
-    save_graph_dir: where to save on disk the Tensorflow graph. If store_graph
-      is True this must be non-empty.
+    Args:
+      tensor_dict: a dictionary holding tensors representing a batch of detections
+        and corresponding groundtruth annotations.
+      summary_dir: a directory to write metrics summaries.
+      evaluators: a list of object of type DetectionEvaluator to be used for
+        evaluation. Note that the metric names produced by different evaluators
+        must be unique.
+      batch_processor: a function taking three arguments:
+        1. tensor_dict: the same tensor_dict that is passed in as the first
+          argument to this function.
+        2. sess: a tensorflow session
+        3. batch_index: an integer representing the index of the batch amongst
+          all batches
+        By default, batch_processor is None, which defaults to running:
+          return sess.run(tensor_dict)
+      checkpoint_dirs: list of directories to load into a DetectionModel or an
+        EnsembleModel if restore_fn isn't set. Also used to determine when to run
+        next evaluation. Must have at least one element.
+      variables_to_restore: None, or a dictionary mapping variable names found in
+        a checkpoint to model variables. The dictionary would normally be
+        generated by creating a tf.train.ExponentialMovingAverage object and
+        calling its variables_to_restore() method. Not used if restore_fn is set.
+      restore_fn: a function that takes a tf.Session object and correctly restores
+        all necessary variables from the correct checkpoint file.
+      num_batches: the number of batches to use for evaluation.
+      eval_interval_secs: the number of seconds between each evaluation run.
+      max_number_of_evaluations: the max number of iterations of the evaluation.
+        If the value is left as None the evaluation continues indefinitely.
+      master: the location of the Tensorflow session.
+      save_graph: whether or not the Tensorflow graph is saved as a pbtxt file.
+      save_graph_dir: where to save on disk the Tensorflow graph. If store_graph
+        is True this must be non-empty.
 
-  Returns:
-    metrics: A dictionary containing metric names and values in the latest
-      evaluation.
+    Returns:
+      metrics: A dictionary containing metric names and values in the latest
+        evaluation.
 
-  Raises:
-    ValueError: if max_num_of_evaluations is not None or a positive number.
-    ValueError: if checkpoint_dirs doesn't have at least one element.
-  """
-  if max_number_of_evaluations and max_number_of_evaluations <= 0:
-    raise ValueError(
-        '`number_of_steps` must be either None or a positive number.')
+    Raises:
+      ValueError: if max_num_of_evaluations is not None or a positive number.
+      ValueError: if checkpoint_dirs doesn't have at least one element.
+    """
+    if max_number_of_evaluations and max_number_of_evaluations <= 0:
+        raise ValueError(
+            '`number_of_steps` must be either None or a positive number.')
 
-  if not checkpoint_dirs:
-    raise ValueError('`checkpoint_dirs` must have at least one entry.')
+    if not checkpoint_dirs:
+        raise ValueError('`checkpoint_dirs` must have at least one entry.')
 
-  last_evaluated_model_path = None
-  number_of_evaluations = 0
-  while True:
-    start = time.time()
-    logging.info('Starting evaluation at ' + time.strftime(
-        '%Y-%m-%d-%H:%M:%S', time.gmtime()))
-    model_path = tf.train.latest_checkpoint(checkpoint_dirs[0])
-    if not model_path:
-      logging.info('No model found in %s. Will try again in %d seconds',
-                   checkpoint_dirs[0], eval_interval_secs)
-    elif model_path == last_evaluated_model_path:
-      logging.info('Found already evaluated checkpoint. Will try again in %d '
-                   'seconds', eval_interval_secs)
-    else:
-      last_evaluated_model_path = model_path
-      global_step, metrics = _run_checkpoint_once(tensor_dict, evaluators,
-                                                  batch_processor,
-                                                  checkpoint_dirs,
-                                                  variables_to_restore,
-                                                  restore_fn, num_batches,
-                                                  master, save_graph,
-                                                  save_graph_dir)
-      write_metrics(metrics, global_step, summary_dir)
-    number_of_evaluations += 1
+    last_evaluated_model_path = None
+    number_of_evaluations = 0
+    while True:
+        start = time.time()
+        logging.info('Starting evaluation at ' + time.strftime(
+            '%Y-%m-%d-%H:%M:%S', time.gmtime()))
+        model_path = tf.train.latest_checkpoint(checkpoint_dirs[0])
+        if not model_path:
+            logging.info('No model found in %s. Will try again in %d seconds',
+                         checkpoint_dirs[0], eval_interval_secs)
+        elif model_path == last_evaluated_model_path:
+            logging.info('Found already evaluated checkpoint. Will try again in %d '
+                         'seconds', eval_interval_secs)
+        else:
+            last_evaluated_model_path = model_path
+            global_step, metrics = _run_checkpoint_once(tensor_dict, evaluators,
+                                                        batch_processor,
+                                                        checkpoint_dirs,
+                                                        variables_to_restore,
+                                                        restore_fn, num_batches,
+                                                        master, save_graph,
+                                                        save_graph_dir)
+            # remove the forward pass times because it crashes the metrics function
+            forward_pass_time = metrics['forward_pass_times']
+            del metrics['forward_pass_times']
+            write_metrics(metrics, global_step, summary_dir)
 
-    if (max_number_of_evaluations and
-        number_of_evaluations >= max_number_of_evaluations):
-      logging.info('Finished evaluation!')
-      break
-    time_to_next_eval = start + eval_interval_secs - time.time()
-    if time_to_next_eval > 0:
-      time.sleep(time_to_next_eval)
+            # write the forward pass times to the file
+            with open(summary_dir + '/forwardpass.json', 'a+') as file:
+                file.write(json.dumps(forward_pass_time.tolist()))
+            # forward_pass_summary = tf.summary.histogram('forwardpass/timing', forward_pass_time)
+            # summary_writer = tf.summary.FileWriter(summary_dir)
+            # summary = tf.Summary(value=[
+            #     tf.Summary.Value(tag='histogram', histo=forward_pass_summary),
+            # ])
+            # summary_writer.add_summary(summary, global_step)
+            # summary_writer.close()
+        number_of_evaluations += 1
 
-  return metrics
+        if (max_number_of_evaluations and
+                    number_of_evaluations >= max_number_of_evaluations):
+            logging.info('Finished evaluation!')
+            break
+        time_to_next_eval = start + eval_interval_secs - time.time()
+        if time_to_next_eval > 0:
+            print('Next evaluation in {0} sec'.format(time_to_next_eval))
+            time.sleep(time_to_next_eval)
+
+    return metrics
 
 
 def result_dict_for_single_example(image,
@@ -399,118 +423,121 @@ def result_dict_for_single_example(image,
                                    groundtruth=None,
                                    class_agnostic=False,
                                    scale_to_absolute=False):
-  """Merges all detection and groundtruth information for a single example.
+    """Merges all detection and groundtruth information for a single example.
 
-  Note that evaluation tools require classes that are 1-indexed, and so this
-  function performs the offset. If `class_agnostic` is True, all output classes
-  have label 1.
+    Note that evaluation tools require classes that are 1-indexed, and so this
+    function performs the offset. If `class_agnostic` is True, all output classes
+    have label 1.
 
-  Args:
-    image: A single 4D image tensor of shape [1, H, W, C].
-    key: A single string tensor identifying the image.
-    detections: A dictionary of detections, returned from
-      DetectionModel.postprocess().
-    groundtruth: (Optional) Dictionary of groundtruth items, with fields:
+    Args:
+      image: A single 4D image tensor of shape [1, H, W, C].
+      key: A single string tensor identifying the image.
+      detections: A dictionary of detections, returned from
+        DetectionModel.postprocess().
+      groundtruth: (Optional) Dictionary of groundtruth items, with fields:
+        'groundtruth_boxes': [num_boxes, 4] float32 tensor of boxes, in
+          normalized coordinates.
+        'groundtruth_classes': [num_boxes] int64 tensor of 1-indexed classes.
+        'groundtruth_area': [num_boxes] float32 tensor of bbox area. (Optional)
+        'groundtruth_is_crowd': [num_boxes] int64 tensor. (Optional)
+        'groundtruth_difficult': [num_boxes] int64 tensor. (Optional)
+        'groundtruth_group_of': [num_boxes] int64 tensor. (Optional)
+        'groundtruth_instance_masks': 3D int64 tensor of instance masks
+          (Optional).
+      class_agnostic: Boolean indicating whether the detections are class-agnostic
+        (i.e. binary). Default False.
+      scale_to_absolute: Boolean indicating whether boxes, masks, keypoints should
+        be scaled to absolute coordinates. Note that for IoU based evaluations,
+        it does not matter whether boxes are expressed in absolute or relative
+        coordinates. Default False.
+
+    Returns:
+      A dictionary with:
+      'original_image': A [1, H, W, C] uint8 image tensor.
+      'key': A string tensor with image identifier.
+      'detection_boxes': [max_detections, 4] float32 tensor of boxes, in
+        normalized or absolute coordinates, depending on the value of
+        `scale_to_absolute`.
+      'detection_scores': [max_detections] float32 tensor of scores.
+      'detection_classes': [max_detections] int64 tensor of 1-indexed classes.
+      'detection_masks': [max_detections, None, None] float32 tensor of binarized
+        masks. (Only present if available in `detections`)
       'groundtruth_boxes': [num_boxes, 4] float32 tensor of boxes, in
-        normalized coordinates.
+        normalized or absolute coordinates, depending on the value of
+        `scale_to_absolute`. (Optional)
       'groundtruth_classes': [num_boxes] int64 tensor of 1-indexed classes.
+        (Optional)
       'groundtruth_area': [num_boxes] float32 tensor of bbox area. (Optional)
       'groundtruth_is_crowd': [num_boxes] int64 tensor. (Optional)
       'groundtruth_difficult': [num_boxes] int64 tensor. (Optional)
       'groundtruth_group_of': [num_boxes] int64 tensor. (Optional)
       'groundtruth_instance_masks': 3D int64 tensor of instance masks
         (Optional).
-    class_agnostic: Boolean indicating whether the detections are class-agnostic
-      (i.e. binary). Default False.
-    scale_to_absolute: Boolean indicating whether boxes, masks, keypoints should
-      be scaled to absolute coordinates. Note that for IoU based evaluations,
-      it does not matter whether boxes are expressed in absolute or relative
-      coordinates. Default False.
 
-  Returns:
-    A dictionary with:
-    'original_image': A [1, H, W, C] uint8 image tensor.
-    'key': A string tensor with image identifier.
-    'detection_boxes': [max_detections, 4] float32 tensor of boxes, in
-      normalized or absolute coordinates, depending on the value of
-      `scale_to_absolute`.
-    'detection_scores': [max_detections] float32 tensor of scores.
-    'detection_classes': [max_detections] int64 tensor of 1-indexed classes.
-    'detection_masks': [max_detections, None, None] float32 tensor of binarized
-      masks. (Only present if available in `detections`)
-    'groundtruth_boxes': [num_boxes, 4] float32 tensor of boxes, in
-      normalized or absolute coordinates, depending on the value of
-      `scale_to_absolute`. (Optional)
-    'groundtruth_classes': [num_boxes] int64 tensor of 1-indexed classes.
-      (Optional)
-    'groundtruth_area': [num_boxes] float32 tensor of bbox area. (Optional)
-    'groundtruth_is_crowd': [num_boxes] int64 tensor. (Optional)
-    'groundtruth_difficult': [num_boxes] int64 tensor. (Optional)
-    'groundtruth_group_of': [num_boxes] int64 tensor. (Optional)
-    'groundtruth_instance_masks': 3D int64 tensor of instance masks
-      (Optional).
+    """
+    label_id_offset = 1  # Applying label id offset (b/63711816)
 
-  """
-  label_id_offset = 1  # Applying label id offset (b/63711816)
+    input_data_fields = fields.InputDataFields()
+    output_dict = {
+        input_data_fields.original_image: image,
+        input_data_fields.key: key,
+    }
 
-  input_data_fields = fields.InputDataFields()
-  output_dict = {
-      input_data_fields.original_image: image,
-      input_data_fields.key: key,
-  }
-
-  detection_fields = fields.DetectionResultFields
-  detection_boxes = detections[detection_fields.detection_boxes][0]
-  output_dict[detection_fields.detection_boxes] = detection_boxes
-  image_shape = tf.shape(image)
-  if scale_to_absolute:
-    absolute_detection_boxlist = box_list_ops.to_absolute_coordinates(
-        box_list.BoxList(detection_boxes), image_shape[1], image_shape[2])
-    output_dict[detection_fields.detection_boxes] = (
-        absolute_detection_boxlist.get())
-  detection_scores = detections[detection_fields.detection_scores][0]
-  output_dict[detection_fields.detection_scores] = detection_scores
-
-  if class_agnostic:
-    detection_classes = tf.ones_like(detection_scores, dtype=tf.int64)
-  else:
-    detection_classes = (
-        tf.to_int64(detections[detection_fields.detection_classes][0]) +
-        label_id_offset)
-  output_dict[detection_fields.detection_classes] = detection_classes
-
-  if detection_fields.detection_masks in detections:
-    detection_masks = detections[detection_fields.detection_masks][0]
-    output_dict[detection_fields.detection_masks] = detection_masks
+    detection_fields = fields.DetectionResultFields
+    detection_boxes = detections[detection_fields.detection_boxes][0]
+    output_dict[detection_fields.detection_boxes] = detection_boxes
+    image_shape = tf.shape(image)
     if scale_to_absolute:
-      # TODO: This should be done in model's postprocess
-      # function ideally.
-      detection_masks_reframed = ops.reframe_box_masks_to_image_masks(
-          detection_masks, detection_boxes, image_shape[1], image_shape[2])
-      detection_masks_reframed = tf.to_float(
-          tf.greater(detection_masks_reframed, 0.5))
-      output_dict[detection_fields.detection_masks] = detection_masks_reframed
-  if detection_fields.detection_keypoints in detections:
-    detection_keypoints = detections[detection_fields.detection_keypoints][0]
-    output_dict[detection_fields.detection_keypoints] = detection_keypoints
-    if scale_to_absolute:
-      absolute_detection_keypoints = keypoint_ops.scale(
-          detection_keypoints, image_shape[1], image_shape[2])
-      output_dict[detection_fields.detection_keypoints] = (
-          absolute_detection_keypoints)
+        absolute_detection_boxlist = box_list_ops.to_absolute_coordinates(
+            box_list.BoxList(detection_boxes), image_shape[1], image_shape[2])
+        output_dict[detection_fields.detection_boxes] = (
+            absolute_detection_boxlist.get())
+    detection_scores = detections[detection_fields.detection_scores][0]
+    output_dict[detection_fields.detection_scores] = detection_scores
 
-  if groundtruth:
-    output_dict.update(groundtruth)
-    if scale_to_absolute:
-      groundtruth_boxes = groundtruth[input_data_fields.groundtruth_boxes]
-      absolute_gt_boxlist = box_list_ops.to_absolute_coordinates(
-          box_list.BoxList(groundtruth_boxes), image_shape[1], image_shape[2])
-      output_dict[input_data_fields.groundtruth_boxes] = (
-          absolute_gt_boxlist.get())
-    # For class-agnostic models, groundtruth classes all become 1.
     if class_agnostic:
-      groundtruth_classes = groundtruth[input_data_fields.groundtruth_classes]
-      groundtruth_classes = tf.ones_like(groundtruth_classes, dtype=tf.int64)
-      output_dict[input_data_fields.groundtruth_classes] = groundtruth_classes
+        detection_classes = tf.ones_like(detection_scores, dtype=tf.int64)
+    else:
+        detection_classes = (
+            tf.to_int64(detections[detection_fields.detection_classes][0]) +
+            label_id_offset)
+    output_dict[detection_fields.detection_classes] = detection_classes
 
-  return output_dict
+    # image_shape = tf.Print(image_shape, [image_shape], 'Shape: ', summarize=100)
+    tf.summary.image('tmpImage', image)
+
+    if detection_fields.detection_masks in detections:
+        detection_masks = detections[detection_fields.detection_masks][0]
+        output_dict[detection_fields.detection_masks] = detection_masks
+        if scale_to_absolute:
+            # TODO: This should be done in model's postprocess
+            # function ideally.
+            detection_masks_reframed = ops.reframe_box_masks_to_image_masks(
+                detection_masks, detection_boxes, image_shape[1], image_shape[2])
+            detection_masks_reframed = tf.to_float(
+                tf.greater(detection_masks_reframed, 0.5))
+            output_dict[detection_fields.detection_masks] = detection_masks_reframed
+    if detection_fields.detection_keypoints in detections:
+        detection_keypoints = detections[detection_fields.detection_keypoints][0]
+        output_dict[detection_fields.detection_keypoints] = detection_keypoints
+        if scale_to_absolute:
+            absolute_detection_keypoints = keypoint_ops.scale(
+                detection_keypoints, image_shape[1], image_shape[2])
+            output_dict[detection_fields.detection_keypoints] = (
+                absolute_detection_keypoints)
+
+    if groundtruth:
+        output_dict.update(groundtruth)
+        if scale_to_absolute:
+            groundtruth_boxes = groundtruth[input_data_fields.groundtruth_boxes]
+            absolute_gt_boxlist = box_list_ops.to_absolute_coordinates(
+                box_list.BoxList(groundtruth_boxes), image_shape[1], image_shape[2])
+            output_dict[input_data_fields.groundtruth_boxes] = (
+                absolute_gt_boxlist.get())
+        # For class-agnostic models, groundtruth classes all become 1.
+        if class_agnostic:
+            groundtruth_classes = groundtruth[input_data_fields.groundtruth_classes]
+            groundtruth_classes = tf.ones_like(groundtruth_classes, dtype=tf.int64)
+            output_dict[input_data_fields.groundtruth_classes] = groundtruth_classes
+
+    return output_dict

--- a/research/object_detection/evaluator.py
+++ b/research/object_detection/evaluator.py
@@ -20,6 +20,9 @@ DetectionModel.
 
 import logging
 import tensorflow as tf
+import time
+
+from os import mkdir
 
 from object_detection import eval_util
 from object_detection.core import prefetcher
@@ -42,173 +45,229 @@ EVAL_METRICS_CLASS_DICT = {
 def _extract_prediction_tensors(model,
                                 create_input_dict_fn,
                                 ignore_groundtruth=False):
-  """Restores the model in a tensorflow session.
+    """Restores the model in a tensorflow session.
 
-  Args:
-    model: model to perform predictions with.
-    create_input_dict_fn: function to create input tensor dictionaries.
-    ignore_groundtruth: whether groundtruth should be ignored.
+    Args:
+      model: model to perform predictions with.
+      create_input_dict_fn: function to create input tensor dictionaries.
+      ignore_groundtruth: whether groundtruth should be ignored.
 
-  Returns:
-    tensor_dict: A tensor dictionary with evaluations.
-  """
-  input_dict = create_input_dict_fn()
-  prefetch_queue = prefetcher.prefetch(input_dict, capacity=500)
-  input_dict = prefetch_queue.dequeue()
-  original_image = tf.expand_dims(input_dict[fields.InputDataFields.image], 0)
-  preprocessed_image = model.preprocess(tf.to_float(original_image))
-  prediction_dict = model.predict(preprocessed_image)
-  detections = model.postprocess(prediction_dict)
+    Returns:
+      tensor_dict: A tensor dictionary with evaluations.
+    """
+    input_dict = create_input_dict_fn()
+    prefetch_queue = prefetcher.prefetch(input_dict, capacity=500)
+    input_dict = prefetch_queue.dequeue()
+    original_image = tf.expand_dims(input_dict[fields.InputDataFields.image], 0)
+    preprocessed_image = model.preprocess(tf.to_float(original_image))
+    prediction_dict = model.predict(preprocessed_image)
+    detections = model.postprocess(prediction_dict)
 
-  groundtruth = None
-  if not ignore_groundtruth:
-    groundtruth = {
-        fields.InputDataFields.groundtruth_boxes:
-            input_dict[fields.InputDataFields.groundtruth_boxes],
-        fields.InputDataFields.groundtruth_classes:
-            input_dict[fields.InputDataFields.groundtruth_classes],
-        fields.InputDataFields.groundtruth_area:
-            input_dict[fields.InputDataFields.groundtruth_area],
-        fields.InputDataFields.groundtruth_is_crowd:
-            input_dict[fields.InputDataFields.groundtruth_is_crowd],
-        fields.InputDataFields.groundtruth_difficult:
-            input_dict[fields.InputDataFields.groundtruth_difficult]
-    }
-    if fields.InputDataFields.groundtruth_group_of in input_dict:
-      groundtruth[fields.InputDataFields.groundtruth_group_of] = (
-          input_dict[fields.InputDataFields.groundtruth_group_of])
-    if fields.DetectionResultFields.detection_masks in detections:
-      groundtruth[fields.InputDataFields.groundtruth_instance_masks] = (
-          input_dict[fields.InputDataFields.groundtruth_instance_masks])
+    groundtruth = None
+    if not ignore_groundtruth:
+        groundtruth = {
+            fields.InputDataFields.groundtruth_boxes:
+                input_dict[fields.InputDataFields.groundtruth_boxes],
+            fields.InputDataFields.groundtruth_classes:
+                input_dict[fields.InputDataFields.groundtruth_classes],
+            fields.InputDataFields.groundtruth_area:
+                input_dict[fields.InputDataFields.groundtruth_area],
+            fields.InputDataFields.groundtruth_is_crowd:
+                input_dict[fields.InputDataFields.groundtruth_is_crowd],
+            fields.InputDataFields.groundtruth_difficult:
+                input_dict[fields.InputDataFields.groundtruth_difficult]
+        }
+        groundtruth['image/filename'] = input_dict['filename']
+        if fields.InputDataFields.groundtruth_group_of in input_dict:
+            groundtruth[fields.InputDataFields.groundtruth_group_of] = (
+                input_dict[fields.InputDataFields.groundtruth_group_of])
+        if fields.DetectionResultFields.detection_masks in detections:
+            groundtruth[fields.InputDataFields.groundtruth_instance_masks] = (
+                input_dict[fields.InputDataFields.groundtruth_instance_masks])
 
-  return eval_util.result_dict_for_single_example(
-      original_image,
-      input_dict[fields.InputDataFields.source_id],
-      detections,
-      groundtruth,
-      class_agnostic=(
-          fields.DetectionResultFields.detection_classes not in detections),
-      scale_to_absolute=True)
+    return eval_util.result_dict_for_single_example(
+        original_image,
+        input_dict[fields.InputDataFields.source_id],
+        detections,
+        groundtruth,
+        class_agnostic=(
+            fields.DetectionResultFields.detection_classes not in detections),
+        scale_to_absolute=True)
 
 
 def get_evaluators(eval_config, categories):
-  """Returns the evaluator class according to eval_config, valid for categories.
+    """Returns the evaluator class according to eval_config, valid for categories.
 
-  Args:
-    eval_config: evaluation configurations.
-    categories: a list of categories to evaluate.
-  Returns:
-    An list of instances of DetectionEvaluator.
+    Args:
+      eval_config: evaluation configurations.
+      categories: a list of categories to evaluate.
+    Returns:
+      An list of instances of DetectionEvaluator.
 
-  Raises:
-    ValueError: if metric is not in the metric class dictionary.
-  """
-  eval_metric_fn_key = eval_config.metrics_set
-  if eval_metric_fn_key not in EVAL_METRICS_CLASS_DICT:
-    raise ValueError('Metric not found: {}'.format(eval_metric_fn_key))
-  return [
-      EVAL_METRICS_CLASS_DICT[eval_metric_fn_key](
-          categories=categories,
-          matching_iou_threshold=round(eval_config.matching_iou_threshold, 4)
-      )
-  ]
+    Raises:
+      ValueError: if metric is not in the metric class dictionary.
+    """
+    eval_metric_fn_key = eval_config.metrics_set
+    if eval_metric_fn_key not in EVAL_METRICS_CLASS_DICT:
+        raise ValueError('Metric not found: {}'.format(eval_metric_fn_key))
+    return [
+        EVAL_METRICS_CLASS_DICT[eval_metric_fn_key](
+            categories=categories,
+            matching_iou_threshold=round(eval_config.matching_iou_threshold, 4)
+        )
+    ]
 
 
 def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
              checkpoint_dir, eval_dir):
-  """Evaluation function for detection models.
-
-  Args:
-    create_input_dict_fn: a function to create a tensor input dictionary.
-    create_model_fn: a function that creates a DetectionModel.
-    eval_config: a eval_pb2.EvalConfig protobuf.
-    categories: a list of category dictionaries. Each dict in the list should
-                have an integer 'id' field and string 'name' field.
-    checkpoint_dir: directory to load the checkpoints to evaluate from.
-    eval_dir: directory to write evaluation metrics summary to.
-
-  Returns:
-    metrics: A dictionary containing metric names and values from the latest
-      run.
-  """
-
-  model = create_model_fn()
-
-  if eval_config.ignore_groundtruth and not eval_config.export_path:
-    logging.fatal('If ignore_groundtruth=True then an export_path is '
-                  'required. Aborting!!!')
-
-  tensor_dict = _extract_prediction_tensors(
-      model=model,
-      create_input_dict_fn=create_input_dict_fn,
-      ignore_groundtruth=eval_config.ignore_groundtruth)
-
-  def _process_batch(tensor_dict, sess, batch_index, counters):
-    """Evaluates tensors in tensor_dict, visualizing the first K examples.
-
-    This function calls sess.run on tensor_dict, evaluating the original_image
-    tensor only on the first K examples and visualizing detections overlaid
-    on this original_image.
+    """Evaluation function for detection models.
 
     Args:
-      tensor_dict: a dictionary of tensors
-      sess: tensorflow session
-      batch_index: the index of the batch amongst all batches in the run.
-      counters: a dictionary holding 'success' and 'skipped' fields which can
-        be updated to keep track of number of successful and failed runs,
-        respectively.  If these fields are not updated, then the success/skipped
-        counter values shown at the end of evaluation will be incorrect.
+      create_input_dict_fn: a function to create a tensor input dictionary.
+      create_model_fn: a function that creates a DetectionModel.
+      eval_config: a eval_pb2.EvalConfig protobuf.
+      categories: a list of category dictionaries. Each dict in the list should
+                  have an integer 'id' field and string 'name' field.
+      checkpoint_dir: directory to load the checkpoints to evaluate from.
+      eval_dir: directory to write evaluation metrics summary to.
 
     Returns:
-      result_dict: a dictionary of numpy arrays
+      metrics: A dictionary containing metric names and values from the latest
+        run.
     """
-    try:
-      result_dict = sess.run(tensor_dict)
-      counters['success'] += 1
-    except tf.errors.InvalidArgumentError:
-      logging.info('Skipping image')
-      counters['skipped'] += 1
-      return {}
-    global_step = tf.train.global_step(sess, tf.train.get_global_step())
-    if batch_index < eval_config.num_visualizations:
-      tag = 'image-{}'.format(batch_index)
-      eval_util.visualize_detection_results(
-          result_dict,
-          tag,
-          global_step,
-          categories=categories,
-          summary_dir=eval_dir,
-          export_dir=eval_config.visualization_export_dir,
-          show_groundtruth=eval_config.visualization_export_dir)
-    return result_dict
 
-  variables_to_restore = tf.global_variables()
-  global_step = tf.train.get_or_create_global_step()
-  variables_to_restore.append(global_step)
-  if eval_config.use_moving_averages:
-    variable_averages = tf.train.ExponentialMovingAverage(0.0)
-    variables_to_restore = variable_averages.variables_to_restore()
-  saver = tf.train.Saver(variables_to_restore)
+    model = create_model_fn()
 
-  def _restore_latest_checkpoint(sess):
-    latest_checkpoint = tf.train.latest_checkpoint(checkpoint_dir)
-    saver.restore(sess, latest_checkpoint)
+    if eval_config.ignore_groundtruth and not eval_config.export_path:
+        logging.fatal('If ignore_groundtruth=True then an export_path is '
+                      'required. Aborting!!!')
 
-  metrics = eval_util.repeated_checkpoint_run(
-      tensor_dict=tensor_dict,
-      summary_dir=eval_dir,
-      evaluators=get_evaluators(eval_config, categories),
-      batch_processor=_process_batch,
-      checkpoint_dirs=[checkpoint_dir],
-      variables_to_restore=None,
-      restore_fn=_restore_latest_checkpoint,
-      num_batches=eval_config.num_examples,
-      eval_interval_secs=eval_config.eval_interval_secs,
-      max_number_of_evaluations=(1 if eval_config.ignore_groundtruth else
-                                 eval_config.max_evals
-                                 if eval_config.max_evals else None),
-      master=eval_config.eval_master,
-      save_graph=eval_config.save_graph,
-      save_graph_dir=(eval_dir if eval_config.save_graph else ''))
+    tensor_dict = _extract_prediction_tensors(
+        model=model,
+        create_input_dict_fn=create_input_dict_fn,
+        ignore_groundtruth=eval_config.ignore_groundtruth)
 
-  return metrics
+    def _process_batch(tensor_dict, sess, batch_index, counters):
+        """Evaluates tensors in tensor_dict, visualizing the first K examples.
+
+        This function calls sess.run on tensor_dict, evaluating the original_image
+        tensor only on the first K examples and visualizing detections overlaid
+        on this original_image.
+
+        Args:
+          tensor_dict: a dictionary of tensors
+          sess: tensorflow session
+          batch_index: the index of the batch amongst all batches in the run.
+          counters: a dictionary holding 'success' and 'skipped' fields which can
+            be updated to keep track of number of successful and failed runs,
+            respectively.  If these fields are not updated, then the success/skipped
+            counter values shown at the end of evaluation will be incorrect.
+
+        Returns:
+          result_dict: a dictionary of numpy arrays
+        """
+        summary_writer = tf.summary.FileWriter(eval_dir)
+        try:
+            global_step = tf.train.global_step(sess, tf.train.get_global_step())
+            start_time = time.time()
+            result_dict = sess.run(tensor_dict)
+            forward_pass_time = time.time() - start_time
+            summary = tf.Summary(value=[
+                tf.Summary.Value(tag='forward', simple_value=forward_pass_time),
+            ])
+
+            summary_writer.add_summary(summary, global_step)
+            result_dict['forward_pass_time'] = forward_pass_time
+
+            counters['success'] += 1
+        except tf.errors.InvalidArgumentError:
+            logging.info('Skipping image')
+            counters['skipped'] += 1
+            summary_writer.close()
+            return {}
+        # print(tensor_dict)
+        import os
+        if 'image/filename' in result_dict:
+            if result_dict['image/filename'] == '':
+                print('Error: Filename is empty')
+                exit(-1)
+        path, file_part = os.path.split(result_dict['image/filename'])
+        file_stem = file_part
+        if file_part.endswith('.png'):
+            file_stem = file_part[:-4]
+        result_dict['image/filename'] = file_stem
+
+        # parse the bounding box results and write them to a file
+        import math
+        score_threshold = .5
+        boxes = []
+        for i, box in enumerate(result_dict['detection_boxes']):
+            if box[0] == 0. and box[1] == 0. and box[2] == 0. and box[3] == 0.:
+                continue
+            if result_dict['detection_scores'][i] < score_threshold:
+                continue
+
+            boxes.append(
+                [int(math.floor(box[0])), int(math.floor(box[1])),
+                 int(math.floor(box[2])), int(math.floor(box[3])), result_dict['detection_scores'][i]]
+            )
+
+        summary_writer.close()
+        global_step = tf.train.global_step(sess, tf.train.get_global_step())
+
+        if boxes:
+            out_bboxes = os.path.join(eval_dir, 'output_boundingboxes')
+            if not os.path.exists(out_bboxes):
+                mkdir(out_bboxes)
+
+            with open(out_bboxes + '/boundingboxes-{0:05d}-{1}.txt'.format(batch_index, global_step), 'w') as f:
+                tmp_line = '{0} '.format(result_dict['image/filename'])
+
+                for box in boxes:
+                    tmp = '{0} {1} {2} {3} {4:.9f}; '.format(*box)
+                    tmp_line += tmp
+                f.write(tmp_line + '\n')
+
+        # visualization of the bounding boxes
+        if batch_index < eval_config.num_visualizations:
+            tag = 'image-{}'.format(batch_index)
+            eval_util.visualize_detection_results(
+                result_dict,
+                tag,
+                global_step,
+                categories=categories,
+                summary_dir=eval_dir,
+                export_dir=eval_config.visualization_export_dir,
+                show_groundtruth=eval_config.visualization_export_dir)
+        return result_dict
+
+    variables_to_restore = tf.global_variables()
+    global_step = tf.train.get_or_create_global_step()
+    variables_to_restore.append(global_step)
+    if eval_config.use_moving_averages:
+        variable_averages = tf.train.ExponentialMovingAverage(0.0)
+        variables_to_restore = variable_averages.variables_to_restore()
+    saver = tf.train.Saver(variables_to_restore)
+
+    def _restore_latest_checkpoint(sess):
+        latest_checkpoint = tf.train.latest_checkpoint(checkpoint_dir)
+        saver.restore(sess, latest_checkpoint)
+
+    metrics = eval_util.repeated_checkpoint_run(
+        tensor_dict=tensor_dict,
+        summary_dir=eval_dir,
+        evaluators=get_evaluators(eval_config, categories),
+        batch_processor=_process_batch,
+        checkpoint_dirs=[checkpoint_dir],
+        variables_to_restore=None,
+        restore_fn=_restore_latest_checkpoint,
+        num_batches=eval_config.num_examples,
+        eval_interval_secs=eval_config.eval_interval_secs,
+        max_number_of_evaluations=(1 if eval_config.ignore_groundtruth else
+                                   eval_config.max_evals
+                                   if eval_config.max_evals else None),
+        master=eval_config.eval_master,
+        save_graph=eval_config.save_graph,
+        save_graph_dir=(eval_dir if eval_config.save_graph else ''))
+
+    return metrics

--- a/research/object_detection/evaluator.py
+++ b/research/object_detection/evaluator.py
@@ -108,7 +108,9 @@ def get_evaluators(eval_config, categories):
     raise ValueError('Metric not found: {}'.format(eval_metric_fn_key))
   return [
       EVAL_METRICS_CLASS_DICT[eval_metric_fn_key](
-          categories=categories)
+          categories=categories,
+          matching_iou_threshold=round(eval_config.matching_iou_threshold, 4)
+      )
   ]
 
 

--- a/research/object_detection/protos/eval.proto
+++ b/research/object_detection/protos/eval.proto
@@ -44,4 +44,7 @@ message EvalConfig {
   // Note that since there is no evaluation code currently for instance
   // segmenation this option is unused.
   optional bool eval_instance_masks = 12 [default=false];
+
+  // IoU Threshold to use during the evaluation
+  optional float matching_iou_threshold = 13 [default=0.5];
 }


### PR DESCRIPTION
At the moment the IoU Threshold used for the evaluation is fixed to 0.5. This pull requests adds another parameter to the EvalConfig and uses it in the constructor of the evaluation metric. 
This allows different IoU thresholds for the evaluation without changing the object_detection code.