### PR TITLE
Add minor performance improvements to resnet input pipeline

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,7 +45,7 @@
 /research/transformer/ @daviddao
 /research/video_prediction/ @cbfinn
 /research/fivo/ @dieterichlawson
-/samples/ @MarkDaoust
+/samples/ @MarkDaoust @lamberta
 /samples/languages/java/ @asimshankar
 /tutorials/embedding/ @zffchen78 @a-dai
 /tutorials/image/ @sherrym @shlens

--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -73,7 +73,6 @@ def parse_record(raw_record, is_training):
   # The first byte represents the label, which we convert from uint8 to int32
   # and then to one-hot.
   label = tf.cast(record_vector[0], tf.int32)
-  label = tf.one_hot(label, _NUM_CLASSES)
 
   # The remaining bytes after the label represent the image, which we reshape
   # from [depth * height * width] to [depth, height, width].

--- a/official/resnet/cifar10_test.py
+++ b/official/resnet/cifar10_test.py
@@ -64,13 +64,13 @@ class BaseTest(tf.test.TestCase):
         lambda val: cifar10_main.parse_record(val, False))
     image, label = fake_dataset.make_one_shot_iterator().get_next()
 
-    self.assertAllEqual(label.shape, (10,))
+    self.assertAllEqual(label.shape, ())
     self.assertAllEqual(image.shape, (_HEIGHT, _WIDTH, _NUM_CHANNELS))
 
     with self.test_session() as sess:
       image, label = sess.run([image, label])
 
-      self.assertAllEqual(label, np.array([int(i == 7) for i in range(10)]))
+      self.assertEqual(label, 7)
 
       for row in image:
         for pixel in row:

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -175,7 +175,7 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1):
     dataset = dataset.shuffle(buffer_size=_NUM_TRAIN_FILES)
 
   # Convert to individual records
-  # TODO(guptapriya): Should we make this cycle_length a flag similar to 
+  # TODO(guptapriya): Should we make this cycle_length a flag similar to
   # num_parallel_calls?
   dataset = dataset.apply(tf.contrib.data.parallel_interleave(
       tf.data.TFRecordDataset, cycle_length=10))

--- a/research/object_detection/utils/dataset_util.py
+++ b/research/object_detection/utils/dataset_util.py
@@ -134,7 +134,7 @@ def read_dataset(file_read_func, decode_func, input_files, config):
           file_read_func, cycle_length=config.num_readers,
           block_length=config.read_block_length, sloppy=config.shuffle))
   if config.shuffle:
-    records_dataset.shuffle(config.shuffle_buffer_size)
+    records_dataset = records_dataset.shuffle(config.shuffle_buffer_size)
   tensor_dataset = records_dataset.map(
       decode_func, num_parallel_calls=config.num_parallel_map_calls)
   return tensor_dataset.prefetch(config.prefetch_size)


### PR DESCRIPTION
Added the following changes to improve input pipeline:
1. Remove usage of one_hot labels  (~2% improvement)
2. Add drop_remainder to batching. This helps in input shape being determined ahead of time which helps improve performance. (~2% improvement)
3. Use parallel_interleave for imagenet dataset reading. (~3% improvement)

The improvements were observed when testing with 8 V100 GPUs on DGX-1 using mirrored strategy (fp16, resnet v2). The differences may not be noticeable in other cases where input pipeline is not the bottleneck.

