### PR TITLE
Support to set inter_op_parallelism_threads and intra_op_parallelism_threads for ResNet

### DIFF
--- a/official/resnet/resnet.py
+++ b/official/resnet/resnet.py
@@ -146,6 +146,10 @@ def fixed_padding(inputs, kernel_size, data_format):
   pad_beg = pad_total // 2
   pad_end = pad_total - pad_beg
 
+  # Optimization to eliminate tf.pad
+  if pad_beg == 0 and pad_end == 0:
+    return inputs
+
   if data_format == 'channels_first':
     padded_inputs = tf.pad(inputs, [[0, 0], [0, 0],
                                     [pad_beg, pad_end], [pad_beg, pad_end]])
@@ -584,8 +588,15 @@ def resnet_main(flags, model_function, input_function):
         model_function,
         loss_reduction=tf.losses.Reduction.MEAN)
 
-  # Set up a RunConfig to only save checkpoints once per training cycle.
-  run_config = tf.estimator.RunConfig().replace(save_checkpoints_secs=1e9)
+  # Create session config based on values of inter_op_parallelism_threads and
+  # intra_op_parallelism_threads.
+  session_config = tf.ConfigProto(
+        inter_op_parallelism_threads=flags.inter_op_parallelism_threads,
+        intra_op_parallelism_threads=flags.intra_op_parallelism_threads)
+
+  # Set up a RunConfig to save checkpoint and set session config.
+  run_config = tf.estimator.RunConfig().replace(save_checkpoints_secs=1e9,
+                                                session_config=session_config)
   classifier = tf.estimator.Estimator(
       model_fn=model_function, model_dir=flags.model_dir, config=run_config,
       params={
@@ -675,3 +686,13 @@ class ResnetArgParser(argparse.ArgumentParser):
         '--multi_gpu', action='store_true',
         help='If set, run across all available GPUs. Note that this is '
         'superseded by the --num_gpus flag.')
+
+    self.add_argument(
+        '--inter_op_parallelism_threads', type=int, default=0,
+        help='Number of inter_op_parallelism_threads to use for CPU.'
+             'See config.proto for details.')
+
+    self.add_argument(
+        '--intra_op_parallelism_threads', type=int, default=0,
+        help='Number of intra_op_parallelism_threads to use for CPU.'
+             'See Config.proto for details.')

--- a/official/resnet/resnet.py
+++ b/official/resnet/resnet.py
@@ -146,10 +146,6 @@ def fixed_padding(inputs, kernel_size, data_format):
   pad_beg = pad_total // 2
   pad_end = pad_total - pad_beg
 
-  # Optimization to eliminate tf.pad
-  if pad_beg == 0 and pad_end == 0:
-    return inputs
-
   if data_format == 'channels_first':
     padded_inputs = tf.pad(inputs, [[0, 0], [0, 0],
                                     [pad_beg, pad_end], [pad_beg, pad_end]])
@@ -689,10 +685,10 @@ class ResnetArgParser(argparse.ArgumentParser):
 
     self.add_argument(
         '--inter_op_parallelism_threads', type=int, default=0,
-        help='Number of inter_op_parallelism_threads to use for CPU.'
-             'See config.proto for details.')
+        help='Number of inter_op_parallelism_threads to use for CPU. '
+             'See TensorFlow config.proto for details.')
 
     self.add_argument(
         '--intra_op_parallelism_threads', type=int, default=0,
-        help='Number of intra_op_parallelism_threads to use for CPU.'
-             'See Config.proto for details.')
+        help='Number of intra_op_parallelism_threads to use for CPU. '
+             'See TensorFlow config.proto for details.')


### PR DESCRIPTION
Also eliminates unnecessary `tf.pad` call in case when all padding values are 0.