### PR TITLE
Update object_detection_tutorial.ipynb

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -269,7 +269,7 @@
     "      # all outputs are float32 numpy arrays, so convert types as appropriate\n",
     "      output_dict['num_detections'] = int(output_dict['num_detections'][0])\n",
     "      output_dict['detection_classes'] = output_dict[\n",
-    "          'detection_classes'][0].astype(np.uint8)\n",
+    "          'detection_classes'][0].astype(np.int32)\n",
     "      output_dict['detection_boxes'] = output_dict['detection_boxes'][0]\n",
     "      output_dict['detection_scores'] = output_dict['detection_scores'][0]\n",
     "      if 'detection_masks' in output_dict:\n",


### PR DESCRIPTION
When number of objects are more than uint8's range, the earlier code crates problems. This is a fix.