### PR TITLE
file() was removed in Python 3 (en masse)

### DIFF
--- a/research/syntaxnet/dragnn/python/dragnn_model_saver_lib_test.py
+++ b/research/syntaxnet/dragnn/python/dragnn_model_saver_lib_test.py
@@ -45,7 +45,7 @@ class DragnnModelSaverLibTest(test_util.TensorFlowTestCase):
     master_spec = spec_pb2.MasterSpec()
     root_dir = os.path.join(FLAGS.test_srcdir,
                             'dragnn/python')
-    with file(os.path.join(root_dir, 'testdata', spec_path), 'r') as fin:
+    with open(os.path.join(root_dir, 'testdata', spec_path), 'r') as fin:
       text_format.Parse(fin.read().replace('TOPDIR', root_dir), master_spec)
       return master_spec
 

--- a/research/syntaxnet/dragnn/python/graph_builder_test.py
+++ b/research/syntaxnet/dragnn/python/graph_builder_test.py
@@ -246,7 +246,7 @@ class GraphBuilderTest(test_util.TensorFlowTestCase):
     master_spec = spec_pb2.MasterSpec()
     testdata = os.path.join(FLAGS.test_srcdir,
                             'dragnn/core/testdata')
-    with file(os.path.join(testdata, spec_path), 'r') as fin:
+    with open(os.path.join(testdata, spec_path), 'r') as fin:
       text_format.Parse(fin.read().replace('TESTDATA', testdata), master_spec)
       return master_spec
 

--- a/research/syntaxnet/syntaxnet/lexicon_builder_test.py
+++ b/research/syntaxnet/syntaxnet/lexicon_builder_test.py
@@ -140,7 +140,7 @@ class LexiconBuilderTest(test_util.TensorFlowTestCase):
       self.assertTrue(last)
 
   def ValidateTagToCategoryMap(self):
-    with file(os.path.join(FLAGS.test_tmpdir, 'tag-to-category'), 'r') as f:
+    with open(os.path.join(FLAGS.test_tmpdir, 'tag-to-category'), 'r') as f:
       entries = [line.strip().split('\t') for line in f.readlines()]
     for tag, category in entries:
       self.assertIn(tag, TAGS)
@@ -148,7 +148,7 @@ class LexiconBuilderTest(test_util.TensorFlowTestCase):
 
   def LoadMap(self, map_name):
     loaded_map = {}
-    with file(os.path.join(FLAGS.test_tmpdir, map_name), 'r') as f:
+    with open(os.path.join(FLAGS.test_tmpdir, map_name), 'r') as f:
       for line in f:
         entries = line.strip().split(' ')
         if len(entries) >= 2:


### PR DESCRIPTION
@nealwu The general advise is http://python-future.org/compatible_idioms.html#file but my sense is that just replacing __file()__ with __open()__ is OK for these use cases.  Your thoughts?