### PR TITLE
Add fp16 support to official ResNet.

### DIFF
--- a/official/resnet/README.md
+++ b/official/resnet/README.md
@@ -55,9 +55,7 @@ You can download 190 MB pre-trained versions of ResNet-50 achieving 76.3% and 75
 
 Other versions and formats:
 
-* [ResNet-v2-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnetv2_imagenet_checkpoint.tar.gz)
-* [ResNet-v2-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnetv2_imagenet_savedmodel.tar.gz)
-* [ResNet-v2-ImageNet Frozen Graph](http://download.tensorflow.org/models/official/resnetv2_imagenet_frozen_graph.pb)
-* [ResNet-v1-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnetv1_imagenet_checkpoint.tar.gz)
-* [ResNet-v1-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnetv1_imagenet_savedmodel.tar.gz)
-* [ResNet-v1-ImageNet Frozen Graph](http://download.tensorflow.org/models/official/resnetv1_imagenet_frozen_graph.pb)
+* [ResNet-v2-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnet_v2_imagenet_checkpoint.tar.gz)
+* [ResNet-v2-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnet_v2_imagenet_savedmodel.tar.gz)
+* [ResNet-v1-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnet_v1_imagenet_checkpoint.tar.gz)
+* [ResNet-v1-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnet_v1_imagenet_savedmodel.tar.gz)

--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -145,7 +145,8 @@ class Cifar10Model(resnet_model.Model):
   """Model class with appropriate defaults for CIFAR-10 data."""
 
   def __init__(self, resnet_size, data_format=None, num_classes=_NUM_CLASSES,
-               version=resnet_model.DEFAULT_VERSION, dtype=None):
+               version=resnet_model.DEFAULT_VERSION,
+               dtype=resnet_model.DEFAULT_DTYPE):
     """These are the parameters that work for CIFAR-10 data.
 
     Args:
@@ -208,8 +209,10 @@ def cifar10_model_fn(features, labels, mode, params):
     return True
 
   return resnet_run_loop.resnet_model_fn(
-      dtype=params['dtype'],
-      features=features, labels=labels, mode=mode, model_class=Cifar10Model,
+      features=features,
+      labels=labels,
+      mode=mode,
+      model_class=Cifar10Model,
       resnet_size=params['resnet_size'],
       weight_decay=weight_decay,
       learning_rate_fn=learning_rate_fn,
@@ -218,7 +221,8 @@ def cifar10_model_fn(features, labels, mode, params):
       version=params['version'],
       loss_scale=params['loss_scale'],
       loss_filter_fn=loss_filter_fn,
-      multi_gpu=params['multi_gpu']
+      multi_gpu=params['multi_gpu'],
+      dtype=params['dtype']
   )
 
 

--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -145,7 +145,7 @@ class Cifar10Model(resnet_model.Model):
   """Model class with appropriate defaults for CIFAR-10 data."""
 
   def __init__(self, resnet_size, data_format=None, num_classes=_NUM_CLASSES,
-               version=resnet_model.DEFAULT_VERSION):
+               version=resnet_model.DEFAULT_VERSION, dtype=None):
     """These are the parameters that work for CIFAR-10 data.
 
     Args:
@@ -156,6 +156,7 @@ class Cifar10Model(resnet_model.Model):
         enables users to extend the same model to their own datasets.
       version: Integer representing which version of the ResNet network to use.
         See README for details. Valid values: [1, 2]
+      dtype: The TensorFlow dtype to use for calculations.
 
     Raises:
       ValueError: if invalid resnet_size is chosen
@@ -180,7 +181,9 @@ class Cifar10Model(resnet_model.Model):
         block_strides=[1, 2, 2],
         final_size=64,
         version=version,
-        data_format=data_format)
+        data_format=data_format,
+        dtype=dtype
+    )
 
 
 def cifar10_model_fn(features, labels, mode, params):
@@ -204,15 +207,19 @@ def cifar10_model_fn(features, labels, mode, params):
   def loss_filter_fn(_):
     return True
 
-  return resnet_run_loop.resnet_model_fn(features, labels, mode, Cifar10Model,
-                                         resnet_size=params['resnet_size'],
-                                         weight_decay=weight_decay,
-                                         learning_rate_fn=learning_rate_fn,
-                                         momentum=0.9,
-                                         data_format=params['data_format'],
-                                         version=params['version'],
-                                         loss_filter_fn=loss_filter_fn,
-                                         multi_gpu=params['multi_gpu'])
+  return resnet_run_loop.resnet_model_fn(
+      dtype=params['dtype'],
+      features=features, labels=labels, mode=mode, model_class=Cifar10Model,
+      resnet_size=params['resnet_size'],
+      weight_decay=weight_decay,
+      learning_rate_fn=learning_rate_fn,
+      momentum=0.9,
+      data_format=params['data_format'],
+      version=params['version'],
+      loss_scale=params['loss_scale'],
+      loss_filter_fn=loss_filter_fn,
+      multi_gpu=params['multi_gpu']
+  )
 
 
 def main(argv):

