### PR TITLE
Update data model download location to temp dir.

### DIFF
--- a/official/mnist/dataset.py
+++ b/official/mnist/dataset.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import gzip
 import os
 import shutil
+import tempfile
 
 import numpy as np
 from six.moves import urllib
@@ -67,7 +68,7 @@ def download(directory, filename):
     tf.gfile.MakeDirs(directory)
   # CVDF mirror of http://yann.lecun.com/exdb/mnist/
   url = 'https://storage.googleapis.com/cvdf-datasets/mnist/' + filename + '.gz'
-  zipped_filepath = filepath + '.gz'
+  _, zipped_filepath = tempfile.mkstemp(suffix='.gz')
   print('Downloading %s to %s' % (url, zipped_filepath))
   urllib.request.urlretrieve(url, zipped_filepath)
   with gzip.open(zipped_filepath, 'rb') as f_in, \


### PR DESCRIPTION
This temp gz file is now save on local as a temp file, and does not depend on the data_dir flag, which could be a remote file system. We do it this way since the urllib use the default python open while copying the content.

Verified on GCP with default mnist.py. 