### PR TITLE
Transformer partial fix

### DIFF
--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -111,9 +111,10 @@ def model_fn(features, labels, mode, params):
     if mode == tf.estimator.ModeKeys.EVAL:
       if params["use_tpu"]:
         # host call functions should only have tensors as arguments.
-        # functools.partial() pre-populates params so that metric_fn is
+        # This lambda pre-populates params so that metric_fn is
         # TPUEstimator compliant.
-        metric_fn = functools.partial(metrics.get_eval_metrics, params=params)
+        metric_fn = lambda logits, labels : (
+            metrics.get_eval_metrics(logits, labels, params=params))
         eval_metrics = (metric_fn, [logits, labels])
         return tf.contrib.tpu.TPUEstimatorSpec(
             mode=mode, loss=loss, predictions={"predictions": logits},

--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import functools
 import os
 import tempfile
 

--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -112,7 +112,7 @@ def model_fn(features, labels, mode, params):
         # host call functions should only have tensors as arguments.
         # This lambda pre-populates params so that metric_fn is
         # TPUEstimator compliant.
-        metric_fn = lambda logits, labels : (
+        metric_fn = lambda logits, labels: (
             metrics.get_eval_metrics(logits, labels, params=params))
         eval_metrics = (metric_fn, [logits, labels])
         return tf.contrib.tpu.TPUEstimatorSpec(


### PR DESCRIPTION
Tensorflow raises an error when tf_inspect.getfullargspec is called on a functools.partial in Python 2.X. This issue would be hit during the eval stage of the Transformer TPU model. This change replaces the call to functools.partial with a lambda to work around the issue.