### PR TITLE
Fix Issue : Change exporter.py in object_detection

### DIFF
--- a/research/object_detection/exporter.py
+++ b/research/object_detection/exporter.py
@@ -69,7 +69,7 @@ def freeze_graph_with_def_protos(
     if optimize_graph:
       logging.info('Graph Rewriter optimizations enabled')
       rewrite_options = rewriter_config_pb2.RewriterConfig(
-          layout_optimizer=1)
+          layout_optimizer=rewriter_config_pb2.RewriterConfig.ON)
       rewrite_options.optimizers.append('pruning')
       rewrite_options.optimizers.append('constfold')
       rewrite_options.optimizers.append('layout')

--- a/research/object_detection/exporter.py
+++ b/research/object_detection/exporter.py
@@ -69,7 +69,7 @@ def freeze_graph_with_def_protos(
     if optimize_graph:
       logging.info('Graph Rewriter optimizations enabled')
       rewrite_options = rewriter_config_pb2.RewriterConfig(
-          optimize_tensor_layout=True)
+          layout_optimizer=1)
       rewrite_options.optimizers.append('pruning')
       rewrite_options.optimizers.append('constfold')
       rewrite_options.optimizers.append('layout')


### PR DESCRIPTION
According to issues [#2861](https://github.com/tensorflow/models/issues/2861) and [#3053](https://github.com/tensorflow/models/issues/3053) , the call to `freeze_graph_with_def_protos` method in `exporter.py` breaks on line [71](https://github.com/tensorflow/models/blob/master/research/object_detection/exporter.py#L71) because of wrong parameter variable mentioned. Current tensorflow version has the corresponding variable called - `layout_optimizer`. Made the corresponding change in exporter.py