### PR TITLE
Record the status for a benchmark run.

### DIFF
--- a/official/benchmark/benchmark_uploader.py
+++ b/official/benchmark/benchmark_uploader.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 import json
 
 from google.cloud import bigquery
+from google.cloud import exceptions
 
 import tensorflow as tf
 
@@ -139,7 +140,10 @@ class BigQueryUploader(object):
              "(run_id, status) "
              "VALUES('{rid}', '{status}')").format(
                  ds=dataset_name, tb=table_name, rid=run_id, status=run_status)
-    self._bq_client.query(query=query).result()
+    try:
+      self._bq_client.query(query=query).result()
+    except exceptions.GoogleCloudError as e:
+      tf.logging.error("Failed to insert run status: %s", e)
 
   def update_run_status(self, dataset_name, table_name, run_id, run_status):
     """Update the run status in in Bigquery run status table."""
@@ -147,4 +151,7 @@ class BigQueryUploader(object):
              "SET status = '{status}' "
              "WHERE run_id = '{rid}'").format(
                  ds=dataset_name, tb=table_name, status=run_status, rid=run_id)
-    self._bq_client.query(query=query).result()
+    try:
+      self._bq_client.query(query=query).result()
+    except exceptions.GoogleCloudError as e:
+      tf.logging.error("Failed to update run status: %s", e)

--- a/official/benchmark/benchmark_uploader.py
+++ b/official/benchmark/benchmark_uploader.py
@@ -133,10 +133,18 @@ class BigQueryUploader(object):
       tf.logging.error(
           "Failed to upload benchmark info to bigquery: {}".format(errors))
 
+  def insert_run_status(self, dataset_name, table_name, run_id, run_status):
+    """Insert the run status in to Bigquery run status table."""
+    query = ("INSERT {ds}.{tb} "
+             "(run_id, status) "
+             "VALUES('{rid}', '{status}')").format(
+                 ds=dataset_name, tb=table_name, rid=run_id, status=run_status)
+    self._bq_client.query(query=query).result()
+
   def update_run_status(self, dataset_name, table_name, run_id, run_status):
-    """Update the run status in to Bigquery run record."""
+    """Update the run status in in Bigquery run status table."""
     query = ("UPDATE {ds}.{tb} "
              "SET status = '{status}' "
              "WHERE run_id = '{rid}'").format(
                  ds=dataset_name, tb=table_name, status=run_status, rid=run_id)
-    self._bq_client.query(query=query)
+    self._bq_client.query(query=query).result()

--- a/official/benchmark/benchmark_uploader.py
+++ b/official/benchmark/benchmark_uploader.py
@@ -132,3 +132,11 @@ class BigQueryUploader(object):
     if errors:
       tf.logging.error(
           "Failed to upload benchmark info to bigquery: {}".format(errors))
+
+  def update_run_status(self, dataset_name, table_name, run_id, run_status):
+    """Update the run status in to Bigquery run record."""
+    query = ("UPDATE {ds}.{tb} "
+             "SET status = '{status}' "
+             "WHERE run_id = '{rid}'").format(
+                 ds=dataset_name, tb=table_name, status=run_status, rid=run_id)
+    self._bq_client.query(query=query)

--- a/official/benchmark/benchmark_uploader_main.py
+++ b/official/benchmark/benchmark_uploader_main.py
@@ -55,7 +55,7 @@ def main(_):
       flags.FLAGS.bigquery_data_set, flags.FLAGS.bigquery_metric_table, run_id,
       metric_json_file)
   # Assume the run finished successfully before user invoke the upload script.
-  uploader.update_run_status(
+  uploader.insert_run_status(
       flags.FLAGS.bigquery_data_set, flags.FLAGS.bigquery_run_status_table,
       run_id, "success")
 

--- a/official/benchmark/benchmark_uploader_main.py
+++ b/official/benchmark/benchmark_uploader_main.py
@@ -57,7 +57,7 @@ def main(_):
   # Assume the run finished successfully before user invoke the upload script.
   uploader.insert_run_status(
       flags.FLAGS.bigquery_data_set, flags.FLAGS.bigquery_run_status_table,
-      run_id, "success")
+      run_id, logger.RUN_STATUS_SUCCESS)
 
 
 if __name__ == "__main__":

--- a/official/benchmark/benchmark_uploader_main.py
+++ b/official/benchmark/benchmark_uploader_main.py
@@ -54,6 +54,10 @@ def main(_):
   uploader.upload_metric_file(
       flags.FLAGS.bigquery_data_set, flags.FLAGS.bigquery_metric_table, run_id,
       metric_json_file)
+  # Assume the run finished successfully before user invoke the upload script.
+  uploader.update_run_status(
+      flags.FLAGS.bigquery_data_set, flags.FLAGS.bigquery_run_status_table,
+      run_id, "success")
 
 
 if __name__ == "__main__":

--- a/official/benchmark/benchmark_uploader_test.py
+++ b/official/benchmark/benchmark_uploader_test.py
@@ -36,10 +36,10 @@ except ImportError:
   benchmark_uploader = None
 
 
-@unittest.skipIf(bigquery is None, 'Bigquery dependency is not installed.')
+@unittest.skipIf(bigquery is None, "Bigquery dependency is not installed.")
 class BigQueryUploaderTest(tf.test.TestCase):
 
-  @patch.object(bigquery, 'Client')
+  @patch.object(bigquery, "Client")
   def setUp(self, mock_bigquery):
     self.mock_client = mock_bigquery.return_value
     self.mock_dataset = MagicMock(name="dataset")
