### PR TITLE
Fix UnicodeEncodeError: 'ascii' codec can't encode

### DIFF
--- a/tutorials/image/cifar10_estimator/generate_cifar10_tfrecords.py
+++ b/tutorials/image/cifar10_estimator/generate_cifar10_tfrecords.py
@@ -63,7 +63,7 @@ def _get_file_names():
 
 def read_pickle_from_file(filename):
   with tf.gfile.Open(filename, 'rb') as f:
-    data_dict = pickle.load(f)
+    data_dict = pickle.load(f,encoding='latin1')
   return data_dict
 
 


### PR DESCRIPTION
I try to use generate_cifar10_tfrecords.py to generate tfrcord,but it report UnicodeEncodeError. I change "data_dict = pickle.load(f)" to "data_dict = pickle.load(f,encoding='latin1')", then it works. Latin-1 works for any input as it maps the byte values 0-255 to the first 256 Unicode codepoints directly