### PR TITLE
unicode() builtin was removed in Python 3 because all str are Unicode

### DIFF
--- a/research/syntaxnet/dragnn/python/render_parse_tree_graphviz.py
+++ b/research/syntaxnet/dragnn/python/render_parse_tree_graphviz.py
@@ -53,7 +53,11 @@ def parse_tree_graph(sentence):
     warnings.simplefilter("ignore")
     svg = graph.draw(format="svg", prog="dot")
 
-  svg = unicode(svg, "utf-8")
+  # unicode() was removed from Python 3 beccause all str are Unicode
+  try:
+      svg = unicode(svg, "utf-8")  # Python 2
+  except NameError:
+      svg = str(svg)               # Python 3
 
   # For both inline and "new window" displays, we show the tokens with the
   # graph. (The sentence order of nodes is sometimes difficult to read.)

--- a/research/syntaxnet/dragnn/python/visualization.py
+++ b/research/syntaxnet/dragnn/python/visualization.py
@@ -71,6 +71,8 @@ def parse_trace_json(trace):
       if isinstance(step_trace.caption, str):
         try:
           unicode(step_trace.caption, 'utf-8')
+        except NameError:  # Python 3
+          step_trace.caption = str(step_trace.caption)
         except UnicodeDecodeError:
           step_trace.caption = repr(step_trace.caption)  # Safe encoding.
 
@@ -137,8 +139,10 @@ def trace_html(trace,
       master_spec_json=_optional_master_spec_json(master_spec),
       elt_id=elt_id,
       div_html=div_html)
-  return unicode(as_str, 'utf-8') if convert_to_unicode else as_str
-
+  try:               # Python 2
+    return unicode(as_str, 'utf-8') if convert_to_unicode else as_str
+  except NameError:  # Python 3
+    return as_str
 
 def open_in_new_window(html, notebook_html_fcn=None, temp_file_basename=None):
   """Opens an HTML visualization in a new window.
@@ -158,8 +162,11 @@ def open_in_new_window(html, notebook_html_fcn=None, temp_file_basename=None):
   Returns:
     HTML notebook element, which will trigger the browser to open a new window.
   """
-  if isinstance(html, unicode):
-    html = html.encode('utf-8')
+  try:               # Python 2
+    if isinstance(html, unicode):
+      html = html.encode('utf-8')
+  except NameError:  # Python 3
+    html = str(html)
 
   if notebook_html_fcn is None:
     from IPython import display
@@ -216,7 +223,10 @@ class InteractiveVisualization(object):
     </script>
     """.format(
         script=script, div_html=div_html)
-    return unicode(html, 'utf-8')  # IPython expects unicode.
+    try:               # Python 2
+      return unicode(html, 'utf-8')  # IPython expects unicode.
+    except NameError:  # Python 3
+      return html
 
   def show_trace(self, trace, master_spec=None):
     """Returns a JS script HTML fragment, which will populate the container.
@@ -239,4 +249,7 @@ class InteractiveVisualization(object):
         json=parse_trace_json(trace),
         master_spec_json=_optional_master_spec_json(master_spec),
         elt_id=self.elt_id)
-    return unicode(html, 'utf-8')  # IPython expects unicode.
+    try:               # Python 2
+      return unicode(html, 'utf-8')  # IPython expects unicode.
+    except NameError:  # Python 3
+      return html


### PR DESCRIPTION
The following files contain calls to __unicode()__ which was removed in Python 3 because all str are Unicode with a default encoding of 'utf-8':
* ./research/neural_programmer/wiki_data.py - 1 instance of __unicode()__
* ./research/syntaxnet/dragnn/python/visualization.py - 1 instance of __unicode()__
* ./research/syntaxnet/dragnn/python/render_parse_tree_graphviz.py - 5 instances of __unicode()__

This PR proposed a fix for __render_parse_tree_graphviz.py__ but leaves the two other files untouched because I was not confident in my solutions.  Fixing them is a TODO for Python 3 compatibility.

$ __python3 -m flake8 --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./research/neural_programmer/wiki_data.py:40:7: F821 undefined name 'unicode'
  u = unicode(s, "utf-8")
      ^
./research/syntaxnet/dragnn/python/render_parse_tree_graphviz.py:56:9: F821 undefined name 'unicode'
  svg = unicode(svg, "utf-8")
        ^
./research/syntaxnet/dragnn/python/visualization.py:73:11: F821 undefined name 'unicode'
          unicode(step_trace.caption, 'utf-8')
          ^
./research/syntaxnet/dragnn/python/visualization.py:140:10: F821 undefined name 'unicode'
  return unicode(as_str, 'utf-8') if convert_to_unicode else as_str
         ^
./research/syntaxnet/dragnn/python/visualization.py:161:23: F821 undefined name 'unicode'
  if isinstance(html, unicode):
                      ^
./research/syntaxnet/dragnn/python/visualization.py:219:12: F821 undefined name 'unicode'
    return unicode(html, 'utf-8')  # IPython expects unicode.
           ^
./research/syntaxnet/dragnn/python/visualization.py:242:12: F821 undefined name 'unicode'
    return unicode(html, 'utf-8')  # IPython expects unicode.
           ^
```