### PR TITLE
Add eager for keras benchmark

### DIFF
--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -80,8 +80,10 @@ def run_keras_model_benchmark(_):
     raise ValueError("Only synthetic dataset is supported!")
 
   # If run with multiple GPUs
+  # If eager mode is enabled, only one GPU is utilized even multiple GPUs
+  # are provided
   num_gpus = flags_core.get_num_gpus(FLAGS)
-  if num_gpus > 0:
+  if num_gpus > 1:
     model = tf.keras.utils.multi_gpu_model(model, gpus=num_gpus)
 
   # Configure the model

--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -94,8 +94,8 @@ def run_keras_model_benchmark(_):
       "batch_size": FLAGS.batch_size,
       "synthetic_data": FLAGS.use_synthetic_data,
       "train_epochs": FLAGS.train_epochs,
-      "num_train_images": FLAGS.num_imgs_train,
-      "num_eval_images": FLAGS.num_imgs_eval,
+      "num_train_images": FLAGS.num_images,
+      "num_eval_images": FLAGS.num_images,
   }
 
   benchmark_logger = logger.get_benchmark_logger()
@@ -116,8 +116,8 @@ def run_keras_model_benchmark(_):
       epochs=FLAGS.train_epochs,
       callbacks=callbacks,
       validation_data=val_dataset,
-      steps_per_epoch=int(np.ceil(FLAGS.num_imgs_train / FLAGS.batch_size)),
-      validation_steps=int(np.ceil(FLAGS.num_imgs_eval / FLAGS.batch_size))
+      steps_per_epoch=int(np.ceil(FLAGS.num_images / FLAGS.batch_size)),
+      validation_steps=int(np.ceil(FLAGS.num_images / FLAGS.batch_size))
   )
 
   tf.logging.info("Logging the evaluation results...")
@@ -126,7 +126,7 @@ def run_keras_model_benchmark(_):
         "accuracy": history.history["val_acc"][epoch],
         "loss": history.history["val_loss"][epoch],
         tf.GraphKeys.GLOBAL_STEP: (epoch + 1) * np.ceil(
-            FLAGS.num_imgs_train/FLAGS.batch_size)
+            FLAGS.num_images/FLAGS.batch_size)
     }
     benchmark_logger.log_evaluation_result(eval_results)
 

--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -77,8 +77,8 @@ def run_keras_model_benchmark(_):
     raise ValueError("Only synthetic dataset is supported!")
 
   # If run with multiple GPUs
-  # If eager mode is enabled, only one GPU is utilized even multiple GPUs
-  # are provided
+  # If eager execution is enabled, only one GPU is utilized even if multiple
+  # GPUs are provided.
   num_gpus = flags_core.get_num_gpus(FLAGS)
   if num_gpus > 1:
     if FLAGS.eager:

--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -54,7 +54,7 @@ def run_keras_model_benchmark(_):
     raise AssertionError("The --model command line argument should "
                          "be a key in the `MODELS` dictionary.")
 
-  # Check if eager mode is enabled
+  # Check if eager execution is enabled
   if FLAGS.eager:
     tf.logging.info("Eager execution is enabled...")
     tf.enable_eager_execution()

--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -46,9 +46,6 @@ MODELS = {
     # "nasnetmobile": tf.keras.applications.NASNetMobile,
 }
 
-# Number images for training and evaluation
-_NUM_IMAGES = 1000
-
 
 def run_keras_model_benchmark(_):
   """Run the benchmark on keras model."""
@@ -59,6 +56,7 @@ def run_keras_model_benchmark(_):
 
   # Check if eager mode is enabled
   if FLAGS.eager:
+    tf.logging.info("Eager execution is enabled...")
     tf.enable_eager_execution()
 
   # Load the model
@@ -83,6 +81,10 @@ def run_keras_model_benchmark(_):
   # are provided
   num_gpus = flags_core.get_num_gpus(FLAGS)
   if num_gpus > 1:
+    if FLAGS.eager:
+      tf.logging.warning(
+          "{} GPUs are provided, but only one GPU is utilized as "
+          "eager execution is enabled.".format(num_gpus))
     model = tf.keras.utils.multi_gpu_model(model, gpus=num_gpus)
 
   model.compile(loss="categorical_crossentropy",
@@ -155,7 +157,7 @@ def define_keras_benchmark_flags():
           "Model to be benchmarked."))
 
   flags.DEFINE_integer(
-      name="num_images", default=_NUM_IMAGES,
+      name="num_images", default=1000,
       help=flags_core.help_wrap(
           "The number of synthetic images for training and evaluation. The "
           "default value is 1000."))
