### PR TITLE
use current directory as default --model_dir 

### DIFF
--- a/tutorials/rnn/quickdraw/train_model.py
+++ b/tutorials/rnn/quickdraw/train_model.py
@@ -366,7 +366,7 @@ if __name__ == "__main__":
   parser.add_argument(
       "--model_dir",
       type=str,
-      default="",
+      default=".",
       help="Path for storing the model checkpoints.")
   parser.add_argument(
       "--self_test",


### PR DESCRIPTION
Running the [Recurrent Neural Networks for Drawing Classification](https://www.tensorflow.org/tutorials/recurrent_quickdraw) tutorial with the suggested command:
```bash
python train_model.py \
    --training_data=rnn_tutorial_data/training.tfrecord-?????-of-????? \
    --eval_data=rnn_tutorial_data/eval.tfrecord-?????-of-????? \
    --classes_file=rnn_tutorial_data/training.tfrecord.classes
```

currently produces a ValueError crash without explicitly specifying the `--model_dir`

e.g.
```
Traceback (most recent call last):
  File "train_model.py", line 388, in <module>
    tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
  File "/Volumes/GP_2T/tensorflow_tutorials/tf_src/venv/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 126, in run
    _sys.exit(main(argv))
  File "train_model.py", line 297, in main
    save_summary_steps=100))
  File "/Volumes/GP_2T/tensorflow_tutorials/tf_src/venv/lib/python2.7/site-packages/tensorflow/python/estimator/run_config.py", line 450, in __init__
    compat_internal.path_to_str(model_dir))
  File "/Volumes/GP_2T/tensorflow_tutorials/tf_src/venv/lib/python2.7/site-packages/tensorflow/python/estimator/run_config.py", line 754, in _get_model_dir
    raise ValueError('model_dir should be non-empty.')
ValueError: model_dir should be non-empty.
```

One option is to update the tutorial to mention the model directory **must** be specified, otherwise a quick fix is to default to the current directory

P.S. I agree with @angersson 's [comment](https://github.com/tensorflow/models/issues/3478#issuecomment-368979610) which is why I've started a [stackoverflow thread](https://stackoverflow.com/questions/49774035/how-to-classify-a-quickdraw-doodle-using-tensorflows-sketch-rnn-tutorial) voicing my confusion over the tutorial