### PR TITLE
Update resnet_v2.py

### DIFF
--- a/research/slim/nets/resnet_v2.py
+++ b/research/slim/nets/resnet_v2.py
@@ -246,7 +246,7 @@ def resnet_v2_block(scope, base_depth, num_units, stride):
       'depth_bottleneck': base_depth,
       'stride': stride
   }])
-resnet_v2.default_image_size = 224
+# resnet_v2.default_image_size = 224
 
 
 def resnet_v2_50(inputs,


### PR DESCRIPTION
I found a unnecessary set "resnet_v2.default_image_size = 224" at line 249 , because it has been set at line 224 .