--- a/official/resnet/cifar10_test.py
+++ b/official/resnet/cifar10_test.py
@@ -71,38 +71,61 @@ class BaseTest(tf.test.TestCase):
         for pixel in row:
           self.assertAllClose(pixel, np.array([-1.225, 0., 1.225]), rtol=1e-3)
 
+  def _cifar10_model_fn_helper(self, mode, version, dtype, multi_gpu=False):
+    with tf.Graph().as_default() as g:
+      input_fn = cifar10_main.get_synth_input_fn()
+      dataset = input_fn(True, '', _BATCH_SIZE)
+      iterator = dataset.make_one_shot_iterator()
+      features, labels = iterator.get_next()
+      spec = cifar10_main.cifar10_model_fn(
+          features, labels, mode, {
+              'dtype': dtype,
+              'resnet_size': 32,
+              'data_format': 'channels_last',
+              'batch_size': _BATCH_SIZE,
+              'version': version,
+              'loss_scale': 128 if dtype == tf.float16 else 1,
+              'multi_gpu': multi_gpu
+          })
+
+      predictions = spec.predictions
+      self.assertAllEqual(predictions['probabilities'].shape,
+                          (_BATCH_SIZE, 10))
+      self.assertEqual(predictions['probabilities'].dtype, tf.float32)
+      self.assertAllEqual(predictions['classes'].shape, (_BATCH_SIZE,))
+      self.assertEqual(predictions['classes'].dtype, tf.int64)
+
+      if mode != tf.estimator.ModeKeys.PREDICT:
+        loss = spec.loss
+        self.assertAllEqual(loss.shape, ())
+        self.assertEqual(loss.dtype, tf.float32)
+
+      if mode == tf.estimator.ModeKeys.EVAL:
+        eval_metric_ops = spec.eval_metric_ops
+        self.assertAllEqual(eval_metric_ops['accuracy'][0].shape, ())
+        self.assertAllEqual(eval_metric_ops['accuracy'][1].shape, ())
+        self.assertEqual(eval_metric_ops['accuracy'][0].dtype, tf.float32)
+        self.assertEqual(eval_metric_ops['accuracy'][1].dtype, tf.float32)
+
+      for v in tf.trainable_variables():
+        self.assertEqual(v.dtype.base_dtype, tf.float32)
+
+      tensors_to_check = ('initial_conv:0', 'block_layer1:0', 'block_layer2:0',
+                          'block_layer3:0', 'final_reduce_mean:0',
+                          'final_dense:0')
+
+      for tensor_name in tensors_to_check:
+        tensor = g.get_tensor_by_name('resnet_model/' + tensor_name)
+        self.assertEqual(tensor.dtype, dtype,
+                         'Tensor {} has dtype {}, while dtype {} was '
+                         'expected'.format(tensor, tensor.dtype,
+                                           dtype))
+
   def cifar10_model_fn_helper(self, mode, version, multi_gpu=False):
-    input_fn = cifar10_main.get_synth_input_fn()
-    dataset = input_fn(True, '', _BATCH_SIZE)
-    iterator = dataset.make_one_shot_iterator()
-    features, labels = iterator.get_next()
-    spec = cifar10_main.cifar10_model_fn(
-        features, labels, mode, {
-            'resnet_size': 32,
-            'data_format': 'channels_last',
-            'batch_size': _BATCH_SIZE,
-            'version': version,
-            'multi_gpu': multi_gpu
-        })
-
-    predictions = spec.predictions
-    self.assertAllEqual(predictions['probabilities'].shape,
-                        (_BATCH_SIZE, 10))
-    self.assertEqual(predictions['probabilities'].dtype, tf.float32)
-    self.assertAllEqual(predictions['classes'].shape, (_BATCH_SIZE,))
-    self.assertEqual(predictions['classes'].dtype, tf.int64)
-
-    if mode != tf.estimator.ModeKeys.PREDICT:
-      loss = spec.loss
-      self.assertAllEqual(loss.shape, ())
-      self.assertEqual(loss.dtype, tf.float32)
-
-    if mode == tf.estimator.ModeKeys.EVAL:
-      eval_metric_ops = spec.eval_metric_ops
-      self.assertAllEqual(eval_metric_ops['accuracy'][0].shape, ())
-      self.assertAllEqual(eval_metric_ops['accuracy'][1].shape, ())
-      self.assertEqual(eval_metric_ops['accuracy'][0].dtype, tf.float32)
-      self.assertEqual(eval_metric_ops['accuracy'][1].dtype, tf.float32)
+    self._cifar10_model_fn_helper(mode=mode, version=version, dtype=tf.float32,
+                                  multi_gpu=multi_gpu)
+    self._cifar10_model_fn_helper(mode=mode, version=version, dtype=tf.float16,
+                                  multi_gpu=multi_gpu)
 
   def test_cifar10_model_fn_train_mode_v1(self):
     self.cifar10_model_fn_helper(tf.estimator.ModeKeys.TRAIN, version=1)
