### PR TITLE
Fix MobileNet example notebook

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -239,7 +239,7 @@
         "image = tf.image.decode_jpeg(tf.read_file(file_input))\n",
         "\n",
         "images = tf.expand_dims(image, 0)\n",
-        "images = tf.cast(images, tf.float32) / 128.  - 1\n",
+        "images = tf.cast(images, tf.float32) / 127.5  - 1\n",
         "images.set_shape((None, None, None, 3))\n",
         "images = tf.image.resize_images(images, (224, 224))\n",
         "\n",
@@ -304,7 +304,7 @@
           "output_type": "stream",
           "text": [
             "INFO:tensorflow:Restoring parameters from mobilenet_v2_1.0_224.ckpt\n",
-            "Top 1 prediction:  389 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca 0.90984344\n"
+            "Top 1 prediction:  389 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca 0.8506243\n"
           ]
         }
       ],
@@ -316,7 +316,7 @@
         "display.display(display.Image('panda.jpg'))\n",
         "\n",
         "with tf.Session() as sess:\n",
-        "  saver.restore(sess,  checkpoint)\n",
+        "  saver.restore(sess, checkpoint)\n",
         "  x = endpoints['Predictions'].eval(feed_dict={file_input: 'panda.jpg'})\n",
         "label_map = imagenet.create_readable_names_for_imagenet_labels()  \n",
         "print(\"Top 1 prediction: \", x.argmax(),label_map[x.argmax()], x.max())\n"
@@ -348,9 +348,9 @@
       "outputs": [],
       "source": [
         "import numpy as np\n",
-        "img = np.array(PIL.Image.open('panda.jpg').resize((224, 224))).astype(np.float) / 128 - 1\n",
+        "img = np.array(PIL.Image.open('panda.jpg').resize((224, 224))).astype(np.float) / 127.5 - 1\n",
         "gd = tf.GraphDef.FromString(open(base_name + '_frozen.pb', 'rb').read())\n",
-        "inp, predictions = tf.import_graph_def(gd,  return_elements = ['input:0', 'MobilenetV2/Predictions/Reshape_1:0'])"
+        "inp, predictions = tf.import_graph_def(gd, return_elements = ['input:0', 'MobilenetV2/Predictions/Reshape_1:0'])"
       ]
     },
     {
@@ -388,7 +388,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Top 1 Prediction:  389 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca 0.9220208\n"
+            "Top 1 Prediction:  389 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca 0.89188564\n"
           ]
         }
       ],


### PR DESCRIPTION
According to [official source code](https://github.com/tensorflow/models/tree/master/research/slim/nets/mobilenet), inception's preprocessing is used during training time. So same method should be used for evaluation.

Note: this modification will decrease prediction accuracy, but increase fairness.