### PR TITLE
fix cityscapes _POSTFIX_MAP

### DIFF
--- a/research/deeplab/datasets/build_cityscapes_data.py
+++ b/research/deeplab/datasets/build_cityscapes_data.py
@@ -90,7 +90,7 @@ _FOLDERS_MAP = {
 # A map from data type to filename postfix.
 _POSTFIX_MAP = {
     'image': '_leftImg8bit',
-    'label': '_gtFine_labelTrainIds',
+    'label': '_gtFine_labelIds',
 }
 
 # A map from data type to data format.


### PR DESCRIPTION
The annotation image file name is like `aachen_000000_000019_gtFine_labelIds.png` with a postfix `_gtFine_labelIds`.