### PR TITLE
Fix a doc typo fashion-mnist example in #21199

### DIFF
--- a/samples/core/tutorials/keras/basic_classification.ipynb
+++ b/samples/core/tutorials/keras/basic_classification.ipynb
@@ -613,7 +613,7 @@
       "source": [
         "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a 2d-array (of 28 by 28 pixels), to a 1d-array of 28 * 28 = 784 pixels. Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
         "\n",
-        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 digit classes.\n",
+        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 classes.\n",
         "\n",
         "### Compile the model\n",
         "\n",


### PR DESCRIPTION
Fix a doc typo in fashion-mnist example in [tensorflow #21199](https://github.com/tensorflow/tensorflow/issues/21199)