### PR TITLE
Add new column for benchmark run status.

### DIFF
--- a/official/benchmark/datastore/schema/benchmark_run.json
+++ b/official/benchmark/datastore/schema/benchmark_run.json
@@ -6,6 +6,12 @@
     "type": "STRING"
   },
   {
+    "description": "The status of the run for the benchmark. Eg, running, failed, success",
+    "mode": "NULLABLE",
+    "name": "status",
+    "type": "STRING"
+  },
+  {
     "description": "The name of the model, E.g ResNet50, LeNet-5 etc.",
     "mode": "REQUIRED",
     "name": "model_name",


### PR DESCRIPTION
Currently the column can only be NULLABLE due to the constrain in https://cloud.google.com/bigquery/docs/managing-table-schemas#manually_adding_an_empty_column. 