### PR TITLE
Change vocab_size from 33708 to 33945 in model_params.py

### DIFF
--- a/official/transformer/model/model_params.py
+++ b/official/transformer/model/model_params.py
@@ -27,7 +27,7 @@ BASE_PARAMS = defaultdict(
 
     # Model params
     initializer_gain=1.0,  # Used in trainable variable initialization.
-    vocab_size=33708,  # Number of tokens defined in the vocabulary file.
+    vocab_size=33945,  # Number of tokens defined in the vocabulary file.
     hidden_size=512,  # Model dimension in the hidden layers.
     num_hidden_layers=6,  # Number of layers in the encoder and decoder stacks.
     num_heads=8,  # Number of heads to use in multi-headed attention.


### PR DESCRIPTION
Change vocab_size from 33708 to 33945 in models/official/transformer/model/model_params.py
The original vocab_size causes InvalidArgumentError when training Transformer using CPU.