### PR TITLE
Fix file reading issue for python3 code

### DIFF
--- a/research/delf/delf/python/datum_io.py
+++ b/research/delf/delf/python/datum_io.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Python interface for DatumProto.
 
 DatumProto is protocol buffer used to serialize tensor with arbitrary shape.
@@ -93,7 +92,7 @@ def ReadFromFile(file_path):
   Returns:
     data: Numpy array.
   """
-  with tf.gfile.FastGFile(file_path, 'r') as f:
+  with tf.gfile.FastGFile(file_path, 'rb') as f:
     return ParseFromString(f.read())
 
 

--- a/research/delf/delf/python/feature_io.py
+++ b/research/delf/delf/python/feature_io.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Python interface for DelfFeatures proto.
 
 Support read and write of DelfFeatures from/to numpy arrays and file.
@@ -168,7 +167,7 @@ def ReadFromFile(file_path):
     attention: [N] float array with attention scores.
     orientations: [N] float array with orientations.
   """
-  with tf.gfile.FastGFile(file_path, 'r') as f:
+  with tf.gfile.FastGFile(file_path, 'rb') as f:
     return ParseFromString(f.read())
 
 


### PR DESCRIPTION
This fixes an issue Python 3 users were having, related to opening binary files. Now the DELF code works both for Python 2.7 and Python 3+.