### PR TITLE
Fix bugs in object detection docs

### DIFF
--- a/research/object_detection/g3doc/defining_your_own_model.md
+++ b/research/object_detection/g3doc/defining_your_own_model.md
@@ -20,7 +20,7 @@ each of these models are responsible for implementing 5 functions:
   postprocess functions.
 * `postprocess`: Convert predicted output tensors to final detections.
 * `loss`: Compute scalar loss tensors with respect to provided groundtruth.
-* `restore`: Load a checkpoint into the Tensorflow graph.
+* `restore_map`: Load a checkpoint into the Tensorflow graph.
 
 Given a `DetectionModel` at training time, we pass each image batch through
 the following sequence of functions to compute a loss which can be optimized via


### PR DESCRIPTION
According to code here:
https://github.com/tensorflow/models/blob/master/research/object_detection/meta_architectures/ssd_meta_arch.py#L780

The interface that DetectionModels should implement to load a checkpoint into the Tensorflow graph should be `restore_map` rather than `restore`.