### PR TITLE
Add requirements.txt to official.

### DIFF
--- a/official/README.md
+++ b/official/README.md
@@ -28,4 +28,6 @@ If you would like to make any fixes or improvements to the models, please [submi
 
 The *Official Models* are made available as a Python module. To run the models and associated scripts, add the top-level ***/models*** folder to the Python path with the command: `export PYTHONPATH="$PYTHONPATH:/path/to/models"`
 
+To install dependencies pass `-r official/requirements.txt` to pip. (i.e. `pip3 install --user -r official/requirements.txt`)
+
 To make Official Models easier to use, we are planning to create a pip installable Official Models package. This is being tracked in [#917](https://github.com/tensorflow/models/issues/917).

--- a/official/requirements.txt
+++ b/official/requirements.txt
@@ -1,0 +1,2 @@
+psutil>=5.4.3
+py-cpuinfo>=3.3.0

--- a/official/utils/logging/logger.py
+++ b/official/utils/logging/logger.py
@@ -16,9 +16,7 @@
 """Logging utilities for benchmark.
 
 For collecting local environment metrics like CPU and memory, certain python
-packages need be installed. Run the following commands for dependency packages:
-  > pip install --upgrade py-cpuinfo
-  > pip install --upgrade psutil
+packages need be installed. See README for details.
 """
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
Now that we have dependencies beyond what TensorFlow already pulls in, we may as well put a bit of formalism to help people out.