### PR TITLE
removed dct_method=dct_method from line 110 as that causes an error w…

### DIFF
--- a/research/object_detection/data_decoders/tf_example_decoder.py
+++ b/research/object_detection/data_decoders/tf_example_decoder.py
@@ -106,8 +106,7 @@ class TfExampleDecoder(data_decoder.DataDecoder):
             slim_example_decoder.Image(
                 image_key='image/encoded',
                 format_key='image/format',
-                channels=3,
-                dct_method=dct_method),
+                channels=3),
         fields.InputDataFields.source_id: (
             slim_example_decoder.Tensor('image/source_id')),
         fields.InputDataFields.key: (


### PR DESCRIPTION
…hen running train.py

In this issue:

https://github.com/tensorflow/models/issues/3476

I've found that the change in this file from

    fields.InputDataFields.image: slim_example_decoder.Image(
        image_key='image/encoded', format_key='image/format', channels=3),

to:

    fields.InputDataFields.image:
        slim_example_decoder.Image(
            image_key='image/encoded',
            format_key='image/format',
            channels=3,
            dct_method=dct_method),

causes an error when running https://github.com/tensorflow/models/blob/master/research/object_detection/train.py

I think this should be changed back as above.  I should mention in issue 3476 another poster verified experiencing the same concern and verified the same fix, thanks!