### PR TITLE
from six.moves import xrange (en masse)

### DIFF
--- a/research/brain_coder/common/config_lib.py
+++ b/research/brain_coder/common/config_lib.py
@@ -10,6 +10,7 @@ else that may be specific to a particular run.
 
 import ast
 import itertools
+from six.moves import xrange
 
 
 class Config(dict):

--- a/research/brain_coder/common/schedules_test.py
+++ b/research/brain_coder/common/schedules_test.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from math import exp
 from math import sqrt
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from common import config_lib  # brain coder

--- a/research/brain_coder/common/utils.py
+++ b/research/brain_coder/common/utils.py
@@ -12,6 +12,7 @@ import random
 
 from absl import logging
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/brain_coder/single_task/code_tasks.py
+++ b/research/brain_coder/single_task/code_tasks.py
@@ -11,6 +11,7 @@ import random
 
 from absl import logging
 import numpy as np
+from six.moves import xrange
 
 from common import bf  # brain coder
 from common import reward as r  # brain coder

--- a/research/brain_coder/single_task/ga_lib.py
+++ b/research/brain_coder/single_task/ga_lib.py
@@ -14,6 +14,7 @@ import random
 from absl import flags
 from absl import logging
 import numpy as np
+from six.moves import xrange
 
 from common import bf  # brain coder
 from common import utils  # brain coder
@@ -469,4 +470,3 @@ class Individual(list):
 
 def random_individual(genome_size):
   return lambda: Individual(np.random.choice(GENES, genome_size).tolist())
-

--- a/research/brain_coder/single_task/ga_train.py
+++ b/research/brain_coder/single_task/ga_train.py
@@ -18,6 +18,7 @@ from time import sleep
 from absl import flags
 from absl import logging
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from common import utils  # brain coder
@@ -321,4 +322,3 @@ def run_random_search(max_num_programs, checkpoint_dir, task_eval_fn,
       solution_found=found_solution, generations=num_programs_seen,
       num_programs=num_programs_seen, max_generations=max_num_programs,
       max_num_programs=max_num_programs)
-

--- a/research/brain_coder/single_task/pg_agent.py
+++ b/research/brain_coder/single_task/pg_agent.py
@@ -15,6 +15,7 @@ import time
 
 from absl import logging
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from common import rollout as rollout_lib  # brain coder
@@ -1294,4 +1295,3 @@ def process_episodes(
     batch_targets = np.array([], dtype=np.float32)
 
   return (batch_targets, batch_returns)
-

--- a/research/brain_coder/single_task/pg_agent_test.py
+++ b/research/brain_coder/single_task/pg_agent_test.py
@@ -8,6 +8,7 @@ from collections import Counter
 
 from absl import logging
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from common import utils  # brain coder

--- a/research/brain_coder/single_task/results_lib.py
+++ b/research/brain_coder/single_task/results_lib.py
@@ -8,6 +8,7 @@ import ast
 from collections import namedtuple
 import os
 import re
+from six.moves import xrange
 import tensorflow as tf
 
 
@@ -152,4 +153,3 @@ class Results(object):
           r for shard_results in results_per_shard for r in shard_results]
 
     return aggregate, shard_stats
-

--- a/research/brain_coder/single_task/results_lib_test.py
+++ b/research/brain_coder/single_task/results_lib_test.py
@@ -8,6 +8,7 @@ import contextlib
 import os
 import shutil
 import tempfile
+from six.moves import xrange
 import tensorflow as tf
 
 from single_task import results_lib  # brain coder

--- a/research/brain_coder/single_task/test_tasks.py
+++ b/research/brain_coder/single_task/test_tasks.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 """Tasks that test correctness of algorithms."""
 
+from six.moves import xrange
 from common import reward as reward_lib  # brain coder
 from single_task import misc  # brain coder
 
@@ -124,5 +125,3 @@ class HillClimbingTask(object):
     # closest next element.
     # Maximum distance possible is num_actions * base / 2 = 3 * 8 / 2 = 12
     return (len(prefix) + (1 - min_dist / 12.0)), False
-
-

--- a/research/brain_coder/single_task/tune.py
+++ b/research/brain_coder/single_task/tune.py
@@ -39,6 +39,7 @@ from absl import app
 from absl import flags
 from absl import logging
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from single_task import defaults  # brain coder