@@ -130,19 +153,22 @@ class BaseTest(tf.test.TestCase):
   def test_cifar10_model_fn_predict_mode_v2(self):
     self.cifar10_model_fn_helper(tf.estimator.ModeKeys.PREDICT, version=2)
 
-  def test_cifar10model_shape(self):
+  def _test_cifar10model_shape(self, version):
     batch_size = 135
     num_classes = 246
 
-    for version in (1, 2):
-      model = cifar10_main.Cifar10Model(
-          32, data_format='channels_last', num_classes=num_classes,
-          version=version)
-      fake_input = tf.random_uniform(
-          [batch_size, _HEIGHT, _WIDTH, _NUM_CHANNELS])
-      output = model(fake_input, training=True)
+    model = cifar10_main.Cifar10Model(32, data_format='channels_last',
+                                      num_classes=num_classes, version=version)
+    fake_input = tf.random_uniform([batch_size, _HEIGHT, _WIDTH, _NUM_CHANNELS])
+    output = model(fake_input, training=True)
 
-      self.assertAllEqual(output.shape, (batch_size, num_classes))
+    self.assertAllEqual(output.shape, (batch_size, num_classes))
+
+  def test_cifar10model_shape_v1(self):
+    self._test_cifar10model_shape(version=1)
+
+  def test_cifar10model_shape_v2(self):
+    self._test_cifar10model_shape(version=2)
 
   def test_cifar10_end_to_end_synthetic_v1(self):
     integration.run_synthetic(

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -203,7 +203,7 @@ class ImagenetModel(resnet_model.Model):
   """Model class with appropriate defaults for Imagenet data."""
 
   def __init__(self, resnet_size, data_format=None, num_classes=_NUM_CLASSES,
-               version=resnet_model.DEFAULT_VERSION):
+               version=resnet_model.DEFAULT_VERSION, dtype=None):
     """These are the parameters that work for Imagenet data.
 
     Args:
@@ -214,6 +214,7 @@ class ImagenetModel(resnet_model.Model):
         enables users to extend the same model to their own datasets.
       version: Integer representing which version of the ResNet network to use.
         See README for details. Valid values: [1, 2]
+      dtype: The TensorFlow dtype to use for calculations.
     """
 
     # For bigger models, we want to use "bottleneck" layers
@@ -239,7 +240,9 @@ class ImagenetModel(resnet_model.Model):
         block_strides=[1, 2, 2, 2],
         final_size=final_size,
         version=version,
-        data_format=data_format)
+        data_format=data_format,
+        dtype=dtype
+    )
 
 
 def _get_block_sizes(resnet_size):
@@ -283,15 +286,22 @@ def imagenet_model_fn(features, labels, mode, params):
       num_images=_NUM_IMAGES['train'], boundary_epochs=[30, 60, 80, 90],
       decay_rates=[1, 0.1, 0.01, 0.001, 1e-4])
 
