### PR TITLE
Fix undefined variable error

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -121,8 +121,8 @@
         "print('Downloading from ', url)\n",
         "!wget {url}\n",
         "print('Unpacking')\n",
-        "!tar -xvf {base_name}.tgz\n",
-        "checkpoint = base_name + '.ckpt'\n",
+        "!tar -xvf {checkpoint_name}.tgz\n",
+        "checkpoint = checkpoint_name + '.ckpt'\n",
         "\n",
         "display.clear_output()\n",
         "print('Successfully downloaded checkpoint from ', url,\n",
@@ -349,7 +349,7 @@
       "source": [
         "import numpy as np\n",
         "img = np.array(PIL.Image.open('panda.jpg').resize((224, 224))).astype(np.float) / 128 - 1\n",
-        "gd = tf.GraphDef.FromString(open(base_name + '_frozen.pb', 'rb').read())\n",
+        "gd = tf.GraphDef.FromString(open(checkpoint_name + '_frozen.pb', 'rb').read())\n",
         "inp, predictions = tf.import_graph_def(gd,  return_elements = ['input:0', 'MobilenetV2/Predictions/Reshape_1:0'])"
       ]
     },


### PR DESCRIPTION
The usage of the variable 'base_name' raise a NameError since it was never defined.
The value which 'base_name' is expected to have is contained in 'checkpoint_name' 
The solution was to change the variable name 'base_name' to 'checkpoint_name'