### PR TITLE
Add pkulzc to object_detection owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,7 @@
 /research/neural_gpu/ @lukaszkaiser
 /research/neural_programmer/ @arvind2505
 /research/next_frame_prediction/ @panyx0718
-/research/object_detection/ @jch1 @tombstone @derekjchow @jesu9 @dreamdragon
+/research/object_detection/ @jch1 @tombstone @derekjchow @jesu9 @dreamdragon @pkulzc
 /research/pcl_rl/ @ofirnachum
 /research/ptn/ @xcyan @arkanath @hellojas @honglaklee
 /research/real_nvp/ @laurent-dinh


### PR DESCRIPTION
pkulzc (lzc@google.com) is a member of tensorflow object detection team.