### PR TITLE
Do not demand filenames to have continous numeration

### DIFF
--- a/research/object_detection/dataset_tools/create_kitti_tf_record.py
+++ b/research/object_detection/dataset_tools/create_kitti_tf_record.py
@@ -110,11 +110,11 @@ def convert_kitti_to_tfrecords(data_dir, output_path, classes_to_use,
                                            output_path)
 
   images = sorted(tf.gfile.ListDirectory(image_dir))
-  for img_name in images:
-    img_num = int(img_name.split('.')[0])
+  for img_num, img_name in enumerate(images):
     is_validation_img = img_num < validation_set_size
-    img_anno = read_annotation_file(os.path.join(annotation_dir,
-                                                 str(img_num).zfill(6)+'.txt'))
+    img_anno = read_annotation_file(os.path.join(
+        annotation_dir,
+        os.path.splitext(img_name)[0] + '.txt'))
 
     image_path = os.path.join(image_dir, img_name)
 


### PR DESCRIPTION
Current code in create_kitti_tf_record.py requires input files to have names in a form of 000123.txt with continuous numeration. It is easy to leverage this restriction and have more semantically meaningful code.