### PR TITLE
Fix comment typos under models/research

### DIFF
--- a/research/attention_ocr/python/inception_preprocessing.py
+++ b/research/attention_ocr/python/inception_preprocessing.py
@@ -51,7 +51,7 @@ def distort_color(image, color_ordering=0, fast_mode=True, scope=None):
 
   Each color distortion is non-commutative and thus ordering of the color ops
   matters. Ideally we would randomly permute the ordering of the color ops.
-  Rather then adding that level of complication, we select a distinct ordering
+  Rather than adding that level of complication, we select a distinct ordering
   of color ops for each preprocessing thread.
 
   Args:

--- a/research/inception/inception/image_processing.py
+++ b/research/inception/inception/image_processing.py
@@ -166,7 +166,7 @@ def distort_color(image, thread_id=0, scope=None):
 
   Each color distortion is non-commutative and thus ordering of the color ops
   matters. Ideally we would randomly permute the ordering of the color ops.
-  Rather then adding that level of complication, we select a distinct ordering
+  Rather than adding that level of complication, we select a distinct ordering
   of color ops for each preprocessing thread.
 
   Args:

--- a/research/slim/preprocessing/inception_preprocessing.py
+++ b/research/slim/preprocessing/inception_preprocessing.py
@@ -47,7 +47,7 @@ def distort_color(image, color_ordering=0, fast_mode=True, scope=None):
 
   Each color distortion is non-commutative and thus ordering of the color ops
   matters. Ideally we would randomly permute the ordering of the color ops.
-  Rather then adding that level of complication, we select a distinct ordering
+  Rather than adding that level of complication, we select a distinct ordering
   of color ops for each preprocessing thread.
 
   Args:

--- a/research/tcn/preprocessing.py
+++ b/research/tcn/preprocessing.py
@@ -120,7 +120,7 @@ def distort_color(image, color_ordering=0, fast_mode=True, scope=None):
 
   Each color distortion is non-commutative and thus ordering of the color ops
   matters. Ideally we would randomly permute the ordering of the color ops.
-  Rather then adding that level of complication, we select a distinct ordering
+  Rather than adding that level of complication, we select a distinct ordering
   of color ops for each preprocessing thread.
   Args:
     image: 3-D Tensor containing single image in [0, 1].


### PR DESCRIPTION
Some python files under models/research, it is wrong to use "Rather then" instead of "Rather than" in  comments.