-  return resnet_run_loop.resnet_model_fn(features, labels, mode, ImagenetModel,
-                                         resnet_size=params['resnet_size'],
-                                         weight_decay=1e-4,
-                                         learning_rate_fn=learning_rate_fn,
-                                         momentum=0.9,
-                                         data_format=params['data_format'],
-                                         version=params['version'],
-                                         loss_filter_fn=None,
-                                         multi_gpu=params['multi_gpu'])
+  return resnet_run_loop.resnet_model_fn(
+      dtype=params['dtype'],
+      features=features,
+      labels=labels,
+      mode=mode,
+      model_class=ImagenetModel,
+      resnet_size=params['resnet_size'],
+      weight_decay=1e-4,
+      learning_rate_fn=learning_rate_fn,
+      momentum=0.9,
+      data_format=params['data_format'],
+      version=params['version'],
+      loss_scale=params['loss_scale'],
+      loss_filter_fn=None,
+      multi_gpu=params['multi_gpu']
+  )
 
 
 def main(argv):

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -203,7 +203,8 @@ class ImagenetModel(resnet_model.Model):
   """Model class with appropriate defaults for Imagenet data."""
 
   def __init__(self, resnet_size, data_format=None, num_classes=_NUM_CLASSES,
-               version=resnet_model.DEFAULT_VERSION, dtype=None):
+               version=resnet_model.DEFAULT_VERSION,
+               dtype=resnet_model.DEFAULT_DTYPE):
     """These are the parameters that work for Imagenet data.
 
     Args:
@@ -287,7 +288,6 @@ def imagenet_model_fn(features, labels, mode, params):
       decay_rates=[1, 0.1, 0.01, 0.001, 1e-4])
 
   return resnet_run_loop.resnet_model_fn(
-      dtype=params['dtype'],
       features=features,
       labels=labels,
       mode=mode,
@@ -300,7 +300,8 @@ def imagenet_model_fn(features, labels, mode, params):
       version=params['version'],
       loss_scale=params['loss_scale'],
       loss_filter_fn=None,
-      multi_gpu=params['multi_gpu']
+      multi_gpu=params['multi_gpu'],
+      dtype=params['dtype']
   )
 
 

--- a/official/resnet/imagenet_test.py
+++ b/official/resnet/imagenet_test.py
@@ -36,7 +36,7 @@ class BaseTest(tf.test.TestCase):
     super(BaseTest, self).tearDown()
     tf.gfile.DeleteRecursively(self.get_temp_dir())
 
-  def tensor_shapes_helper(self, resnet_size, version, with_gpu=False):
+  def _tensor_shapes_helper(self, resnet_size, version, dtype, with_gpu):
     """Checks the tensor shapes after each phase of the ResNet model."""
     def reshape(shape):
       """Returns the expected dimensions depending on if a GPU is being used."""
@@ -50,22 +50,24 @@ class BaseTest(tf.test.TestCase):
     graph = tf.Graph()
 
     with graph.as_default(), self.test_session(
-        use_gpu=with_gpu, force_gpu=with_gpu):
+        graph=graph, use_gpu=with_gpu, force_gpu=with_gpu):
       model = imagenet_main.ImagenetModel(
-          resnet_size,
+          resnet_size=resnet_size,
           data_format='channels_first' if with_gpu else 'channels_last',
-          version=version)
+          version=version,
+          dtype=dtype
+      )
       inputs = tf.random_uniform([1, 224, 224, 3])
       output = model(inputs, training=True)
 
-      initial_conv = graph.get_tensor_by_name('initial_conv:0')
-      max_pool = graph.get_tensor_by_name('initial_max_pool:0')
-      block_layer1 = graph.get_tensor_by_name('block_layer1:0')
-      block_layer2 = graph.get_tensor_by_name('block_layer2:0')
-      block_layer3 = graph.get_tensor_by_name('block_layer3:0')
-      block_layer4 = graph.get_tensor_by_name('block_layer4:0')
-      reduce_mean = graph.get_tensor_by_name('final_reduce_mean:0')
-      dense = graph.get_tensor_by_name('final_dense:0')
+      initial_conv = graph.get_tensor_by_name('resnet_model/initial_conv:0')
+      max_pool = graph.get_tensor_by_name('resnet_model/initial_max_pool:0')
+      block_layer1 = graph.get_tensor_by_name('resnet_model/block_layer1:0')
+      block_layer2 = graph.get_tensor_by_name('resnet_model/block_layer2:0')
+      block_layer3 = graph.get_tensor_by_name('resnet_model/block_layer3:0')
+      block_layer4 = graph.get_tensor_by_name('resnet_model/block_layer4:0')
+      reduce_mean = graph.get_tensor_by_name('resnet_model/final_reduce_mean:0')
+      dense = graph.get_tensor_by_name('resnet_model/final_dense:0')
 
       self.assertAllEqual(initial_conv.shape, reshape((1, 64, 112, 112)))
       self.assertAllEqual(max_pool.shape, reshape((1, 64, 56, 56)))
@@ -87,6 +89,12 @@ class BaseTest(tf.test.TestCase):
 
       self.assertAllEqual(dense.shape, (1, _LABEL_CLASSES))
       self.assertAllEqual(output.shape, (1, _LABEL_CLASSES))
+
+  def tensor_shapes_helper(self, resnet_size, version, with_gpu=False):
+    self._tensor_shapes_helper(resnet_size=resnet_size, version=version,
+                               dtype=tf.float32, with_gpu=with_gpu)
+    self._tensor_shapes_helper(resnet_size=resnet_size, version=version,
+                               dtype=tf.float16, with_gpu=with_gpu)
 
   def test_tensor_shapes_resnet_18_v1(self):
     self.tensor_shapes_helper(18, version=1)
@@ -172,41 +180,62 @@ class BaseTest(tf.test.TestCase):
   def test_tensor_shapes_resnet_200_with_gpu_v2(self):
     self.tensor_shapes_helper(200, version=2, with_gpu=True)
 
-  def resnet_model_fn_helper(self, mode, version, multi_gpu=False):
+  def _resnet_model_fn_helper(self, mode, version, dtype, multi_gpu):
     """Tests that the EstimatorSpec is given the appropriate arguments."""
-    tf.train.create_global_step()
+    with tf.Graph().as_default() as g:
+      tf.train.create_global_step()
 
-    input_fn = imagenet_main.get_synth_input_fn()
-    dataset = input_fn(True, '', _BATCH_SIZE)
-    iterator = dataset.make_one_shot_iterator()
-    features, labels = iterator.get_next()
-    spec = imagenet_main.imagenet_model_fn(
-        features, labels, mode, {
-            'resnet_size': 50,
-            'data_format': 'channels_last',
-            'batch_size': _BATCH_SIZE,
-            'version': version,
-            'multi_gpu': multi_gpu,
-        })
+      input_fn = imagenet_main.get_synth_input_fn()
+      dataset = input_fn(True, '', _BATCH_SIZE)
+      iterator = dataset.make_one_shot_iterator()
+      features, labels = iterator.get_next()
+      spec = imagenet_main.imagenet_model_fn(
+          features, labels, mode, {
+              'dtype': dtype,
+              'resnet_size': 50,
+              'data_format': 'channels_last',
+              'batch_size': _BATCH_SIZE,
+              'version': version,
+              'loss_scale': 128 if dtype == tf.float16 else 1,
+              'multi_gpu': multi_gpu,
+          })
 
-    predictions = spec.predictions
-    self.assertAllEqual(predictions['probabilities'].shape,
-                        (_BATCH_SIZE, _LABEL_CLASSES))
-    self.assertEqual(predictions['probabilities'].dtype, tf.float32)
-    self.assertAllEqual(predictions['classes'].shape, (_BATCH_SIZE,))
-    self.assertEqual(predictions['classes'].dtype, tf.int64)
+      predictions = spec.predictions
+      self.assertAllEqual(predictions['probabilities'].shape,
+                          (_BATCH_SIZE, _LABEL_CLASSES))
+      self.assertEqual(predictions['probabilities'].dtype, tf.float32)
+      self.assertAllEqual(predictions['classes'].shape, (_BATCH_SIZE,))
+      self.assertEqual(predictions['classes'].dtype, tf.int64)
 
-    if mode != tf.estimator.ModeKeys.PREDICT:
-      loss = spec.loss
-      self.assertAllEqual(loss.shape, ())
-      self.assertEqual(loss.dtype, tf.float32)
+      if mode != tf.estimator.ModeKeys.PREDICT:
+        loss = spec.loss
+        self.assertAllEqual(loss.shape, ())
+        self.assertEqual(loss.dtype, tf.float32)
 
-    if mode == tf.estimator.ModeKeys.EVAL:
-      eval_metric_ops = spec.eval_metric_ops
-      self.assertAllEqual(eval_metric_ops['accuracy'][0].shape, ())
-      self.assertAllEqual(eval_metric_ops['accuracy'][1].shape, ())
-      self.assertEqual(eval_metric_ops['accuracy'][0].dtype, tf.float32)
-      self.assertEqual(eval_metric_ops['accuracy'][1].dtype, tf.float32)
+      if mode == tf.estimator.ModeKeys.EVAL:
+        eval_metric_ops = spec.eval_metric_ops
+        self.assertAllEqual(eval_metric_ops['accuracy'][0].shape, ())
+        self.assertAllEqual(eval_metric_ops['accuracy'][1].shape, ())
+        self.assertEqual(eval_metric_ops['accuracy'][0].dtype, tf.float32)
+        self.assertEqual(eval_metric_ops['accuracy'][1].dtype, tf.float32)
+
+        tensors_to_check = ('initial_conv:0', 'initial_max_pool:0',
+                            'block_layer1:0', 'block_layer2:0',
+                            'block_layer3:0', 'block_layer4:0',
+                            'final_reduce_mean:0', 'final_dense:0')
+
+        for tensor_name in tensors_to_check:
+          tensor = g.get_tensor_by_name('resnet_model/' + tensor_name)
+          self.assertEqual(tensor.dtype, dtype,
+                           'Tensor {} has dtype {}, while dtype {} was '
+                           'expected'.format(tensor, tensor.dtype,
+                                             dtype))
+
+  def resnet_model_fn_helper(self, mode, version, multi_gpu=False):
+    self._resnet_model_fn_helper(mode=mode, version=version, dtype=tf.float32,
+                                 multi_gpu=multi_gpu)
+    self._resnet_model_fn_helper(mode=mode, version=version, dtype=tf.float16,
+                                 multi_gpu=multi_gpu)
 
   def test_resnet_model_fn_train_mode_v1(self):
     self.resnet_model_fn_helper(tf.estimator.ModeKeys.TRAIN, version=1)
@@ -234,18 +263,24 @@ class BaseTest(tf.test.TestCase):
   def test_resnet_model_fn_predict_mode_v2(self):
     self.resnet_model_fn_helper(tf.estimator.ModeKeys.PREDICT, version=2)
 
-  def test_imagenetmodel_shape(self):
+  def _test_imagenetmodel_shape(self, version):
     batch_size = 135
     num_classes = 246
 
-    for version in (1, 2):
-      model = imagenet_main.ImagenetModel(
-          50, data_format='channels_last', num_classes=num_classes,
-          version=version)
-      fake_input = tf.random_uniform([batch_size, 224, 224, 3])
-      output = model(fake_input, training=True)
+    model = imagenet_main.ImagenetModel(
+        50, data_format='channels_last', num_classes=num_classes,
+        version=version)
 
-      self.assertAllEqual(output.shape, (batch_size, num_classes))
+    fake_input = tf.random_uniform([batch_size, 224, 224, 3])
+    output = model(fake_input, training=True)
+
+    self.assertAllEqual(output.shape, (batch_size, num_classes))
+
+  def test_imagenetmodel_shape_v1(self):
+    self._test_imagenetmodel_shape(version=1)
+
+  def test_imagenetmodel_shape_v2(self):
+    self._test_imagenetmodel_shape(version=2)
 
   def test_imagenet_end_to_end_synthetic_v1(self):
     integration.run_synthetic(

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -413,7 +413,7 @@ class Model(object):
         self.block_fn = _building_block_v2
 
     if dtype not in ALLOWED_TYPES:
-      raise ValueError("dtype must be one of: {}".format(LEGAL_TYPES))
+      raise ValueError('dtype must be one of: {}'.format(ALLOWED_TYPES))
 
     self.data_format = data_format
     self.num_classes = num_classes

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -38,6 +38,7 @@ _BATCH_NORM_EPSILON = 1e-5
 DEFAULT_VERSION = 2
 DEFAULT_DTYPE = tf.float32
 CASTABLE_TYPES = (tf.float16,)
+ALLOWED_TYPES = (tf.float32,) + CASTABLE_TYPES
 
 
 ################################################################################
@@ -410,6 +411,9 @@ class Model(object):
         self.block_fn = _building_block_v1
       else:
         self.block_fn = _building_block_v2
+
+    if dtype not in ALLOWED_TYPES:
+      raise ValueError("dtype must be one of: {}".format(LEGAL_TYPES))
 
     self.data_format = data_format
     self.num_classes = num_classes

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -38,7 +38,7 @@ _BATCH_NORM_EPSILON = 1e-5
 DEFAULT_VERSION = 2
 DEFAULT_DTYPE = tf.float32
 CASTABLE_TYPES = (tf.float16,)
-ALLOWED_TYPES = (tf.float32,) + CASTABLE_TYPES
+ALLOWED_TYPES = (DEFAULT_DTYPE,) + CASTABLE_TYPES
 
 
 ################################################################################
@@ -443,7 +443,7 @@ class Model(object):
     been called if no custom getter was used. Custom getters typically get a
     variable with `getter`, then modify it in some way.
 
-    This custom getter will create an fp32 variable. If an low precision
+    This custom getter will create an fp32 variable. If a low precision
     (e.g. float16) variable was requested it will then cast the variable to the
     requested dtype. The reason we do not directly create variables in low
     precision dtypes is that applying small gradients to such variables may

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -351,7 +351,8 @@ class Model(object):
                kernel_size,
                conv_stride, first_pool_size, first_pool_stride,
                second_pool_size, second_pool_stride, block_sizes, block_strides,
-               final_size, version=DEFAULT_VERSION, data_format=None):
+               final_size, version=DEFAULT_VERSION, data_format=None,
+               dtype=None):
     """Creates a model for classifying an image.
 
     Args:
