### PR TITLE
Pets' mask type should be default to `PNG_MASKS`

### DIFF
--- a/research/object_detection/samples/configs/mask_rcnn_resnet101_pets.config
+++ b/research/object_detection/samples/configs/mask_rcnn_resnet101_pets.config
@@ -137,6 +137,7 @@ train_input_reader: {
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
   load_instance_masks: true
+  mask_type: PNG_MASKS
 }
 
 eval_config: {
@@ -152,6 +153,7 @@ eval_input_reader: {
   }
   label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
   load_instance_masks: true
+  mask_type: PNG_MASKS
   shuffle: false
   num_readers: 1
 }


### PR DESCRIPTION
The pets data set provides PNG masks. The default mask type should be set to `PNG_MASKS` according to the input reader source code https://github.com/tensorflow/models/blob/master/research/object_detection/protos/input_reader.proto#L22. Currently, the setting is null, which means the default is `NUMERICAL_MASKS` according to https://github.com/tensorflow/models/blob/master/research/object_detection/protos/input_reader.proto#L20, which causes errors.

This issue hindered fresh users to train pets data set for instance segmentation. A friendly config file could save a lot of people's time.