### PR TITLE
from six.moves import xrange (en masse) AGAIN

### DIFF
--- a/research/adversarial_text/adversarial_losses.py
+++ b/research/adversarial_text/adversarial_losses.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 # Dependency imports
 
+from six.moves import xrange
 import tensorflow as tf
 
 flags = tf.app.flags

--- a/research/adversarial_text/layers.py
+++ b/research/adversarial_text/layers.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 # Dependency imports
 
+from six.moves import xrange
 import tensorflow as tf
 K = tf.keras
 

--- a/research/maskgan/generate_samples.py
+++ b/research/maskgan/generate_samples.py
@@ -37,7 +37,7 @@ import os
 # Dependency imports
 
 import numpy as np
-
+from six.moves import xrange
 import tensorflow as tf
 
 import train_mask_gan

--- a/research/maskgan/model_utils/helper.py
+++ b/research/maskgan/model_utils/helper.py
@@ -22,6 +22,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 

--- a/research/maskgan/model_utils/model_losses.py
+++ b/research/maskgan/model_utils/model_losses.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 # Dependency imports
 import numpy as np
-
+from six.moves import xrange
 import tensorflow as tf
 
 # Useful for REINFORCE baseline.

--- a/research/maskgan/model_utils/n_gram.py
+++ b/research/maskgan/model_utils/n_gram.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
+
 
 def hash_function(input_tuple):
   """Hash function for a tuple."""

--- a/research/maskgan/models/critic_vd.py
+++ b/research/maskgan/models/critic_vd.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 from regularization import variational_dropout
 

--- a/research/maskgan/models/feedforward.py
+++ b/research/maskgan/models/feedforward.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 FLAGS = tf.app.flags.FLAGS

--- a/research/maskgan/models/rnn.py
+++ b/research/maskgan/models/rnn.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 # ZoneoutWrapper.

--- a/research/maskgan/models/rnn_nas.py
+++ b/research/maskgan/models/rnn_nas.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+from six.moves import xrange
 import tensorflow as tf
 
 # NAS Code..

--- a/research/maskgan/models/rnn_vd.py
+++ b/research/maskgan/models/rnn_vd.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 from regularization import variational_dropout
 

--- a/research/maskgan/models/rnn_zaremba.py
+++ b/research/maskgan/models/rnn_zaremba.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 FLAGS = tf.app.flags.FLAGS

--- a/research/maskgan/models/rollout.py
+++ b/research/maskgan/models/rollout.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import collections
 
+from six.moves import xrange
 import tensorflow as tf
 
 from losses import losses

--- a/research/maskgan/models/seq2seq.py
+++ b/research/maskgan/models/seq2seq.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-
+from six.moves import xrange
 from models import attention_utils
 
 # ZoneoutWrapper.

--- a/research/maskgan/models/seq2seq_nas.py
+++ b/research/maskgan/models/seq2seq_nas.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+from six.moves import xrange
 import tensorflow as tf
 
 from models import attention_utils

--- a/research/maskgan/models/seq2seq_vd.py
+++ b/research/maskgan/models/seq2seq_vd.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 from models import attention_utils

--- a/research/maskgan/models/seq2seq_zaremba.py
+++ b/research/maskgan/models/seq2seq_zaremba.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-
+from six.moves import xrange
 from models import attention_utils
 
 FLAGS = tf.app.flags.FLAGS

--- a/research/maskgan/train_mask_gan.py
+++ b/research/maskgan/train_mask_gan.py
@@ -47,7 +47,7 @@ import time
 # Dependency imports
 
 import numpy as np
-
+from six.moves import xrange
 import tensorflow as tf
 
 import pretrain_mask_gan

--- a/research/slim/datasets/build_imagenet_data.py
+++ b/research/slim/datasets/build_imagenet_data.py
@@ -93,6 +93,7 @@ import sys
 import threading
 
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 tf.app.flags.DEFINE_string('train_directory', '/tmp/',

--- a/research/slim/datasets/preprocess_imagenet_validation_data.py
+++ b/research/slim/datasets/preprocess_imagenet_validation_data.py
@@ -52,6 +52,8 @@ import os
 import os.path
 import sys
 
+from six.moves import xrange
+
 
 if __name__ == '__main__':
   if len(sys.argv) < 3:

--- a/research/slim/datasets/process_bounding_boxes.py
+++ b/research/slim/datasets/process_bounding_boxes.py
@@ -86,6 +86,8 @@ import os.path
 import sys
 import xml.etree.ElementTree as ET
 
+from six.moves import xrange
+
 
 class BoundingBox(object):
   pass

--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-
+from six.moves import xrange
 import tensorflow as tf
 
 layers = tf.contrib.layers

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 
 from math import log
 
+from six.moves import xrange
+
 import tensorflow as tf
 slim = tf.contrib.slim
 

--- a/research/slim/nets/dcgan_test.py
+++ b/research/slim/nets/dcgan_test.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 from nets import dcgan
 


### PR DESCRIPTION
In the six weeks since #3206 was merged, the Python 2-only function __xrange()__ was introduced into 24 files in this repo.  This PR reapplies the same fix as last time: __from six.moves import xrange__.

It would be quite helpful if we could have __flake8 . --select=E901,E999,F821,F822,F823__ added to the test suite to catch these issues compatibility before code is reviewed and merged.  Our current test suite does not flag them.