### PR TITLE
Open Inference graph file as a binary file

### DIFF
--- a/research/object_detection/inference/detection_inference.py
+++ b/research/object_detection/inference/detection_inference.py
@@ -65,7 +65,7 @@ def build_inference_graph(image_tensor, inference_graph_path):
     detected_labels_tensor: Detected labels. Int64 tensor,
         shape=[num_detections]
   """
-  with tf.gfile.Open(inference_graph_path, 'r') as graph_def_file:
+  with tf.gfile.Open(inference_graph_path, 'rb') as graph_def_file:
     graph_content = graph_def_file.read()
   graph_def = tf.GraphDef()
   graph_def.MergeFromString(graph_content)


### PR DESCRIPTION
An inference graph file should be opened as a binary file. Please fix a bug reported here. https://github.com/tensorflow/models/issues/2892 , https://github.com/tensorflow/models/issues/3772 and https://github.com/tensorflow/models/issues/3903 .