### PR TITLE
Return dataset from input_fn

### DIFF
--- a/samples/core/get_started/iris_data.py
+++ b/samples/core/get_started/iris_data.py
@@ -35,8 +35,8 @@ def train_input_fn(features, labels, batch_size):
     # Shuffle, repeat, and batch the examples.
     dataset = dataset.shuffle(1000).repeat().batch(batch_size)
 
-    # Return the read end of the pipeline.
-    return dataset.make_one_shot_iterator().get_next()
+    # Return the dataset.
+    return dataset
 
 
 def eval_input_fn(features, labels, batch_size):
@@ -55,8 +55,8 @@ def eval_input_fn(features, labels, batch_size):
     assert batch_size is not None, "batch_size must not be None"
     dataset = dataset.batch(batch_size)
 
-    # Return the read end of the pipeline.
-    return dataset.make_one_shot_iterator().get_next()
+    # Return the dataset.
+    return dataset
 
 
 # The remainder of this file contains a simple example of a csv parser,
@@ -89,5 +89,5 @@ def csv_input_fn(csv_path, batch_size):
     # Shuffle, repeat, and batch the examples.
     dataset = dataset.shuffle(1000).repeat().batch(batch_size)
 
-    # Return the read end of the pipeline.
-    return dataset.make_one_shot_iterator().get_next()
+    # Return the dataset.
+    return dataset


### PR DESCRIPTION
As of r1.5 an `input_fn` can directly return a dataset. 

This approach is more flexible because it allows the estimator to initialize the dataset, and is less boiler-plate for the user.

Local tests pass, training converges.

> python estimator_test.py 
> python premade_estimator.py
> python custom_estimator.py

Like the `sparse_softmax_cross_entropy` we may eventually want to apply this fix more widely.