### PR TITLE
Use six and feature detection in string conversion

### DIFF
--- a/official/transformer/utils/tokenizer.py
+++ b/official/transformer/utils/tokenizer.py
@@ -202,17 +202,14 @@ def _load_vocab_file(vocab_file, reserved_tokens=None):
 
 def _native_to_unicode(s):
   """Convert string to unicode (required in Python 2)."""
-  if six.PY2:
-    return s if isinstance(s, unicode) else s.decode("utf-8")  # pylint: disable=undefined-variable
-  else:
-    return s
+  return six.ensure_text(s)
 
 
 def _unicode_to_native(s):
   """Convert string from unicode to native format (required in Python 2)."""
-  if six.PY2:
-    return s.encode("utf-8") if isinstance(s, unicode) else s  # pylint: disable=undefined-variable
-  else:
+  try:               # Python 2
+    return s.encode("utf-8") if isinstance(s, unicode) else s
+  except NameError:  # Python 3
     return s
 
 

--- a/official/transformer/utils/tokenizer.py
+++ b/official/transformer/utils/tokenizer.py
@@ -202,7 +202,10 @@ def _load_vocab_file(vocab_file, reserved_tokens=None):
 
 def _native_to_unicode(s):
   """Convert string to unicode (required in Python 2)."""
-  return six.ensure_text(s)
+  try:               # Python 2
+    return s if isinstance(s, unicode) else s.decode("utf-8")
+  except NameError:  # Python 3
+    return s
 
 
 def _unicode_to_native(s):


### PR DESCRIPTION
Leverage [__six.ensure_text()__](https://github.com/benjaminp/six/blob/master/six.py#L890) to deliver Unicode text in both Python 2 and Python 3.

Follow Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) in ___unicode_to_native()__.