### PR TITLE
Add new import paths to mnist_tpu.py

### DIFF
--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -32,8 +32,8 @@ import tensorflow as tf  # pylint: disable=g-bad-import-order
 sys.path.append(os.path.dirname(os.path.abspath(sys.path[0])))
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(sys.path[0]))))
 
-from official.mnist import dataset  # pylint: wrong-import-position
-from official.mnist import mnist  # pylint: wrong-import-position
+from official.mnist import dataset  # pylint: disable=wrong-import-position
+from official.mnist import mnist  # pylint: disable=wrong-import-position
 
 # Cloud TPU Cluster Resolver flags
 tf.flags.DEFINE_string(

--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -25,6 +25,12 @@ from __future__ import print_function
 
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
+# For open source environment, add parent and grandparent directories for import
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(sys.path[0])))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(sys.path[0]))))
+
 from official.mnist import dataset
 from official.mnist import mnist
 

--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -29,7 +29,6 @@ import sys
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 # For open source environment, add parent and grandparent directories for import
-sys.path.append(os.path.dirname(os.path.abspath(sys.path[0])))
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(sys.path[0]))))
 
 from official.mnist import dataset  # pylint: disable=wrong-import-position

--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -23,16 +23,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import sys
+
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 # For open source environment, add parent and grandparent directories for import
-import sys
-import os
 sys.path.append(os.path.dirname(os.path.abspath(sys.path[0])))
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(sys.path[0]))))
 
-from official.mnist import dataset
-from official.mnist import mnist
+from official.mnist import dataset  # pylint: wrong-import-position
+from official.mnist import mnist  # pylint: wrong-import-position
 
 # Cloud TPU Cluster Resolver flags
 tf.flags.DEFINE_string(

--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -28,7 +28,7 @@ import sys
 
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
-# For open source environment, add parent and grandparent directories for import
+# For open source environment, add grandparent directory for import
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(sys.path[0]))))
 
 from official.mnist import dataset  # pylint: disable=wrong-import-position


### PR DESCRIPTION
This adds new import paths to mnist_tpu.py so individuals can check out the git repository and run `python mnist_tpu.py` without finagling with python import search paths.