### PR TITLE
restore --version flag in resnet parser

### DIFF
--- a/official/resnet/resnet.py
+++ b/official/resnet/resnet.py
@@ -788,7 +788,7 @@ class ResnetArgParser(argparse.ArgumentParser):
     ])
 
     self.add_argument(
-        '-v', '--version', type=int, choices=[1, 2], dest="version",
+        '--version', '-v', type=int, choices=[1, 2],
         default=DEFAULT_VERSION,
         help="Version of ResNet. (1 or 2) See README.md for details."
     )

--- a/official/resnet/resnet.py
+++ b/official/resnet/resnet.py
@@ -788,6 +788,12 @@ class ResnetArgParser(argparse.ArgumentParser):
     ])
 
     self.add_argument(
+        '-v', '--version', type=int, choices=[1, 2], dest="version",
+        default=DEFAULT_VERSION,
+        help="Version of ResNet. (1 or 2) See README.md for details."
+    )
+
+    self.add_argument(
         '--resnet_size', '-rs', type=int, default=50,
         choices=resnet_size_choices,
         help='[default: %(default)s]The size of the ResNet model to use.',


### PR DESCRIPTION
This corrects a mistake merging in the unified arg parser.