### PR TITLE
Datasets have _mask in their name only when faces_only is False

### DIFF
--- a/research/object_detection/dataset_tools/create_pet_tf_record.py
+++ b/research/object_detection/dataset_tools/create_pet_tf_record.py
@@ -257,7 +257,7 @@ def main(_):
 
   train_output_path = os.path.join(FLAGS.output_dir, 'pet_train.record')
   val_output_path = os.path.join(FLAGS.output_dir, 'pet_val.record')
-  if FLAGS.faces_only:
+  if not FLAGS.faces_only:
     train_output_path = os.path.join(FLAGS.output_dir,
                                      'pet_train_with_masks.record')
     val_output_path = os.path.join(FLAGS.output_dir,


### PR DESCRIPTION
Ref: [Distributed Training on the Oxford-IIIT Pets Dataset on Google Cloud](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/running_pets.md)

---

The names of the datasets should be:
- `pet_train.record`
- `pet_val.record`

But, the script outputs the datasets with the names of:
- `pet_train_with_masks.record`
- `pet_val_with_masks.record`

Default value for `faces_only` is `True`.

- [research/object_detection/dataset_tools/create_pet_tf_record.py#L49](https://github.com/tensorflow/models/blob/master/research/object_detection/dataset_tools/create_pet_tf_record.py#L49)

---

*NOTE: I am not a 💯 sure about this change as I started just 2 days using this repository.*