### PR TITLE
Fixed error while converting between data formats.

### DIFF
--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -493,11 +493,12 @@ class Model(object):
     """
 
     with self._model_variable_scope():
-      if self.data_format == 'channels_first':
+      if self.data_format == 'channels_last':
         # Convert the inputs from channels_last (NHWC) to channels_first (NCHW).
         # This provides a large performance boost on GPU. See
         # https://www.tensorflow.org/performance/performance_guide#data_formats
         inputs = tf.transpose(inputs, [0, 3, 1, 2])
+        self.data_format = 'channels_first'
 
       inputs = conv2d_fixed_padding(
           inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,


### PR DESCRIPTION
Fixed an error where data of type 'channels_last' was not being correctly transformed to 'channels_first'.

1. The if statement was incorrectly checking for the string 'channels_first' instead of checking for 'channels_last'.
2. After transposing the data the variable self.data_format has to be updated to 'channels_first' to reflect the changes made.