### PR TITLE
Adding a google cloud container builder spec to build cpu and gpu based images

### DIFF
--- a/official/cloudbuild.yaml
+++ b/official/cloudbuild.yaml
@@ -1,0 +1,29 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+  '-t', 'gcr.io/$PROJECT_ID/models-gpu:$COMMIT_SHA',
+  '-t', 'gcr.io/$PROJECT_ID/models-gpu:latest',
+  '-f', 'Dockerfile.gpu',
+  '.'
+  ]
+  
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+  '-t', 'gcr.io/$PROJECT_ID/models:$COMMIT_SHA',
+  '-t', 'gcr.io/$PROJECT_ID/models:latest',
+  '-f', 'Dockerfile.cpu',
+  '.'
+  ]
+
+# Building GPU images require additional memory.
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+# List of images to be pushed as part of this build.  
+images:
+  - 'gcr.io/$PROJECT_ID/models:latest'
+  - 'gcr.io/$PROJECT_ID/models:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/models-gpu:latest'
+  - 'gcr.io/$PROJECT_ID/models-gpu:$COMMIT_SHA'
+
+


### PR DESCRIPTION
To setup continuous builds of container images that will includes all the models in this repo via [google cloud container builder](https://cloud.google.com/container-builder/), this PR introduces a container builder configuration file that explicitly specified the images that will be built for every commit to this branch and more importantly the need for a larger size VM to run these builds in the background.

To submit builds manually to container builder run the following command:
```shell
$ cd official 
$ gcloud container builds submit --config cloudbuild.yaml . --project <your-gcp-project> --substitutions=COMMIT_SHA=$(git rev-parse HEAD)
```

Builds will be automated via container builder and you can list the images available periodically as follows:
```shell
$ gcloud container images list-tags gcr.io/tensorflow/models
$ gcloud container images list-tags gcr.io/tensorflow/models-gpu
```