### PR TITLE
Fix string to bytes conversion in deeplab data input. #3885

### DIFF
--- a/research/deeplab/datasets/build_data.py
+++ b/research/deeplab/datasets/build_data.py
@@ -30,6 +30,7 @@ The Example proto contains the following fields:
   image/segmentation/class/format: semantic segmentation file format.
 """
 import collections
+import six
 import tensorflow as tf
 
 FLAGS = tf.app.flags.FLAGS
@@ -126,7 +127,7 @@ def _bytes_list_feature(values):
     A TF-Feature.
   """
   def norm2bytes(value):
-      return value.encode() if isinstance(value, str) else value
+      return value.encode() if isinstance(value, str) and six.PY3 else value
 
   return tf.train.Feature(bytes_list=tf.train.BytesList(value=[norm2bytes(values)]))
 


### PR DESCRIPTION
The current code does not work in py2 since the input string could
contain unicode string, and default encoding in ASCII in py2. Change
the method to only do encode() which convert string to byte array
when running python3.