### PR TITLE
Add colab+github buttons

### DIFF
--- a/samples/core/get_started/eager.ipynb
+++ b/samples/core/get_started/eager.ipynb
@@ -65,8 +65,22 @@
       "source": [
         "# Get Started with Eager Execution\n",
         "\n",
-        "Note: you can run **[this notebook, live in Google Colab](https://colab.research.google.com/github/tensorflow/models/blob/master/samples/core/get_started/eager.ipynb)** with zero setup.\n",
         "\n",
+        "<table align=\"left\"><td>\n",
+        "<a target=\"_blank\"  href=\"https://colab.sandbox.google.com/github/tensorflow/models/blob/master/samples/core/get_started/eager.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
+        "</td><td>\n",
+        "<a target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/samples/core/get_started/eager.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on Github</a></td></table>\n",
+        "\n"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "LDrzLFXE8T1l",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
         "This tutorial describes how to use machine learning to *categorize* Iris flowers by species. It uses [TensorFlow](https://www.tensorflow.org)'s eager execution to (1) build a *model*, (2) *train* the model on example data, and (3) use the model to make *predictions* on unknown data. Machine learning experience isn't required to follow this guide, but you'll need to read some Python code.\n",
         "\n",
         "## TensorFlow programming\n",


### PR DESCRIPTION
If this seems good I'll apply it to all of the notebooks. 
I'll use the same pattern for the "source on github" blocks in the api-docs.

Using a table is the only way to get something that's at all reasonable on all 4 platforms:

* [Github](https://drive.google.com/open?id=1ni6osln5_eGhtkfaGe9Fzta4ZNlkB_mO)
* [Colab](https://drive.google.com/open?id=1LqCuSc-svCiumwlpkXgQRGtwuR9tWDIm)
* [Jupyter](https://drive.google.com/open?id=1tw_FND8QiGDKav8q0BsYEw29ADMHV8vb)
* [TensorFlow.org](https://drive.google.com/file/d/1dRkaRxaHkN_6Vc9SNpgtxU16d2_y66YQ)