### PR TITLE
Make ncf dataset test less brittle

### DIFF
--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -105,7 +105,10 @@ class BaseTest(tf.test.TestCase):
         batch_size=BATCH_SIZE, eval_batch_size=BATCH_SIZE, num_data_readers=2,
         num_neg=NUM_NEG)
 
-    time.sleep(5)  # allow `alive` file to be written
+    for _ in range(30):
+      if tf.gfile.Exists(ncf_dataset.cache_paths.subproc_alive):
+        break
+      time.sleep(1)  # allow `alive` file to be written
 
     g = tf.Graph()
     with g.as_default():


### PR DESCRIPTION
Previously the NCF test waited 5 seconds for the generation subprocess to open and signal that it is alive. However this turned out not to be enough in some cases.