@@ -379,6 +380,8 @@ class Model(object):
         See README for details. Valid values: [1, 2]
       data_format: Input format ('channels_last', 'channels_first', or None).
         If set to None, the format is dependent on whether a GPU is available.
+      dtype: The TensorFlow dtype to use for calculations. If not specified
+        tf.float32 is used.
 
     Raises:
       ValueError: if invalid version is selected.
@@ -418,6 +421,60 @@ class Model(object):
     self.block_sizes = block_sizes
     self.block_strides = block_strides
     self.final_size = final_size
+    self.dtype = dtype or tf.float32
+
+  def _custom_getter(self, getter, name, shape=None, dtype=tf.float32,
+                     *args, **kwargs):
+    """Creates variables in fp32, then casts to fp16 if necessary.
+
+      This function is a custom getter. A custom getter is a function with the
+    same signature as tf.get_variable, except it has an additional getter
+    parameter. Custom getters can be passed as the `custom_getter` parameter of
+    tf.variable_scope. Then, tf.get_variable will call the custom getter,
+    instead of directly getting a variable itself. This can be used to change
+    the types of variables that are retrieved with tf.get_variable.
+    The `getter` parameter is the underlying variable getter, that would have
+    been called if no custom getter was used. Custom getters typically get a
+    variable with `getter`, then modify it in some way.
+    This custom getter will create an fp32 variable if an fp16 variable was
+    requested. It will then cast the variable to fp16 and return the result.
+    The reason we do not directly create variables in fp16 is that applying
+    small gradients to fp16 variables may cause the variable not to change. This
+    is because fp16 variables have very low precision.
+
+    Args:
+      getter: The underlying variable getter, that has the same signature as
+        tf.get_variable and returns a variable.
+      name: The name of the variable to get.
+      shape: The shape of the variable to get.
+      dtype: The dtype of the variable to get. Note that if this if tf.float16,
+        the variable will be created as a tf.float32 variable, then casted to
+        tf.float16
+      *args: Additional arguments to pass unmodified to getter.
+      **kwargs: Additional keyword arguments to pass unmodified to getter.
+
+    Returns:
+      A variable which is cast to fp16 if necessary.
+    """
+
+    if dtype == tf.float16:
+      var = getter(name, shape, tf.float32, *args, **kwargs)
+      return tf.cast(var, tf.float16, name=name + '_casted')
+    else:
+      return getter(name, shape, dtype, *args, **kwargs)
+
+  def _model_variable_scope(self):
+    """Returns a variable scope that the model should be created under.
+
+    If self.use_fp16 is True, model variable will be created in fp32 then casted
+    to fp16 before being used.
+
+    Returns:
+      A variable scope for the model.
+    """
+
+    custom_getter = self._custom_getter if self.dtype == tf.float16 else None
+    return tf.variable_scope('resnet_model', custom_getter=custom_getter)
 
   def __call__(self, inputs, training):
     """Add operations to classify a batch of input images.
@@ -431,46 +488,46 @@ class Model(object):
       A logits Tensor with shape [<batch_size>, self.num_classes].
     """
 
