### PR TITLE
Add time to train logging

### DIFF
--- a/official/benchmark/datastore/schema/benchmark_run.json
+++ b/official/benchmark/datastore/schema/benchmark_run.json
@@ -18,6 +18,24 @@
     "type": "TIMESTAMP"
   },
   {
+    "description": "The date when the test of the model is ended",
+    "mode": "REQUIRED",
+    "name": "end_date",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The human-readable duration between run_date and end_date",
+    "mode": "REQUIRED",
+    "name": "elapsed_time",
+    "type": "STRING"
+  },
+  {
+    "description": "The duration in seconds between run_date and end_date",
+    "mode": "REQUIRED",
+    "name": "elapsed_seconds",
+    "type": "FLOAT"
+  },
+  {
     "description": "The tensorflow version information.",
     "fields": [
       {

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -369,7 +369,7 @@ def resnet_main(flags, model_function, input_function, shape=None):
 
   if flags.benchmark_log_dir is not None:
     benchmark_logger = logger.BenchmarkLogger(flags.benchmark_log_dir)
-    benchmark_logger.log_run_info("resnet")
+    benchmark_logger.log_run_info('resnet')
   else:
     benchmark_logger = None
 
@@ -407,6 +407,9 @@ def resnet_main(flags, model_function, input_function, shape=None):
 
     if benchmark_logger:
       benchmark_logger.log_estimator_evaluation_result(eval_results)
+
+  if benchmark_logger:
+    benchmark_logger.log_run_end()
 
   if flags.export_dir is not None:
     warn_on_multi_gpu_export(flags.multi_gpu)


### PR DESCRIPTION
This writes the end time of training as well as elapsed time to benchmark_run.log. If used as in the resnet loop, this will be equivalent to time-to-converge in cases where we run from start to convergence.

Note that this does not handle run starting and stopping; this is intentional for now.
Note also that the user bears the burden of calling the log_run_end method; this is also intentional, as we want to maintain flexibility in the face of different model architectures and rule sets.

@yhliang2018 - For new models added, we would want to add the logging logic as in Resnet.
@qlzh727 - This will require an update to the BigQuery Table, which, once approved, I can do.

Sample output (emphasis added):

{**"end_date": "2018-04-04T20:49:41.972510Z"**, "run_date": "2018-04-04T20:15:49.432197Z", "machine_config": {"cpu_info": {"cpu_info": "Intel(R) Xeon(R) CPU @ 2.30GHz", "mhz_per_cpu": 2300.0, "num_cores": 32}, "gpu_info": {"count": 4, "model": "Tesla P100-PCIE-16GB"}, "memory_total": 126739050496, "memory_available": 121141805056}, "tensorflow_version": {"git_hash": "v1.7.0-rc1-1091-gc7a04561fb", "version": "1.8.0-dev20180402"}, **"elapsed_time": "0:33:52.540313"**, **"elapsed_seconds": 2032.540313**, "tensorflow_environment_variables": [{"name": "TF_ENABLE_WINOGRAD_NONFUSED", "value": "1"}], "model_name": "resnet"}