@@ -52,72 +52,72 @@ class BigQueryUploaderTest(tf.test.TestCase):
     self.benchmark_uploader._bq_client = self.mock_client
 
     self.log_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
-    with open(os.path.join(self.log_dir, 'metric.log'), 'a') as f:
-      json.dump({'name': 'accuracy', 'value': 1.0}, f)
+    with open(os.path.join(self.log_dir, "metric.log"), "a") as f:
+      json.dump({"name": "accuracy", "value": 1.0}, f)
       f.write("\n")
-      json.dump({'name': 'loss', 'value': 0.5}, f)
+      json.dump({"name": "loss", "value": 0.5}, f)
       f.write("\n")
-    with open(os.path.join(self.log_dir, 'run.log'), 'w') as f:
-      json.dump({'model_name': 'value'}, f)
+    with open(os.path.join(self.log_dir, "run.log"), "w") as f:
+      json.dump({"model_name": "value"}, f)
 
   def tearDown(self):
     tf.gfile.DeleteRecursively(self.get_temp_dir())
 
   def test_upload_benchmark_run_json(self):
     self.benchmark_uploader.upload_benchmark_run_json(
-        'dataset', 'table', 'run_id', {'model_name': 'value'})
+        "dataset", "table", "run_id", {"model_name": "value"})
 
     self.mock_client.insert_rows_json.assert_called_once_with(
-        self.mock_table, [{'model_name': 'value', 'model_id': 'run_id'}])
+        self.mock_table, [{"model_name": "value", "model_id": "run_id"}])
 
   def test_upload_benchmark_metric_json(self):
     metric_json_list = [
-        {'name': 'accuracy', 'value': 1.0},
-        {'name': 'loss', 'value': 0.5}
+        {"name": "accuracy", "value": 1.0},
+        {"name": "loss", "value": 0.5}
     ]
     expected_params = [
-        {'run_id': 'run_id', 'name': 'accuracy', 'value': 1.0},
-        {'run_id': 'run_id', 'name': 'loss', 'value': 0.5}
+        {"run_id": "run_id", "name": "accuracy", "value": 1.0},
+        {"run_id": "run_id", "name": "loss", "value": 0.5}
     ]
     self.benchmark_uploader.upload_benchmark_metric_json(
-        'dataset', 'table', 'run_id', metric_json_list)
+        "dataset", "table", "run_id", metric_json_list)
     self.mock_client.insert_rows_json.assert_called_once_with(
         self.mock_table, expected_params)
 
   def test_upload_benchmark_run_file(self):
     self.benchmark_uploader.upload_benchmark_run_file(
-        'dataset', 'table', 'run_id', os.path.join(self.log_dir, 'run.log'))
+        "dataset", "table", "run_id", os.path.join(self.log_dir, "run.log"))
 
     self.mock_client.insert_rows_json.assert_called_once_with(
-        self.mock_table, [{'model_name': 'value', 'model_id': 'run_id'}])
+        self.mock_table, [{"model_name": "value", "model_id": "run_id"}])
 
   def test_upload_metric_file(self):
     self.benchmark_uploader.upload_metric_file(
-        'dataset', 'table', 'run_id',
-        os.path.join(self.log_dir, 'metric.log'))
+        "dataset", "table", "run_id",
+        os.path.join(self.log_dir, "metric.log"))
     expected_params = [
-        {'run_id': 'run_id', 'name': 'accuracy', 'value': 1.0},
-        {'run_id': 'run_id', 'name': 'loss', 'value': 0.5}
+        {"run_id": "run_id", "name": "accuracy", "value": 1.0},
+        {"run_id": "run_id", "name": "loss", "value": 0.5}
     ]
     self.mock_client.insert_rows_json.assert_called_once_with(
         self.mock_table, expected_params)
 
   def test_insert_run_status(self):
     self.benchmark_uploader.insert_run_status(
-        'dataset', 'table', 'run_id', 'status')
-    expected_query = ('INSERT dataset.table '
-                      '(run_id, status) '
-                      'VALUES(\'run_id\', \'status\')')
+        "dataset", "table", "run_id", "status")
+    expected_query = ("INSERT dataset.table "
+                      "(run_id, status) "
+                      "VALUES('run_id', 'status')")
     self.mock_client.query.assert_called_once_with(query=expected_query)
 
   def test_update_run_status(self):
     self.benchmark_uploader.update_run_status(
-        'dataset', 'table', 'run_id', 'status')
-    expected_query = ('UPDATE dataset.table '
-                      'SET status = \'status\' '
-                      'WHERE run_id = \'run_id\'')
+        "dataset", "table", "run_id", "status")
+    expected_query = ("UPDATE dataset.table "
+                      "SET status = 'status' "
+                      "WHERE run_id = 'run_id'")
     self.mock_client.query.assert_called_once_with(query=expected_query)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   tf.test.main()

--- a/official/benchmark/benchmark_uploader_test.py
+++ b/official/benchmark/benchmark_uploader_test.py
@@ -102,6 +102,14 @@ class BigQueryUploaderTest(tf.test.TestCase):
     self.mock_client.insert_rows_json.assert_called_once_with(
         self.mock_table, expected_params)
 
+  def test_update_run_status(self):
+    self.benchmark_uploader.update_run_status(
+        'dataset', 'table', 'run_id', 'status')
+    expected_query = ('UPDATE dataset.table '
+                      'SET status = \'status\' '
+                      'WHERE run_id = \'run_id\'')
+    self.mock_client.query.assert_called_once_with(query=expected_query)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/official/benchmark/benchmark_uploader_test.py
+++ b/official/benchmark/benchmark_uploader_test.py
@@ -102,6 +102,14 @@ class BigQueryUploaderTest(tf.test.TestCase):
     self.mock_client.insert_rows_json.assert_called_once_with(
         self.mock_table, expected_params)
 
