### PR TITLE
Fix resnet missing layers.

### DIFF
--- a/official/resnet/README.md
+++ b/official/resnet/README.md
@@ -50,15 +50,6 @@ The model will begin training and will automatically evaluate itself on the vali
 
 Note that there are a number of other options you can specify, including `--model_dir` to choose where to store the model and `--resnet_size` to choose the model size (options include ResNet-18 through ResNet-200). See [`resnet.py`](resnet.py) for the full list of options.
 
-### Pre-trained model
-You can download 190 MB pre-trained versions of ResNet-50 achieving 76.3% and 75.3% (respectively) top-1 single-crop accuracy here: [resnetv2_imagenet_checkpoint.tar.gz](http://download.tensorflow.org/models/official/resnetv2_imagenet_checkpoint.tar.gz), [resnetv1_imagenet_checkpoint.tar.gz](http://download.tensorflow.org/models/official/resnetv1_imagenet_checkpoint.tar.gz). Simply download and uncompress the file, and point the model to the extracted directory using the `--model_dir` flag.
-
-Other versions and formats:
-
-* [ResNet-v2-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnet_v2_imagenet_checkpoint.tar.gz)
-* [ResNet-v2-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnet_v2_imagenet_savedmodel.tar.gz)
-* [ResNet-v1-ImageNet Checkpoint](http://download.tensorflow.org/models/official/resnet_v1_imagenet_checkpoint.tar.gz)
-* [ResNet-v1-ImageNet SavedModel](http://download.tensorflow.org/models/official/resnet_v1_imagenet_savedmodel.tar.gz)
 
 ## Compute Devices
 Training is accomplished using the DistributionStrategies API. (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/README.md)

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -505,8 +505,9 @@ class Model(object):
       inputs = tf.identity(inputs, 'initial_conv')
 
       # We do not include batch normalization or activation functions in V2
-      # conv1 because the first ResNet unit will perform these for both paths.
-      # Cf. Appendix of [2].
+      # for the initial conv1 because the first ResNet unit will perform these
+      # for both the shortcut and non-shortcut paths as part of the first
+      # block's projection. Cf. Appendix of [2].
       if self.resnet_version == 1:
         inputs = batch_norm(inputs, training, self.data_format)
         inputs = tf.nn.relu(inputs)

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -503,6 +503,8 @@ class Model(object):
           inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,
           strides=self.conv_stride, data_format=self.data_format)
       inputs = tf.identity(inputs, 'initial_conv')
+      inputs = batch_norm(inputs, training, self.data_format)
+      inputs = tf.nn.relu(inputs)
 
       if self.first_pool_size:
         inputs = tf.layers.max_pooling2d(

--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -503,8 +503,13 @@ class Model(object):
           inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,
           strides=self.conv_stride, data_format=self.data_format)
       inputs = tf.identity(inputs, 'initial_conv')
-      inputs = batch_norm(inputs, training, self.data_format)
-      inputs = tf.nn.relu(inputs)
+
+      # We do not include batch normalization or activation functions in V2
+      # conv1 because the first ResNet unit will perform these for both paths.
+      # Cf. Appendix of [2].
+      if self.resnet_version == 1:
+        inputs = batch_norm(inputs, training, self.data_format)
+        inputs = tf.nn.relu(inputs)
 
       if self.first_pool_size:
         inputs = tf.layers.max_pooling2d(


### PR DESCRIPTION
The official v1 model contains BN and Relu between input layer and pooling. See http://ethereon.github.io/netscope/#/gist/db945b393d40bfa26006. 

For v2, I am also convinced that it should have those 2 layers, based on Appendix: Implementation Details in https://arxiv.org/pdf/1603.05027.pdf. Here is the quote:

"When using the pre-activation Residual Units (Fig. 4(d)(e) and Fig. 5), we
pay special attention to the first and the last Residual Units of the entire network.
For the first Residual Unit (that follows a stand-alone convolutional layer,
conv1), **we adopt the first activation right after conv1 and before splitting into
two paths**; for the last Residual Unit (followed by average pooling and a fullyconnected
classifier), we adopt an extra activation right after its element-wise
addition. These two special cases are the natural outcome when we obtain the
pre-activation network via the modification procedure as shown in Fig. 5."