### PR TITLE
Explicitly cast range function to list or tuple for Python 3 compatibility.

### DIFF
--- a/research/object_detection/utils/learning_schedules.py
+++ b/research/object_detection/utils/learning_schedules.py
@@ -157,7 +157,7 @@ def manual_stepping(global_step, boundaries, rates, warmup=False):
 
   if warmup and boundaries:
     slope = (rates[1] - rates[0]) * 1.0 / boundaries[0]
-    warmup_steps = range(boundaries[0])
+    warmup_steps = list(range(boundaries[0]))
     warmup_rates = [rates[0] + slope * step for step in warmup_steps]
     boundaries = warmup_steps + boundaries
     rates = warmup_rates + rates[1:]
@@ -165,7 +165,7 @@ def manual_stepping(global_step, boundaries, rates, warmup=False):
     boundaries = [0] + boundaries
   num_boundaries = len(boundaries)
   rate_index = tf.reduce_max(tf.where(tf.greater_equal(global_step, boundaries),
-                                      range(num_boundaries),
+                                      list(range(num_boundaries)),
                                       [0] * num_boundaries))
   return tf.reduce_sum(rates * tf.one_hot(rate_index, depth=num_boundaries),
                        name='learning_rate')

--- a/research/object_detection/utils/ops_test.py
+++ b/research/object_detection/utils/ops_test.py
@@ -838,7 +838,7 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     image_shape = [1, 3, 3, 4]
     crop_size = [2, 2]
 
-    image = tf.constant(range(1, 3 * 3 + 1), dtype=tf.float32,
+    image = tf.constant(tuple(range(1, 3 * 3 + 1)), dtype=tf.float32,
                         shape=[1, 3, 3, 1])
     tiled_image = tf.tile(image, [1, 1, 1, image_shape[3]])
     boxes = tf.random_uniform((3, 4))
@@ -929,7 +929,7 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     num_boxes = 2
 
     # First channel is 1's, second channel is 2's, etc.
-    image = tf.constant(range(1, 3 * 2 + 1) * 6, dtype=tf.float32,
+    image = tf.constant(tuple(range(1, 3 * 2 + 1)) * 6, dtype=tf.float32,
                         shape=image_shape)
     boxes = tf.random_uniform((num_boxes, 4))
     box_ind = tf.constant([0, 0], dtype=tf.int32)
@@ -967,7 +967,7 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     image_shape = [2, 2, 2, 4]
     crop_size = [2, 2]
 
-    image = tf.constant(range(1, 2 * 2 * 4  + 1) * 2, dtype=tf.float32,
+    image = tf.constant(tuple(range(1, 2 * 2 * 4 + 1)) * 2, dtype=tf.float32,
                         shape=image_shape)
 
     # First box contains whole image, and second box contains only first row.
@@ -1025,7 +1025,7 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     num_boxes = 2
 
     # First channel is 1's, second channel is 2's, etc.
-    image = tf.constant(range(1, 3 * 2 + 1) * 6, dtype=tf.float32,
+    image = tf.constant(tuple(range(1, 3 * 2 + 1)) * 6, dtype=tf.float32,
                         shape=image_shape)
     boxes = tf.random_uniform((num_boxes, 4))
     box_ind = tf.constant([0, 0], dtype=tf.int32)


### PR DESCRIPTION
Explicitly cast range function to list or tuple when the result is not used as an iterator. This makes the code Python 3 compatible.

This fixes an issue that I had running the Pet detector example with Python 3 and tensorflow 1.8. I tested the Pet detector example with tensorflow 1.8 and Python 3.6 locally and Python 3.5 on GC. This PR fixes the issues that I had.

Similar issue as #3465. Also related to the fixes suggested in #3705 and #3752.