-    if self.data_format == 'channels_first':
-      # Convert the inputs from channels_last (NHWC) to channels_first (NCHW).
-      # This provides a large performance boost on GPU. See
-      # https://www.tensorflow.org/performance/performance_guide#data_formats
-      inputs = tf.transpose(inputs, [0, 3, 1, 2])
+    with self._model_variable_scope():
+      if self.data_format == 'channels_first':
+        # Convert the inputs from channels_last (NHWC) to channels_first (NCHW).
+        # This provides a large performance boost on GPU. See
+        # https://www.tensorflow.org/performance/performance_guide#data_formats
+        inputs = tf.transpose(inputs, [0, 3, 1, 2])
 
-    inputs = conv2d_fixed_padding(
-        inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,
-        strides=self.conv_stride, data_format=self.data_format)
-    inputs = tf.identity(inputs, 'initial_conv')
+      inputs = conv2d_fixed_padding(
+          inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,
+          strides=self.conv_stride, data_format=self.data_format)
+      inputs = tf.identity(inputs, 'initial_conv')
 
-    if self.first_pool_size:
-      inputs = tf.layers.max_pooling2d(
-          inputs=inputs, pool_size=self.first_pool_size,
-          strides=self.first_pool_stride, padding='SAME',
-          data_format=self.data_format)
-      inputs = tf.identity(inputs, 'initial_max_pool')
+      if self.first_pool_size:
+        inputs = tf.layers.max_pooling2d(
+            inputs=inputs, pool_size=self.first_pool_size,
+            strides=self.first_pool_stride, padding='SAME',
+            data_format=self.data_format)
+        inputs = tf.identity(inputs, 'initial_max_pool')
 
