### PR TITLE
tensorrt: long was removed in Python 3

### DIFF
--- a/research/tensorrt/tensorrt.py
+++ b/research/tensorrt/tensorrt.py
@@ -35,6 +35,12 @@ import tensorflow.contrib.tensorrt as trt
 
 from official.resnet import imagenet_preprocessing  # pylint: disable=g-bad-import-order
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
+
 _GPU_MEM_FRACTION = 0.50
 _WARMUP_NUM_LOOPS = 50
 _LOG_FILE = "log.txt"


### PR DESCRIPTION
__long__ (used on line 603) was removed in Python 3 in favor of __int__.