### PR TITLE
adds second_stage_batch_size to faster_rcnn_nas_coco.config

### DIFF
--- a/research/object_detection/samples/configs/faster_rcnn_nas_coco.config
+++ b/research/object_detection/samples/configs/faster_rcnn_nas_coco.config
@@ -46,6 +46,7 @@ model {
     first_stage_max_proposals: 50
     first_stage_localization_loss_weight: 2.0
     first_stage_objectness_loss_weight: 1.0
+    second_stage_batch_size: 49
     initial_crop_size: 17
     maxpool_kernel_size: 1
     maxpool_stride: 1


### PR DESCRIPTION
The parameter `second_stage_batch_size` is required in configuration files but is missing.
A Value error is being raised as a result of which.
Fixes #2668
Thanks to @mattryles for the solution.