### PR TITLE
vis.py: use basename of image when saving raw annotations to prevent file-not-found error

### DIFF
--- a/research/deeplab/vis.py
+++ b/research/deeplab/vis.py
@@ -173,7 +173,7 @@ def _process_batch(sess, original_images, semantic_predictions, image_names,
         colormap_type=FLAGS.colormap_type)
 
     if FLAGS.also_save_raw_predictions:
-      image_filename = image_names[i]
+      image_filename = os.path.basename(image_names[i])
 
       if train_id_to_eval_id is not None:
         crop_semantic_prediction = _convert_train_id_to_eval_id(


### PR DESCRIPTION
when setting `--also_save_raw_predictions=True`, a file-not-found error is report because we are saving into the `--vis_logdir` using the fullpath of that image.