### PR TITLE
Update trainer.py - fix CUDNN_STATUS_INTERNAL_ERROR

### DIFF
--- a/research/object_detection/legacy/trainer.py
+++ b/research/object_detection/legacy/trainer.py
@@ -370,6 +370,11 @@ def train(create_tensor_dict_fn,
     session_config = tf.ConfigProto(allow_soft_placement=True,
                                     log_device_placement=False)
 
+    # These loc are necessary for avoid GPU memory saturation
+    session_config.gpu_options.allocator_type = 'BFC'
+    session_config.gpu_options.per_process_gpu_memory_fraction = 0.40
+    session_config.gpu_options.allow_growth = True
+    
     # Save checkpoints regularly.
     keep_checkpoint_every_n_hours = train_config.keep_checkpoint_every_n_hours
     saver = tf.train.Saver(


### PR DESCRIPTION
Some user still prefers to run concurrently legacy/train.py and legacy/eval.py instead of /model_main.py. What happens is that both files cannot be executed at the same time because the first one saturates the GPU memory. With just these 3 loc it is possible to avoid this problem.
At this [link](https://gist.github.com/giacomobartoli/694986a2d9a0d89bd9a92d58a3c1743f) you can find a gist of this reported error.