### PR TITLE
dict_items to list for mnet py3 support

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -81,7 +81,7 @@ def _set_arg_scope_defaults(defaults):
     context manager where all defaults are set.
   """
   if hasattr(defaults, 'items'):
-    items = defaults.items()
+    items = list(defaults.items())
   else:
     items = defaults
   if not items:


### PR DESCRIPTION
`defaults.items()` in `slim/nets/mobilenet/mobilenet.py` returns `dict_item` in Python 3 rather than a list. `list(defaults.items())` works on both Python versions.

To reproduce the original problem run
```bash
python3 deeplab/model_test.py
```
which throws the error:
```bash
E...
======================================================================
ERROR: testBuildDeepLabv2 (__main__.DeeplabModelTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "deeplab/model_test.py", line 71, in testBuildDeepLabv2
    inputs, model_options, image_pyramid=image_pyramid)
  ...
  File "/home/fmannan/workspace/models/research/slim/nets/mobilenet/mobilenet.py", line 90, in _set_arg_scope_defaults
    func, default_arg = items[0]
TypeError: 'dict_items' object does not support indexing

======================================================================
ERROR: testForwardpassDeepLabv3plus (__main__.DeeplabModelTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "deeplab/model_test.py", line 105, in testForwardpassDeepLabv3plus
    image_pyramid=[1.0])
  ...
  File "/home/fmannan/workspace/models/research/slim/nets/mobilenet/mobilenet.py", line 90, in _set_arg_scope_defaults
    func, default_arg = items[0]
TypeError: 'dict_items' object does not support indexing

----------------------------------------------------------------------
Ran 5 tests in 8.985s

FAILED (errors=2)
```