--- a/research/compression/entropy_coder/dataset/gen_synthetic_dataset.py
+++ b/research/compression/entropy_coder/dataset/gen_synthetic_dataset.py
@@ -18,6 +18,7 @@
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import synthetic_model

--- a/research/compression/entropy_coder/dataset/synthetic_model.py
+++ b/research/compression/entropy_coder/dataset/synthetic_model.py
@@ -16,6 +16,7 @@
 """Binary code sample generator."""
 
 import numpy as np
+from six.moves import xrange
 
 
 _CRC_LINE = [

--- a/research/compression/entropy_coder/lib/blocks_masked_conv2d.py
+++ b/research/compression/entropy_coder/lib/blocks_masked_conv2d.py
@@ -16,6 +16,7 @@
 """Define some typical masked 2D convolutions."""
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import block_util

--- a/research/compression/entropy_coder/lib/blocks_masked_conv2d_test.py
+++ b/research/compression/entropy_coder/lib/blocks_masked_conv2d_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import blocks_masked_conv2d

--- a/research/compression/entropy_coder/lib/blocks_std_test.py
+++ b/research/compression/entropy_coder/lib/blocks_std_test.py
@@ -22,6 +22,7 @@ import math
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import blocks_std

--- a/research/delf/delf/python/feature_io.py
+++ b/research/delf/delf/python/feature_io.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 from delf import feature_pb2
 from delf import datum_io
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/differential_privacy/dp_sgd/dp_mnist/dp_mnist.py
+++ b/research/differential_privacy/dp_sgd/dp_mnist/dp_mnist.py
@@ -22,6 +22,7 @@ import sys
 import time
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from differential_privacy.dp_sgd.dp_optimizer import dp_optimizer

--- a/research/differential_privacy/dp_sgd/per_example_gradients/per_example_gradients.py
+++ b/research/differential_privacy/dp_sgd/per_example_gradients/per_example_gradients.py
@@ -17,6 +17,7 @@
 
 import collections
 
+from six.moves import xrange
 import tensorflow as tf
 
 OrderedDict = collections.OrderedDict

--- a/research/differential_privacy/multiple_teachers/aggregation.py
+++ b/research/differential_privacy/multiple_teachers/aggregation.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange
 
 
 def labels_from_probs(probs):
@@ -127,5 +128,3 @@ def aggregation_most_frequent(logits):
     result[i] = np.argmax(label_counts)
 
   return np.asarray(result, dtype=np.int32)
-
-

--- a/research/differential_privacy/multiple_teachers/deep_cnn.py
+++ b/research/differential_privacy/multiple_teachers/deep_cnn.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 from datetime import datetime
 import math
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 import time
 
@@ -600,5 +601,3 @@ def softmax_preds(images, ckpt_path, return_logits=False):
   tf.reset_default_graph()
 
   return preds
-
-

--- a/research/differential_privacy/multiple_teachers/input.py
+++ b/research/differential_privacy/multiple_teachers/input.py
@@ -24,6 +24,7 @@ import numpy as np
 import os
 from scipy.io import loadmat as loadmat
 from six.moves import urllib
+from six.moves import xrange
 import sys
 import tarfile
 

--- a/research/differential_privacy/multiple_teachers/train_student.py
+++ b/research/differential_privacy/multiple_teachers/train_student.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from differential_privacy.multiple_teachers import aggregation

--- a/research/domain_adaptation/domain_separation/dsn_eval.py
+++ b/research/domain_adaptation/domain_separation/dsn_eval.py
@@ -19,6 +19,7 @@
 import math
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from domain_adaptation.datasets import dataset_factory

--- a/research/gan/cifar/util.py
+++ b/research/gan/cifar/util.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 tfgan = tf.contrib.gan
 

--- a/research/gan/image_compression/networks_test.py
+++ b/research/gan/image_compression/networks_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+from six.moves import xrange
 import networks
 
 

--- a/research/gan/mnist/util.py
+++ b/research/gan/mnist/util.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 ds = tf.contrib.distributions

--- a/research/gan/mnist_estimator/train.py
+++ b/research/gan/mnist_estimator/train.py
@@ -22,6 +22,7 @@ import os
 
 import numpy as np
 import scipy.misc
+from six.moves import xrange
 import tensorflow as tf
 
 from mnist import data_provider

--- a/research/im2txt/im2txt/data/build_mscoco_data.py
+++ b/research/im2txt/im2txt/data/build_mscoco_data.py
@@ -97,6 +97,7 @@ import threading
 
 import nltk.tokenize
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 tf.flags.DEFINE_string("train_image_dir", "/tmp/train2014/",

--- a/research/learned_optimizer/metaopt.py
+++ b/research/learned_optimizer/metaopt.py
@@ -21,6 +21,7 @@ import sys
 import time
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from learned_optimizer.optimizer import trainable_optimizer

--- a/research/learning_to_remember_rare_events/data_utils.py
+++ b/research/learning_to_remember_rare_events/data_utils.py
@@ -29,6 +29,7 @@ import numpy as np
 from scipy.misc import imresize
 from scipy.misc import imrotate
 from scipy.ndimage import imread
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/learning_to_remember_rare_events/memory.py
+++ b/research/learning_to_remember_rare_events/memory.py
@@ -23,6 +23,7 @@ published as a conference paper at ICLR 2017.
 """
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/learning_to_remember_rare_events/train.py
+++ b/research/learning_to_remember_rare_events/train.py
@@ -26,6 +26,7 @@ import os
 import random
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import data_utils

--- a/research/lfads/synth_data/generate_itb_data.py
+++ b/research/lfads/synth_data/generate_itb_data.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import h5py
 import numpy as np
 import os
+from six.moves import xrange
 import tensorflow as tf
 
 from utils import write_datasets
@@ -47,12 +48,12 @@ flags.DEFINE_float("max_firing_rate", 30.0,
 flags.DEFINE_float("u_std", 0.25,
                    "Std dev of input to integration to bound model")
 flags.DEFINE_string("checkpoint_path", "SAMPLE_CHECKPOINT",
-                    """Path to directory with checkpoints of model 
+                    """Path to directory with checkpoints of model
                     trained on integration to bound task. Currently this
                     is a placeholder which tells the code to grab the
-                    checkpoint that is provided with the code 
-                    (in /trained_itb/..). If you have your own checkpoint 
-                    you would like to restore, you would point it to 
+                    checkpoint that is provided with the code
+                    (in /trained_itb/..). If you have your own checkpoint
+                    you would like to restore, you would point it to
                     that path.""")
 FLAGS = flags.FLAGS
 

--- a/research/lfads/synth_data/generate_labeled_rnn_data.py
+++ b/research/lfads/synth_data/generate_labeled_rnn_data.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 import h5py
 import numpy as np
+from six.moves import xrange
 
 from synthetic_data_utils import generate_data, generate_rnn
 from synthetic_data_utils import get_train_n_valid_inds

--- a/research/neural_gpu/data_utils.py
+++ b/research/neural_gpu/data_utils.py
@@ -21,6 +21,7 @@ import sys
 import time
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import program_utils

--- a/research/next_frame_prediction/cross_conv/eval.py
+++ b/research/next_frame_prediction/cross_conv/eval.py
@@ -20,6 +20,7 @@ import sys
 import time
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import model as cross_conv_model

--- a/research/next_frame_prediction/cross_conv/example_gen.py
+++ b/research/next_frame_prediction/cross_conv/example_gen.py
@@ -18,6 +18,7 @@ import random
 import sys
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/next_frame_prediction/cross_conv/model.py
+++ b/research/next_frame_prediction/cross_conv/model.py
@@ -20,6 +20,7 @@ https://arxiv.org/pdf/1607.02586v1.pdf
 import math
 import sys
 
+from six.moves import xrange
 import tensorflow as tf
 
 slim = tf.contrib.slim

--- a/research/next_frame_prediction/cross_conv/reader.py
+++ b/research/next_frame_prediction/cross_conv/reader.py
@@ -15,6 +15,7 @@
 
 """Read image sequence."""
 
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/next_frame_prediction/cross_conv/sprites_gen.py
+++ b/research/next_frame_prediction/cross_conv/sprites_gen.py
@@ -21,6 +21,7 @@ import sys
 
 import numpy as np
 import scipy.misc
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/object_detection/dataset_tools/oid_tfrecord_creation.py
+++ b/research/object_detection/dataset_tools/oid_tfrecord_creation.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 from object_detection.core import standard_fields

--- a/research/object_detection/utils/np_box_list_ops.py
+++ b/research/object_detection/utils/np_box_list_ops.py
@@ -21,6 +21,7 @@ Example box operations that are supported:
 """
 
 import numpy as np
+from six.moves import xrange
 
 from object_detection.utils import np_box_list
 from object_detection.utils import np_box_ops

--- a/research/pcl_rl/baseline.py
+++ b/research/pcl_rl/baseline.py
@@ -20,6 +20,7 @@ In some cases this is just an additional linear layer on the policy.
 In other cases, it is a completely separate neural network.
 """
 
+from six.moves import xrange
 import tensorflow as tf
 import numpy as np
 

--- a/research/pcl_rl/controller.py
+++ b/research/pcl_rl/controller.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 import numpy as np
 import pickle

--- a/research/pcl_rl/env_spec.py
+++ b/research/pcl_rl/env_spec.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange
 
 
 class spaces(object):

--- a/research/pcl_rl/expert_paths.py
+++ b/research/pcl_rl/expert_paths.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 import random
 import os
 import numpy as np
+from six.moves import xrange
 import pickle
 
 gfile = tf.gfile

--- a/research/pcl_rl/gym_wrapper.py
+++ b/research/pcl_rl/gym_wrapper.py
@@ -22,6 +22,7 @@ import gym
 import numpy as np
 import random
 
+from six.moves import xrange
 import env_spec
 
 

--- a/research/pcl_rl/optimizers.py
+++ b/research/pcl_rl/optimizers.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 import numpy as np
 import scipy.optimize

--- a/research/pcl_rl/replay_buffer.py
+++ b/research/pcl_rl/replay_buffer.py
@@ -20,6 +20,7 @@ Implements replay buffer in Python.
 
 import random
 import numpy as np
+from six.moves import xrange
 
 
 class ReplayBuffer(object):

--- a/research/pcl_rl/trainer.py
+++ b/research/pcl_rl/trainer.py
@@ -25,6 +25,7 @@ import random
 import os
 import pickle
 
+from six.moves import xrange
 import controller
 import model
 import policy

--- a/research/pcl_rl/trust_region.py
+++ b/research/pcl_rl/trust_region.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 import numpy as np
 

--- a/research/ptn/metrics.py
+++ b/research/ptn/metrics.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 slim = tf.contrib.slim
@@ -108,5 +109,3 @@ def add_volume_iou_metrics(inputs, outputs):
   names_to_values['volume_iou'] = tmp_values * 3.0
   names_to_updates['volume_iou'] = tmp_updates
   return names_to_values, names_to_updates
-
-

--- a/research/ptn/model_ptn.py
+++ b/research/ptn/model_ptn.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import losses

--- a/research/ptn/model_rotator.py
+++ b/research/ptn/model_rotator.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import input_generator
@@ -191,19 +192,19 @@ def get_train_op_for_scope(loss, optimizer, scopes, params):
 
 def get_metrics(inputs, outputs, params):
   """Aggregate the metrics for rotator model.
-  
+
   Args:
     inputs: Input dictionary of the rotator model.
     outputs: Output dictionary returned by the rotator model.
     params: Hyperparameters of the rotator model.
-  
+
   Returns:
     names_to_values: metrics->values (dict).
     names_to_updates: metrics->ops (dict).
   """
   names_to_values = dict()
   names_to_updates = dict()
-  
+
   tmp_values, tmp_updates = metrics.add_image_pred_metrics(
       inputs, outputs, params.num_views, 3*params.image_size**2)
   names_to_values.update(tmp_values)
@@ -217,7 +218,7 @@ def get_metrics(inputs, outputs, params):
   for name, value in names_to_values.iteritems():
     slim.summaries.add_scalar_summary(
         value, name, prefix='eval', print_summary=True)
- 
+
   return names_to_values, names_to_updates
 
 

--- a/research/ptn/model_voxel_generation.py
+++ b/research/ptn/model_voxel_generation.py
@@ -22,6 +22,7 @@ import abc
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 import input_generator

--- a/research/ptn/pretrain_rotator.py
+++ b/research/ptn/pretrain_rotator.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import os
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from tensorflow import app

--- a/research/ptn/utils.py
+++ b/research/ptn/utils.py
@@ -28,6 +28,7 @@ from mpl_toolkits.mplot3d import axes3d as p3  # pylint:disable=unused-import
 import numpy as np
 from PIL import Image
 from skimage import measure
+from six.moves import xrange
 
 import tensorflow as tf
 
@@ -116,4 +117,3 @@ def visualize_voxel_scatter(points, vis_size=128):
           vis_size, vis_size, 3)
   p.close('all')
   return data
