### PR TITLE
Build ImageNet TFRecord

### DIFF
--- a/research/inception/inception/data/build_imagenet_data.py
+++ b/research/inception/inception/data/build_imagenet_data.py
@@ -168,11 +168,15 @@ def _float_feature(value):
     value = [value]
   return tf.train.Feature(float_list=tf.train.FloatList(value=value))
 
-
+import random
 def _bytes_feature(value):
   """Wrapper for inserting bytes features into Example proto."""
-  if isinstance(value, six.string_types):           
-    value = six.binary_type(value, encoding='utf-8') 
+  if isinstance(value, six.string_types):
+    try:
+      value = six.binary_type(value, encoding='utf-8')
+    except TypeError:
+      value = six.binary_type(value)
+
   return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
 
 
@@ -224,6 +228,7 @@ def _convert_to_example(filename, image_buffer, label, synset, human, bbox,
       'image/format': _bytes_feature(image_format),
       'image/filename': _bytes_feature(os.path.basename(filename)),
       'image/encoded': _bytes_feature(image_buffer)}))
+
   return example
 
 

--- a/research/inception/inception/data/build_imagenet_data.py
+++ b/research/inception/inception/data/build_imagenet_data.py
@@ -168,7 +168,6 @@ def _float_feature(value):
     value = [value]
   return tf.train.Feature(float_list=tf.train.FloatList(value=value))
 
-import random
 def _bytes_feature(value):
   """Wrapper for inserting bytes features into Example proto."""
   if isinstance(value, six.string_types):


### PR DESCRIPTION
When building the TFRecord of ILSVRC, I get the following error:
```
file: research/inception/inception/data/build_imagenet_data.py
line: 175: six.binary_type TypeError: str() takes at most 1 argument
```
This probably due to the incompatible of python2 and python3 even if the author uses the six module.
In Python3: 
`class str(object='', encoding='utf-8', ...)
`
however, In Python2:
`class str(object='')`
i.e. It only take one argument.

I fix this bug by catching the exception and assign the string without encoding.