@@ -163,7 +165,7 @@ def define_keras_benchmark_flags():
   flags.DEFINE_boolean(
       name="eager", default=False, help=flags_core.help_wrap(
           "To enable eager execution. Note that if eager execution is enabled, "
-          "only one GPU is utilized even multiple GPUs are provided and "
+          "only one GPU is utilized even if multiple GPUs are provided and "
           "multi_gpu_model is used."))
 
   flags.DEFINE_list(

--- a/official/keras_application_models/dataset.py
+++ b/official/keras_application_models/dataset.py
@@ -19,8 +19,7 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-# pylint: disable=g-bad-import-order
-from official.utils.misc import model_helpers
+from official.utils.misc import model_helpers  # pylint: disable=g-bad-import-order
 
 # Default values for dataset.
 _NUM_CHANNELS = 3

--- a/official/keras_application_models/dataset.py
+++ b/official/keras_application_models/dataset.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+from official.utils.misc import model_helpers
 
 # Default values for dataset.
 _NUM_CHANNELS = 3
@@ -34,13 +35,14 @@ def _get_default_image_size(model):
   return image_size
 
 
-def generate_synthetic_input_dataset(model, num_imgs):
+def generate_synthetic_input_dataset(model, batch_size):
   """Generate synthetic dataset."""
   image_size = _get_default_image_size(model)
-  image_shape = (num_imgs,) + image_size + (_NUM_CHANNELS,)
-  label_shape = (num_imgs, _NUM_CLASSES)
+  image_shape = (batch_size,) + image_size + (_NUM_CHANNELS,)
+  label_shape = (batch_size, _NUM_CLASSES)
 
-  images = tf.random_uniform(image_shape, maxval=255, dtype=tf.int32)
-  labels = tf.random_uniform(label_shape, maxval=_NUM_CLASSES, dtype=tf.int32)
-
-  return tf.data.Dataset.from_tensors((images, labels)).repeat()
+  return model_helpers.generate_synthetic_data(
+        input_shape=tf.TensorShape(image_shape),
+        input_dtype=tf.float32,
+        label_shape=tf.TensorShape(label_shape),
+        label_dtype=tf.float32)

--- a/official/keras_application_models/dataset.py
+++ b/official/keras_application_models/dataset.py
@@ -37,9 +37,10 @@ def _get_default_image_size(model):
 def generate_synthetic_input_dataset(model, num_imgs):
   """Generate synthetic dataset."""
   image_size = _get_default_image_size(model)
-  input_shape = (num_imgs,) + image_size + (_NUM_CHANNELS,)
+  image_shape = (num_imgs,) + image_size + (_NUM_CHANNELS,)
+  label_shape = (num_imgs, _NUM_CLASSES)
 
-  images = tf.zeros(input_shape, dtype=tf.float32)
-  labels = tf.zeros((num_imgs, _NUM_CLASSES), dtype=tf.float32)
+  images = tf.random_uniform(image_shape, maxval=255, dtype=tf.int32)
+  labels = tf.random_uniform(label_shape, maxval=_NUM_CLASSES, dtype=tf.int32)
 
   return tf.data.Dataset.from_tensors((images, labels)).repeat()

--- a/official/keras_application_models/dataset.py
+++ b/official/keras_application_models/dataset.py
@@ -18,6 +18,8 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+
+# pylint: disable=g-bad-import-order
 from official.utils.misc import model_helpers
 
 # Default values for dataset.
@@ -42,7 +44,7 @@ def generate_synthetic_input_dataset(model, batch_size):
   label_shape = (batch_size, _NUM_CLASSES)
 
   return model_helpers.generate_synthetic_data(
-        input_shape=tf.TensorShape(image_shape),
-        input_dtype=tf.float32,
-        label_shape=tf.TensorShape(label_shape),
-        label_dtype=tf.float32)
+      input_shape=tf.TensorShape(image_shape),
+      input_dtype=tf.float32,
+      label_shape=tf.TensorShape(label_shape),
+      label_dtype=tf.float32)


### PR DESCRIPTION
Hi All,

Could you help to review this PR? This PR is created to refine the keras model benchmark by:
1) Use models_helper for synthetic dataset generation
2) Add eager mode for keras model. 

Some notes about eager mode: to run with eager mode, the optimizer should be TF native; Also, currently eager mode and keras multi_gpu_model are not compatible. With eager mode enabled, only one GPU is used even multiple GPUs are provided.

Thanks,
Yanhui
