### PR TITLE
Use the short path for TPUClusterResolver

### DIFF
--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -140,7 +140,7 @@ def main(argv):
     tpu_grpc_url = FLAGS.master
   else:
     tpu_cluster_resolver = (
-        tf.contrib.cluster_resolver.python.training.TPUClusterResolver(
+        tf.contrib.cluster_resolver.TPUClusterResolver(
             tpu_names=[FLAGS.tpu_name],
             zone=FLAGS.tpu_zone,
             project=FLAGS.gcp_project))


### PR DESCRIPTION
The long path doesn't work for TensorFlow 1.6 because the .python package under cluster_resolver doesn't exist.