### PR TITLE
fix newline issue with sed on osX

### DIFF
--- a/research/object_detection/dataset_tools/create_pycocotools_package.sh
+++ b/research/object_detection/dataset_tools/create_pycocotools_package.sh
@@ -44,7 +44,7 @@ sed "s/\.\.\/common/common/g" pycocotools/_mask.pyx > _mask.pyx.updated
 cp -f _mask.pyx.updated pycocotools/_mask.pyx
 rm _mask.pyx.updated
 
-sed "s/import matplotlib\.pyplot as plt/import matplotlib\nmatplotlib\.use\(\'Agg\'\)\nimport matplotlib\.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
+sed "s/import matplotlib\.pyplot as plt/import matplotlib;matplotlib\.use\(\'Agg\'\);import matplotlib\.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
 cp -f coco.py.updated pycocotools/coco.py
 rm coco.py.updated
 

--- a/research/object_detection/dataset_tools/create_pycocotools_package.sh
+++ b/research/object_detection/dataset_tools/create_pycocotools_package.sh
@@ -44,7 +44,7 @@ sed "s/\.\.\/common/common/g" pycocotools/_mask.pyx > _mask.pyx.updated
 cp -f _mask.pyx.updated pycocotools/_mask.pyx
 rm _mask.pyx.updated
 
-sed "s/import matplotlib\.pyplot as plt/import matplotlib;matplotlib\.use\(\'Agg\'\);import matplotlib\.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
+sed "s/import matplotlib\.pyplot as plt/import matplotlib;matplotlib\.use\(\'Agg\'\);import matplotlib.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
 cp -f coco.py.updated pycocotools/coco.py
 rm coco.py.updated
 

--- a/research/object_detection/dataset_tools/create_pycocotools_package.sh
+++ b/research/object_detection/dataset_tools/create_pycocotools_package.sh
@@ -44,7 +44,7 @@ sed "s/\.\.\/common/common/g" pycocotools/_mask.pyx > _mask.pyx.updated
 cp -f _mask.pyx.updated pycocotools/_mask.pyx
 rm _mask.pyx.updated
 
-sed "s/import matplotlib\.pyplot as plt/import matplotlib;matplotlib\.use\(\'Agg\'\);import matplotlib.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
+sed "s/import matplotlib\.pyplot as plt/import matplotlib;matplotlib\.use\(\'Agg\'\);import matplotlib\.pyplot as plt/g" pycocotools/coco.py > coco.py.updated
 cp -f coco.py.updated pycocotools/coco.py
 rm coco.py.updated
 


### PR DESCRIPTION
This is a hotfix for an issue with sed on osX brought to attention by [#5033](https://github.com/tensorflow/models/issues/5033). Although it isn't very readable have semi-colon imports the files are packaged into a gzip for use in internals on cloud ml engine.