### PR TITLE
Fixing code-doc inconsistency

### DIFF
--- a/research/slim/nets/mobilenet/conv_blocks.py
+++ b/research/slim/nets/mobilenet/conv_blocks.py
@@ -321,7 +321,7 @@ def split_conv(input_tensor,
   """Creates a split convolution.
 
   Split convolution splits the input and output into
-  'num_blocks' blocks of approximately the same size each,
+  'num_ways' blocks of approximately the same size each,
   and only connects $i$-th input to $i$ output.
 
   Args:


### PR DESCRIPTION
The doc string should be consistent with the parameter names.