### PR TITLE
fix for constant extension length

### DIFF
--- a/research/deeplab/datasets/remove_gt_colormap.py
+++ b/research/deeplab/datasets/remove_gt_colormap.py
@@ -72,7 +72,7 @@ def main(unused_argv):
                                        '*.' + FLAGS.segmentation_format))
   for annotation in annotations:
     raw_annotation = _remove_colormap(annotation)
-    filename = os.path.basename(annotation)[:-4]
+    filename = os.path.splitext(os.path.basename(annotation))[0]
     _save_annotation(raw_annotation,
                      os.path.join(
                          FLAGS.output_dir,


### PR DESCRIPTION
Fixed the constant extension length which assumes extensions are always of length 3 but fails for other lengths. eg. for file types **tiff**.