### PR TITLE
Fix typo in README

### DIFF
--- a/tutorials/image/cifar10_estimator/README.md
+++ b/tutorials/image/cifar10_estimator/README.md
@@ -123,7 +123,7 @@ cluster = {'master': ['master-ip:8000'],
 
 TF_CONFIG = json.dumps(
   {'cluster': cluster,
-   'task': {'type': master, 'index': 0},
+   'task': {'type': 'master', 'index': 0},
    'model_dir': 'gs://<bucket_path>/<dir_path>',
    'environment': 'cloud'
   })
@@ -159,7 +159,7 @@ cluster = {'master': ['master-ip:8000'],
 
 TF_CONFIG = json.dumps(
   {'cluster': cluster,
-   'task': {'type': worker, 'index': 0},
+   'task': {'type': 'worker', 'index': 0},
    'model_dir': 'gs://<bucket_path>/<dir_path>',
    'environment': 'cloud'
   })


### PR DESCRIPTION
Had variables for `master`, `worker` in the pyobject being `json.dumps`'d instead of strings.