### PR TITLE
np.Array to tf.data.Dataset using buffer files and decode_raw()

### DIFF
--- a/official/utils/data/buffer.py
+++ b/official/utils/data/buffer.py
@@ -137,7 +137,7 @@ class _ArrayBytesView(object):
     x_view = memoryview(source_array)
 
     if six.PY3:
-      nbytes = x_view.nbytes
+      nbytes = x_view.nbytes  # pylint: disable=no-member
     else:
       nbytes = int(np.product(x_view.shape) * x_view.itemsize)
 
@@ -213,7 +213,7 @@ class _FileBackedArrayBytesView(_ArrayBytesView):
         f.write(chunk)
 
   def to_dataset(self, decode_procs=2, decode_batch_size=16,
-      extra_map_fn=None, unbatch=True):
+                 extra_map_fn=None, unbatch=True):
     """Create a Dataset from the underlying buffer file.
 
     Args:

--- a/official/utils/data/buffer.py
+++ b/official/utils/data/buffer.py
@@ -1,0 +1,292 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Create TensorFlow Datasets from NumPy binary buffers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import atexit
+import tempfile
+import uuid
+
+import numpy as np
+import six
+import tensorflow as tf
+
+# I'm sure these already exist somewhere, but for now this is expedient.
+_NP_DTYPE_MAP = {
+    "uint8": np.uint8,
+    "uint16": np.uint16,
+    "int8": np.int8,
+    "int32": np.int32,
+    "int64": np.int64,
+    "float32": np.float32,
+}
+
+_TF_DTYPE_MAP = {
+    "uint8": tf.uint8,
+    "uint16": tf.uint16,
+    "int8": tf.int8,
+    "int32": tf.int32,
+    "int64": tf.int64,
+    "float32": tf.float32,
+}
+
+# NumPy arrays are written to the underlying file in chunks to prevent
+# I/O latency from bottlenecking.
+_DEFAULT_CHUNK_SIZE = 1024 ** 2  # 1 MB
+
+
+def _cleanup_buffer_file(path):
+  try:
+    if tf.gfile.Exists(path):
+      tf.gfile.Remove(path)
+      tf.logging.info("Buffer file {} removed".format(path))
+  except Exception as e:
+    tf.logging.error(
+        "Failed to cleanup temp file {}. Exception: {}".format(path, e))
+
+
+class _CleanupManager(object):
+  """Prevent buildup over the course of execution.
+
+  This module is responsible for creating large blocks of bytes, either as
+  buffer files or bytes in memory. Over the course of a long execution, these
+  artifacts can accumulate and cause various issues. The purpose of this class
+  is to provide an interface for a user to indicate that a view is no longer
+  needed, and may be spun down. Otherwise they will be cleaned up at program
+  exit.
+  """
+  def __init__(self):
+    self.views = {}
+
+  def register(self, name, view):
+    if name in self.views:
+      raise ValueError("Name '{}' is already registered. Call `cleanup()` to "
+                       "reuse namespaces.".format(name))
+    self.views[name] = view
+
+  def cleanup(self, name):
+    if name not in self.views:
+      return
+
+    view, self.views[name] = self.views[name], None
+    view.cleanup()
+    del view
+    self.views.pop(name)
+
+  def purge(self):
+    view_names = list(self.views.keys())
+    for i in view_names:
+      try:
+        self.cleanup(i)
+      except Exception as e:
+        tf.logging.error("Failed to cleanup view: {} Continuing.".format(e))
+
+
+_CLEANUP_MANAGER = _CleanupManager()
+def cleanup(name):
+  return _CLEANUP_MANAGER.cleanup(name=name)
+
+def purge():
+  _CLEANUP_MANAGER.purge()
+atexit.register(purge)
+
+
+class _ArrayBytesView(object):
+  """Helper class for moving numpy array data into TensorFlow Datasets."""
+
+  def __init__(self, source_array):
+    """Check array and store key invariants.
+
+    This class should not "hold onto" a source array; it simply records all
+    relevant information. Subclasses may choose to copy the underlying data
+    or work directly with the source_array (including locking it), but the base
+    class does not assume any claim of ownership of the source array.
+
+    Args:
+      source_array: NumPy array to be converted into a dataset.
+    """
+    assert isinstance(source_array, np.ndarray)
+    assert source_array.shape
+    assert source_array.shape[0] > 0
+    assert source_array.dtype.name in _NP_DTYPE_MAP
+    assert source_array.dtype.name in _TF_DTYPE_MAP
+    assert source_array.flags.c_contiguous
+
+    self._rows = source_array.shape[0]
+    self._row_shape = (1,) + source_array.shape[1:]
+    self._values_per_row = int(np.product(self._row_shape))
+
+    self._np_dtype = source_array.dtype
+    self._tf_dtype = _TF_DTYPE_MAP[source_array.dtype.name]
+
+    x_view = memoryview(source_array)
+
+    if six.PY3:
+      nbytes = x_view.nbytes
+    else:
+      nbytes = int(np.product(x_view.shape) * x_view.itemsize)
+
+    assert nbytes % self._rows == 0
+    self._bytes_per_row = int(nbytes / self._rows)
+    del x_view
+
+  def cleanup(self):
+    pass
+
+  @property
+  def rows(self):
+    return self._rows
+
+  @property
+  def row_shape(self):
+    return self._row_shape
+
+  @property
+  def bytes_per_row(self):
+    return self._bytes_per_row
+
+  @property
+  def tf_dtype(self):
+    return self._tf_dtype
+
+
+class _FileBackedArrayBytesView(_ArrayBytesView):
+  """Write a NumPy array buffer to a file, and then make a dataset from it."""
+
+  def __init__(self, source_array, chunk_size=_DEFAULT_CHUNK_SIZE):
+    """Copy array bytes into a temporary buffer file.
+
+    Args:
+      source_array: NumPy array to be converted into a dataset.
+      chunk_size: data is copied from the array in approximately chunk_size
+        segments. This way if there is significant I/O latency (i.e. a
+        distributed file system) it is less likely to bottleneck the copy.
+    """
+    super(_FileBackedArrayBytesView, self).__init__(source_array)
+
+    # TODO(robieta): enable GCS buffer files
+    _, self._buffer_path = tempfile.mkstemp()
+    atexit.register(_cleanup_buffer_file, path=self._buffer_path)
+    self._write_buffer(source_array=source_array, chunk_size=chunk_size)
+
+  def cleanup(self):
+    _cleanup_buffer_file(path=self._buffer_path)
+
+  def _write_buffer(self, source_array, chunk_size):
+    """Dump NumPy array bytes to be used as the basis of a dataset.
+
+    Args:
+      source_array: NumPy array to be converted into a dataset.
+      chunk_size: The number of bytes written in a pass.
+    """
+    if tf.gfile.Stat(self._buffer_path).length != 0:
+      raise OSError("Buffer file {} exists and is not empty."
+                    .format(self._buffer_path))
+
+    rows_per_chunk = int(chunk_size // self.bytes_per_row)
+    if rows_per_chunk == 0:
+      tf.logging.warning(
+          "chunk_size {} is less than the size of a single row ({} bytes). "
+          "chunk_size will be rounded up to write one row at a time."
+          .format(chunk_size, self.bytes_per_row))
+
+    bytes_per_write = self.bytes_per_row * rows_per_chunk
+    with tf.gfile.Open(self._buffer_path, "wb") as f:
+      for i in range(int(np.ceil(self.rows / rows_per_chunk))):
+        chunk = bytes(
+            source_array.data[i * bytes_per_write:(i+1) * bytes_per_write])
+        f.write(chunk)
+
+  def to_dataset(self, decode_procs=2, decode_batch_size=16,
+      extra_map_fn=None, unbatch=True):
+    """Create a Dataset from the underlying buffer file.
+
+    Args:
+      decode_procs: Number of parallel decoding map workers called in the
+        constructed dataset. Two is often significantly faster than one, but
+        very little marginal benefit has been observed above two.
+    """
+    if not tf.gfile.Exists(self._buffer_path):
+      raise OSError("Array buffer does not exist.")
+
+    expected_length = self.rows * self.bytes_per_row
+    actual_length = tf.gfile.Stat(self._buffer_path).length
+
+    if expected_length != actual_length:
+      raise OSError("Array buffer has size {}. Expected size {}."
+                    .format(actual_length, expected_length))
+
+    dataset = tf.data.FixedLengthRecordDataset(
+        filenames=self._buffer_path, record_bytes=self.bytes_per_row,
+        buffer_size=decode_procs * decode_batch_size * self.bytes_per_row * 2)
+    dataset = dataset.batch(batch_size=decode_batch_size)
+
+    tf_dtype = self._tf_dtype
+    row_shape = self.row_shape
+
+    def deserialize(input_bytes):
+      flat_row = tf.decode_raw(input_bytes, out_type=tf_dtype)
+      output = tf.reshape(flat_row, (-1,) + row_shape[1:])
+      if extra_map_fn:
+        output = extra_map_fn(output)
+      return output
+
+    dataset = dataset.map(deserialize, num_parallel_calls=decode_procs)
+
+    if unbatch:
+      # This is equivalent to:
+      #     dataset = dataset.flat_map(tf.data.Dataset.from_tensor_slices)
+      # The apply() + unbatch() approach incurs a ~ 2 second overhead when
+      # the dataset is defined, but executes significantly faster than the
+      # from_tensor_slices() approach, and is therefore generally worth the
+      # wait.
+      dataset = dataset.apply(tf.contrib.data.unbatch())
+
+    return dataset
+
+
+def array_to_dataset(source_array, decode_procs=2, decode_batch_size=16,
+                     extra_map_fn=None, unbatch=True,
+                     namespace=None):
+  """Helper function to expose view class.
+
+  Args:
+    source_array: NumPy array to be converted into a dataset.
+    decode_procs: Number of parallel byte arrays to decode into tensors.
+    decode_batch_size: Number of rows worth of bytes to decode in a single
+      decode batch.
+    extra_map_fn: A map function to be applied after the raw bytes are decoded.
+      performing a map during this step is generally more efficient than
+      unbatching, performing a per element map, and then batching to the final
+      batch size.
+    unbatch: Whether to return single rows as elements (True) or batches of rows
+      (False) where the batch size is the decode_batch_size.
+    namespace: A key for the binary file that backs this dataset. This key is
+      used to signal that a dataset will no longer be used, and allow cleanup
+      of tempfiles throughout training.
+  """
+  if namespace is None:
+    namespace = str(uuid.uuid4().hex)
+
+  view = _FileBackedArrayBytesView(source_array=source_array)
+  _CLEANUP_MANAGER.register(name=namespace, view=view)
+
+  return view.to_dataset(decode_procs=decode_procs,
+                         decode_batch_size=decode_batch_size,
+                         extra_map_fn=extra_map_fn,
+                         unbatch=unbatch)

--- a/official/utils/data/buffer_test.py
+++ b/official/utils/data/buffer_test.py
@@ -1,0 +1,71 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Ensure that NumPy array to Dataset works as expected."""
+
+import numpy as np
+import tensorflow as tf
+
+from official.utils.data import buffer
+
+
+_NAMESPACE = "test_array"
+_NUM_ROWS = 100
+
+
+class BaseTest(tf.test.TestCase):
+  def setUp(self):
+    buffer.cleanup(_NAMESPACE)
+
+  def _compare_input_and_output(self, dtype):
+    shape = (_NUM_ROWS, 4)
+    min_val = np.iinfo(dtype).min
+    max_val = np.iinfo(dtype).max
+    if dtype.__name__.startswith("float"):
+      x = np.random.uniform(low=min_val, high=max_val, size=shape)
+    else:
+      x = np.random.randint(low=min_val, high=max_val, size=shape)
+
+    g = tf.Graph()
+
+    with g.as_default():
+      dataset = buffer.array_to_dataset(source_array=x, namespace=_NAMESPACE)
+
+    with self.test_session(graph=g) as sess:
+      row_op = dataset.make_one_shot_iterator().get_next()
+      for i in range(_NUM_ROWS):
+        row = sess.run(row_op)
+        self.assertAllClose(row, x[i, :])
+
+      with self.assertRaises(tf.errors.OutOfRangeError):
+        sess.run(row_op)
+
+  def test_uint8(self):
+    self._compare_input_and_output(dtype=np.uint8)
+
+  def test_uint16(self):
+    self._compare_input_and_output(dtype=np.uint16)
+
+  def test_int8(self):
+    self._compare_input_and_output(dtype=np.int8)
+
+  def test_int32(self):
+    self._compare_input_and_output(dtype=np.int32)
+
+  def test_int64(self):
+    self._compare_input_and_output(dtype=np.int64)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/official/utils/data/performance_comparison.py
+++ b/official/utils/data/performance_comparison.py
@@ -1,0 +1,228 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Compare run times for buffer and TFRecord based datasets."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import atexit
+import multiprocessing
+import tempfile
+import timeit
+
+import numpy as np
+import pandas as pd
+
+import tensorflow as tf
+
+from official.utils.data import buffer
+
+
+_BATCH_SIZE = 512
+_NUM_BATCHES = 15000
+_NUM_PTS = _BATCH_SIZE * _NUM_BATCHES
+_NUM_COLS = 6
+_DUMMY_KEY = "a"  # TFRecords has to include keys, so using a one letter ascii
+# key helps performance.
+
+_FEATURE_MAP = {
+    _DUMMY_KEY: tf.FixedLenFeature([_NUM_COLS], dtype=tf.int64),
+}
+
+
+def make_array():
+  """Construct data arrays for testing.
+
+  This function makes the same array from scratch. This way experiments are
+  guaranteed not to interact.
+  """
+  np.random.seed(1)
+  shape = (_NUM_PTS, _NUM_COLS)
+  return np.random.randint(0, 2 ** 8 - 1, shape, dtype=np.uint8)
+
+
+class TimeSections(object):
+  """Convenience context manager to time steps in the dataset process."""
+
+  def __init__(self):
+    self.section_times = {}
+    self.total_time = 0
+    self.current_section = None
+    self.start_time = -1
+
+  def name_section(self, name):
+    self.current_section = name
+
+  def __enter__(self):
+    self.start_time = timeit.default_timer()
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    run_time = timeit.default_timer() - self.start_time
+    if self.current_section is None:
+      self.current_section = "section_{}".format(len(self.section_times))
+    assert self.current_section not in self.section_times
+    self.section_times[self.current_section] = run_time
+    self.current_section = None
+
+
+def consume_dataset(dataset, source_array, num_parallel=16):
+  """Iterate through the dataset to test timing."""
+  dataset = dataset.batch(_BATCH_SIZE)
+  dataset = dataset.prefetch(1)
+
+  g = tf.Graph()
+  # print(len(str(g.as_graph_def()).encode("utf-8")))
+  with g.as_default():
+    row = dataset.make_one_shot_iterator().get_next()
+  # print(len(str(g.as_graph_def()).encode("utf-8")))
+
+  with tf.Session(graph=g).as_default() as sess:
+    for i in range(int(_NUM_BATCHES // num_parallel)):
+      results = sess.run([row for _ in range(num_parallel)])
+      if i == 0:
+        # Sanity check
+        assert np.allclose(results[0], source_array[:_BATCH_SIZE])
+
+
+def _deserialize(example_byte_tensor):
+  return tf.parse_single_example(example_byte_tensor, _FEATURE_MAP)[_DUMMY_KEY]
+
+
+def make_simple_tfrecord_experiment():
+  """Convert NumPy array to TFRecords using a single thread.
+
+  The task of serializing to TFRecords is naively parallelizable, but not
+  trivial to implement, requiring various sharding and multiprocessing
+  machinery. This is intended as a baseline of what can be accomplished fairly
+  easily.
+  """
+  data = make_array()
+  _, buffer_path = tempfile.mkstemp()
+  atexit.register(buffer._cleanup_buffer_file, path=buffer_path)
+  section_timer = TimeSections()
+
+  with section_timer as t:
+    t.name_section("serialize")
+    with tf.python_io.TFRecordWriter(buffer_path) as writer:
+      for row in data:
+        feature = tf.train.Feature(int64_list=tf.train.Int64List(value=row))
+        example = tf.train.Example(features=tf.train.Features(
+            feature={_DUMMY_KEY: feature}))
+        example_bytes = example.SerializeToString()
+        writer.write(example_bytes)
+
+  with section_timer as t:
+    t.name_section("define_dataset")
+    dataset = tf.data.TFRecordDataset(filenames=buffer_path)
+    dataset = dataset.map(_deserialize,
+                          num_parallel_calls=multiprocessing.cpu_count())
+
+  with section_timer as t:
+    t.name_section("consume")
+    consume_dataset(dataset, source_array=data)
+
+  return section_timer.section_times
+
+
+def _serialize_shard(shard):
+  # type: (np.ndarray) -> list
+  output = []
+  for row in shard:
+    feature = tf.train.Feature(int64_list=tf.train.Int64List(value=row))
+    example = tf.train.Example(features=tf.train.Features(
+        feature={_DUMMY_KEY: feature}))
+    example_bytes = example.SerializeToString()
+    output.append(example_bytes)
+  return output
+
+
+def make_tfrecord_parallel_experiment(num_cores=4):
+  """Serialize an example array into TFRecords."""
+  data = make_array()
+  section_timer = TimeSections()
+
+  boundaries = np.linspace(0, _NUM_PTS, num_cores+1).astype("int")
+  shards = []
+  for i in range(num_cores):
+    shards.append(data[boundaries[i]:boundaries[i+1]])
+
+  with section_timer as t:
+    t.name_section("serialize")
+    with multiprocessing.Pool(processes=num_cores) as pool:
+      encoded_shards = pool.map(_serialize_shard, shards)
+
+    _, buffer_path = tempfile.mkstemp()
+    atexit.register(buffer._cleanup_buffer_file, path=buffer_path)
+
+    with tf.python_io.TFRecordWriter(buffer_path) as writer:
+      for section in encoded_shards:
+        for example in section:
+          writer.write(example)
+
+
+  with section_timer as t:
+    t.name_section("define_dataset")
+    dataset = tf.data.TFRecordDataset(filenames=buffer_path)
+    dataset = dataset.map(_deserialize,
+                          num_parallel_calls=multiprocessing.cpu_count())
+
+  with section_timer as t:
+    t.name_section("consume")
+    consume_dataset(dataset, source_array=data)
+
+  return section_timer.section_times
+
+
+def make_file_buffer_experiment():
+  """Write a NumPy array buffer to a file and construct a dataset from it."""
+  data = make_array()
+  section_timer = TimeSections()
+
+  with section_timer as t:
+    t.name_section("serialize")
+    array_view = buffer._FileBackedArrayBytesView(source_array=data)
+
+  with section_timer as t:
+    t.name_section("define_dataset")
+    dataset = array_view.to_dataset(decode_procs=8, decode_batch_size=32)
+
+  with section_timer as t:
+    t.name_section("consume")
+    consume_dataset(dataset, source_array=data)
+
+  return section_timer.section_times
+
+
+def pretty_print(timings, name):
+  print(name)
+  print("Total: {:.2f}".format(sum([i for i in timings.values()])))
+  print("  Serialize:   {:.2f}".format(timings["serialize"]))
+  print("  Instantiate: {:.2f}".format(timings["define_dataset"]))
+  print("  Consume:     {:.2f}".format(timings["consume"]))
+  print()
+
+
+def main():
+  pretty_print(make_file_buffer_experiment(), "NumPy Buffer (file backed)")
+  num_cores = min([multiprocessing.cpu_count(), 8])
+  pretty_print(make_tfrecord_parallel_experiment(num_cores=num_cores),
+               "Parallel TFRecords (num_cores: {})".format(num_cores))
+  pretty_print(make_simple_tfrecord_experiment(), "Simple TFRecords.")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
This PR presents an initial implementation of an alternative to TFRecords as a format for feeding highly structured numeric data during training.

The context for this PR comes from performance tuning of NCF Recommendation (`official/recommendation`). NCF is arguably a worst case scenario for TFRecords:
1) New data must be generated each epoch, so the serialization is a per-epoch cost rather than a one-time upfront cost.
2) The amount of information per example is very small, consisting of one int32, one uint16, and one int8. So TFRecords is forced to spend 24 bytes to store 7 bytes of information.

I'm saving the refactor of NCF for a separate PR since it contains other optimizations and I don't want to clutter the discussion.

The basic approach is to write an array's binary buffer to a file, ingest the bytes using FixedLengthRecordDataset, and then use .map() and tf.decode_raw() to get the bytes into tensors. I experimented with using .from_generator() and a python generator that fed bytes and it was somewhat faster, but not much and involved doing dangerous things like hanging onto a memoryview() of a numpy array, so I abandoned that approach.

This is all implemented using the public API as I did not feel confident writing a new class in the c++ side, and time is somewhat important for the MLPerf deadline. However even as a strawman it performs quite well. I have included a script `official/utils/data/performance_comparison.py` that I don't intend to merge into master, but is useful for demonstration.

@mrry I'm curious what you think of this practice of looting the bytes from array buffers.