### PR TITLE
Image encoder: fix binary files parsed as UTF-8

### DIFF
--- a/research/compression/image_encoder/decoder.py
+++ b/research/compression/image_encoder/decoder.py
@@ -71,7 +71,7 @@ def main(_):
     return
 
   contents = ''
-  with tf.gfile.FastGFile(FLAGS.input_codes, 'r') as code_file:
+  with tf.gfile.FastGFile(FLAGS.input_codes, 'rb') as code_file:
     contents = code_file.read()
     loaded_codes = np.load(io.BytesIO(contents))
     assert ['codes', 'shape'] not in loaded_codes.files

--- a/research/compression/image_encoder/encoder.py
+++ b/research/compression/image_encoder/encoder.py
@@ -59,7 +59,7 @@ def main(_):
     print('\n--iteration must be between 0 and 15 inclusive.\n')
     return
 
-  with tf.gfile.FastGFile(FLAGS.input_image) as input_image:
+  with tf.gfile.FastGFile(FLAGS.input_image, 'rb') as input_image:
     input_image_str = input_image.read()
 
   with tf.Graph().as_default() as graph:

--- a/research/compression/image_encoder/msssim.py
+++ b/research/compression/image_encoder/msssim.py
@@ -199,9 +199,9 @@ def main(_):
     return
 
   with tf.gfile.FastGFile(FLAGS.original_image) as image_file:
-    img1_str = image_file.read()
+    img1_str = image_file.read('rb')
   with tf.gfile.FastGFile(FLAGS.compared_image) as image_file:
-    img2_str = image_file.read()
+    img2_str = image_file.read('rb')
 
   input_img = tf.placeholder(tf.string)
   decoded_image = tf.expand_dims(tf.image.decode_png(input_img, channels=3), 0)


### PR DESCRIPTION
This is a fix for #1467 and a related decoder error, where binary files are parsed as (invalid) UTF-8. The behavior is reproducible with Python 3.6 and Tensorflow 1.6, with the example image provided in the repository, `example.png`.