### PR TITLE
from six.moves import xrange (en masse) still yet again

### DIFF
--- a/research/differential_privacy/pate/ICLR2018/rdp_bucketized.py
+++ b/research/differential_privacy/pate/ICLR2018/rdp_bucketized.py
@@ -45,6 +45,7 @@ matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # pylint: disable=g-import-not-at-top
 import numpy as np
 import core as pate
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 plt.style.use('ggplot')
 

--- a/research/differential_privacy/pate/ICLR2018/rdp_cumulative.py
+++ b/research/differential_privacy/pate/ICLR2018/rdp_cumulative.py
@@ -45,6 +45,7 @@ matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # pylint: disable=g-import-not-at-top
 import numpy as np
 import core as pate
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 plt.style.use('ggplot')
 

--- a/research/differential_privacy/pate/ICLR2018/rdp_flow.py
+++ b/research/differential_privacy/pate/ICLR2018/rdp_flow.py
@@ -43,6 +43,7 @@ matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # pylint: disable=g-import-not-at-top
 import numpy as np
 import core as pate
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 plt.style.use('ggplot')
 

--- a/research/learning_unsupervised_learning/meta_objective/linear_regression.py
+++ b/research/learning_unsupervised_learning/meta_objective/linear_regression.py
@@ -28,6 +28,7 @@ import collections
 import numpy as np
 import sonnet as snt
 import tensorflow as tf
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from learning_unsupervised_learning import utils
 from learning_unsupervised_learning import variable_replace

--- a/research/learning_unsupervised_learning/meta_objective/utils.py
+++ b/research/learning_unsupervised_learning/meta_objective/utils.py
@@ -22,6 +22,7 @@ import collections
 import numpy as np
 import sonnet as snt
 import tensorflow as tf
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from learning_unsupervised_learning import optimizers
 from learning_unsupervised_learning import utils

--- a/research/learning_unsupervised_learning/summary_utils.py
+++ b/research/learning_unsupervised_learning/summary_utils.py
@@ -29,6 +29,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import scipy.signal
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.python.util import tf_should_use
 from tensorflow.contrib.summary import summary_ops
 from tensorflow.python.ops import summary_op_util

--- a/research/learning_unsupervised_learning/utils.py
+++ b/research/learning_unsupervised_learning/utils.py
@@ -26,6 +26,7 @@ import sonnet as snt
 import itertools
 import functools
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.framework import device as pydev
 from tensorflow.python.framework import errors
@@ -284,4 +285,3 @@ def create_variables_in_class_scope(method):
           return out_ops
 
   return wrapper
-


### PR DESCRIPTION
A repeat of PRs #3702 #3520 #3206

Could __python3 -m flake8 . --select=F821__ be added to the testing to automatically spot these?