-

--- a/research/real_nvp/real_nvp_utils.py
+++ b/research/real_nvp/real_nvp_utils.py
@@ -19,6 +19,7 @@ r"""Utility functions for Real NVP.
 # pylint: disable=dangerous-default-value
 
 import numpy
+from six.moves import xrange
 import tensorflow as tf
 from tensorflow.python.framework import ops
 

--- a/research/slim/datasets/build_imagenet_data.py
+++ b/research/slim/datasets/build_imagenet_data.py
@@ -94,6 +94,7 @@ import threading
 
 import google3
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 tf.app.flags.DEFINE_string('train_directory', '/tmp/',

--- a/research/slim/datasets/preprocess_imagenet_validation_data.py
+++ b/research/slim/datasets/preprocess_imagenet_validation_data.py
@@ -51,6 +51,7 @@ from __future__ import print_function
 import os
 import os.path
 import sys
+from six.moves import xrange
 
 
 if __name__ == '__main__':

--- a/research/slim/datasets/process_bounding_boxes.py
+++ b/research/slim/datasets/process_bounding_boxes.py
@@ -85,6 +85,7 @@ import glob
 import os.path
 import sys
 import xml.etree.ElementTree as ET
+from six.moves import xrange
 
 
 class BoundingBox(object):

--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-
+from six.moves import xrange
 import tensorflow as tf
 
 layers = tf.contrib.layers

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 from math import log
 
+from six.moves import xrange
 import tensorflow as tf
 slim = tf.contrib.slim
 

--- a/research/slim/nets/dcgan_test.py
+++ b/research/slim/nets/dcgan_test.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 from nets import dcgan
 

--- a/research/street/python/decoder.py
+++ b/research/street/python/decoder.py
@@ -25,6 +25,7 @@ import collections
 import re
 
 import errorcounter as ec
+from six.moves import xrange
 import tensorflow as tf
 
 # Named tuple Part describes a part of a multi (1 or more) part code that

--- a/research/street/python/shapes.py
+++ b/research/street/python/shapes.py
@@ -24,6 +24,7 @@ tensor_dim: gets a shape dimension as a constant integer if known otherwise a
   runtime usable tensor value.
 tensor_shape: returns the full shape of a tensor as the tensor_dim.
 """
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/street/python/vgslspecs.py
+++ b/research/street/python/vgslspecs.py
@@ -23,6 +23,7 @@ from string import maketrans
 
 import nn_ops
 import shapes
