### PR TITLE
Adding the team to the CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
-/official/ @nealwu @k-w-w @karmel
+* @tensorflow/tf-garden-team
+/official/ @tensorflow/tf-garden-team @karmel
 /research/adversarial_crypto/ @dave-andersen
 /research/adversarial_text/ @rsepassi @a-dai
 /research/adv_imagenet_models/ @AlexeyKurakin


### PR DESCRIPTION
I'm not exactly sure what this will do, as Github's docs are unclear. In the ideal, this will round-robin someone, but it might actually just auto-assign everyone. If that's true, I will remove the team, and act as the primary triager for the time being. Though, of course, team members should tag relevant people to review if they know them (ie, secondaries or interested parties). 

In any case, probably not necessary to have @k-w-w and @nealwu as reviewers on every PR anymore.