### PR TITLE
Update README.md

### DIFF
--- a/research/attention_ocr/README.md
+++ b/research/attention_ocr/README.md
@@ -51,7 +51,7 @@ To run all unit tests:
 
 ```
 cd research/attention_ocr/python
-python -m unittest discover -p  '*_test.py'
+CUDA_VISIBLE_DEVICES=1 python -m unittest discover -p  '*_test.py'
 ```
 
 To train from scratch:


### PR DESCRIPTION
In '*_test.py', no function set the GPU device, default is 0. So if the GPU 0 is used by others and the memory is full, there will an exception like
'''failed to allocate 6.04G (6487007744 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY'''
so there is a necessity to set the GPU device(and it's optional).