### PR TITLE
A few linting fixes

### DIFF
--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -40,7 +40,7 @@ good-names=main,_
 inlinevar-rgx=^[a-z][a-z0-9_]*$
 
 # Regular expression matching correct method names
-method-rgx=^(?:(?P<exempt>__[a-z0-9_]+__|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+method-rgx=^(?:(?P<exempt>__[a-z0-9_]+__|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*)|(setUp|tearDown))$
 
 # Regular expression matching correct module names
 module-rgx=^(_?[a-z][a-z0-9_]*)|__init__|PRESUBMIT|PRESUBMIT_unittest$


### PR DESCRIPTION
Not sure why, but Kokoro's pylint is complaining about a few method names that were okay locally. Fixing the rcfile here.