### PR TITLE
Fix for box color assignment in visualization_utils.py

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -619,7 +619,7 @@ def visualize_boxes_and_labels_on_image_array(
         box_to_display_str_map[box].append(display_str)
         if agnostic_mode:
           box_to_color_map[box] = 'DarkOrange'
-        elif box not in box_to_color_map[box]:
+        elif box not in box_to_color_map:
           box_to_color_map[box] = STANDARD_COLORS[
               classes[i] % len(STANDARD_COLORS)]
 

--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -619,7 +619,7 @@ def visualize_boxes_and_labels_on_image_array(
         box_to_display_str_map[box].append(display_str)
         if agnostic_mode:
           box_to_color_map[box] = 'DarkOrange'
-        else:
+        elif box not in box_to_color_map[box]:
           box_to_color_map[box] = STANDARD_COLORS[
               classes[i] % len(STANDARD_COLORS)]
 


### PR DESCRIPTION
In research/object_detection/utils/visualization_utils.py, boxes with identical locations are grouped together within visualize_boxes_and_labels_on_image_array(). However, since we are typically processing in order of decreasing score, the color of the boxes and labels are overwritten by lower-scoring classes within a group. As a result, the lowest-scoring class color is what ends up showing through (BAD). This commit fixes the issue.