### PR TITLE
Fix crash when Python interpreter not on PATH.

### DIFF
--- a/official/recommendation/popen_helper.py
+++ b/official/recommendation/popen_helper.py
@@ -15,7 +15,6 @@
 """Helper file for running the async data generation process in OSS."""
 
 import os
-import six
 import sys
 
 

--- a/official/recommendation/popen_helper.py
+++ b/official/recommendation/popen_helper.py
@@ -16,9 +16,13 @@
 
 import os
 import six
+import sys
 
 
-_PYTHON = "python3" if six.PY3 else "python2"
+_PYTHON = sys.executable
+if not _PYTHON:
+  raise RuntimeError("Could not find path to Python interpreter in order to "
+                     "spawn subprocesses.")
 
 _ASYNC_GEN_PATH = os.path.join(os.path.dirname(__file__),
                                "data_async_generation.py")


### PR DESCRIPTION
This can occur when using a virtualenv Python without activating it first.