### PR TITLE
Add shorter timeout for GCP util.

### DIFF
--- a/official/utils/logs/cloud_lib.py
+++ b/official/utils/logs/cloud_lib.py
@@ -25,6 +25,8 @@ GCP_METADATA_HEADER = {"Metadata-Flavor": "Google"}
 def on_gcp():
   """Detect whether the current running environment is on GCP."""
   try:
+    # Timeout in 5 seconds, in case the test environment has connectivity issue.
+    # There is not default timeout, which means it might block forever.
     response = requests.get(
         GCP_METADATA_URL, headers=GCP_METADATA_HEADER, timeout=5)
     return response.status_code == 200

--- a/official/utils/logs/cloud_lib.py
+++ b/official/utils/logs/cloud_lib.py
@@ -25,7 +25,8 @@ GCP_METADATA_HEADER = {"Metadata-Flavor": "Google"}
 def on_gcp():
   """Detect whether the current running environment is on GCP."""
   try:
-    response = requests.get(GCP_METADATA_URL, headers=GCP_METADATA_HEADER)
+    response = requests.get(
+        GCP_METADATA_URL, headers=GCP_METADATA_HEADER, timeout=5)
     return response.status_code == 200
   except requests.exceptions.RequestException:
     return False


### PR DESCRIPTION
This is trying to address the long pause in https://github.com/tensorflow/models/pull/4749.