### PR TITLE
fix the miss suffix 'py' of /build_imagenet_data.py

### DIFF
--- a/research/slim/datasets/download_and_convert_imagenet.sh
+++ b/research/slim/datasets/download_and_convert_imagenet.sh
@@ -90,7 +90,7 @@ BOUNDING_BOX_DIR="${SCRATCH_DIR}bounding_boxes/"
 echo "Finished downloading and preprocessing the ImageNet data."
 
 # Build the TFRecords version of the ImageNet data.
-BUILD_SCRIPT="${WORK_DIR}/build_imagenet_data"
+BUILD_SCRIPT="${WORK_DIR}/build_imagenet_data.py"
 OUTPUT_DIRECTORY="${DATA_DIR}"
 IMAGENET_METADATA_FILE="${WORK_DIR}/datasets/imagenet_metadata.txt"
 


### PR DESCRIPTION
fix the miss suffix 'py' of /build_imagenet_data.py