+  def test_insert_run_status(self):
+    self.benchmark_uploader.insert_run_status(
+        'dataset', 'table', 'run_id', 'status')
+    expected_query = ('INSERT dataset.table '
+                      '(run_id, status) '
+                      'VALUES(\'run_id\', \'status\')')
+    self.mock_client.query.assert_called_once_with(query=expected_query)
+
   def test_update_run_status(self):
     self.benchmark_uploader.update_run_status(
         'dataset', 'table', 'run_id', 'status')

--- a/official/benchmark/datastore/schema/benchmark_run.json
+++ b/official/benchmark/datastore/schema/benchmark_run.json
@@ -6,12 +6,6 @@
     "type": "STRING"
   },
   {
-    "description": "The status of the run for the benchmark. Eg, running, failed, success",
-    "mode": "NULLABLE",
-    "name": "status",
-    "type": "STRING"
-  },
-  {
     "description": "The name of the model, E.g ResNet50, LeNet-5 etc.",
     "mode": "REQUIRED",
     "name": "model_name",

--- a/official/benchmark/datastore/schema/benchmark_run_status.json
+++ b/official/benchmark/datastore/schema/benchmark_run_status.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "The UUID of the run for the benchmark.",
+    "mode": "REQUIRED",
+    "name": "run_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The status of the run for the benchmark. Eg, running, failed, success",
+    "mode": "REQUIRED",
+    "name": "status",
+    "type": "STRING"
+  }
+]

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -251,29 +251,30 @@ def main(_):
 
   total_training_cycle = FLAGS.train_epochs // FLAGS.epochs_between_evals
 
-  for cycle_index in range(total_training_cycle):
-    tf.logging.info("Starting a training cycle: {}/{}".format(
-        cycle_index + 1, total_training_cycle))
+  with logger.benchmark_context(benchmark_logger):
+    for cycle_index in range(total_training_cycle):
+      tf.logging.info("Starting a training cycle: {}/{}".format(
+          cycle_index + 1, total_training_cycle))
 
-    # Train the model
-    estimator.train(input_fn=train_input_fn, hooks=train_hooks)
+      # Train the model
+      estimator.train(input_fn=train_input_fn, hooks=train_hooks)
 
-    # Evaluate the model
-    eval_results = evaluate_model(
-        estimator, FLAGS.batch_size, num_gpus, ncf_dataset)
+      # Evaluate the model
+      eval_results = evaluate_model(
+          estimator, FLAGS.batch_size, num_gpus, ncf_dataset)
 
-    # Benchmark the evaluation results
-    benchmark_logger.log_evaluation_result(eval_results)
-    # Log the HR and NDCG results.
-    hr = eval_results[_HR_KEY]
-    ndcg = eval_results[_NDCG_KEY]
-    tf.logging.info(
-        "Iteration {}: HR = {:.4f}, NDCG = {:.4f}".format(
-            cycle_index + 1, hr, ndcg))
+      # Benchmark the evaluation results
+      benchmark_logger.log_evaluation_result(eval_results)
+      # Log the HR and NDCG results.
+      hr = eval_results[_HR_KEY]
+      ndcg = eval_results[_NDCG_KEY]
+      tf.logging.info(
+          "Iteration {}: HR = {:.4f}, NDCG = {:.4f}".format(
+              cycle_index + 1, hr, ndcg))
 
-    # If some evaluation threshold is met
-    if model_helpers.past_stop_threshold(FLAGS.hr_threshold, hr):
-      break
+      # If some evaluation threshold is met
+      if model_helpers.past_stop_threshold(FLAGS.hr_threshold, hr):
+        break
 
   # Clear the session explicitly to avoid session delete error
   tf.keras.backend.clear_session()

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -203,6 +203,7 @@ def main(_):
 
 
 def run_ncf(_):
