### PR TITLE
Slim: Fix Python 3 syntax error

### DIFF
--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -350,7 +350,7 @@ class MobilenetV1Test(tf.test.TestCase):
       mobilenet_v1.mobilenet_v1_base(inputs)
       total_params, _ = slim.model_analyzer.analyze_vars(
           slim.get_model_variables())
-      self.assertAlmostEqual(3217920L, total_params)
+      self.assertAlmostEqual(3217920, total_params)
 
   def testBuildEndPointsWithDepthMultiplierLessThanOne(self):
     batch_size = 5


### PR DESCRIPTION
Repeat of #2849 -- This change seem to have been lost.

In Python 2.7, the trailing L is no longer needed and in Python 3 it is a Syntax Error.