### PR TITLE
Fix tensorflow/models gan typos. fixes #3295

### DIFF
--- a/research/gan/cifar/launch_jobs.sh
+++ b/research/gan/cifar/launch_jobs.sh
@@ -89,7 +89,7 @@ if [[ "$gan_type" == "unconditional" ]]; then
     --dataset_dir=${DATASET_DIR} \
     --eval_real_images=false \
     --conditional_eval=false \
-    --max_number_of_evaluation=1
+    --max_number_of_evaluations=1
   Banner "Finished unconditional evaluation. See ${UNCONDITIONAL_EVAL_DIR} for output images."
 fi
 
@@ -116,6 +116,6 @@ if [[ "$gan_type" == "conditional" ]]; then
     --dataset_dir=${DATASET_DIR} \
     --eval_real_images=false \
     --conditional_eval=true \
-    --max_number_of_evaluation=1
+    --max_number_of_evaluations=1
   Banner "Finished conditional evaluation. See ${CONDITIONAL_EVAL_DIR} for output images."
 fi

--- a/research/gan/image_compression/launch_jobs.sh
+++ b/research/gan/image_compression/launch_jobs.sh
@@ -80,5 +80,5 @@ python "${git_repo}/research/gan/image_compression/eval.py" \
   --checkpoint_dir=${MODEL_TRAIN_DIR} \
   --eval_dir=${MODEL_EVAL_DIR} \
   --dataset_dir=${DATASET_DIR} \
-  --max_number_of_evaluation=1
+  --max_number_of_evaluations=1
 Banner "Finished evaluation. See ${MODEL_EVAL_DIR} for output images."

--- a/research/gan/mnist/launch_jobs.sh
+++ b/research/gan/mnist/launch_jobs.sh
@@ -102,7 +102,7 @@ if [[ "$gan_type" == "unconditional" ]]; then
     --dataset_dir=${DATASET_DIR} \
     --eval_real_images=false \
     --classifier_filename=${FROZEN_GRAPH} \
-    --max_number_of_evaluation=1
+    --max_number_of_evaluations=1
   Banner "Finished unconditional evaluation. See ${UNCONDITIONAL_EVAL_DIR} for output images."
 fi
 
@@ -127,7 +127,7 @@ if [[ "$gan_type" == "conditional" ]]; then
     --checkpoint_dir=${CONDITIONAL_TRAIN_DIR} \
     --eval_dir=${CONDITIONAL_EVAL_DIR} \
     --classifier_filename=${FROZEN_GRAPH} \
-    --max_number_of_evaluation=1
+    --max_number_of_evaluations=1
   Banner "Finished conditional evaluation. See ${CONDITIONAL_EVAL_DIR} for output images."
 fi
 
@@ -152,6 +152,6 @@ if [[ "$gan_type" == "infogan" ]]; then
     --checkpoint_dir=${INFOGAN_TRAIN_DIR} \
     --eval_dir=${INFOGAN_EVAL_DIR} \
     --classifier_filename=${FROZEN_GRAPH} \
-    --max_number_of_evaluation=1
+    --max_number_of_evaluations=1
   Banner "Finished InfoGAN evaluation. See ${INFOGAN_EVAL_DIR} for output images."
 fi


### PR DESCRIPTION
`max_number_of_evaluation` -> `max_number_of_evaluations`.