+from six.moves import xrange
 import tensorflow as tf
 import tensorflow.contrib.slim as slim
 

--- a/research/syntaxnet/dragnn/python/graph_builder_test.py
+++ b/research/syntaxnet/dragnn/python/graph_builder_test.py
@@ -20,6 +20,7 @@ import os.path
 
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from google.protobuf import text_format

--- a/research/syntaxnet/dragnn/python/network_units.py
+++ b/research/syntaxnet/dragnn/python/network_units.py
@@ -22,6 +22,7 @@ import abc
 
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import tensor_array_ops as ta

--- a/research/syntaxnet/dragnn/python/spec_builder.py
+++ b/research/syntaxnet/dragnn/python/spec_builder.py
@@ -15,6 +15,7 @@
 """Utils for building DRAGNN specs."""
 
 
+from six.moves import xrange
 import tensorflow as tf
 
 from dragnn.protos import spec_pb2

--- a/research/syntaxnet/dragnn/python/trainer_lib.py
+++ b/research/syntaxnet/dragnn/python/trainer_lib.py
@@ -23,6 +23,7 @@ import random
 
 
 import tensorflow as tf
+from six.moves import xrange
 from tensorflow.core.framework.summary_pb2 import Summary
 from tensorflow.python.framework import errors
 from tensorflow.python.platform import gfile

--- a/research/tcn/labeled_eval.py
+++ b/research/tcn/labeled_eval.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 import os
 import numpy as np
 from sklearn.metrics.pairwise import pairwise_distances
+from six.moves import xrange
 import data_providers
 from estimators.get_estimator import get_estimator
 from utils import util


### PR DESCRIPTION
@nealwu As requested at https://github.com/tensorflow/models/issues/3103#issuecomment-356150374

For all files that use the Python 2-only builtin function __xrange()__, add the line __from six.moves import xrange__ for compatibility with Python 3.