### PR TITLE
Inception: import six in build_imagenet_data.py

### DIFF
--- a/research/inception/inception/data/build_imagenet_data.py
+++ b/research/inception/inception/data/build_imagenet_data.py
@@ -93,6 +93,7 @@ import sys
 import threading
 
 import numpy as np
+import six
 import tensorflow as tf
 
 tf.app.flags.DEFINE_string('train_directory', '/tmp/',


### PR DESCRIPTION
__six__ is used on lines 174 and 175 but is never imported or defined.  @nealwu 