### PR TITLE
Improve the BenchmarkFileLogger performance.

### DIFF
--- a/official/utils/logs/logger.py
+++ b/official/utils/logs/logger.py
@@ -162,6 +162,8 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
     self._logging_dir = logging_dir
     if not tf.gfile.IsDirectory(self._logging_dir):
       tf.gfile.MakeDirs(self._logging_dir)
+    self._metric_file_fh = tf.gfile.GFile(
+        os.path.join(self._logging_dir, METRIC_LOG_FILE_NAME), "a")
 
   def log_metric(self, name, value, unit=None, global_step=None, extras=None):
     """Log the benchmark metric information to local file.
@@ -179,14 +181,13 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
     """
     metric = _process_metric_to_json(name, value, unit, global_step, extras)
     if metric:
-      with tf.gfile.GFile(
-          os.path.join(self._logging_dir, METRIC_LOG_FILE_NAME), "a") as f:
-        try:
-          json.dump(metric, f)
-          f.write("\n")
-        except (TypeError, ValueError) as e:
-          tf.logging.warning("Failed to dump metric to log file: "
-                             "name %s, value %s, error %s", name, value, e)
+      try:
+        json.dump(metric, self._metric_file_fh)
+        self._metric_file_fh.write("\n")
+        self._metric_file_fh.flush()
+      except (TypeError, ValueError) as e:
+        tf.logging.warning("Failed to dump metric to log file: "
+                           "name %s, value %s, error %s", name, value, e)
 
   def log_run_info(self, model_name, dataset_name, run_params, test_id=None):
     """Collect most of the TF runtime information for the local env.
@@ -213,7 +214,8 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
                            e)
 
   def on_finish(self, status):
-    pass
+    self._metric_file_fh.flush()
+    self._metric_file_fh.close()
 
 
 class BenchmarkBigQueryLogger(BaseBenchmarkLogger):

--- a/official/utils/logs/logger.py
+++ b/official/utils/logs/logger.py
@@ -162,7 +162,7 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
     self._logging_dir = logging_dir
     if not tf.gfile.IsDirectory(self._logging_dir):
       tf.gfile.MakeDirs(self._logging_dir)
-    self._metric_file_fh = tf.gfile.GFile(
+    self._metric_file_handler = tf.gfile.GFile(
         os.path.join(self._logging_dir, METRIC_LOG_FILE_NAME), "a")
 
   def log_metric(self, name, value, unit=None, global_step=None, extras=None):
@@ -182,9 +182,9 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
     metric = _process_metric_to_json(name, value, unit, global_step, extras)
     if metric:
       try:
-        json.dump(metric, self._metric_file_fh)
-        self._metric_file_fh.write("\n")
-        self._metric_file_fh.flush()
+        json.dump(metric, self._metric_file_handler)
+        self._metric_file_handler.write("\n")
+        self._metric_file_handler.flush()
       except (TypeError, ValueError) as e:
         tf.logging.warning("Failed to dump metric to log file: "
                            "name %s, value %s, error %s", name, value, e)
@@ -214,8 +214,8 @@ class BenchmarkFileLogger(BaseBenchmarkLogger):
                            e)
 
   def on_finish(self, status):
-    self._metric_file_fh.flush()
-    self._metric_file_fh.close()
+    self._metric_file_handler.flush()
+    self._metric_file_handler.close()
 
 
 class BenchmarkBigQueryLogger(BaseBenchmarkLogger):


### PR DESCRIPTION
Open and preserve the file handler of the metric log file during
init, which reduce the overhead of open/close the file for each
log_metric call.