### PR TITLE
Fix NasNet used hiddenstates to match https://arxiv.org/abs/1707.07012

### DIFF
--- a/research/slim/nets/nasnet/nasnet_utils.py
+++ b/research/slim/nets/nasnet/nasnet_utils.py
@@ -450,6 +450,19 @@ class NasNetABaseCell(object):
     return net
 
 
+def get_used_hiddenstates(hiddenstate_indices):
+  assert len(hiddenstate_indices) % 2 == 0 # 2 indices per block
+
+  B = len(hiddenstate_indices) // 2
+
+  used_hiddenstates = [0] * (2 + B) # prev-prev cell + prev cell + B blocks
+
+  for i in hiddenstate_indices:
+    used_hiddenstates[i] = 1
+
+  return used_hiddenstates
+
+
 class NasNetANormalCell(NasNetABaseCell):
   """NASNetA Normal Cell."""
 
@@ -465,8 +478,8 @@ class NasNetANormalCell(NasNetABaseCell):
                   'avg_pool_3x3',
                   'separable_3x3_2',
                   'none']
-    used_hiddenstates = [1, 0, 0, 0, 0, 0, 0]
     hiddenstate_indices = [0, 1, 1, 1, 0, 1, 1, 1, 0, 0]
+    used_hiddenstates = get_used_hiddenstates(hiddenstate_indices)
     super(NasNetANormalCell, self).__init__(num_conv_filters, operations,
                                             used_hiddenstates,
                                             hiddenstate_indices,
@@ -490,8 +503,8 @@ class NasNetAReductionCell(NasNetABaseCell):
                   'avg_pool_3x3',
                   'separable_3x3_2',
                   'max_pool_3x3']
-    used_hiddenstates = [1, 1, 1, 0, 0, 0, 0]
     hiddenstate_indices = [0, 1, 0, 1, 0, 1, 3, 2, 2, 0]
+    used_hiddenstates = get_used_hiddenstates(hiddenstate_indices)
     super(NasNetAReductionCell, self).__init__(num_conv_filters, operations,
                                                used_hiddenstates,
                                                hiddenstate_indices,


### PR DESCRIPTION
I think there is a bug in NasNet normal and reduction cell: used_hiddenstates does not match the authors article. The current code introduces additional skip connections from prev prev cell to concat for normal cell and from second block to concat for reduction cell that are not present in the paper. This claim is easily verified by observing the graph of the provided checkpoint in tensorboard.

There are 3 possibilities:
- The schemas in the paper are wrong and should be fixed. Minor changes in the text should describe the motivations for these additional connections.
- The code is not correct and the present request can be used to fix it.
- I am missing something and it would be helpful if someone could clarify for me.

In case the code is wrong, provided checkpoints should be fixed.