### PR TITLE
old style exceptions --> new style for Python 3

### DIFF
--- a/research/swivel/text2bin.py
+++ b/research/swivel/text2bin.py
@@ -49,7 +49,7 @@ import sys
 try:
   opts, args = getopt(
       sys.argv[1:], 'o:v:', ['output=', 'vocab='])
-except GetoptError, e:
+except GetoptError as e:
   print >> sys.stderr, e
   sys.exit(2)
 

--- a/research/syntaxnet/dragnn/python/graph_builder.py
+++ b/research/syntaxnet/dragnn/python/graph_builder.py
@@ -28,7 +28,7 @@ from syntaxnet.util import check
 
 try:
   tf.NotDifferentiable('ExtractFixedFeatures')
-except KeyError, e:
+except KeyError as e:
   logging.info(str(e))
 
 


### PR DESCRIPTION
Old style exceptions were removed from Python 3 because that syntax was too ambiguous.

See: http://python-future.org/compatible_idioms.html#catching-exceptions

@nealwu @panyx0718 