### PR TITLE
Adds max_to_keep as a possible train pipeline parameter

### DIFF
--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -19,6 +19,9 @@ message TrainConfig {
   // How frequently to keep checkpoints.
   optional uint32 keep_checkpoint_every_n_hours = 4 [default=1000];
 
+  // Maximum number of checkpoints to keep.
+  optional uint32 max_to_keep = 24 [default=5];
+
   // Optimizer used to train the DetectionModel.
   optional Optimizer optimizer = 5;
 

--- a/research/object_detection/trainer.py
+++ b/research/object_detection/trainer.py
@@ -328,8 +328,10 @@ def train(create_tensor_dict_fn, create_model_fn, train_config, master, task,
 
     # Save checkpoints regularly.
     keep_checkpoint_every_n_hours = train_config.keep_checkpoint_every_n_hours
+    max_to_keep = train_config.max_to_keep
     saver = tf.train.Saver(
-        keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+        keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+        max_to_keep=max_to_keep)
 
     # Create ops required to initialize the model from a given checkpoint.
     init_fn = None


### PR DESCRIPTION
I have the need to keep more than just 5 checkpoints during training. So, I've added tf.train.Saver's max_to_keep as a configurable parameter in the training pipeline file.