### PR TITLE
Use float32 metrics in mnist_eager

### DIFF
--- a/official/mnist/mnist_eager.py
+++ b/official/mnist/mnist_eager.py
@@ -83,8 +83,8 @@ def train(model, optimizer, dataset, step_counter, log_interval=None):
 
 def test(model, dataset):
   """Perform an evaluation of `model` on the examples from `dataset`."""
-  avg_loss = tfe.metrics.Mean('loss')
-  accuracy = tfe.metrics.Accuracy('accuracy')
+  avg_loss = tfe.metrics.Mean('loss', dtype=tf.float32)
+  accuracy = tfe.metrics.Accuracy('accuracy', dtype=tf.float32)
 
   for (images, labels) in dataset:
     logits = model(images, training=False)


### PR DESCRIPTION
float32 should be fine for mnist loss and accuracy metrics and float64
is not available on TPUs.