### PR TITLE
Clarified .bashrc Configuration in G3Doc Installation

### DIFF
--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -91,7 +91,8 @@ export PYTHONPATH=$PYTHONPATH:`pwd`:`pwd`/slim
 
 Note: This command needs to run from every new terminal you start. If you wish
 to avoid running this manually, you can add it as a new line to the end of your
-~/.bashrc file.
+~/.bashrc file, replacing \`pwd\` with the absolute path of
+tensorflow/models/research on your system.
 
 # Testing the Installation
 


### PR DESCRIPTION
Very minor documentation edit, but for those that are not overly familiar with `.bashrc` configuration I figured it's worth being explicit on what to do with the installation docs