### PR TITLE
Update faster_rcnn_inception_resnet_v2_atrous_oid.config

### DIFF
--- a/research/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_oid.config
+++ b/research/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_oid.config
@@ -106,6 +106,7 @@ train_config: {
   }
   gradient_clipping_by_norm: 10.0
   fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  from_detection_checkpoint: true
   # Note: The below line limits the training process to 800K steps, which we
   # empirically found to be sufficient enough to train the Open Images dataset.
   # This effectively bypasses the learning rate schedule (the learning rate will


### PR DESCRIPTION
from_detection_checkpoint check needs to be true to using pre-trained models.
(otherwise no variables found error thrown while training)