### PR TITLE
Fixed minor typo in Figure 3 caption

### DIFF
--- a/samples/core/get_started/eager.ipynb
+++ b/samples/core/get_started/eager.ipynb
@@ -560,7 +560,7 @@
         "         alt=\"Optimization algorthims visualized over time in 3D space.\">\n",
         "  </td></tr>\n",
         "  <tr><td align=\"center\">\n",
-        "    <b>Figure 3.</b> Optimization algorthims visualized over time in 3D space. (Source: <a href=\"http://cs231n.github.io/neural-networks-3/\">Stanford class CS231n</a>, MIT License)<br/>&nbsp;\n",
+        "    <b>Figure 3.</b> Optimization algorithms visualized over time in 3D space. (Source: <a href=\"http://cs231n.github.io/neural-networks-3/\">Stanford class CS231n</a>, MIT License)<br/>&nbsp;\n",
         "  </td></tr>\n",
         "</table>\n",
         "\n",


### PR DESCRIPTION
The word "algorithms" is currently mis-spelled as "algorthims".