### PR TITLE
Fix PythonPath dependencies

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -35,6 +35,9 @@
     "from io import StringIO\n",
     "from matplotlib import pyplot as plt\n",
     "from PIL import Image\n",
+    "\n",
+    "# This is needed since the notebook is stored in the object_detection folder.\n",
+    "sys.path.append(\"..\")\n",
     "from object_detection.utils import ops as utils_ops\n",
     "\n",
     "if tf.__version__ < '1.4.0':\n",
@@ -55,10 +58,7 @@
    "outputs": [],
    "source": [
     "# This is needed to display the images.\n",
-    "%matplotlib inline\n",
-    "\n",
-    "# This is needed since the notebook is stored in the object_detection folder.\n",
-    "sys.path.append(\"..\")"
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
Previously, code block one attempted to import `from object_detection.utils` before the `object_detection` directory was added to the PythonPath via `sys.path.append("..")`.

This generated a `ModuleNotFoundError`.

Accordingly, append `".."` to the PythonPath before attempting to import from `object_detection` as a module, instead of after.