### PR TITLE
add learning rate to summaries

### DIFF
--- a/research/object_detection/builders/optimizer_builder.py
+++ b/research/object_detection/builders/optimizer_builder.py
@@ -119,4 +119,5 @@ def _create_learning_rate(learning_rate_config):
   if learning_rate is None:
     raise ValueError('Learning_rate %s not supported.' % learning_rate_type)
 
+  learning_rate = tf.identity(learning_rate, name='learning_rate')
   return learning_rate

--- a/research/object_detection/trainer.py
+++ b/research/object_detection/trainer.py
@@ -323,6 +323,9 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
       global_summaries.add(tf.summary.scalar(loss_tensor.op.name, loss_tensor))
     global_summaries.add(
         tf.summary.scalar('TotalLoss', tf.losses.get_total_loss()))
+    global_summaries.add(
+        tf.summary.scalar('LearningRate',
+        tf.get_default_graph().get_tensor_by_name('learning_rate:0')))
 
     # Add the summaries from the first clone. These contain the summaries
     # created by model_fn and either optimize_clones() or _gather_clone_loss().


### PR DESCRIPTION
Learning rate is a handy thing to visualize. Is there a cleaner way to do this than `tf.get_default_graph` with a hard-coded tensor name?