### PR TITLE
Changing file doc for sample consistency

### DIFF
--- a/research/object_detection/eval.py
+++ b/research/object_detection/eval.py
@@ -27,7 +27,7 @@ Example usage:
         --logtostderr \
         --checkpoint_dir=path/to/checkpoint_dir \
         --eval_dir=path/to/eval_dir \
-        --pipeline_config_path=pipeline_config.pbtxt
+        --pipeline_config_path=pipeline_config.config
 
 2) Three configuration files may be provided: a model_pb2.DetectionModel
 configuration file to define what type of DetectionModel is being evaluated, an

--- a/research/object_detection/train.py
+++ b/research/object_detection/train.py
@@ -25,7 +25,7 @@ Example usage:
     ./train \
         --logtostderr \
         --train_dir=path/to/train_dir \
-        --pipeline_config_path=pipeline_config.pbtxt
+        --pipeline_config_path=pipeline_config.config
 
 2) Three configuration files can be provided: a model_pb2.DetectionModel
 configuration file to define what type of DetectionModel is being trained, an


### PR DESCRIPTION
Changing `.pbtxt` to `.config` to align with samples provided in `research\object_detection\samples\configs\`

Consistency will help avoid confusion when supplying pipeline file to train and eval scripts.

Files:
`research/object_detection/eval.py`
`research/object_detection/train.py`

___
Note:
`export_inference_graph.py` uses the consistent extensions proposed.
```
Example Usage:
--------------
python export_inference_graph \
    --input_type image_tensor \
    --pipeline_config_path path/to/ssd_inception_v2.config \
    --trained_checkpoint_prefix path/to/model.ckpt \
    --output_directory path/to/exported_model_directory
```

