### PR TITLE
Add config options to change default saving behavior in TrainConfig

### DIFF
--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -94,4 +94,13 @@ message TrainConfig {
   // Whether to remove padding along `num_boxes` dimension of the groundtruth
   // tensors.
   optional bool unpad_groundtruth_tensors = 21 [default=true];
+
+  // How often to save checkpoints
+  optional uint32 checkpoint_save_interval_secs = 22 [default=600];
+
+  // How often to save summaries
+  optional uint32 save_summaries_secs = 23 [default=120];
+
+  // How many checkpoint to keep
+  optional uint32 max_checkpoints_to_keep = 24 [default=5];
 }

--- a/research/object_detection/trainer.py
+++ b/research/object_detection/trainer.py
@@ -366,7 +366,7 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
         summary_op=summary_op,
         number_of_steps=(
             train_config.num_steps if train_config.num_steps else None),
-        save_summaries_secs=save_interval_secs=train_config.save_summaries_secs,
+        save_summaries_secs=train_config.save_summaries_secs,
         save_interval_secs=train_config.checkpoint_save_interval_secs,
         sync_optimizer=sync_optimizer,
         saver=saver)

--- a/research/object_detection/trainer.py
+++ b/research/object_detection/trainer.py
@@ -352,6 +352,7 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
     # Save checkpoints regularly.
     keep_checkpoint_every_n_hours = train_config.keep_checkpoint_every_n_hours
     saver = tf.train.Saver(
+        max_to_keep=train_config.max_checkpoints_to_keep,
         keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     slim.learning.train(
@@ -365,6 +366,7 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
         summary_op=summary_op,
         number_of_steps=(
             train_config.num_steps if train_config.num_steps else None),
-        save_summaries_secs=120,
+        save_summaries_secs=save_interval_secs=train_config.save_summaries_secs,
+        save_interval_secs=train_config.checkpoint_save_interval_secs,
         sync_optimizer=sync_optimizer,
         saver=saver)


### PR DESCRIPTION
* checkpoint_save_interval_secs is used to change how often the checkpoints are serialized (default 600 seconds)

* save_summaries_secs is used to change how often summaries are saved (default 120 seconds)

* max_checkpoints_to_keep is used to change how many checkpoints are kept (default 5 checkpoints)