### PR TITLE
Internal changes to object detection.

### DIFF
--- a/research/object_detection/README.md
+++ b/research/object_detection/README.md
@@ -90,6 +90,15 @@ reporting an issue.
 
 ## Release information
 
+### April 30, 2018
+
+We have released a Faster R-CNN detector with ResNet-101 feature extractor trained on [AVA](https://research.google.com/ava/) v2.1.
+Compared with other commonly used object detectors, it changes the action classification loss function to per-class Sigmoid loss to handle boxes with multiple labels.
+The model is trained on the training split of AVA v2.1 for 1.5M iterations, it achieves mean AP of 11.25% over 60 classes on the validation split of AVA v2.1.
+For more details please refer to this [paper](https://arxiv.org/abs/1705.08421).
+
+<b>Thanks to contributors</b>: Chen Sun, David Ross
+
 ### April 2, 2018
 
 Supercharge your mobile phones with the next generation mobile object detector!

--- a/research/object_detection/data/ava_label_map_v2.1.pbtxt
+++ b/research/object_detection/data/ava_label_map_v2.1.pbtxt
@@ -1,0 +1,240 @@
+item {
+  name: "bend/bow (at the waist)"
+  id: 1
+}
+item {
+  name: "crouch/kneel"
+  id: 3
+}
+item {
+  name: "dance"
+  id: 4
+}
+item {
+  name: "fall down"
+  id: 5
+}
+item {
+  name: "get up"
+  id: 6
+}
+item {
+  name: "jump/leap"
+  id: 7
+}
+item {
+  name: "lie/sleep"
+  id: 8
+}
+item {
+  name: "martial art"
+  id: 9
+}
+item {
+  name: "run/jog"
+  id: 10
+}
+item {
+  name: "sit"
+  id: 11
+}
+item {
+  name: "stand"
+  id: 12
+}
+item {
+  name: "swim"
+  id: 13
+}
+item {
+  name: "walk"
+  id: 14
+}
+item {
+  name: "answer phone"
+  id: 15
+}
+item {
+  name: "carry/hold (an object)"
+  id: 17
+}
+item {
+  name: "climb (e.g., a mountain)"
+  id: 20
+}
+item {
+  name: "close (e.g., a door, a box)"
+  id: 22
+}
+item {
+  name: "cut"
+  id: 24
+}
+item {
+  name: "dress/put on clothing"
+  id: 26
+}
+item {
+  name: "drink"
+  id: 27
+}
+item {
+  name: "drive (e.g., a car, a truck)"
+  id: 28
+}
+item {
+  name: "eat"
+  id: 29
+}
+item {
+  name: "enter"
+  id: 30
+}
+item {
+  name: "hit (an object)"
+  id: 34
+}
+item {
+  name: "lift/pick up"
+  id: 36
+}
+item {
+  name: "listen (e.g., to music)"
+  id: 37
+}
+item {
+  name: "open (e.g., a window, a car door)"
+  id: 38
+}
+item {
+  name: "play musical instrument"
+  id: 41
+}
+item {
+  name: "point to (an object)"
+  id: 43
+}
+item {
+  name: "pull (an object)"
+  id: 45
+}
+item {
+  name: "push (an object)"
+  id: 46
+}
+item {
+  name: "put down"
+  id: 47
+}
+item {
+  name: "read"
+  id: 48
+}
+item {
+  name: "ride (e.g., a bike, a car, a horse)"
+  id: 49
+}
+item {
+  name: "sail boat"
+  id: 51
+}
+item {
+  name: "shoot"
+  id: 52
+}
+item {
+  name: "smoke"
+  id: 54
+}
+item {
+  name: "take a photo"
+  id: 56
+}
+item {
+  name: "text on/look at a cellphone"
+  id: 57
+}
+item {
+  name: "throw"
+  id: 58
+}
+item {
+  name: "touch (an object)"
+  id: 59
+}
+item {
+  name: "turn (e.g., a screwdriver)"
+  id: 60
+}
+item {
+  name: "watch (e.g., TV)"
+  id: 61
+}
+item {
+  name: "work on a computer"
+  id: 62
+}
+item {
+  name: "write"
+  id: 63
+}
+item {
+  name: "fight/hit (a person)"
+  id: 64
+}
+item {
+  name: "give/serve (an object) to (a person)"
+  id: 65
+}
+item {
+  name: "grab (a person)"
+  id: 66
+}
+item {
+  name: "hand clap"
+  id: 67
+}
+item {
+  name: "hand shake"
+  id: 68
+}
+item {
+  name: "hand wave"
+  id: 69
+}
+item {
+  name: "hug (a person)"
+  id: 70
+}
+item {
+  name: "kiss (a person)"
+  id: 72
+}
+item {
+  name: "lift (a person)"
+  id: 73
+}
+item {
+  name: "listen to (a person)"
+  id: 74
+}
+item {
+  name: "push (another person)"
+  id: 76
+}
+item {
+  name: "sing to (e.g., self, a person, a group)"
+  id: 77
+}
+item {
+  name: "take (an object) from (a person)"
+  id: 78
+}
+item {
+  name: "talk to (e.g., self, a person, a group)"
+  id: 79
+}
+item {
+  name: "watch (a person)"
+  id: 80
+}

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -91,7 +91,7 @@ Some remarks on frozen inference graphs:
 
 ## Kitti-trained models {#kitti-models}
 
-Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 (ms) | Outputs
+Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 | Outputs
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
 [faster_rcnn_resnet101_kitti](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_kitti_2018_01_28.tar.gz) | 79  | 87              | Boxes
 
@@ -101,6 +101,13 @@ Model name                                                                      
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
 [faster_rcnn_inception_resnet_v2_atrous_oid](http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_resnet_v2_atrous_oid_2018_01_28.tar.gz) | 727 | 37              | Boxes
 [faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid](http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid_2018_01_28.tar.gz) | 347  |               | Boxes
+
+
+## AVA v2.1 trained models {#ava-models}
+
+Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 | Outputs
+----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
+[faster_rcnn_resnet101_ava_v2.1](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_ava_v2.1_2018_04_30.tar.gz) | 93  | 11              | Boxes
 
 
 [^1]: See [MSCOCO evaluation protocol](http://cocodataset.org/#detections-eval).

--- a/research/object_detection/samples/configs/faster_rcnn_resnet101_ava_v2.1.config
+++ b/research/object_detection/samples/configs/faster_rcnn_resnet101_ava_v2.1.config
@@ -1,0 +1,138 @@
+# Faster R-CNN with Resnet-101 (v1), configuration for AVA v2.1.
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  faster_rcnn {
+    num_classes: 80
+    image_resizer {
+      keep_aspect_ratio_resizer {
+        min_dimension: 600
+        max_dimension: 1024
+      }
+    }
+    feature_extractor {
+      type: 'faster_rcnn_resnet101'
+      first_stage_features_stride: 16
+    }
+    first_stage_anchor_generator {
+      grid_anchor_generator {
+        scales: [0.25, 0.5, 1.0, 2.0]
+        aspect_ratios: [0.5, 1.0, 2.0]
+        height_stride: 16
+        width_stride: 16
+      }
+    }
+    first_stage_box_predictor_conv_hyperparams {
+      op: CONV
+      regularizer {
+        l2_regularizer {
+          weight: 0.0
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+          stddev: 0.01
+        }
+      }
+    }
+    first_stage_nms_score_threshold: 0.0
+    first_stage_nms_iou_threshold: 0.7
+    first_stage_max_proposals: 300
+    first_stage_localization_loss_weight: 2.0
+    first_stage_objectness_loss_weight: 1.0
+    initial_crop_size: 14
+    maxpool_kernel_size: 2
+    maxpool_stride: 2
+    second_stage_box_predictor {
+      mask_rcnn_box_predictor {
+        use_dropout: false
+        dropout_keep_probability: 1.0
+        fc_hyperparams {
+          op: FC
+          regularizer {
+            l2_regularizer {
+              weight: 0.0
+            }
+          }
+          initializer {
+            variance_scaling_initializer {
+              factor: 1.0
+              uniform: true
+              mode: FAN_AVG
+            }
+          }
+        }
+      }
+    }
+    second_stage_post_processing {
+      batch_non_max_suppression {
+        score_threshold: 0.0
+        iou_threshold: 0.6
+        max_detections_per_class: 100
+        max_total_detections: 300
+      }
+      score_converter: SIGMOID
+    }
+    second_stage_localization_loss_weight: 2.0
+    second_stage_classification_loss_weight: 1.0
+    second_stage_classification_loss {
+      weighted_sigmoid {
+        anchorwise_output: true
+      }
+    }
+  }
+}
+
+train_config: {
+  batch_size: 1
+  num_steps: 1500000
+  optimizer {
+    momentum_optimizer: {
+      learning_rate: {
+        manual_step_learning_rate {
+          initial_learning_rate: 0.0003
+          schedule {
+            step: 1200000
+            learning_rate: .00003
+          }
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  gradient_clipping_by_norm: 10.0
+  merge_multiple_label_boxes: true
+  fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+  max_number_of_boxes: 100
+}
+
+train_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/ava_train.record"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/ava_label_map_v2.1.pbtxt"
+}
+
+eval_config: {
+  metrics_set: "pascal_voc_detection_metrics"
+  use_moving_averages: false
+  num_examples: 57371
+}
+
+eval_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/ava_val.record"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/ava_label_map_v2.1.pbtxt"
+  shuffle: false
+  num_readers: 1
+}
+

--- a/research/object_detection/samples/configs/ssd_mobilenet_v2_coco.config
+++ b/research/object_detection/samples/configs/ssd_mobilenet_v2_coco.config
@@ -54,6 +54,7 @@ model {
         use_dropout: false
         dropout_keep_probability: 0.8
         kernel_size: 3
+        use_depthwise: true
         box_code_size: 4
         apply_sigmoid_to_scores: false
         conv_hyperparams {

--- a/research/object_detection/utils/vrd_evaluation.py
+++ b/research/object_detection/utils/vrd_evaluation.py
@@ -1,0 +1,463 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Evaluator class for Visual Relations Detection.
+
+VRDDetectionEvaluator is a class which manages ground truth information of a
+visual relations detection dataset, and computes frequently used detection
+metrics such as Precision, Recall, Recall@k, MedianRank@k of the provided vrd
+detection results.
+It supports the following operations:
+1) Adding ground truth information of images sequentially.
+2) Adding detection results of images sequentially.
+3) Evaluating detection metrics on already inserted detection results.
+
+Note1: groundtruth should be inserted before evaluation.
+Note2: This module operates on numpy boxes and box lists.
+"""
+
+from abc import abstractmethod
+import collections
+import logging
+import numpy as np
+
+from object_detection.core import standard_fields
+from object_detection.utils import metrics
+from object_detection.utils import object_detection_evaluation
+from object_detection.utils import per_image_vrd_evaluation
+
+# Below standard input numpy datatypes are defined:
+# box_data_type - datatype of the groundtruth visual relations box annotations;
+# this datatype consists of two named boxes: subject bounding box and object
+# bounding box. Each box is of the format [y_min, x_min, y_max, x_max], each
+# coordinate being of type float32.
+# label_data_type - corresponding datatype of the visual relations label
+# annotaions; it consists of three numerical class labels: subject class label,
+# object class label and relation class label, each class label being of type
+# int32.
+vrd_box_data_type = np.dtype([('subject', 'f4', (4,)), ('object', 'f4', (4,))])
+single_box_data_type = np.dtype([('box', 'f4', (4,))])
+label_data_type = np.dtype([('subject', 'i4'), ('object', 'i4'), ('relation',
+                                                                  'i4')])
+
+
+class VRDDetectionEvaluator(object_detection_evaluation.DetectionEvaluator):
+  """A class to evaluate VRD detections.
+
+  This class serves as a base class for VRD evaluation in two settings:
+  - phrase detection
+  - relation detection.
+  """
+
+  def __init__(self, matching_iou_threshold=0.5, metric_prefix=None):
+    """Constructor.
+
+    Args:
+      matching_iou_threshold: IOU threshold to use for matching groundtruth
+        boxes to detection boxes.
+      metric_prefix: (optional) string prefix for metric name; if None, no
+        prefix is used.
+
+    """
+    super(VRDDetectionEvaluator, self).__init__([])
+    self._matching_iou_threshold = matching_iou_threshold
+    self._evaluation = _VRDDetectionEvaluation(
+        matching_iou_threshold=self._matching_iou_threshold)
+    self._image_ids = set([])
+    self._metric_prefix = (metric_prefix + '_') if metric_prefix else ''
+    self._evaluatable_labels = {}
+    self._negative_labels = {}
+
+  @abstractmethod
+  def _process_groundtruth_boxes(self, groundtruth_box_tuples):
+    """Pre-processes boxes before adding them to the VRDDetectionEvaluation.
+
+    Phrase detection and Relation detection subclasses re-implement this method
+    depending on the task.
+
+    Args:
+      groundtruth_box_tuples:  A numpy array of structures with the shape
+        [M, 1], each structure containing the same number of named bounding
+        boxes. Each box is of the format [y_min, x_min, y_max, x_max] (see
+        datatype vrd_box_data_type, single_box_data_type above).
+    """
+    raise NotImplementedError(
+        '_process_groundtruth_boxes method should be implemented in subclasses'
+        'of VRDDetectionEvaluator.')
+
+  def add_single_ground_truth_image_info(self, image_id, groundtruth_dict):
+    """Adds groundtruth for a single image to be used for evaluation.
+
+    Args:
+      image_id: A unique string/integer identifier for the image.
+      groundtruth_dict: A dictionary containing -
+        standard_fields.InputDataFields.groundtruth_boxes: A numpy array
+          of structures with the shape [M, 1], representing M tuples, each tuple
+          containing the same number of named bounding boxes.
+          Each box is of the format [y_min, x_min, y_max, x_max] (see
+          datatype vrd_box_data_type, single_box_data_type above).
+        standard_fields.InputDataFields.groundtruth_classes: A numpy array of
+          structures shape [M, 1], representing  the class labels of the
+          corresponding bounding boxes and possibly additional classes (see
+          datatype label_data_type above).
+        standard_fields.InputDataFields.verified_labels: numpy array
+          of shape [K] containing verified labels.
+    Raises:
+      ValueError: On adding groundtruth for an image more than once.
+    """
+    if image_id in self._image_ids:
+      raise ValueError('Image with id {} already added.'.format(image_id))
+
+    groundtruth_class_tuples = (
+        groundtruth_dict[standard_fields.InputDataFields.groundtruth_classes])
+
+    self._evaluation.add_single_ground_truth_image_info(
+        image_key=image_id,
+        groundtruth_box_tuples=self._process_groundtruth_boxes(groundtruth_dict[
+            standard_fields.InputDataFields.groundtruth_boxes]),
+        groundtruth_class_tuples=groundtruth_class_tuples)
+    self._image_ids.update([image_id])
+    all_classes = []
+    for field in groundtruth_class_tuples.dtype.fields:
+      all_classes.append(groundtruth_class_tuples[field])
+    groudtruth_positive_classes = np.unique(np.concatenate(all_classes))
+    verified_labels = groundtruth_dict.get(
+        standard_fields.InputDataFields.verified_labels, np.array(
+            [], dtype=int))
+    self._evaluatable_labels[image_id] = np.unique(
+        np.concatenate((verified_labels, groudtruth_positive_classes)))
+
+    self._negative_labels[image_id] = np.setdiff1d(verified_labels,
+                                                   groudtruth_positive_classes)
+
+  def add_single_detected_image_info(self, image_id, detections_dict):
+    """Adds detections for a single image to be used for evaluation.
+
+    Args:
+      image_id: A unique string/integer identifier for the image.
+      detections_dict: A dictionary containing -
+        standard_fields.DetectionResultFields.detection_boxes: A numpy array of
+          structures with shape [N, 1], representing N tuples, each tuple
+          containing the same number of named bounding boxes.
+          Each box is of the format [y_min, x_min, y_max, x_max] (as an example
+          see datatype vrd_box_data_type, single_box_data_type above).
+        standard_fields.DetectionResultFields.detection_scores: float32 numpy
+          array of shape [N] containing detection scores for the boxes.
+        standard_fields.DetectionResultFields.detection_classes: A numpy array
+          of structures shape [N, 1], representing the class labels of the
+          corresponding bounding boxes and possibly additional classes (see
+          datatype label_data_type above).
+    """
+    num_detections = detections_dict[
+        standard_fields.DetectionResultFields.detection_boxes].shape[0]
+    detection_class_tuples = detections_dict[
+        standard_fields.DetectionResultFields.detection_classes]
+    selector = np.ones(num_detections, dtype=bool)
+    for field in detection_class_tuples.dtype.fields:
+      # Verify if one of the labels is negative (this is sure FP)
+      selector |= np.isin(detection_class_tuples[field],
+                          self._negative_labels[image_id])
+      # Verify if all labels are verified
+      selector |= np.isin(detection_class_tuples[field],
+                          self._evaluatable_labels[image_id])
+
+    self._evaluation.add_single_detected_image_info(
+        image_key=image_id,
+        detected_box_tuples=detections_dict[
+            standard_fields.DetectionResultFields.detection_boxes][selector],
+        detected_scores=detections_dict[
+            standard_fields.DetectionResultFields.detection_scores][selector],
+        detected_class_tuples=detection_class_tuples[selector])
+
+  def evaluate(self):
+    """Compute evaluation result.
+
+    Returns:
+      A dictionary of metrics with the following fields -
+
+      summary_metrics:
+        'AP/mAP@<matching_iou_threshold>IOU': average precision at the specified
+        IOU threshold.
+        'Recall@50@<matching_iou_threshold>IOU': recall@50 at the specified IOU
+        threshold.
+        'Recall@100@<matching_iou_threshold>IOU': recall@100 at the specified
+        IOU threshold.
+        'MedianRank@50@<matching_iou_threshold>IOU: recall@50 at the specified
+        IOU threshold.
+        'MedianRank@100@<matching_iou_threshold>IOU: recall@100 at the specified
+        IOU threshold.
+    """
+    (average_precision, _, _, recall_50, recall_100, median_rank_50,
+     median_rank_100) = (
+         self._evaluation.evaluate())
+
+    vrd_metrics = {
+        self._metric_prefix + 'AP@{}IOU'.format(self._matching_iou_threshold):
+            average_precision,
+        self._metric_prefix + 'Recall@50@{}IOU'.format(
+            self._matching_iou_threshold):
+            recall_50,
+        self._metric_prefix + 'Recall@100@{}IOU'.format(
+            self._matching_iou_threshold):
+            recall_100,
+        self._metric_prefix + 'MedianRank@50@{}IOU'.format(
+            self._matching_iou_threshold):
+            median_rank_50,
+        self._metric_prefix + 'MedianRank@100@{}IOU'.format(
+            self._matching_iou_threshold):
+            median_rank_100,
+    }
+
+    return vrd_metrics
+
+  def clear(self):
+    """Clears the state to prepare for a fresh evaluation."""
+    self._evaluation = _VRDDetectionEvaluation(
+        matching_iou_threshold=self._matching_iou_threshold)
+    self._image_ids.clear()
+    self._negative_labels.clear()
+    self._evaluatable_labels.clear()
+
+
+class VRDRelationDetectionEvaluator(VRDDetectionEvaluator):
+  """A class to evaluate VRD detections in relations setting.
+
+  Expected groundtruth box datatype is vrd_box_data_type, expected groudtruth
+  labels datatype is label_data_type.
+  Expected detection box datatype is vrd_box_data_type, expected detection
+  labels
+  datatype is label_data_type.
+  """
+
+  def __init__(self, matching_iou_threshold=0.5):
+    super(VRDRelationDetectionEvaluator, self).__init__(
+        matching_iou_threshold=matching_iou_threshold,
+        metric_prefix='VRDMetric_Relations')
+
+  def _process_groundtruth_boxes(self, groundtruth_box_tuples):
+    """Pre-processes boxes before adding them to the VRDDetectionEvaluation.
+
+    Args:
+      groundtruth_box_tuples: A numpy array of structures with the shape
+        [M, 1], each structure containing the same number of named bounding
+        boxes. Each box is of the format [y_min, x_min, y_max, x_max].
+
+    Returns:
+      Unchanged input.
+    """
+
+    return groundtruth_box_tuples
+
+
+class VRDPhraseDetectionEvaluator(VRDDetectionEvaluator):
+  """A class to evaluate VRD detections in phrase setting.
+
+  Expected groundtruth box datatype is vrd_box_data_type, expected groudtruth
+  labels datatype is label_data_type.
+  Expected detection box datatype is single_box_data_type, expected detection
+  labels datatype is label_data_type.
+  """
+
+  def __init__(self, matching_iou_threshold=0.5):
+    super(VRDPhraseDetectionEvaluator, self).__init__(
+        matching_iou_threshold=matching_iou_threshold,
+        metric_prefix='VRDMetric_Phrases')
+
+  def _process_groundtruth_boxes(self, groundtruth_box_tuples):
+    """Pre-processes boxes before adding them to the VRDDetectionEvaluation.
+
+    In case of phrase evaluation task, evaluation expects exactly one bounding
+    box containing all objects in the phrase. This bounding box is computed
+    as an enclosing box of all groundtruth boxes of a phrase.
+
+    Args:
+      groundtruth_box_tuples: A numpy array of structures with the shape
+        [M, 1], each structure containing the same number of named bounding
+        boxes. Each box is of the format [y_min, x_min, y_max, x_max].
+
+    Returns:
+      result: A numpy array of structures with the shape [M, 1], each
+        structure containing exactly one named bounding box. i-th output
+        structure corresponds to the result of processing i-th input structure,
+        where the named bounding box is computed as an enclosing bounding box
+        of all bounding boxes of the i-th input structure.
+    """
+    first_box_key = groundtruth_box_tuples.dtype.fields.keys()[0]
+    miny = groundtruth_box_tuples[first_box_key][:, 0]
+    minx = groundtruth_box_tuples[first_box_key][:, 1]
+    maxy = groundtruth_box_tuples[first_box_key][:, 2]
+    maxx = groundtruth_box_tuples[first_box_key][:, 3]
+    for fields in groundtruth_box_tuples.dtype.fields:
+      miny = np.minimum(groundtruth_box_tuples[fields][:, 0], miny)
+      minx = np.minimum(groundtruth_box_tuples[fields][:, 1], minx)
+      maxy = np.maximum(groundtruth_box_tuples[fields][:, 2], maxy)
+      maxx = np.maximum(groundtruth_box_tuples[fields][:, 3], maxx)
+    data_result = []
+    for i in range(groundtruth_box_tuples.shape[0]):
+      data_result.append(([miny[i], minx[i], maxy[i], maxx[i]],))
+    result = np.array(data_result, dtype=[('box', 'f4', (4,))])
+    return result
+
+
+VRDDetectionEvalMetrics = collections.namedtuple('VRDDetectionEvalMetrics', [
+    'average_precision', 'precisions', 'recalls', 'recall_50', 'recall_100',
+    'average_rank_50', 'average_rank_100'
+])
+
+
+class _VRDDetectionEvaluation(object):
+  """Performs metric computation for the VRD task. This class is internal.
+  """
+
+  def __init__(self, matching_iou_threshold=0.5):
+    """Constructor.
+
+    Args:
+      matching_iou_threshold: IOU threshold to use for matching groundtruth
+        boxes to detection boxes.
+    """
+    self._per_image_eval = per_image_vrd_evaluation.PerImageVRDEvaluation(
+        matching_iou_threshold=matching_iou_threshold)
+
+    self._groundtruth_box_tuples = {}
+    self._groundtruth_class_tuples = {}
+    self._num_gt_instances = 0
+    self._num_gt_imgs = 0
+
+    self.clear_detections()
+
+  def clear_detections(self):
+    """Clears detections."""
+    self._detection_keys = set()
+    self._scores = []
+    self._tp_fp_labels = []
+    self._average_precision = np.nan
+    self._precisions = []
+    self._recalls = []
+
+  def add_single_ground_truth_image_info(
+      self, image_key, groundtruth_box_tuples, groundtruth_class_tuples):
+    """Adds groundtruth for a single image to be used for evaluation.
+
+    Args:
+      image_key: A unique string/integer identifier for the image.
+      groundtruth_box_tuples: A numpy array of structures with the shape
+          [M, 1], representing M tuples, each tuple containing the same number
+          of named bounding boxes.
+          Each box is of the format [y_min, x_min, y_max, x_max].
+      groundtruth_class_tuples: A numpy array of structures shape [M, 1],
+          representing  the class labels of the corresponding bounding boxes and
+          possibly additional classes.
+    """
+    if image_key in self._groundtruth_box_tuples:
+      logging.warn(
+          'image %s has already been added to the ground truth database.',
+          image_key)
+      return
+
+    self._groundtruth_box_tuples[image_key] = groundtruth_box_tuples
+    self._groundtruth_class_tuples[image_key] = groundtruth_class_tuples
+
+    self._update_groundtruth_statistics(groundtruth_class_tuples)
+
+  def add_single_detected_image_info(self, image_key, detected_box_tuples,
+                                     detected_scores, detected_class_tuples):
+    """Adds detections for a single image to be used for evaluation.
+
+    Args:
+      image_key: A unique string/integer identifier for the image.
+      detected_box_tuples: A numpy array of structures with shape [N, 1],
+          representing N tuples, each tuple containing the same number of named
+          bounding boxes.
+          Each box is of the format [y_min, x_min, y_max, x_max].
+      detected_scores: A float numpy array of shape [N, 1], representing
+          the confidence scores of the detected N object instances.
+      detected_class_tuples: A numpy array of structures shape [N, 1],
+          representing the class labels of the corresponding bounding boxes and
+          possibly additional classes.
+    """
+    self._detection_keys.add(image_key)
+    if image_key in self._groundtruth_box_tuples:
+      groundtruth_box_tuples = self._groundtruth_box_tuples[image_key]
+      groundtruth_class_tuples = self._groundtruth_class_tuples[image_key]
+    else:
+      groundtruth_box_tuples = np.empty(shape=[0, 4], dtype=float)
+      groundtruth_class_tuples = np.array([], dtype=int)
+
+    scores, tp_fp_labels = (
+        self._per_image_eval.compute_detection_tp_fp(
+            detected_box_tuples=detected_box_tuples,
+            detected_scores=detected_scores,
+            detected_class_tuples=detected_class_tuples,
+            groundtruth_box_tuples=groundtruth_box_tuples,
+            groundtruth_class_tuples=groundtruth_class_tuples))
+
+    self._scores += [scores]
+    self._tp_fp_labels += [tp_fp_labels]
+
+  def _update_groundtruth_statistics(self, groundtruth_class_tuples):
+    """Updates grouth truth statistics.
+
+    Args:
+      groundtruth_class_tuples: A numpy array of structures shape [M, 1],
+          representing  the class labels of the corresponding bounding boxes and
+          possibly additional classes.
+    """
+    self._num_gt_instances += groundtruth_class_tuples.shape[0]
+    self._num_gt_imgs += 1
+
+  def evaluate(self):
+    """Computes evaluation result.
+
+    Returns:
+      A named tuple with the following fields -
+        average_precision: a float number corresponding to average precision.
+        precisions: an array of precisions.
+        recalls: an array of recalls.
+        recall@50: recall computed on 50 top-scoring samples.
+        recall@100: recall computed on 100 top-scoring samples.
+        median_rank@50: median rank computed on 50 top-scoring samples.
+        median_rank@100: median rank computed on 100 top-scoring samples.
+    """
+    if self._num_gt_instances == 0:
+      logging.warn('No ground truth instances')
+
+    if not self._scores:
+      scores = np.array([], dtype=float)
+      tp_fp_labels = np.array([], dtype=bool)
+    else:
+      scores = np.concatenate(self._scores)
+      tp_fp_labels = np.concatenate(self._tp_fp_labels)
+    self._precisions, self._recalls = metrics.compute_precision_recall(
+        scores, tp_fp_labels, self._num_gt_instances)
+
+    self._average_precision = metrics.compute_average_precision(
+        self._precisions, self._recalls)
+
+    self._recall_50 = (
+        metrics.compute_recall_at_k(self._tp_fp_labels, self._num_gt_instances,
+                                    50))
+    self._median_rank_50 = (
+        metrics.compute_median_rank_at_k(self._tp_fp_labels, 50))
+    self._recall_100 = (
+        metrics.compute_recall_at_k(self._tp_fp_labels, self._num_gt_instances,
+                                    100))
+    self._median_rank_100 = (
+        metrics.compute_median_rank_at_k(self._tp_fp_labels, 100))
+
+    return VRDDetectionEvalMetrics(self._average_precision, self._precisions,
+                                   self._recalls, self._recall_50,
+                                   self._recall_100, self._median_rank_50,
+                                   self._median_rank_100)

--- a/research/object_detection/utils/vrd_evaluation_test.py
+++ b/research/object_detection/utils/vrd_evaluation_test.py
@@ -1,0 +1,245 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tensorflow_models.object_detection.utils.vrd_evaluation."""
+
+import numpy as np
+import tensorflow as tf
+
+from object_detection.core import standard_fields
+from object_detection.utils import vrd_evaluation
+
+
+class VRDRelationDetectionEvaluatorTest(tf.test.TestCase):
+
+  def test_vrdrelation_evaluator(self):
+    self.vrd_eval = vrd_evaluation.VRDRelationDetectionEvaluator()
+
+    image_key1 = 'img1'
+    groundtruth_box_tuples1 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2]), ([0, 0, 1, 1], [1, 2, 2, 3])],
+        dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples1 = np.array(
+        [(1, 2, 3), (1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    groundtruth_verified_labels1 = np.array([1, 2, 3, 4, 5], dtype=int)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key1, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples1,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples1,
+            standard_fields.InputDataFields.verified_labels:
+                groundtruth_verified_labels1
+        })
+
+    image_key2 = 'img2'
+    groundtruth_box_tuples2 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples2 = np.array(
+        [(1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key2, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples2,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples2,
+        })
+
+    image_key3 = 'img3'
+    groundtruth_box_tuples3 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples3 = np.array(
+        [(1, 2, 4)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key3, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples3,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples3,
+        })
+
+    image_key = 'img1'
+    detected_box_tuples = np.array(
+        [([0, 0.3, 1, 1], [1.1, 1, 2, 2]), ([0, 0, 1, 1], [1, 1, 2, 2])],
+        dtype=vrd_evaluation.vrd_box_data_type)
+    detected_class_tuples = np.array(
+        [(1, 2, 5), (1, 2, 3)], dtype=vrd_evaluation.label_data_type)
+    detected_scores = np.array([0.7, 0.8], dtype=float)
+    self.vrd_eval.add_single_detected_image_info(
+        image_key, {
+            standard_fields.DetectionResultFields.detection_boxes:
+                detected_box_tuples,
+            standard_fields.DetectionResultFields.detection_scores:
+                detected_scores,
+            standard_fields.DetectionResultFields.detection_classes:
+                detected_class_tuples
+        })
+
+    metrics = self.vrd_eval.evaluate()
+
+    self.assertAlmostEqual(metrics['VRDMetric_Relations_AP@0.5IOU'], 0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Relations_Recall@50@0.5IOU'],
+                           0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Relations_Recall@100@0.5IOU'],
+                           0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Relations_MedianRank@50@0.5IOU'],
+                           0)
+    self.assertAlmostEqual(metrics['VRDMetric_Relations_MedianRank@100@0.5IOU'],
+                           0)
+
+    self.vrd_eval.clear()
+    self.assertFalse(self.vrd_eval._image_ids)
+
+
+class VRDPhraseDetectionEvaluatorTest(tf.test.TestCase):
+
+  def test_vrdphrase_evaluator(self):
+    self.vrd_eval = vrd_evaluation.VRDPhraseDetectionEvaluator()
+
+    image_key1 = 'img1'
+    groundtruth_box_tuples1 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2]), ([0, 0, 1, 1], [1, 2, 2, 3])],
+        dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples1 = np.array(
+        [(1, 2, 3), (1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    groundtruth_verified_labels1 = np.array([1, 2, 3, 4, 5], dtype=int)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key1, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples1,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples1,
+            standard_fields.InputDataFields.verified_labels:
+                groundtruth_verified_labels1
+        })
+
+    image_key2 = 'img2'
+    groundtruth_box_tuples2 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples2 = np.array(
+        [(1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key2, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples2,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples2,
+        })
+
+    image_key3 = 'img3'
+    groundtruth_box_tuples3 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples3 = np.array(
+        [(1, 2, 4)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key3, {
+            standard_fields.InputDataFields.groundtruth_boxes:
+                groundtruth_box_tuples3,
+            standard_fields.InputDataFields.groundtruth_classes:
+                groundtruth_class_tuples3,
+        })
+
+    image_key = 'img1'
+    detected_box_tuples = np.array(
+        [([0, 0.3, 1, 1],), ([0, 0, 2, 2],)],
+        dtype=vrd_evaluation.single_box_data_type)
+    detected_class_tuples = np.array(
+        [(1, 2, 5), (1, 2, 3)], dtype=vrd_evaluation.label_data_type)
+    detected_scores = np.array([0.7, 0.8], dtype=float)
+    self.vrd_eval.add_single_detected_image_info(
+        image_key, {
+            standard_fields.DetectionResultFields.detection_boxes:
+                detected_box_tuples,
+            standard_fields.DetectionResultFields.detection_scores:
+                detected_scores,
+            standard_fields.DetectionResultFields.detection_classes:
+                detected_class_tuples
+        })
+
+    metrics = self.vrd_eval.evaluate()
+
+    self.assertAlmostEqual(metrics['VRDMetric_Phrases_AP@0.5IOU'], 0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Phrases_Recall@50@0.5IOU'], 0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Phrases_Recall@100@0.5IOU'], 0.25)
+    self.assertAlmostEqual(metrics['VRDMetric_Phrases_MedianRank@50@0.5IOU'], 0)
+    self.assertAlmostEqual(metrics['VRDMetric_Phrases_MedianRank@100@0.5IOU'],
+                           0)
+
+    self.vrd_eval.clear()
+    self.assertFalse(self.vrd_eval._image_ids)
+
+
+class VRDDetectionEvaluationTest(tf.test.TestCase):
+
+  def setUp(self):
+
+    self.vrd_eval = vrd_evaluation._VRDDetectionEvaluation(
+        matching_iou_threshold=0.5)
+
+    image_key1 = 'img1'
+    groundtruth_box_tuples1 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2]), ([0, 0, 1, 1], [1, 2, 2, 3])],
+        dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples1 = np.array(
+        [(1, 2, 3), (1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key1, groundtruth_box_tuples1, groundtruth_class_tuples1)
+
+    image_key2 = 'img2'
+    groundtruth_box_tuples2 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples2 = np.array(
+        [(1, 4, 3)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key2, groundtruth_box_tuples2, groundtruth_class_tuples2)
+
+    image_key3 = 'img3'
+    groundtruth_box_tuples3 = np.array(
+        [([0, 0, 1, 1], [1, 1, 2, 2])], dtype=vrd_evaluation.vrd_box_data_type)
+    groundtruth_class_tuples3 = np.array(
+        [(1, 2, 4)], dtype=vrd_evaluation.label_data_type)
+    self.vrd_eval.add_single_ground_truth_image_info(
+        image_key3, groundtruth_box_tuples3, groundtruth_class_tuples3)
+
+    image_key = 'img1'
+    detected_box_tuples = np.array(
+        [([0, 0.3, 1, 1], [1.1, 1, 2, 2]), ([0, 0, 1, 1], [1, 1, 2, 2])],
+        dtype=vrd_evaluation.vrd_box_data_type)
+    detected_class_tuples = np.array(
+        [(1, 2, 3), (1, 2, 3)], dtype=vrd_evaluation.label_data_type)
+    detected_scores = np.array([0.7, 0.8], dtype=float)
+    self.vrd_eval.add_single_detected_image_info(
+        image_key, detected_box_tuples, detected_scores, detected_class_tuples)
+
+    metrics = self.vrd_eval.evaluate()
+    expected_average_precision = 0.25
+    expected_precision = np.array([1., 0.5], dtype=float)
+    expected_recall = np.array([0.25, 0.25], dtype=float)
+    expected_recall_50 = 0.25
+    expected_recall_100 = 0.25
+    average_rank_50 = 0
+    average_rank_100 = 0
+
+    self.assertAlmostEqual(expected_average_precision,
+                           metrics.average_precision)
+    self.assertAllClose(expected_precision, metrics.precisions)
+    self.assertAllClose(expected_recall, metrics.recalls)
+    self.assertAlmostEqual(expected_recall_50, metrics.recall_50)
+    self.assertAlmostEqual(expected_recall_100, metrics.recall_100)
+    self.assertAlmostEqual(average_rank_50, metrics.average_rank_50)
+    self.assertAlmostEqual(average_rank_100, metrics.average_rank_100)
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
195147413  by Zhichao Lu:

    SSDLite config for mobilenet v2.

--
194883585  by Zhichao Lu:

    Simplify TPU compatible nearest neighbor upsampling using reshape and broadcasting.

--
194851009  by Zhichao Lu:

    Include ava v2.1 detection models in model zoo.

--
194510347  by Zhichao Lu:

    Contains implementation of Visual Relations Detection evaluation metric
    (evaluation metric itself).

--
194292198  by Zhichao Lu:

    Add option to evaluate any checkpoint (without requiring write access to that directory and overwriting any existing logs there).

--
194122420  by Zhichao Lu:

    num_gt_boxes_per_image and num_det_boxes_per_image value incorrect.
    Should be not the expand dim.

--
193974479  by Zhichao Lu:

    Fixing a bug in the coco evaluator.

--
193959861  by Zhichao Lu:

    Read the default batch size from config file.

--
193737238  by Zhichao Lu:

    Fix data augmentation functions.

--
193576336  by Zhichao Lu:

    Add support for training keypoints.

--
193409179  by Zhichao Lu:

    Update protobuf requirements to 3+ in installation docs.

--
193382651  by Zhichao Lu:

    Updating coco evaluation metrics to allow for a batch of image info, rather than a single image.

--
193244778  by Zhichao Lu:

    Remove deprecated batch_norm_trainable field from ssd mobilenet v2 config

--
193228972  by Zhichao Lu:

    Make sure the final layers are also resized proportional to conv_depth_ratio.

--
193204364  by Zhichao Lu:

    Do not add batch norm parameters to final conv2d ops that predict boxes encodings and class scores in weight shared conv box predictor.

    This allows us to set proper bias and force initial predictions to be background when using focal loss.

--
193137342  by Zhichao Lu:

    Add a util function to visualize value histogram as a tf.summary.image.

--
193119411  by Zhichao Lu:

    Adding support for reading in logits as groundtruth labels and applying an optional temperature (scaling) before softmax in support of distillation.

--
193087707  by Zhichao Lu:

    Post-process now works again in train mode.

--
193067658  by Zhichao Lu:

    fix flakiness in testSSDRandomCropWithMultiClassScores due to randomness.

--
192922089  by Zhichao Lu:

    Add option to set dropout for classification net in weight shared box predictor.

--
192850747  by Zhichao Lu:

    Remove inaccurate caveat from proto file.

--
192837477  by Zhichao Lu:

    Extend to accept different ratios of conv channels.

--
192813444  by Zhichao Lu:

    Adding option for one_box_for_all_classes to the box_predictor

--
192624207  by Zhichao Lu:

    Update to trainer to allow for reading multiclass scores

--
192583425  by Zhichao Lu:

    Contains implementation of Visual Relations Detection evaluation metric (per
    image evaluation).

--
192529600  by Zhichao Lu:

    Modify the ssd meta arch to allow the option of not adding an implicit background class.

--
192512429  by Zhichao Lu:

    Refactor model_tpu_main.py files and move continuous eval loop into model_lib.py

--
192494267  by Zhichao Lu:

    Update create_pascal_tf_record.py and create_pet_tf_record.py

--
192485456  by Zhichao Lu:

    Enforcing that all eval metric ops have valid python strings.

--
192472546  by Zhichao Lu:

    Set regularize_depthwise to true in mobilenet_v1_argscope.

--
192421843  by Zhichao Lu:

    Refactoring of Mask-RCNN to put all mask prediction code in third stage.

--
192320460  by Zhichao Lu:

    Returning eval_on_train_input_fn from create_estimator_and_inputs(), rather than using train_input_fn in EVAL mode (which will still have data augmentation).

--
192226678  by Zhichao Lu:

    Access TPUEstimator and CrossShardOptimizer from tf namesspace.

--
192195514  by Zhichao Lu:

    Fix test that was flaky due to randomness

--
192166224  by Zhichao Lu:

    Minor fixes to match git repo.

--
192147130  by Zhichao Lu:

    use shape utils for assertion in feature extractor.

--
192132440  by Zhichao Lu:

    Class agnostic masks for mask_rcnn

--
192006190  by Zhichao Lu:

    Add learning rate summary in EVAL mode in model.py

--
192004845  by Zhichao Lu:

    Migrating away from Experiment class, as it is now deprecated. Also, refactoring into a separate model library and binaries.

--
191957195  by Zhichao Lu:

    Add classification_loss and localiztion_loss metrics for TPU jobs.

--
191932855  by Zhichao Lu:

    Add an option to skip the last striding in mobilenet. The modified network has nominal output stride 16 instead of 32.

--
191787921  by Zhichao Lu:

    Add option to override base feature extractor hyperparams in SSD models. This would allow us to use the same set of hyperparams for the complete feature extractor (base + new layers) if desired.

--
191743097  by Zhichao Lu:

    Adding an attribute to SSD model to indicate which fields in prediction dictionary have a batch dimension. This will be useful for future video models.

--
191668425  by Zhichao Lu:

    Internal change.

--
191649512  by Zhichao Lu:

    Introduce two parameters in ssd.proto - freeze_batchnorm, inplace_batchnorm_update - and set up slim arg_scopes in ssd_meta_arch.py such that applies it to all batchnorm ops in the predict() method.

    This centralizes the control of freezing and doing inplace batchnorm updates.

--
191620303  by Zhichao Lu:

    Modifications to the preprocessor to support multiclass scores

--

PiperOrigin-RevId: 195147413