### PR TITLE
long was removed in Python 3 (en masse)

### DIFF
--- a/research/brain_coder/common/utils.py
+++ b/research/brain_coder/common/utils.py
@@ -12,6 +12,7 @@ import random
 
 from absl import logging
 import numpy as np
+import six
 from six.moves import xrange
 import tensorflow as tf
 
@@ -138,7 +139,7 @@ def stack_pad(tensors, pad_axes=None, pad_to_lengths=None, dtype=np.float32,
   same_axes = dict(enumerate(max_lengths))
   if pad_axes is None:
     pad_axes = []
-  if isinstance(pad_axes, (int, long)):
+  if isinstance(pad_axes, six.integer_types):
     if pad_to_lengths is not None:
       max_lengths[pad_axes] = pad_to_lengths
     del same_axes[pad_axes]

--- a/research/compression/entropy_coder/lib/block_util.py
+++ b/research/compression/entropy_coder/lib/block_util.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 import math
 
 import numpy as np
+import six
 import tensorflow as tf
 
 
@@ -39,7 +40,7 @@ class RsqrtInitializer(object):
         1.0 / sqrt(product(shape[dims]))
       **kwargs: Extra keyword arguments to pass to tf.truncated_normal.
     """
-    if isinstance(dims, (int, long)):
+    if isinstance(dims, six.integer_types):
       self._dims = [dims]
     else:
       self._dims = dims
@@ -73,7 +74,7 @@ class RectifierInitializer(object):
         sqrt(scale / product(shape[dims])).
       **kwargs: Extra keyword arguments to pass to tf.truncated_normal.
     """
-    if isinstance(dims, (int, long)):
+    if isinstance(dims, six.integer_types):
       self._dims = [dims]
     else:
       self._dims = dims

--- a/research/object_detection/dataset_tools/create_oid_tf_record.py
+++ b/research/object_detection/dataset_tools/create_oid_tf_record.py
@@ -42,11 +42,6 @@ import tensorflow as tf
 from object_detection.dataset_tools import oid_tfrecord_creation
 from object_detection.utils import label_map_util
 
-try:
-    long        # Python 2
-except NameError:
-    long = int  # Python 3
-
 tf.flags.DEFINE_string('input_annotations_csv', None,
                        'Path to CSV containing image bounding box annotations')
 tf.flags.DEFINE_string('input_images_directory', None,
@@ -101,7 +96,7 @@ def main(_):
       tf_example = oid_tfrecord_creation.tf_example_from_annotations_data_frame(
           image_annotations, label_map, encoded_image)
       if tf_example:
-        shard_idx = long(image_id, 16) % FLAGS.num_shards
+        shard_idx = int(image_id, 16) % FLAGS.num_shards
         output_tfrecords[shard_idx].write(tf_example.SerializeToString())
 
 

--- a/research/object_detection/dataset_tools/create_oid_tf_record.py
+++ b/research/object_detection/dataset_tools/create_oid_tf_record.py
@@ -42,6 +42,11 @@ import tensorflow as tf
 from object_detection.dataset_tools import oid_tfrecord_creation
 from object_detection.utils import label_map_util
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 tf.flags.DEFINE_string('input_annotations_csv', None,
                        'Path to CSV containing image bounding box annotations')
 tf.flags.DEFINE_string('input_images_directory', None,

--- a/research/object_detection/utils/ops.py
+++ b/research/object_detection/utils/ops.py
@@ -203,9 +203,9 @@ def padded_one_hot_encoding(indices, depth, left_pad):
 
   TODO: add runtime checks for depth and indices.
   """
-  if depth < 0 or not isinstance(depth, (int, long) if six.PY2 else int):
+  if depth < 0 or not isinstance(depth, six.integer_types):
     raise ValueError('`depth` must be a non-negative integer.')
-  if left_pad < 0 or not isinstance(left_pad, (int, long) if six.PY2 else int):
+  if left_pad < 0 or not isinstance(left_pad, six.integer_types):
     raise ValueError('`left_pad` must be a non-negative integer.')
   if depth == 0:
     return None


### PR DESCRIPTION
__long__ was [removed](https://docs.python.org/3/whatsnew/3.0.html#integers) from Python 3 in favor of __int__.

@nealwu Like we did for __xrange()__ in #3206 but this time for the builtin type __long__.
