### PR TITLE
Fix momentum value flag from string => float

### DIFF
--- a/research/attention_ocr/python/common_flags.py
+++ b/research/attention_ocr/python/common_flags.py
@@ -73,7 +73,7 @@ def define():
   flags.DEFINE_string('optimizer', 'momentum',
                       'the optimizer to use')
 
-  flags.DEFINE_string('momentum', 0.9,
+  flags.DEFINE_float('momentum', 0.9,
                       'momentum value for the momentum optimizer if used')
 
   flags.DEFINE_bool('use_augment_input', True,


### PR DESCRIPTION
This addresses a runtime error describing below (for the attention_ocr) model. Please have a look if it is acceptable. @alexgorban 

Following the README.txt file, after running "python -m unittest discover -p  '*_test.py'", I would get the following error message. It seems this comes from the defining of the flag momentum in common_flags.py
IllegalFlagValueError: flag --momentum=0.9: flag value must be a string, found "<type 'float'>"

Note that I tested on the following environment (Ubuntu 16.04.3 LTS, Python 2.7.12, Tensorflow version 1.5.0)
