### PR TITLE
Strip \ufeff if system cannot support unicode

### DIFF
--- a/official/utils/flags/_conventions.py
+++ b/official/utils/flags/_conventions.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import codecs
 import functools
 
 from absl import app as absl_app
@@ -28,8 +29,17 @@ from absl import flags
 # necessary. Currently the only major effect is that help bodies start on the
 # line after flags are listed. All flag definitions should wrap the text bodies
 # with help wrap when calling DEFINE_*.
-help_wrap = functools.partial(flags.text_wrap, length=80, indent="",
+_help_wrap = functools.partial(flags.text_wrap, length=80, indent="",
                               firstline_indent="\n")
+
+
+# Pretty formatting causes issues when utf-8 is not installed on a system.
+try:
+  codecs.lookup("utf-8")
+  help_wrap = _help_wrap
+except LookupError:
+  def help_wrap(text, *args, **kwargs):
+    return _help_wrap(text, *args, **kwargs).replace("\ufeff", "")
 
 
 # Replace None with h to also allow -h

--- a/official/utils/flags/_conventions.py
+++ b/official/utils/flags/_conventions.py
@@ -30,7 +30,7 @@ from absl import flags
 # line after flags are listed. All flag definitions should wrap the text bodies
 # with help wrap when calling DEFINE_*.
 _help_wrap = functools.partial(flags.text_wrap, length=80, indent="",
-                              firstline_indent="\n")
+                               firstline_indent="\n")
 
 
 # Pretty formatting causes issues when utf-8 is not installed on a system.


### PR DESCRIPTION
There is a unicode character that makes flags a bit nicer, but breaks `--helpfull` if python can't find utf-8. This PR just removes that character.

cc @tfboyd 