### PR TITLE
Use r-string to avoid raising Python 3 SyntaxError

### DIFF
--- a/research/cognitive_mapping_and_planning/scripts/script_plot_trajectory.py
+++ b/research/cognitive_mapping_and_planning/scripts/script_plot_trajectory.py
@@ -220,7 +220,7 @@ def plot_trajectory_first_person(dt, orig_maps, out_dir):
       t.set_bbox(dict(color='white', alpha=0.85, pad=-0.1))
 
       # Action to take.
-      action_latex = ['$\odot$ ', '$\curvearrowright$ ', '$\curvearrowleft$ ', '$\Uparrow$ ']
+      action_latex = ['$\odot$ ', '$\curvearrowright$ ', '$\curvearrowleft$ ', r'$\Uparrow$ ']
       t = ax.text(0.99, 0.99, action_latex[actions[step_number]],
           horizontalalignment='right',
           verticalalignment='top',


### PR DESCRIPTION
In Python 2 the string and the r-string behave the same:
$ __python2__
```
>>> '$\Uparrow$ '
'$\\Uparrow$ '
>>> r'$\Uparrow$ '
'$\\Uparrow$ '
>>> '$\Uparrow$ ' == r'$\Uparrow$ '
True
```

In Python 3 the string raises a Syntax Error while the r-string works just like Python 2.
$ __python3__
```
>>> '$\Uparrow$ '
  File "<stdin>", line 1
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 1-2: truncated \UXXXXXXXX escape
>>> r'$\Uparrow$ '
'$\\Uparrow$ '
```