### PR TITLE
Adding dockerfiles that encapsulate this repository.

### DIFF
--- a/official/Dockerfile.cpu
+++ b/official/Dockerfile.cpu
@@ -1,0 +1,17 @@
+# Docker image for running examples in Tensorflow models.
+# base_image depends on whether we are running on GPUs or non-GPUs
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    git \
+    python \
+    python-pip \
+    python-setuptools
+    
+RUN pip install tf-nightly
+
+# Checkout tensorflow/models and pin to a particular version
+RUN git clone https://github.com/tensorflow/models.git /tensorflow_models
+

--- a/official/Dockerfile.gpu
+++ b/official/Dockerfile.gpu
@@ -1,0 +1,18 @@
+# Docker image for running examples in Tensorflow models.
+# base_image depends on whether we are running on GPUs or non-GPUs
+FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    git \
+    python \
+    python-pip \
+    python-setuptools
+    
+RUN pip install tf-nightly-gpu
+
+# Checkout tensorflow/models and pin to a particular version
+RUN git clone https://github.com/tensorflow/models.git /tensorflow_models && \
+    cd /tensorflow_models && git checkout feat/multi-gpu-resnet
+


### PR DESCRIPTION
1. These Dockerfiles can be used to generate official docker images that can used for running models in this repo on container based platforms
2. We can leverage google container builder to build images for every branch, tag and/or HEAD.