### PR TITLE
Revert "Clear softmax_cross_entropy deprecation warning."

### DIFF
--- a/official/mnist/dataset.py
+++ b/official/mnist/dataset.py
@@ -89,14 +89,15 @@ def dataset(directory, images_file, labels_file):
     image = tf.reshape(image, [784])
     return image / 255.0
 
-  def decode_label(label):
-    label = tf.decode_raw(label, tf.uint8)  # tf.string -> [tf.uint8]
-    return tf.to_int32(label)
+  def one_hot_label(label):
+    label = tf.decode_raw(label, tf.uint8)  # tf.string -> tf.uint8
+    label = tf.reshape(label, [])  # label is a scalar
+    return tf.one_hot(label, 10)
 
   images = tf.data.FixedLengthRecordDataset(
       images_file, 28 * 28, header_bytes=16).map(decode_image)
   labels = tf.data.FixedLengthRecordDataset(
-      labels_file, 1, header_bytes=8).map(decode_label)
+      labels_file, 1, header_bytes=8).map(one_hot_label)
   return tf.data.Dataset.zip((images, labels))
 
 

--- a/official/mnist/mnist.py
+++ b/official/mnist/mnist.py
@@ -102,9 +102,9 @@ def model_fn(features, labels, mode, params):
       optimizer = tf.contrib.estimator.TowerOptimizer(optimizer)
 
     logits = model(image, training=True)
-    loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+    loss = tf.losses.softmax_cross_entropy(onehot_labels=labels, logits=logits)
     accuracy = tf.metrics.accuracy(
-        labels=labels, predictions=tf.argmax(logits, axis=1))
+        labels=tf.argmax(labels, axis=1), predictions=tf.argmax(logits, axis=1))
     # Name the accuracy tensor 'train_accuracy' to demonstrate the
     # LoggingTensorHook.
     tf.identity(accuracy[1], name='train_accuracy')
@@ -115,7 +115,7 @@ def model_fn(features, labels, mode, params):
         train_op=optimizer.minimize(loss, tf.train.get_or_create_global_step()))
   if mode == tf.estimator.ModeKeys.EVAL:
     logits = model(image, training=False)
-    loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+    loss = tf.losses.softmax_cross_entropy(onehot_labels=labels, logits=logits)
     return tf.estimator.EstimatorSpec(
         mode=tf.estimator.ModeKeys.EVAL,
         loss=loss,

--- a/official/mnist/mnist_test.py
+++ b/official/mnist/mnist_test.py
@@ -27,8 +27,8 @@ BATCH_SIZE = 100
 
 def dummy_input_fn():
   image = tf.random_uniform([BATCH_SIZE, 784])
-  labels = tf.random_uniform([BATCH_SIZE, 1], maxval=9, dtype=tf.int32)
-  return image, labels
+  labels = tf.random_uniform([BATCH_SIZE], maxval=9, dtype=tf.int32)
+  return image, tf.one_hot(labels, 10)
 
 
 def make_estimator():

--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -50,7 +50,7 @@ FLAGS = tf.flags.FLAGS
 
 def metric_fn(labels, logits):
   accuracy = tf.metrics.accuracy(
-      labels=labels, predictions=tf.argmax(logits, axis=1))
+      labels=tf.argmax(labels, axis=1), predictions=tf.argmax(logits, axis=1))
   return {"accuracy": accuracy}
 
 
@@ -64,7 +64,7 @@ def model_fn(features, labels, mode, params):
 
   model = mnist.Model("channels_last")
   logits = model(image, training=(mode == tf.estimator.ModeKeys.TRAIN))
-  loss = tf.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+  loss = tf.losses.softmax_cross_entropy(onehot_labels=labels, logits=logits)
 
   if mode == tf.estimator.ModeKeys.TRAIN:
     learning_rate = tf.train.exponential_decay(


### PR DESCRIPTION
Reverts tensorflow/models#3227 for the sake of model convergence.