### PR TITLE
Bug fix: change dict.iteritems() to dict.items()

### DIFF
--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -392,7 +392,7 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
       if img_summary is not None:
         eval_metric_ops['Detections_Left_Groundtruth_Right'] = (
             img_summary, tf.no_op())
-      eval_metric_ops = {str(k): v for k, v in eval_metric_ops.iteritems()}
+      eval_metric_ops = {str(k): v for k, v in eval_metric_ops.items()}
 
       if eval_config.use_moving_averages:
         variable_averages = tf.train.ExponentialMovingAverage(0.0)


### PR DESCRIPTION
`iteritems()` was removed from python3. `items()` does the same functionality so changing it will work in both python2 and python3. The only difference as far as I know is `iteritems()` returns a generator where `items` returns a list. But for this this code it will not make any difference where we are just changing the key of the dict to a string.