### PR TITLE
Update eval_util.py: force metrics to file

### DIFF
--- a/research/object_detection/eval_util.py
+++ b/research/object_detection/eval_util.py
@@ -48,6 +48,7 @@ def write_metrics(metrics, global_step, summary_dir):
         tf.Summary.Value(tag=key, simple_value=metrics[key]),
     ])
     summary_writer.add_summary(summary, global_step)
+    summary_writer.flush()
     logging.info('%s: %f', key, metrics[key])
   logging.info('Metrics written to tf summary.')
 


### PR DESCRIPTION
This fixes a problem when running evaluation with run_once. Examples get evaluated and logging shows the result, but the summary_writer doesn't write to disk.
Force the summary_writer to write the changes to file.