### PR TITLE
unsupervised_learning: Fix two syntax errors in Python 3

### DIFF
--- a/research/learning_unsupervised_learning/meta_objective/sklearn.py
+++ b/research/learning_unsupervised_learning/meta_objective/sklearn.py
@@ -113,7 +113,8 @@ class SKLearn(meta_obj_utils.MultiTrialMetaObjective):
       teY = tf.to_int64(te_batch.label)
       teY_shape = teY.shape.as_list()
 
-      def blackbox((trX, trY, teX, teY)):
+      def blackbox(trX__trY__teX__teY):
+        trX, trY, teX, teY = trX__trY__teX__teY
         trY = tf.to_int32(tf.rint(trY))
         teY = tf.to_int32(tf.rint(teY))
         tf_fn = build_fit(

--- a/research/learning_unsupervised_learning/variable_replace.py
+++ b/research/learning_unsupervised_learning/variable_replace.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
 import tensorflow as tf
 from contextlib import contextmanager
@@ -70,9 +71,9 @@ def variable_replace(replacements, no_new=True):
     names_replace[strip_name] = v
     # TODO(lmetz) is there a cleaner way to do this?
   def new_get_variable(name, *args, **kwargs):
-    #print "Monkeypatch get variable run with name:", name
+    #print("Monkeypatch get variable run with name:", name)
     n = tf.get_variable_scope().name + "/" + name
-    #print "Monkeypatch get variable run with name:", n
+    #print("Monkeypatch get variable run with name:", n)
     if n in names_replace:
       has_replaced_names.append(n)
       return names_replace[n]
@@ -91,15 +92,15 @@ def variable_replace(replacements, no_new=True):
   yield
 
   if set(has_replaced_names) != set(names_replace.keys()):
-    print "Didn't use all replacements"
-    print "replaced variables that are not requested??"
-    print "==="
+    print("Didn't use all replacements")
+    print("replaced variables that are not requested??")
+    print("===")
     for n in list(set(has_replaced_names) - set(names_replace.keys())):
-      print n
-    print "Missed replacing variables"
-    print "==="
+      print(n)
+    print("Missed replacing variables")
+    print("===")
     for n in list(set(names_replace.keys()) - set(has_replaced_names)):
-      print n, "==>", names_replace[n].name
+      print(n, "==>", names_replace[n].name)
     raise ValueError("Fix this -- see stderr")
 
   # undo the monkey patch


### PR DESCRIPTION
Pylint will catch more Syntax Errors if it is run on Python 3 rather than on Python 2.

$ __python2 -m pylint --disable=all --enable=E0001 research/learning_unsupervised_learning__
```
No config file found, using default configuration

------------------------------------
Your code has been rated at 10.00/10
```
$ __python3 -m pylint --disable=all --enable=E0001 research/learning_unsupervised_learning__
```
No config file found, using default configuration

************* Module learning_unsupervised_learning.variable_replace
E: 94, 0: Missing parentheses in call to 'print'. Did you mean print("Didn't use all replacements")? (<string>, line 94) (syntax-error)
************* Module learning_unsupervised_learning.meta_objective.sklearn
E:116, 0: invalid syntax (<string>, line 116) (syntax-error)
```

Codeowners: @lukemetz @nirum