+  """Run NCF training and eval loop."""
   # Data preprocessing
   # The file name of training and test dataset
   train_fname = os.path.join(

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -198,6 +198,11 @@ def per_device_batch_size(batch_size, num_gpus):
 
 
 def main(_):
+  with logger.benchmark_context(FLAGS):
+    run_ncf(FLAGS)
+
+
+def run_ncf(_):
   # Data preprocessing
   # The file name of training and test dataset
   train_fname = os.path.join(
@@ -237,7 +242,7 @@ def main(_):
       "hr_threshold": FLAGS.hr_threshold,
       "train_epochs": FLAGS.train_epochs,
   }
-  benchmark_logger = logger.config_benchmark_logger(FLAGS)
+  benchmark_logger = logger.get_benchmark_logger()
   benchmark_logger.log_run_info(
       model_name="recommendation",
       dataset_name=FLAGS.dataset,
@@ -251,30 +256,29 @@ def main(_):
 
   total_training_cycle = FLAGS.train_epochs // FLAGS.epochs_between_evals
 
-  with logger.benchmark_context(benchmark_logger):
-    for cycle_index in range(total_training_cycle):
-      tf.logging.info("Starting a training cycle: {}/{}".format(
-          cycle_index + 1, total_training_cycle))
+  for cycle_index in range(total_training_cycle):
+    tf.logging.info("Starting a training cycle: {}/{}".format(
+        cycle_index + 1, total_training_cycle))
 
-      # Train the model
-      estimator.train(input_fn=train_input_fn, hooks=train_hooks)
+    # Train the model
+    estimator.train(input_fn=train_input_fn, hooks=train_hooks)
 
-      # Evaluate the model
-      eval_results = evaluate_model(
-          estimator, FLAGS.batch_size, num_gpus, ncf_dataset)
+    # Evaluate the model
+    eval_results = evaluate_model(
+        estimator, FLAGS.batch_size, num_gpus, ncf_dataset)
 
-      # Benchmark the evaluation results
-      benchmark_logger.log_evaluation_result(eval_results)
-      # Log the HR and NDCG results.
-      hr = eval_results[_HR_KEY]
-      ndcg = eval_results[_NDCG_KEY]
-      tf.logging.info(
-          "Iteration {}: HR = {:.4f}, NDCG = {:.4f}".format(
-              cycle_index + 1, hr, ndcg))
+    # Benchmark the evaluation results
+    benchmark_logger.log_evaluation_result(eval_results)
+    # Log the HR and NDCG results.
+    hr = eval_results[_HR_KEY]
+    ndcg = eval_results[_NDCG_KEY]
+    tf.logging.info(
+        "Iteration {}: HR = {:.4f}, NDCG = {:.4f}".format(
+            cycle_index + 1, hr, ndcg))
 
-      # If some evaluation threshold is met
-      if model_helpers.past_stop_threshold(FLAGS.hr_threshold, hr):
-        break
+    # If some evaluation threshold is met
+    if model_helpers.past_stop_threshold(FLAGS.hr_threshold, hr):
+      break
 
   # Clear the session explicitly to avoid session delete error
   tf.keras.backend.clear_session()

--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -25,6 +25,7 @@ from absl import flags
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.utils.flags import core as flags_core
+from official.utils.logs import logger
 from official.resnet import resnet_model
 from official.resnet import resnet_run_loop
 
@@ -236,14 +237,14 @@ def run_cifar(flags_obj):
   """
   input_function = (flags_obj.use_synthetic_data and get_synth_input_fn()
                     or input_fn)
-
   resnet_run_loop.resnet_main(
       flags_obj, cifar10_model_fn, input_function, DATASET_NAME,
       shape=[_HEIGHT, _WIDTH, _NUM_CHANNELS])
 
 
 def main(_):
-  run_cifar(flags.FLAGS)
+  with logger.benchmark_context(flags.FLAGS):
+    run_cifar(flags.FLAGS)
 
 
 if __name__ == '__main__':

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -25,6 +25,7 @@ from absl import flags
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.utils.flags import core as flags_core
+from official.utils.logs import logger
 from official.resnet import imagenet_preprocessing
 from official.resnet import resnet_model
 from official.resnet import resnet_run_loop
@@ -321,7 +322,8 @@ def run_imagenet(flags_obj):
 
 
 def main(_):
-  run_imagenet(flags.FLAGS)
+  with logger.benchmark_context(flags.FLAGS):
+    run_imagenet(flags.FLAGS)
 
 
 if __name__ == '__main__':

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -415,32 +415,32 @@ def resnet_main(
         batch_size=per_device_batch_size(
             flags_obj.batch_size, flags_core.get_num_gpus(flags_obj)),
         num_epochs=1)
+  with logger.benchmark_context(benchmark_logger):
+    total_training_cycle = (flags_obj.train_epochs //
+                            flags_obj.epochs_between_evals)
+    for cycle_index in range(total_training_cycle):
+      tf.logging.info('Starting a training cycle: %d/%d',
+                      cycle_index, total_training_cycle)
 
-  total_training_cycle = (flags_obj.train_epochs //
-                          flags_obj.epochs_between_evals)
-  for cycle_index in range(total_training_cycle):
-    tf.logging.info('Starting a training cycle: %d/%d',
-                    cycle_index, total_training_cycle)
+      classifier.train(input_fn=input_fn_train, hooks=train_hooks,
+                       max_steps=flags_obj.max_train_steps)
 
-    classifier.train(input_fn=input_fn_train, hooks=train_hooks,
-                     max_steps=flags_obj.max_train_steps)
+      tf.logging.info('Starting to evaluate.')
 
-    tf.logging.info('Starting to evaluate.')
+      # flags_obj.max_train_steps is generally associated with testing and
+      # profiling. As a result it is frequently called with synthetic data,
+      # which will iterate forever. Passing steps=flags_obj.max_train_steps
+      # allows the eval (which is generally unimportant in those circumstances)
+      # to terminate. Note that eval will run for max_train_steps each loop,
+      # regardless of the global_step count.
+      eval_results = classifier.evaluate(input_fn=input_fn_eval,
+                                         steps=flags_obj.max_train_steps)
 
-    # flags_obj.max_train_steps is generally associated with testing and
-    # profiling. As a result it is frequently called with synthetic data, which
-    # will iterate forever. Passing steps=flags_obj.max_train_steps allows the
-    # eval (which is generally unimportant in those circumstances) to terminate.
-    # Note that eval will run for max_train_steps each loop, regardless of the
-    # global_step count.
-    eval_results = classifier.evaluate(input_fn=input_fn_eval,
-                                       steps=flags_obj.max_train_steps)
+      benchmark_logger.log_evaluation_result(eval_results)
 
-    benchmark_logger.log_evaluation_result(eval_results)
-
-    if model_helpers.past_stop_threshold(
-        flags_obj.stop_threshold, eval_results['accuracy']):
-      break
+      if model_helpers.past_stop_threshold(
+          flags_obj.stop_threshold, eval_results['accuracy']):
+        break
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -427,11 +427,11 @@ def resnet_main(
     tf.logging.info('Starting to evaluate.')
 
     # flags_obj.max_train_steps is generally associated with testing and
-    # profiling. As a result it is frequently called with synthetic data,
-    # which will iterate forever. Passing steps=flags_obj.max_train_steps
-    # allows the eval (which is generally unimportant in those circumstances)
-    # to terminate. Note that eval will run for max_train_steps each loop,
-    # regardless of the global_step count.
+    # profiling. As a result it is frequently called with synthetic data, which
+    # will iterate forever. Passing steps=flags_obj.max_train_steps allows the
+    # eval (which is generally unimportant in those circumstances) to terminate.
+    # Note that eval will run for max_train_steps each loop, regardless of the
+    # global_step count.
     eval_results = classifier.evaluate(input_fn=input_fn_eval,
                                        steps=flags_obj.max_train_steps)
 

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -395,7 +395,7 @@ def resnet_main(
       'synthetic_data': flags_obj.use_synthetic_data,
       'train_epochs': flags_obj.train_epochs,
   }
-  benchmark_logger = logger.config_benchmark_logger(flags_obj)
+  benchmark_logger = logger.get_benchmark_logger()
   benchmark_logger.log_run_info('resnet', dataset_name, run_params)
 
   train_hooks = hooks_helper.get_train_hooks(
@@ -415,32 +415,31 @@ def resnet_main(
         batch_size=per_device_batch_size(
             flags_obj.batch_size, flags_core.get_num_gpus(flags_obj)),
         num_epochs=1)
-  with logger.benchmark_context(benchmark_logger):
-    total_training_cycle = (flags_obj.train_epochs //
-                            flags_obj.epochs_between_evals)
-    for cycle_index in range(total_training_cycle):
-      tf.logging.info('Starting a training cycle: %d/%d',
-                      cycle_index, total_training_cycle)
+  total_training_cycle = (flags_obj.train_epochs //
+                          flags_obj.epochs_between_evals)
+  for cycle_index in range(total_training_cycle):
+    tf.logging.info('Starting a training cycle: %d/%d',
+                    cycle_index, total_training_cycle)
 
-      classifier.train(input_fn=input_fn_train, hooks=train_hooks,
-                       max_steps=flags_obj.max_train_steps)
+    classifier.train(input_fn=input_fn_train, hooks=train_hooks,
+                     max_steps=flags_obj.max_train_steps)
 
-      tf.logging.info('Starting to evaluate.')
+    tf.logging.info('Starting to evaluate.')
 
-      # flags_obj.max_train_steps is generally associated with testing and
-      # profiling. As a result it is frequently called with synthetic data,
-      # which will iterate forever. Passing steps=flags_obj.max_train_steps
-      # allows the eval (which is generally unimportant in those circumstances)
-      # to terminate. Note that eval will run for max_train_steps each loop,
-      # regardless of the global_step count.
-      eval_results = classifier.evaluate(input_fn=input_fn_eval,
-                                         steps=flags_obj.max_train_steps)
+    # flags_obj.max_train_steps is generally associated with testing and
+    # profiling. As a result it is frequently called with synthetic data,
+    # which will iterate forever. Passing steps=flags_obj.max_train_steps
+    # allows the eval (which is generally unimportant in those circumstances)
+    # to terminate. Note that eval will run for max_train_steps each loop,
+    # regardless of the global_step count.
+    eval_results = classifier.evaluate(input_fn=input_fn_eval,
+                                       steps=flags_obj.max_train_steps)
 
-      benchmark_logger.log_evaluation_result(eval_results)
+    benchmark_logger.log_evaluation_result(eval_results)
 
-      if model_helpers.past_stop_threshold(
-          flags_obj.stop_threshold, eval_results['accuracy']):
-        break
+    if model_helpers.past_stop_threshold(
+        flags_obj.stop_threshold, eval_results['accuracy']):
+      break
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.

--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -436,7 +436,7 @@ def run_transformer(flags_obj):
       tensors_to_log=TENSORS_TO_LOG,  # used for logging hooks
       batch_size=params.batch_size  # for ExamplesPerSecondHook
   )
-  benchmark_logger = logger.config_benchmark_logger(flags_obj)
+  benchmark_logger = logger.get_benchmark_logger()
   benchmark_logger.log_run_info(
       model_name="transformer",
       dataset_name="wmt_translate_ende",
@@ -445,24 +445,25 @@ def run_transformer(flags_obj):
   # Train and evaluate transformer model
   estimator = tf.estimator.Estimator(
       model_fn=model_fn, model_dir=flags_obj.model_dir, params=params)
-  with logger.benchmark_context(benchmark_logger):
-    train_schedule(
-        estimator=estimator,
-        # Training arguments
-        train_eval_iterations=train_eval_iterations,
-        single_iteration_train_steps=single_iteration_train_steps,
-        single_iteration_train_epochs=single_iteration_train_epochs,
-        train_hooks=train_hooks,
-        benchmark_logger=benchmark_logger,
-        # BLEU calculation arguments
-        bleu_source=flags_obj.bleu_source,
-        bleu_ref=flags_obj.bleu_ref,
-        bleu_threshold=flags_obj.stop_threshold,
-        vocab_file_path=os.path.join(flags_obj.data_dir, flags_obj.vocab_file))
+
+  train_schedule(
+      estimator=estimator,
+      # Training arguments
+      train_eval_iterations=train_eval_iterations,
+      single_iteration_train_steps=single_iteration_train_steps,
+      single_iteration_train_epochs=single_iteration_train_epochs,
+      train_hooks=train_hooks,
+      benchmark_logger=benchmark_logger,
+      # BLEU calculation arguments
+      bleu_source=flags_obj.bleu_source,
+      bleu_ref=flags_obj.bleu_ref,
+      bleu_threshold=flags_obj.stop_threshold,
+      vocab_file_path=os.path.join(flags_obj.data_dir, flags_obj.vocab_file))
 
 
 def main(_):
-  run_transformer(flags.FLAGS)
+  with logger.benchmark_context(flags.FLAGS):
+    run_transformer(flags.FLAGS)
 
 
 if __name__ == "__main__":

--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -445,19 +445,20 @@ def run_transformer(flags_obj):
   # Train and evaluate transformer model
   estimator = tf.estimator.Estimator(
       model_fn=model_fn, model_dir=flags_obj.model_dir, params=params)
-  train_schedule(
-      estimator=estimator,
-      # Training arguments
-      train_eval_iterations=train_eval_iterations,
-      single_iteration_train_steps=single_iteration_train_steps,
-      single_iteration_train_epochs=single_iteration_train_epochs,
-      train_hooks=train_hooks,
-      benchmark_logger=benchmark_logger,
-      # BLEU calculation arguments
-      bleu_source=flags_obj.bleu_source,
-      bleu_ref=flags_obj.bleu_ref,
-      bleu_threshold=flags_obj.stop_threshold,
-      vocab_file_path=os.path.join(flags_obj.data_dir, flags_obj.vocab_file))
+  with logger.benchmark_context(benchmark_logger):
+    train_schedule(
+        estimator=estimator,
+        # Training arguments
+        train_eval_iterations=train_eval_iterations,
+        single_iteration_train_steps=single_iteration_train_steps,
+        single_iteration_train_epochs=single_iteration_train_epochs,
+        train_hooks=train_hooks,
+        benchmark_logger=benchmark_logger,
+        # BLEU calculation arguments
+        bleu_source=flags_obj.bleu_source,
+        bleu_ref=flags_obj.bleu_ref,
+        bleu_threshold=flags_obj.stop_threshold,
+        vocab_file_path=os.path.join(flags_obj.data_dir, flags_obj.vocab_file))
 
 
 def main(_):

--- a/official/utils/flags/_benchmark.py
+++ b/official/utils/flags/_benchmark.py
@@ -67,6 +67,12 @@ def define_benchmark(benchmark_log_dir=True, bigquery_uploader=True):
                        "information will be uploaded."))
 
     flags.DEFINE_string(
+        name="bigquery_run_status_table", short_name="brst",
+        default="benchmark_run_status",
+        help=help_wrap("The Bigquery table name where the benchmark run "
+                       "status information will be uploaded."))
+
+    flags.DEFINE_string(
         name="bigquery_metric_table", short_name="bmt",
         default="benchmark_metric",
         help=help_wrap("The Bigquery table name where the benchmark metric "

--- a/official/utils/logs/logger.py
+++ b/official/utils/logs/logger.py
@@ -66,6 +66,7 @@ def config_benchmark_logger(flag_obj=None):
           bigquery_uploader=bq_uploader,
           bigquery_data_set=flag_obj.bigquery_data_set,
           bigquery_run_table=flag_obj.bigquery_run_table,
+          bigquery_run_status_table=flag_obj.bigquery_run_status_table,
           bigquery_metric_table=flag_obj.bigquery_metric_table,
           run_id=str(uuid.uuid4()))
     else:
@@ -177,7 +178,6 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
         include hyperparameters or other params that are important for the run.
     """
     run_info = _gather_run_info(model_name, dataset_name, run_params)
-    run_info["status"] = "running"
 
     with tf.gfile.GFile(os.path.join(
         self._logging_dir, BENCHMARK_RUN_LOG_FILE_NAME), "w") as f:
@@ -189,15 +189,7 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
                            e)
 
   def on_finish(self):
-    """Update the run log file with status 'success'."""
-    with tf.gfile.GFile(os.path.join(
-        self._logging_dir, BENCHMARK_RUN_LOG_FILE_NAME), "r") as f:
-      run_info = json.load(f)
-    run_info["status"] = "success"
-    with tf.gfile.GFile(os.path.join(
-        self._logging_dir, BENCHMARK_RUN_LOG_FILE_NAME), "w") as f:
-      json.dump(run_info, f)
-      f.write("\n")
+    pass
 
 
 class BenchmarkBigQueryLogger(BaseBenchmarkLogger):
@@ -207,12 +199,14 @@ class BenchmarkBigQueryLogger(BaseBenchmarkLogger):
                bigquery_uploader,
                bigquery_data_set,
                bigquery_run_table,
+               bigquery_run_status_table,
                bigquery_metric_table,
                run_id):
     super(BenchmarkBigQueryLogger, self).__init__()
     self._bigquery_uploader = bigquery_uploader
     self._bigquery_data_set = bigquery_data_set
     self._bigquery_run_table = bigquery_run_table
