### PR TITLE
Add license headers

### DIFF
--- a/official/boosted_trees/data_download.py
+++ b/official/boosted_trees/data_download.py
@@ -1,3 +1,17 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 """Downloads the UCI HIGGS Dataset and prepares train data.
 
 The details on the dataset are in https://archive.ics.uci.edu/ml/datasets/HIGGS

--- a/official/boosted_trees/train_higgs.py
+++ b/official/boosted_trees/train_higgs.py
@@ -1,3 +1,17 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 r"""A script that builds boosted trees over higgs data.
 
 If you haven't, please run data_download.py beforehand to prepare the data.


### PR DESCRIPTION
The lack of license headers is preventing official models from being packaged by cloud TPU.