### PR TITLE
mnist_eager to use GPU if not specified otherwise

### DIFF
--- a/official/mnist/mnist_eager.py
+++ b/official/mnist/mnist_eager.py
@@ -107,7 +107,7 @@ def run_mnist_eager(flags_obj):
 
   # Automatically determine device and data_format
   (device, data_format) = ('/gpu:0', 'channels_first')
-  if flags_obj.no_gpu or tf.test.is_gpu_available():
+  if flags_obj.no_gpu or not tf.test.is_gpu_available():
     (device, data_format) = ('/cpu:0', 'channels_last')
   # If data_format is defined in FLAGS, overwrite automatically set value.
   if flags_obj.data_format is not None:


### PR DESCRIPTION
Update mnist_eager.py to use GPU if available and not specified otherwise. At the moment it uses the CPU even if a GPU is available, since "if flags_obj.no_gpu or tf.test.is_gpu_available():" in "def run_mnist_eager(flags_obj):" evaluates to True if a GPU is available.