### PR TITLE
bugfix type mismatch tf.float32 != tf.int32 (fixes #2774)

### DIFF
--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -91,7 +91,7 @@ def _build_non_max_suppressor(nms_config):
 def _score_converter_fn_with_logit_scale(tf_score_converter_fn, logit_scale):
   """Create a function to scale logits then apply a Tensorflow function."""
   def score_converter_fn(logits):
-    scaled_logits = tf.divide(logits, logit_scale, name='scale_logits')
+    scaled_logits = tf.divide(logits, tf.constant([[logit_scale]],tf.float32), name='scale_logits')
     return tf_score_converter_fn(scaled_logits, name='convert_scores')
   score_converter_fn.__name__ = '%s_with_logit_scale' % (
       tf_score_converter_fn.__name__)


### PR DESCRIPTION
it fixes the bug discussed at https://github.com/tensorflow/models/issues/2774
TypeError: x and y must have the same dtype, got tf.float32 != tf.int32