### PR TITLE
Update CLOUD.md

### DIFF
--- a/research/syntaxnet/g3doc/CLOUD.md
+++ b/research/syntaxnet/g3doc/CLOUD.md
@@ -48,8 +48,8 @@ Run this command in the Cloud Shell.
 
 ```shell
 gcloud compute instances create dragnn-instance \
-    --image-family gci-stable \
-    --image-project google-containers \
+    --image-family cos-stable \
+    --image-project cos-cloud \
     --zone us-central1-b --boot-disk-size=100GB \
     --machine-type n1-standard-1
 ```


### PR DESCRIPTION
The image family `gci-stable` in `google-containers` project has long been deprecated.
```
$ gcloud compute images list --project google-containers --no-standard-images
NAME                    PROJECT            FAMILY        DEPRECATED  STATUS
container-vm-v20170214  google-containers  container-vm              READY
```
The preferred way to use COS images is via `cos-stable` image family in `cos-cloud` project.