### PR TITLE
explicitely create list from range() for python3 compatibility

### DIFF
--- a/research/object_detection/utils/learning_schedules.py
+++ b/research/object_detection/utils/learning_schedules.py
@@ -150,7 +150,7 @@ def manual_stepping(global_step, boundaries, rates):
           # Casting global step to tf.int32 is dangerous, but necessary to be
           # compatible with TPU.
           tf.greater(step_boundaries, tf.cast(global_step, tf.int32)),
-          tf.constant(range(num_boundaries), dtype=tf.int32),
+          tf.constant(list(range(num_boundaries)), dtype=tf.int32),
           tf.constant([num_boundaries] * num_boundaries, dtype=tf.int32)))
   return tf.reduce_sum(learning_rates * tf.one_hot(index, len(rates),
                                                    dtype=tf.float32))


### PR DESCRIPTION
Fixes the error below when running `train.py` using python3 with the [default rcnn_inception_v2_coco mask-rcnn config file](https://github.com/tensorflow/models/blob/master/research/object_detection/samples/configs/mask_rcnn_inception_v2_coco.config) linked in the [instance segmentation readme](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/instance_segmentation.md).

```
python object_detection/train.py     --logtostderr     --pipeline_config_path="../../../mask_rcnn_inception_v2_coco.config" --train_dir="../../../train/"
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:Scale of 0 disables regularizer.
WARNING:tensorflow:From /home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/trainer.py:228: create_global_step (from tensorflow.contrib.framework.python.ops.variables) is deprecated and will be removed in a future version.
Instructions for updating:
Please switch to tf.train.create_global_step
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:depth of additional conv before box predictor: 0
WARNING:tensorflow:From /home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/core/box_predictor.py:391: calling reduce_mean (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
WARNING:tensorflow:From /home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/core/losses.py:306: softmax_cross_entropy_with_logits (from tensorflow.python.ops.nn_ops) is deprecated and will be removed in a future version.
Instructions for updating:

Future major versions of TensorFlow will allow gradients to flow
into the labels input on backprop by default.

See tf.nn.softmax_cross_entropy_with_logits_v2.

WARNING:tensorflow:From /home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py:1851: calling reduce_sum (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
Traceback (most recent call last):
  File "object_detection/train.py", line 167, in <module>
    tf.app.run()
  File "/home/delcourj/tfenv/lib/python3.5/site-packages/tensorflow/python/platform/app.py", line 124, in run
    _sys.exit(main(argv))
  File "object_detection/train.py", line 163, in main
    worker_job_name, is_chief, FLAGS.train_dir)
  File "/home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/trainer.py", line 255, in train
    train_config.optimizer)
  File "/home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/builders/optimizer_builder.py", line 50, in build
    learning_rate = _create_learning_rate(config.learning_rate)
  File "/home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/builders/optimizer_builder.py", line 108, in _create_learning_rate
    learning_rate_sequence)
  File "/home/delcourj/BAM_Telecom_grond/tensorflow/models/research/object_detection/utils/learning_schedules.py", line 153, in manual_stepping
    tf.constant(range(num_boundaries), dtype=tf.int32),
  File "/home/delcourj/tfenv/lib/python3.5/site-packages/tensorflow/python/framework/constant_op.py", line 212, in constant
    value, dtype=dtype, shape=shape, verify_shape=verify_shape))
  File "/home/delcourj/tfenv/lib/python3.5/site-packages/tensorflow/python/framework/tensor_util.py", line 413, in make_tensor_proto
    _AssertCompatible(values, dtype)
  File "/home/delcourj/tfenv/lib/python3.5/site-packages/tensorflow/python/framework/tensor_util.py", line 328, in _AssertCompatible
    (dtype.name, repr(mismatch), type(mismatch).__name__))
TypeError: Expected int32, got range(0, 3) of type 'range' instead.
```