### PR TITLE
Fix/error in metrics order

### DIFF
--- a/official/resnet/resnet_model.py
+++ b/official/resnet/resnet_model.py
@@ -493,11 +493,12 @@ class Model(object):
     """
 
     with self._model_variable_scope():
-      if self.data_format == 'channels_first':
+      if self.data_format == 'channels_last':
         # Convert the inputs from channels_last (NHWC) to channels_first (NCHW).
         # This provides a large performance boost on GPU. See
         # https://www.tensorflow.org/performance/performance_guide#data_formats
         inputs = tf.transpose(inputs, [0, 3, 1, 2])
+        self.data_format = 'channels_first'
 
       inputs = conv2d_fixed_padding(
           inputs=inputs, filters=self.num_filters, kernel_size=self.kernel_size,

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -305,7 +305,7 @@ def resnet_model_fn(features, labels, mode, model_class,
   else:
     # Metrics are currently not compatible with distribution strategies during
     # training. This does not affect the overall performance of the model.
-    accuracy = (tf.no_op(), tf.constant(0))
+    accuracy = (tf.constant(0), tf.no_op())
 
   metrics = {'accuracy': accuracy}
 


### PR DESCRIPTION
The order in which metrics were computed for distributed strategies was incorrect and had to interchanged.

Error with regards to data_format was also fixed. This was mentioned in a separate pull request.