### PR TITLE
tcn: Fix undefined 'v' in Python 3

### DIFF
--- a/research/tcn/data_providers.py
+++ b/research/tcn/data_providers.py
@@ -165,7 +165,7 @@ def parse_sequence_example(serialized_example, num_views):
   views = tf.stack([sequence_parse[v] for v in view_names])
   lens = [sequence_parse[v].get_shape().as_list()[0] for v in view_names]
   assert len(set(lens)) == 1
-  seq_len = tf.shape(sequence_parse[v])[0]
+  seq_len = tf.shape(sequence_parse[view_names[-1]])[0]
   return context_parse, views, seq_len
 
 


### PR DESCRIPTION
flake8 testing of https://github.com/tensorflow/models on Python 3.6.4

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
../research/tcn/data_providers.py:168:37: F821 undefined name 'v'
  seq_len = tf.shape(sequence_parse[v])[0]
                                    ^
```

The issue here is that variable scoping is more restrictive in Python 3 than it is in Python 2.  Variables created inside a list comprehension are not visible outside of that comprehension as can be seen in this simplification:
```
>>> my_word = 'TensorFlow'
>>> letters = [letter for letter in my_word]
>>> print(my_word[-1])  # --> 'w' in both Python 2 and Python 3
>>> print(letters[-1])  # --> 'w' in both Python 2 and Python 3
>>> print(letter)       # --> 'w' in Python2 and NameError in Python 3
```

The fix proposed here is a _literal translation_ of the current Python 2 functionality: __v__ is the last item of __view_names__.  This appears to be a safe change given the assertion on the line just above that all __view_names__ must have the same shape.

