### PR TITLE
Compression: long was removed from Python 3

### DIFF
--- a/research/compression/entropy_coder/lib/block_util.py
+++ b/research/compression/entropy_coder/lib/block_util.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 import math
 
 import numpy as np
+from six import integer_types
 import tensorflow as tf
 
 
@@ -39,7 +40,7 @@ class RsqrtInitializer(object):
         1.0 / sqrt(product(shape[dims]))
       **kwargs: Extra keyword arguments to pass to tf.truncated_normal.
     """
-    if isinstance(dims, (int, long)):
+    if isinstance(dims, integer_types):
       self._dims = [dims]
     else:
       self._dims = dims
@@ -73,7 +74,7 @@ class RectifierInitializer(object):
         sqrt(scale / product(shape[dims])).
       **kwargs: Extra keyword arguments to pass to tf.truncated_normal.
     """
-    if isinstance(dims, (int, long)):
+    if isinstance(dims, integer_types):
       self._dims = [dims]
     else:
       self._dims = dims


### PR DESCRIPTION
from six.moves import integer_types