### PR TITLE
[blog_estimators_dataset.py] bug fix for failing demo

### DIFF
--- a/samples/outreach/blogs/blog_estimators_dataset.py
+++ b/samples/outreach/blogs/blog_estimators_dataset.py
@@ -65,7 +65,7 @@ feature_names = [
 def my_input_fn(file_path, perform_shuffle=False, repeat_count=1):
     def decode_csv(line):
         parsed_line = tf.decode_csv(line, [[0.], [0.], [0.], [0.], [0]])
-        label = parsed_line[-1:]  # Last element is the label
+        label = parsed_line[-1]  # Last element is the label
         del parsed_line[-1]  # Delete last element
         features = parsed_line  # Everything but last elements are the features
         d = dict(zip(feature_names, features)), label


### PR DESCRIPTION
Here's the error I got before making this fix:

```
TensorFlow version: 1.5.0-rc0
Traceback (most recent call last):
  File "/Users/timmolter/workspaces/workspace_tf/models/samples/outreach/blogs/blog_estimators_dataset.py", line 86, in <module>
    next_batch = my_input_fn(FILE_TRAIN, True)  # Will return 32 random elements
  File "/Users/timmolter/workspaces/workspace_tf/models/samples/outreach/blogs/blog_estimators_dataset.py", line 76, in my_input_fn
    .map(decode_csv))  # Transform each elem by applying decode_csv fn
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 780, in map
    return MapDataset(self, map_func)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1583, in __init__
    self._map_func.add_to_graph(ops.get_default_graph())
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/function.py", line 486, in add_to_graph
    self._create_definition_if_needed()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/function.py", line 321, in _create_definition_if_needed
    self._create_definition_if_needed_impl()
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/function.py", line 338, in _create_definition_if_needed_impl
    outputs = self._func(*inputs)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1571, in tf_map_func
    ret, [t.get_shape() for t in nest.flatten(ret)])
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1571, in <listcomp>
    ret, [t.get_shape() for t in nest.flatten(ret)])
AttributeError: 'list' object has no attribute 'get_shape'
```