### PR TITLE
Fix incompatible usage of 'filter' in Python3

### DIFF
--- a/research/object_detection/utils/variables_helper.py
+++ b/research/object_detection/utils/variables_helper.py
@@ -42,7 +42,7 @@ def filter_variables(variables, filter_regex_list, invert=False):
     a list of filtered variables.
   """
   kept_vars = []
-  variables_to_ignore_patterns = filter(None, filter_regex_list)
+  variables_to_ignore_patterns = list(filter(None, filter_regex_list))
   for var in variables:
     add = True
     for pattern in variables_to_ignore_patterns:


### PR DESCRIPTION
I've been trying to freeze some layers in my module with Python3, but only one parameter was frozen.
After carefully inspection, I found the function `filter()`  in Python3 is  incompatible with Python2 which returns a `iterator`.

```python
from __future__ import print_function
variables=['a','b','c']
variables_to_ignore_patterns=filter(None,['1'])
for var in variables:
    for pattern in variables_to_ignore_patterns:
        print(var,pattern)
```
the results in Python2 and Python3 are kind of discrepant:

Python2: 

> a  1
> b  1
> c  1

Python3:

> a  1
