### PR TITLE
Mock the bigquery client in the unit test.

### DIFF
--- a/official/utils/logs/logger_test.py
+++ b/official/utils/logs/logger_test.py
@@ -66,7 +66,8 @@ class BenchmarkLoggerTest(tf.test.TestCase):
                               logger.BenchmarkFileLogger)
 
   @unittest.skipIf(bigquery is None, 'Bigquery dependency is not installed.')
-  def test_config_benchmark_bigquery_logger(self):
+  @mock.patch.object(bigquery, "Client")
+  def test_config_benchmark_bigquery_logger(self, mock_bigquery_client):
     with flagsaver.flagsaver(benchmark_logger_type='BenchmarkBigQueryLogger'):
       logger.config_benchmark_logger()
       self.assertIsInstance(logger.get_benchmark_logger(),


### PR DESCRIPTION
This will prevent the unit test to read the local config of the GCP API, which does not necessary to exist for the test environment.