### PR TITLE
Arg parsing cleanup for MNIST and Wide-Deep

### DIFF
--- a/official/mnist/mnist_eager.py
+++ b/official/mnist/mnist_eager.py
@@ -38,8 +38,6 @@ from official.mnist import dataset as mnist_dataset
 from official.mnist import mnist
 from official.utils.arg_parsers import parsers
 
-FLAGS = None
-
 
 def loss(logits, labels):
   return tf.reduce_mean(
@@ -97,35 +95,38 @@ def test(model, dataset):
     tf.contrib.summary.scalar('accuracy', accuracy.result())
 
 
-def main(_):
+def main(argv):
+  parser = MNISTEagerArgParser()
+  flags = parser.parse_args(args=argv[1:])
+
   tfe.enable_eager_execution()
 
   # Automatically determine device and data_format
   (device, data_format) = ('/gpu:0', 'channels_first')
-  if FLAGS.no_gpu or tfe.num_gpus() <= 0:
+  if flags.no_gpu or tfe.num_gpus() <= 0:
     (device, data_format) = ('/cpu:0', 'channels_last')
   # If data_format is defined in FLAGS, overwrite automatically set value.
-  if FLAGS.data_format is not None:
+  if flags.data_format is not None:
     data_format = data_format
   print('Using device %s, and data format %s.' % (device, data_format))
 
   # Load the datasets
-  train_ds = mnist_dataset.train(FLAGS.data_dir).shuffle(60000).batch(
-      FLAGS.batch_size)
-  test_ds = mnist_dataset.test(FLAGS.data_dir).batch(FLAGS.batch_size)
+  train_ds = mnist_dataset.train(flags.data_dir).shuffle(60000).batch(
+      flags.batch_size)
+  test_ds = mnist_dataset.test(flags.data_dir).batch(flags.batch_size)
 
   # Create the model and optimizer
   model = mnist.Model(data_format)
-  optimizer = tf.train.MomentumOptimizer(FLAGS.lr, FLAGS.momentum)
+  optimizer = tf.train.MomentumOptimizer(flags.lr, flags.momentum)
 
   # Create file writers for writing TensorBoard summaries.
-  if FLAGS.output_dir:
+  if flags.output_dir:
     # Create directories to which summaries will be written
     # tensorboard --logdir=<output_dir>
     # can then be used to see the recorded summaries.
-    train_dir = os.path.join(FLAGS.output_dir, 'train')
-    test_dir = os.path.join(FLAGS.output_dir, 'eval')
-    tf.gfile.MakeDirs(FLAGS.output_dir)
+    train_dir = os.path.join(flags.output_dir, 'train')
+    test_dir = os.path.join(flags.output_dir, 'eval')
+    tf.gfile.MakeDirs(flags.output_dir)
   else:
     train_dir = None
     test_dir = None
@@ -135,19 +136,19 @@ def main(_):
       test_dir, flush_millis=10000, name='test')
 
   # Create and restore checkpoint (if one exists on the path)
-  checkpoint_prefix = os.path.join(FLAGS.model_dir, 'ckpt')
+  checkpoint_prefix = os.path.join(flags.model_dir, 'ckpt')
   step_counter = tf.train.get_or_create_global_step()
   checkpoint = tfe.Checkpoint(
       model=model, optimizer=optimizer, step_counter=step_counter)
   # Restore variables on creation if a checkpoint exists.
-  checkpoint.restore(tf.train.latest_checkpoint(FLAGS.model_dir))
+  checkpoint.restore(tf.train.latest_checkpoint(flags.model_dir))
 
   # Train and evaluate for a set number of epochs.
   with tf.device(device):
-    for _ in range(FLAGS.train_epochs):
+    for _ in range(flags.train_epochs):
       start = time.time()
       with summary_writer.as_default():
-        train(model, optimizer, train_ds, step_counter, FLAGS.log_interval)
+        train(model, optimizer, train_ds, step_counter, flags.log_interval)
       end = time.time()
       print('\nTrain time for epoch #%d (%d total steps): %f' %
             (checkpoint.save_counter.numpy() + 1,
@@ -205,6 +206,4 @@ class MNISTEagerArgParser(argparse.ArgumentParser):
     )
 
 if __name__ == '__main__':
-  parser = MNISTEagerArgParser()
-  FLAGS, unparsed = parser.parse_known_args()
-  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  main(argv=sys.argv)


### PR DESCRIPTION
This PR replaces tf.app.run() with a simple main(argv) following what has already been done with resnet. It also replaces the parser.parse_known_args() with parser.parse_args() calls so that mistakes in typing args raise errors.