### PR TITLE
 fix bug when user specifies input_shape

### DIFF
--- a/research/object_detection/export_inference_graph.py
+++ b/research/object_detection/export_inference_graph.py
@@ -133,7 +133,7 @@ def main(_):
   text_format.Merge(FLAGS.config_override, pipeline_config)
   if FLAGS.input_shape:
     input_shape = [
-        int(dim) if dim != '-1' else None
+        int(dim) if dim != 'None' else None
         for dim in FLAGS.input_shape.split(',')
     ]
   else:

--- a/research/object_detection/export_inference_graph.py
+++ b/research/object_detection/export_inference_graph.py
@@ -106,7 +106,7 @@ flags.DEFINE_string('input_shape', None,
                     'If input_type is `image_tensor`, this can explicitly set '
                     'the shape of this input tensor to a fixed size. The '
                     'dimensions are to be provided as a comma-separated list '
-                    'of integers. A value of -1 can be used for unknown '
+                    'of integers. A value of `None` can be used for unknown '
                     'dimensions. If not specified, for an `image_tensor, the '
                     'default shape will be partially specified as '
                     '`[None, None, None, 3]`.')


### PR DESCRIPTION
fix bug when user sets the batch_size of input_shape to -1,  such as '-1,128,128,3'. In this case the program interprets -1 as part of parameter name, not a parameter value.