-    for i, num_blocks in enumerate(self.block_sizes):
-      num_filters = self.num_filters * (2**i)
-      inputs = block_layer(
-          inputs=inputs, filters=num_filters, bottleneck=self.bottleneck,
-          block_fn=self.block_fn, blocks=num_blocks,
-          strides=self.block_strides[i], training=training,
-          name='block_layer{}'.format(i + 1), data_format=self.data_format)
+      for i, num_blocks in enumerate(self.block_sizes):
+        num_filters = self.num_filters * (2**i)
+        inputs = block_layer(
+            inputs=inputs, filters=num_filters, bottleneck=self.bottleneck,
+            block_fn=self.block_fn, blocks=num_blocks,
+            strides=self.block_strides[i], training=training,
+            name='block_layer{}'.format(i + 1), data_format=self.data_format)
 
-    inputs = batch_norm(inputs, training, self.data_format)
-    inputs = tf.nn.relu(inputs)
+      inputs = batch_norm(inputs, training, self.data_format)
+      inputs = tf.nn.relu(inputs)
 
-    # The current top layer has shape
-    # `batch_size x pool_size x pool_size x final_size`.
-    # ResNet does an Average Pooling layer over pool_size,
-    # but that is the same as doing a reduce_mean. We do a reduce_mean
-    # here because it performs better than AveragePooling2D.
-    axes = [2, 3] if self.data_format == 'channels_first' else [1, 2]
-    inputs = tf.reduce_mean(inputs, axes, keepdims=True)
-    inputs = tf.identity(inputs, 'final_reduce_mean')
+      # The current top layer has shape
+      # `batch_size x pool_size x pool_size x final_size`.
+      # ResNet does an Average Pooling layer over pool_size,
+      # but that is the same as doing a reduce_mean. We do a reduce_mean
+      # here because it performs better than AveragePooling2D.
+      axes = [2, 3] if self.data_format == 'channels_first' else [1, 2]
+      inputs = tf.reduce_mean(inputs, axes, keepdims=True)
+      inputs = tf.identity(inputs, 'final_reduce_mean')
 
