### PR TITLE
Intel-MKL: add inter/intra-op and performance tuning parameters specific to MKL

### DIFF
--- a/research/object_detection/eval_util.py
+++ b/research/object_detection/eval_util.py
@@ -206,6 +206,8 @@ def _run_checkpoint_once(tensor_dict,
                          master='',
                          save_graph=False,
                          save_graph_dir='',
+                         inter_op=0,
+                         intra_op=0,
                          losses_dict=None):
   """Evaluates metrics defined in evaluators and returns summaries.
 
@@ -246,6 +248,10 @@ def _run_checkpoint_once(tensor_dict,
     save_graph_dir: where to store the Tensorflow graph on disk. If save_graph
       is True this must be non-empty.
     losses_dict: optional dictionary of scalar detection losses.
+    inter_op: Number of threads to use for inter-op parallelism. If set to 0,
+      the system will pick an appropriate number.
+    intra_op: Number of threads to use for intra-op parallelism. If set to 0,
+      the system will pick an appropriate number.
 
   Returns:
     global_step: the count of global steps.
@@ -258,7 +264,9 @@ def _run_checkpoint_once(tensor_dict,
   """
   if save_graph and not save_graph_dir:
     raise ValueError('`save_graph_dir` must be defined.')
-  sess = tf.Session(master, graph=tf.get_default_graph())
+  config = tf.ConfigProto(inter_op_parallelism_threads=inter_op,
+                          intra_op_parallelism_threads=intra_op)
+  sess = tf.Session(master, graph=tf.get_default_graph(), config=config)
   sess.run(tf.global_variables_initializer())
   sess.run(tf.local_variables_initializer())
   sess.run(tf.tables_initializer())
@@ -344,6 +352,8 @@ def repeated_checkpoint_run(tensor_dict,
                             master='',
                             save_graph=False,
                             save_graph_dir='',
+                            inter_op=0,
+                            intra_op=0,
                             losses_dict=None):
   """Periodically evaluates desired tensors using checkpoint_dirs or restore_fn.
 
@@ -423,6 +433,8 @@ def repeated_checkpoint_run(tensor_dict,
                                                   restore_fn, num_batches,
                                                   master, save_graph,
                                                   save_graph_dir,
+                                                  inter_op=inter_op,
+                                                  intra_op=intra_op,
                                                   losses_dict=losses_dict)
       write_metrics(metrics, global_step, summary_dir)
     number_of_evaluations += 1

--- a/research/object_detection/evaluator.py
+++ b/research/object_detection/evaluator.py
@@ -150,7 +150,8 @@ def get_evaluators(eval_config, categories):
 
 
 def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
-             checkpoint_dir, eval_dir, graph_hook_fn=None, evaluator_list=None):
+             checkpoint_dir, eval_dir, inter_op=0, intra_op=0,
+             graph_hook_fn=None, evaluator_list=None):
   """Evaluation function for detection models.
 
   Args:
@@ -271,6 +272,8 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
       master=eval_config.eval_master,
       save_graph=eval_config.save_graph,
       save_graph_dir=(eval_dir if eval_config.save_graph else ''),
+      inter_op=inter_op,
+      intra_op=intra_op,
       losses_dict=losses_dict)
 
   return metrics

--- a/research/object_detection/trainer.py
+++ b/research/object_detection/trainer.py
@@ -214,7 +214,9 @@ def train(create_tensor_dict_fn,
           worker_job_name,
           is_chief,
           train_dir,
-          graph_hook_fn=None):
+          graph_hook_fn=None,
+          inter_op=0,
+          intra_op=0):
   """Training function for detection models.
 
   Args:
@@ -235,6 +237,10 @@ def train(create_tensor_dict_fn,
       built (before optimization). This is helpful to perform additional changes
       to the training graph such as adding FakeQuant ops. The function should
       modify the default graph.
+    inter_op: Number of threads to use for inter-op parallelism. If set to 0,
+              the system will pick an appropriate number.
+    intra_op: Number of threads to use for intra-op parallelism. If set to 0,
+              the system will pick an appropriate number.
   """
 
   detection_model = create_model_fn()
@@ -353,7 +359,9 @@ def train(create_tensor_dict_fn,
 
     # Soft placement allows placing on CPU ops without GPU implementation.
     session_config = tf.ConfigProto(allow_soft_placement=True,
-                                    log_device_placement=False)
+                                    log_device_placement=False,
+                                    inter_op_parallelism_threads=inter_op,
+                                    intra_op_parallelism_threads=intra_op)
 
     # Save checkpoints regularly.
     keep_checkpoint_every_n_hours = train_config.keep_checkpoint_every_n_hours


### PR DESCRIPTION
In this PR, We added following parameters to improve the training and evaluation out-of-box experiences on CPU and make it easier for users to control the parallelism on CPU for object detection API.
1) inter_op and intra_op to control the parallelism.
2) performance tuning parameters specific to MKL (kmp_block_time and kmp_affinity) if MKL is enabled.