### PR TITLE
Fix too much big value of default max_steps of 2560 epoch to 256 epoch

### DIFF
--- a/tutorials/image/cifar10/cifar10_train.py
+++ b/tutorials/image/cifar10/cifar10_train.py
@@ -48,7 +48,7 @@ FLAGS = tf.app.flags.FLAGS
 tf.app.flags.DEFINE_string('train_dir', '/tmp/cifar10_train',
                            """Directory where to write event logs """
                            """and checkpoint.""")
-tf.app.flags.DEFINE_integer('max_steps', 1000000,
+tf.app.flags.DEFINE_integer('max_steps', 100000,
                             """Number of batches to run.""")
 tf.app.flags.DEFINE_boolean('log_device_placement', False,
                             """Whether to log device placement.""")


### PR DESCRIPTION
the default max_step is set to 100000 which makes epoch 2560.
It confuses users whether 256 epoch or 2560 epoch.
256 epoch is presented as previous comments and example results.
Also cifar-10 and this kind of network written here doesn't need too many epoch.