### PR TITLE
Catch errors during mkdirs, prevent duplicated download

### DIFF
--- a/research/inception/inception/data/download_imagenet.sh
+++ b/research/inception/inception/data/download_imagenet.sh
@@ -55,11 +55,11 @@ BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nonpub"
 BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
 BBOX_TAR_BALL="${BBOX_DIR}/annotations.tar.gz"
 echo "Downloading bounding box annotations."
-wget -c "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}" || BASE_URL_CHANGE=1
+wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}" || BASE_URL_CHANGE=1
 if [ $BASE_URL_CHANGE ]; then
   BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nnoupb"
   BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
-  wget -c "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}"
+  wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}"
 fi
 echo "Uncompressing bounding box annotations ..."
 tar xzf "${BBOX_TAR_BALL}" -C "${BBOX_DIR}"

--- a/research/inception/inception/data/download_imagenet.sh
+++ b/research/inception/inception/data/download_imagenet.sh
@@ -55,13 +55,12 @@ BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nonpub"
 BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
 BBOX_TAR_BALL="${BBOX_DIR}/annotations.tar.gz"
 echo "Downloading bounding box annotations."
-wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}" || BASE_URL_CHANGE=1
+wget -c "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}" || BASE_URL_CHANGE=1
 if [ $BASE_URL_CHANGE ]; then
   BASE_URL="http://www.image-net.org/challenges/LSVRC/2012/nnoupb"
   BOUNDING_BOX_ANNOTATIONS="${BASE_URL}/ILSVRC2012_bbox_train_v2.tar.gz"
-  BBOX_TAR_BALL="${BBOX_DIR}/annotations.tar.gz"
+  wget -c "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}"
 fi
-wget "${BOUNDING_BOX_ANNOTATIONS}" -O "${BBOX_TAR_BALL}"
 echo "Uncompressing bounding box annotations ..."
 tar xzf "${BBOX_TAR_BALL}" -C "${BBOX_DIR}"
 

--- a/research/inception/inception/data/preprocess_imagenet_validation_data.py
+++ b/research/inception/inception/data/preprocess_imagenet_validation_data.py
@@ -49,6 +49,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import errno
 import os.path
 import sys
 
@@ -69,7 +70,13 @@ if __name__ == '__main__':
   # Make all sub-directories in the validation data dir.
   for label in unique_labels:
     labeled_data_dir = os.path.join(data_dir, label)
-    os.makedirs(labeled_data_dir)
+    # Catch error if sub-directory exists
+    try:
+      os.makedirs(labeled_data_dir)
+    except OSError as e:
+      # Raise all errors but 'EEXIST'
+      if e.errno != errno.EEXIST:
+        raise
 
   # Move all of the image to the appropriate sub-directory.
   for i in range(len(labels)):


### PR DESCRIPTION
This PR catches errors during the directory creating, which previously resulted in executing the whole script again.
Now, if the script was previously interrupted the script will continue if the needed directories already exist.

Furthermore, the `ILSVRC2012_bbox_train_v2.tar.gz` is now only downloaded once, in the case where no `BASE_URL_CHANGE` was neccessary.