### PR TITLE
Fix order of variable update and moving average update

### DIFF
--- a/tutorials/image/cifar10/cifar10.py
+++ b/tutorials/image/cifar10/cifar10.py
@@ -370,12 +370,10 @@ def train(total_loss, global_step):
   # Track the moving averages of all trainable variables.
   variable_averages = tf.train.ExponentialMovingAverage(
       MOVING_AVERAGE_DECAY, global_step)
-  variables_averages_op = variable_averages.apply(tf.trainable_variables())
+  with tf.control_dependencies([apply_gradient_op]):
+    variables_averages_op = variable_averages.apply(tf.trainable_variables())
 
-  with tf.control_dependencies([apply_gradient_op, variables_averages_op]):
-    train_op = tf.no_op(name='train')
-
-  return train_op
+  return variables_averages_op
 
 
 def maybe_download_and_extract():


### PR DESCRIPTION
While the original code works fine in practice, it technically
allows gradient application and moving average update to happen
in any order. This causes the behavior to deviate from pure
mathematical specifications.