### PR TITLE
fix read mode of  build_ade20k_data.py

### DIFF
--- a/research/deeplab/datasets/build_ade20k_data.py
+++ b/research/deeplab/datasets/build_ade20k_data.py
@@ -89,11 +89,11 @@ def _convert_dataset(dataset_split, dataset_dir, dataset_label_dir):
         sys.stdout.flush()
         # Read the image.
         image_filename = img_names[i]
-        image_data = tf.gfile.FastGFile(image_filename, 'r').read()
+        image_data = tf.gfile.FastGFile(image_filename, 'rb').read()
         height, width = image_reader.read_image_dims(image_data)
         # Read the semantic segmentation annotation.
         seg_filename = seg_names[i]
-        seg_data = tf.gfile.FastGFile(seg_filename, 'r').read()
+        seg_data = tf.gfile.FastGFile(seg_filename, 'rb').read()
         seg_height, seg_width = label_reader.read_image_dims(seg_data)
         if height != seg_height or width != seg_width:
           raise RuntimeError('Shape mismatched between image and label.')


### PR DESCRIPTION
related : https://github.com/tensorflow/models/pull/3741  
build_ade20k_data.py has a same problem.
The FastGFile(.., 'b') does not work for Python 3