### PR TITLE
Object detection export dir

### DIFF
--- a/research/object_detection/g3doc/exporting_models.md
+++ b/research/object_detection/g3doc/exporting_models.md
@@ -3,7 +3,7 @@
 After your model has been trained, you should export it to a Tensorflow
 graph proto. A checkpoint will typically consist of three files:
 
-* model.ckpt-${CHECKPOINT_NUMBER}.data-00000-of-00001,
+* model.ckpt-${CHECKPOINT_NUMBER}.data-00000-of-00001
 * model.ckpt-${CHECKPOINT_NUMBER}.index
 * model.ckpt-${CHECKPOINT_NUMBER}.meta
 

--- a/research/object_detection/g3doc/exporting_models.md
+++ b/research/object_detection/g3doc/exporting_models.md
@@ -16,7 +16,12 @@ python object_detection/export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path ${PIPELINE_CONFIG_PATH} \
     --trained_checkpoint_prefix ${TRAIN_PATH} \
-    --output_directory output_inference_graph.pb
+    --output_directory ${EXPORT_DIR}
 ```
 
-Afterwards, you should see a graph named output_inference_graph.pb.
+Afterwards, you should see the directory ${EXPORT_DIR} containing the following:
+
+* output_inference_graph.pb, the frozen graph format of the exported model
+* saved_model/, a directory containing the saved model format of the exported model
+* model.ckpt.*, the model checkpoints used for exporting
+* checkpoint, a file specifying to restore included checkpoint files


### PR DESCRIPTION
The instructions for exporting object detection models state that the `--output_directory` argument is the path to where the frozen inference graph is saved, when actually the argument specifies the directory where the model is exported, which exports more than just a frozen graph.

This corrects the argument and description to match the actual implementation.