-    inputs = tf.reshape(inputs, [-1, self.final_size])
-    inputs = tf.layers.dense(inputs=inputs, units=self.num_classes)
-    inputs = tf.identity(inputs, 'final_dense')
-
-    return inputs
+      inputs = tf.reshape(inputs, [-1, self.final_size])
+      inputs = tf.layers.dense(inputs=inputs, units=self.num_classes)
+      inputs = tf.identity(inputs, 'final_dense')
+      return inputs

--- a/official/utils/arg_parsers/parsers.py
+++ b/official/utils/arg_parsers/parsers.py
@@ -83,7 +83,10 @@ def parse_dtype_info(flags):
     raise ValueError("Invalid dtype: {}".format(flags.dtype))
 
   if flags.loss_scale is None:
-    flags.loss_scale = 128 if flags.dtype == tf.float16 else 1
+    flags.loss_scale = {
+      "float16": 128,
+      "float32": 1,
+    }[flags.dtype.name]
 
 
 class BaseParser(argparse.ArgumentParser):
@@ -230,7 +233,7 @@ class PerformanceParser(argparse.ArgumentParser):
       self.add_argument(
           "--dtype", "-dt",
           default="fp32",
-          choices=["fp16", "float16", "fp32", "float32"],
+          choices=["fp16", "float16", "fp32", "float32", "int8"],
           help="[default: %(default)s] {%(choices)s} The TensorFlow datatype "
                "used for calculations. Variables may be cast to a higher"
                "precision on a case-by-case basis for numerical stability.",

--- a/official/utils/arg_parsers/parsers.py
+++ b/official/utils/arg_parsers/parsers.py
@@ -79,7 +79,7 @@ def parse_dtype_info(flags):
   Raises:
     ValueError: If an invalid dtype is provided.
   """
-  if not (flags.dtype is None or isinstance(flags.dtype, str)):
+  if flags.dtype in (i[0] for i in DTYPE_MAP.values()):
     return  # Make function idempotent
 
   try:
@@ -87,8 +87,7 @@ def parse_dtype_info(flags):
   except KeyError:
     raise ValueError("Invalid dtype: {}".format(flags.dtype))
 
-  flags.loss_scale = (flags.loss_scale if flags.loss_scale else
-                      default_loss_scale)
+  flags.loss_scale = flags.loss_scale or default_loss_scale
 
 
 class BaseParser(argparse.ArgumentParser):

--- a/official/utils/arg_parsers/parsers.py
+++ b/official/utils/arg_parsers/parsers.py
@@ -84,8 +84,8 @@ def parse_dtype_info(flags):
 
   if flags.loss_scale is None:
     flags.loss_scale = {
-      "float16": 128,
-      "float32": 1,
+        "float16": 128,
+        "float32": 1,
     }[flags.dtype.name]
 
 

--- a/official/utils/arg_parsers/parsers_test.py
+++ b/official/utils/arg_parsers/parsers_test.py
@@ -99,6 +99,9 @@ class BaseTester(unittest.TestCase):
 
       assert args.loss_scale == 5
 
+    with self.assertRaises(SystemExit):
+      parser.parse_args(["--dtype", "int8"])
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/official/utils/arg_parsers/parsers_test.py
+++ b/official/utils/arg_parsers/parsers_test.py
@@ -16,6 +16,7 @@
 import argparse
 import unittest
 
+import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.utils.arg_parsers import parsers
 
@@ -82,6 +83,21 @@ class BaseTester(unittest.TestCase):
 
     assert namespace.multi_gpu
     assert namespace.use_synthetic_data
+
+  def test_parse_dtype_info(self):
+    parser = TestParser()
+    for dtype_str, tf_dtype, loss_scale in [["fp16", tf.float16, 128],
+                                            ["fp32", tf.float32, 1]]:
+      args = parser.parse_args(["--dtype", dtype_str])
+      parsers.parse_dtype_info(args)
+
+      assert args.dtype == tf_dtype
+      assert args.loss_scale == loss_scale
+
+      args = parser.parse_args(["--dtype", dtype_str, "--loss_scale", "5"])
+      parsers.parse_dtype_info(args)
+
+      assert args.loss_scale == 5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds fp16 support to official/resnet. The vast majority of the work was already done by Reed a month ago (including wonderful comments), and this just rolls those changes into the current master.

Currently training is I/O bound; however synthetic data runs confirm the fp16 accelleration to ~4000 images/sec during training.

I will update when I have run results.