+    self._bigquery_run_status_table = bigquery_run_status_table
     self._bigquery_metric_table = bigquery_metric_table
     self._run_id = run_id
 
@@ -252,7 +246,6 @@ class BenchmarkBigQueryLogger(BaseBenchmarkLogger):
         include hyperparameters or other params that are important for the run.
     """
     run_info = _gather_run_info(model_name, dataset_name, run_params)
-    run_info["status"] = "running"
     # Starting new thread for bigquery upload in case it might take long time
     # and impact the benchmark and performance measurement. Starting a new
     # thread might have potential performance impact for model that run on CPU.
@@ -262,12 +255,18 @@ class BenchmarkBigQueryLogger(BaseBenchmarkLogger):
          self._bigquery_run_table,
          self._run_id,
          run_info))
+    thread.start_new_thread(
+        self._bigquery_uploader.insert_run_status,
+        (self._bigquery_data_set,
+         self._bigquery_run_status_table,
+         self._run_id,
+         "running"))
 
   def on_finish(self):
     thread.start_new_thread(
         self._bigquery_uploader.update_run_status,
         (self._bigquery_data_set,
-         self._bigquery_run_table,
+         self._bigquery_run_status_table,
          self._run_id,
          "success"))
 

--- a/official/utils/logs/logger.py
+++ b/official/utils/logs/logger.py
@@ -144,7 +144,7 @@ class BaseBenchmarkLogger(object):
     tf.logging.info("Benchmark run: %s",
                     _gather_run_info(model_name, dataset_name, run_params))
 
-  def on_finish(self):
+  def on_finish(self, status):
     pass
 
 
@@ -204,7 +204,7 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
         tf.logging.warning("Failed to dump benchmark run info to log file: %s",
                            e)
 
-  def on_finish(self):
+  def on_finish(self, status):
     pass
 
 
@@ -278,13 +278,13 @@ class BenchmarkBigQueryLogger(BaseBenchmarkLogger):
          self._run_id,
          RUN_STATUS_RUNNING))
 
-  def on_finish(self):
+  def on_finish(self, status):
     thread.start_new_thread(
         self._bigquery_uploader.update_run_status,
         (self._bigquery_data_set,
          self._bigquery_run_status_table,
          self._run_id,
-         RUN_STATUS_SUCCESS))
+         status))
 
 
 def _gather_run_info(model_name, dataset_name, run_params):

--- a/official/utils/logs/logger.py
+++ b/official/utils/logs/logger.py
@@ -89,8 +89,9 @@ def get_benchmark_logger():
 
 
 @contextlib.contextmanager
-def benchmark_context(benchmark_logger):
+def benchmark_context(flag_obj):
   """Context of benchmark, which will update status of the run accordingly."""
+  benchmark_logger = config_benchmark_logger(flag_obj)
   try:
     yield
     benchmark_logger.on_finish(RUN_STATUS_SUCCESS)

--- a/official/utils/logs/logger_test.py
+++ b/official/utils/logs/logger_test.py
@@ -347,12 +347,12 @@ class BenchmarkBigQueryLoggerTest(tf.test.TestCase):
         "dataset", "run_status_table", "run_id", "running")
 
   def test_on_finish(self):
-    self.logger.on_finish()
+    self.logger.on_finish(logger.RUN_STATUS_SUCCESS)
     # log_metric will call upload_benchmark_metric_json in a separate thread.
     # Give it some grace period for the new thread before assert.
     time.sleep(1)
     self.mock_bq_uploader.update_run_status.assert_called_once_with(
-        "dataset", "run_status_table", "run_id", "success")
+        "dataset", "run_status_table", "run_id", logger.RUN_STATUS_SUCCESS)
 
 
 if __name__ == "__main__":

--- a/official/utils/logs/logger_test.py
+++ b/official/utils/logs/logger_test.py
@@ -200,6 +200,45 @@ class BenchmarkFileLoggerTest(tf.test.TestCase):
     metric_log = os.path.join(log_dir, "metric.log")
     self.assertFalse(tf.gfile.Exists(metric_log))
 
+  @mock.patch("official.utils.logs.logger._gather_run_info")
+  def test_log_run_info(self, mock_gather_run_info):
+    log_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
+    log = logger.BenchmarkFileLogger(log_dir)
+    run_info = {"model_name": "model_name",
+                "dataset": "dataset_name",
+                "run_info": "run_value"}
+    mock_gather_run_info.return_value = run_info
+    log.log_run_info("model_name", "dataset_name", {})
+
+    run_log = os.path.join(log_dir, "benchmark_run.log")
+    self.assertTrue(tf.gfile.Exists(run_log))
+    with tf.gfile.GFile(run_log) as f:
+      run_info = json.loads(f.readline())
+      self.assertEqual(run_info["status"], "running")
+      self.assertEqual(run_info["model_name"], "model_name")
+      self.assertEqual(run_info["dataset"], "dataset_name")
+      self.assertEqual(run_info["run_info"], "run_value")
+
+  @mock.patch("official.utils.logs.logger._gather_run_info")
+  def test_on_finish(self, mock_gather_run_info):
+    log_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
+    log = logger.BenchmarkFileLogger(log_dir)
+    run_info = {"model_name": "model_name",
+                "dataset": "dataset_name",
+                "run_info": "run_value"}
+    mock_gather_run_info.return_value = run_info
+    log.log_run_info("model_name", "dataset_name", {})
+    log.on_finish()
+
+    run_log = os.path.join(log_dir, "benchmark_run.log")
+    self.assertTrue(tf.gfile.Exists(run_log))
+    with tf.gfile.GFile(run_log) as f:
+      run_info = json.loads(f.readline())
+      self.assertEqual(run_info["status"], "success")
+      self.assertEqual(run_info["model_name"], "model_name")
+      self.assertEqual(run_info["dataset"], "dataset_name")
+      self.assertEqual(run_info["run_info"], "run_value")
+
   def test_collect_tensorflow_info(self):
     run_info = {}
     logger._collect_tensorflow_info(run_info)
@@ -299,6 +338,14 @@ class BenchmarkBigQueryLoggerTest(tf.test.TestCase):
     time.sleep(1)
     self.mock_bq_uploader.upload_benchmark_metric_json.assert_called_once_with(
         "dataset", "metric_table", "run_id", expected_metric_json)
+
+  def test_on_finish(self):
+    self.logger.on_finish()
+    # log_metric will call upload_benchmark_metric_json in a separate thread.
+    # Give it some grace period for the new thread before assert.
+    time.sleep(1)
+    self.mock_bq_uploader.update_run_status.assert_called_once_with(
+        "dataset", "run_table", "run_id", "success")
 
 
 if __name__ == "__main__":

--- a/official/utils/logs/logger_test.py
+++ b/official/utils/logs/logger_test.py
@@ -72,16 +72,20 @@ class BenchmarkLoggerTest(tf.test.TestCase):
       self.assertIsInstance(logger.get_benchmark_logger(),
                             logger.BenchmarkBigQueryLogger)
 
-  def test_benchmark_context(self):
+  @mock.patch("official.utils.logs.logger.config_benchmark_logger")
+  def test_benchmark_context(self, mock_config_benchmark_logger):
     mock_logger = mock.MagicMock()
-    with logger.benchmark_context(mock_logger):
+    mock_config_benchmark_logger.return_value = mock_logger
+    with logger.benchmark_context(None):
       tf.logging.info("start benchmarking")
     mock_logger.on_finish.assert_called_once_with(logger.RUN_STATUS_SUCCESS)
 
-  def test_benchmark_context_failure(self):
+  @mock.patch("official.utils.logs.logger.config_benchmark_logger")
+  def test_benchmark_context_failure(self, mock_config_benchmark_logger):
     mock_logger = mock.MagicMock()
+    mock_config_benchmark_logger.return_value = mock_logger
     with self.assertRaises(RuntimeError):
-      with logger.benchmark_context(mock_logger):
+      with logger.benchmark_context(None):
         raise RuntimeError("training error")
     mock_logger.on_finish.assert_called_once_with(logger.RUN_STATUS_FAILURE)
 

--- a/official/utils/logs/logger_test.py
+++ b/official/utils/logs/logger_test.py
@@ -72,6 +72,19 @@ class BenchmarkLoggerTest(tf.test.TestCase):
       self.assertIsInstance(logger.get_benchmark_logger(),
                             logger.BenchmarkBigQueryLogger)
 
+  def test_benchmark_context(self):
+    mock_logger = mock.MagicMock()
+    with logger.benchmark_context(mock_logger):
+      tf.logging.info("start benchmarking")
+    mock_logger.on_finish.assert_called_once_with(logger.RUN_STATUS_SUCCESS)
+
+  def test_benchmark_context_failure(self):
+    mock_logger = mock.MagicMock()
+    with self.assertRaises(RuntimeError):
+      with logger.benchmark_context(mock_logger):
+        raise RuntimeError("training error")
+    mock_logger.on_finish.assert_called_once_with(logger.RUN_STATUS_FAILURE)
+
 
 class BaseBenchmarkLoggerTest(tf.test.TestCase):
 

--- a/official/wide_deep/wide_deep.py
+++ b/official/wide_deep/wide_deep.py
@@ -254,25 +254,26 @@ def run_wide_deep(flags_obj):
       tensors_to_log={'average_loss': loss_prefix + 'head/truediv',
                       'loss': loss_prefix + 'head/weighted_loss/Sum'})
 
-  # Train and evaluate the model every `flags.epochs_between_evals` epochs.
-  for n in range(flags_obj.train_epochs // flags_obj.epochs_between_evals):
-    model.train(input_fn=train_input_fn, hooks=train_hooks)
-    results = model.evaluate(input_fn=eval_input_fn)
+  with logger.benchmark_context(benchmark_logger):
+    # Train and evaluate the model every `flags.epochs_between_evals` epochs.
+    for n in range(flags_obj.train_epochs // flags_obj.epochs_between_evals):
+      model.train(input_fn=train_input_fn, hooks=train_hooks)
+      results = model.evaluate(input_fn=eval_input_fn)
 
-    # Display evaluation metrics
-    tf.logging.info('Results at epoch %d / %d',
-                    (n + 1) * flags_obj.epochs_between_evals,
-                    flags_obj.train_epochs)
-    tf.logging.info('-' * 60)
+      # Display evaluation metrics
+      tf.logging.info('Results at epoch %d / %d',
+                      (n + 1) * flags_obj.epochs_between_evals,
+                      flags_obj.train_epochs)
+      tf.logging.info('-' * 60)
 
-    for key in sorted(results):
-      tf.logging.info('%s: %s' % (key, results[key]))
+      for key in sorted(results):
+        tf.logging.info('%s: %s' % (key, results[key]))
 
-    benchmark_logger.log_evaluation_result(results)
+      benchmark_logger.log_evaluation_result(results)
 
-    if model_helpers.past_stop_threshold(
-        flags_obj.stop_threshold, results['accuracy']):
-      break
+      if model_helpers.past_stop_threshold(
+          flags_obj.stop_threshold, results['accuracy']):
+        break
 
   # Export the model
   if flags_obj.export_dir is not None:


### PR DESCRIPTION
The status is recorded into a separate bigquery table, due to the limit of streaming uploading of run that block the record from being updated. The new status table is only inserted/updated via standard SQL query.