### PR TITLE
Adding cast to fp32 for TensorRT no image case

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@
 /research/swivel/ @waterson
 /research/syntaxnet/ @calberti @andorardo @bogatyy @markomernick
 /research/tcn/ @coreylynch @sermanet
+/research/tensorrt/ @karmel
 /research/textsum/ @panyx0718 @peterjliu
 /research/transformer/ @daviddao
 /research/video_prediction/ @cbfinn

--- a/research/tensorrt/tensorrt.py
+++ b/research/tensorrt/tensorrt.py
@@ -118,7 +118,8 @@ def batch_from_random(batch_size, output_height=224, output_width=224,
       [batch_size, output_height, output_width, num_channels]
   """
   shape = [batch_size, output_height, output_width, num_channels]
-  return np.random.random_sample(shape)
+  # Make sure we return float32, as float64 will not get cast automatically.
+  return np.random.random_sample(shape).astype(np.float32)
 
 
 ################################################################################


### PR DESCRIPTION
Numpy defaults to creating fp64, which causes TF/tensorRT to reject the random data. This fixes that.

Just for fun-- what does random data look like to the classifier? This particular bit of randomness came out as: 
Precision:  native [u'nematode, nematode worm, roundworm', u'panpipe, pandean pipe, syrinx', u'revolver, six-gun, six-shooter', u'bolo tie, bolo, bola tie, bola', u'hatchet']