### PR TITLE
fixed dimension compatibility issue for numpy

### DIFF
--- a/tutorials/image/cifar10/cifar10.py
+++ b/tutorials/image/cifar10/cifar10.py
@@ -240,7 +240,7 @@ def inference(images):
   # local3
   with tf.variable_scope('local3') as scope:
     # Move everything into depth so we can perform a single matrix multiply.
-    reshape = tf.reshape(pool2, [images.get_shape()[0], -1])
+    reshape = tf.reshape(pool2, [images.get_shape().as_list()[0], -1])
     dim = reshape.get_shape()[1].value
     weights = _variable_with_weight_decay('weights', shape=[dim, 384],
                                           stddev=0.04, wd=0.004)


### PR DESCRIPTION
The original code passes a dimension object to tf.reshape(), which is not recognized with error. This pull request casts the dimension object to int to fix this problem. The stack trace of the original code is attached below:


  File "/home/models/tutorials/image/cifar10/cifar10.py", line 243, in inference
    reshape = tf.reshape(pool2, [images.get_shape()[0], -1])
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/gen_array_ops.py", line 2619, in reshape
    name=name)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/op_def_library.py", line 493, in apply_op
    raise err
TypeError: Failed to convert object of type <type 'list'> to Tensor. Contents: [Dimension(128), -1]. Consider casting elements to a supported type.