### PR TITLE
Add minor performance improvements to resnet input pipeline

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -73,7 +73,6 @@ def parse_record(raw_record, is_training):
   # The first byte represents the label, which we convert from uint8 to int32
   # and then to one-hot.
   label = tf.cast(record_vector[0], tf.int32)
-  label = tf.one_hot(label, _NUM_CLASSES)
 
   # The remaining bytes after the label represent the image, which we reshape
   # from [depth * height * width] to [depth, height, width].

--- a/official/resnet/cifar10_test.py
+++ b/official/resnet/cifar10_test.py
@@ -64,13 +64,13 @@ class BaseTest(tf.test.TestCase):
         lambda val: cifar10_main.parse_record(val, False))
     image, label = fake_dataset.make_one_shot_iterator().get_next()
 
-    self.assertAllEqual(label.shape, (10,))
+    self.assertAllEqual(label.shape, ())
     self.assertAllEqual(image.shape, (_HEIGHT, _WIDTH, _NUM_CHANNELS))
 
     with self.test_session() as sess:
       image, label = sess.run([image, label])
 
-      self.assertAllEqual(label, np.array([int(i == 7) for i in range(10)]))
+      self.assertEqual(label, 7)
 
       for row in image:
         for pixel in row:

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -175,7 +175,7 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1):
     dataset = dataset.shuffle(buffer_size=_NUM_TRAIN_FILES)
 
   # Convert to individual records
-  # TODO(guptapriya): Should we make this cycle_length a flag similar to 
+  # TODO(guptapriya): Should we make this cycle_length a flag similar to
   # num_parallel_calls?
   dataset = dataset.apply(tf.contrib.data.parallel_interleave(
       tf.data.TFRecordDataset, cycle_length=10))

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -179,7 +179,6 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1):
   # num_parallel_calls?
   dataset = dataset.apply(tf.contrib.data.parallel_interleave(
       tf.data.TFRecordDataset, cycle_length=10))
-  dataset = dataset.flat_map(tf.data.TFRecordDataset)
 
   return resnet_run_loop.process_record_dataset(
       dataset, is_training, batch_size, _SHUFFLE_BUFFER, parse_record,

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -174,9 +174,11 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1):
     # Shuffle the input files
     dataset = dataset.shuffle(buffer_size=_NUM_TRAIN_FILES)
 
-  # Convert to individual records
-  # TODO(guptapriya): Should we make this cycle_length a flag similar to
-  # num_parallel_calls?
+  # Convert to individual records.
+  # cycle_length = 10 means 10 files will be read and deserialized in parallel.
+  # This number is low enough to not cause too much contention on small systems
+  # but high enough to provide the benefits of parallelization. You may want
+  # to increase this number if you have a large number of CPU cores.
   dataset = dataset.apply(tf.contrib.data.parallel_interleave(
       tf.data.TFRecordDataset, cycle_length=10))
 


### PR DESCRIPTION
Added the following changes to improve input pipeline.

1. Remove usage of one_hot labels (~2% improvement)
2. Add drop_remainder to batching. This helps in input shape being determined ahead of time which helps improve performance. (~2% improvement)
3. Use parallel_interleave for imagenet dataset reading. (~3% improvement)

The improvements were observed when testing with 8 V100 GPUs on DGX-1 using mirrored strategy (fp16, resnet v2). Also saw improvements in GCE V100. No improvement observed on K80s but that is expected since they are not bottlenecked on input. 