### PR TITLE
fixed use of wrong variable

### DIFF
--- a/research/object_detection/evaluator.py
+++ b/research/object_detection/evaluator.py
@@ -177,7 +177,7 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
           categories=categories,
           summary_dir=eval_dir,
           export_dir=eval_config.visualization_export_dir,
-          show_groundtruth=eval_config.visualization_export_dir)
+          show_groundtruth=not eval_config.ignore_groundtruth)
     return result_dict
 
   variables_to_restore = tf.global_variables()


### PR DESCRIPTION
Fixed what was probably a type:
`show_groundtruth` now uses `ignore_groundtruth` instead of unrelated `visualization_export_dir`.