### PR TITLE
Using Python 2 convention of xrange

### DIFF
--- a/research/object_detection/anchor_generators/multiscale_grid_anchor_generator.py
+++ b/research/object_detection/anchor_generators/multiscale_grid_anchor_generator.py
@@ -58,7 +58,7 @@ class MultiscaleGridAnchorGenerator(anchor_generator.AnchorGenerator):
     self._normalize_coordinates = normalize_coordinates
 
     scales = [2**(float(scale) / scales_per_octave)
-              for scale in xrange(scales_per_octave)]
+              for scale in range(scales_per_octave)]
     aspects = list(aspect_ratios)
 
     for level in range(min_level, max_level + 1):


### PR DESCRIPTION
Changed line 'xrange' in line 61 to 'range'. This is more up to date to Python 3, and also helps to pass the test in the installation instructions.