### PR TITLE
Force the type of height and width to be int in visualization_utils.py for detection

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -518,7 +518,7 @@ def add_cdf_image_summary(values, name):
     fig.canvas.draw()
     width, height = fig.get_size_inches() * fig.get_dpi()
     image = np.fromstring(fig.canvas.tostring_rgb(), dtype='uint8').reshape(
-        1, height, width, 3)
+        1, int(height), int(width), 3)
     return image
   cdf_plot = tf.py_func(cdf_plot, [values], tf.uint8)
   tf.summary.image(name, cdf_plot)


### PR DESCRIPTION
Since the functionality to use floating point indices was deprecated in numpy>1.11.0, a TypeError "'numpy.float64' object cannot be interpreted as an index" may occur when calling `add_cdf_image_summary` function. It happens when using numpy>=1.12.0, where `height` and `width` can be floating point numbers which makes `np.reshape` to fail. Forcing `height` and `width` to be integer can make the code more robust.