### PR TITLE
Added support for specifying label weights for loss calculation

### DIFF
--- a/research/deeplab/datasets/segmentation_dataset.py
+++ b/research/deeplab/datasets/segmentation_dataset.py
@@ -74,6 +74,8 @@ DatasetDescriptor = collections.namedtuple(
                       # foreground classes + 1 background class in the PASCAL
                       # VOC 2012 dataset. Thus, we set num_classes=21.
      'ignore_label',  # Ignore label value.
+     'label_weights',  # List of weights for each label. Length of the list must
+                       # be same as num_classes.
     ]
 )
 
@@ -84,6 +86,7 @@ _CITYSCAPES_INFORMATION = DatasetDescriptor(
     },
     num_classes=19,
     ignore_label=255,
+    label_weights=[1.] * 19,
 )
 
 _PASCAL_VOC_SEG_INFORMATION = DatasetDescriptor(
@@ -95,6 +98,7 @@ _PASCAL_VOC_SEG_INFORMATION = DatasetDescriptor(
     },
     num_classes=21,
     ignore_label=255,
+    label_weights=[1.] * 21,
 )
 
 # These number (i.e., 'train'/'test') seems to have to be hard coded
@@ -106,6 +110,7 @@ _ADE20K_INFORMATION = DatasetDescriptor(
     },
     num_classes=151,
     ignore_label=0,
+    label_weights=[1.] * 151,
 )
 
 
@@ -148,6 +153,7 @@ def get_dataset(dataset_name, split_name, dataset_dir):
   # Prepare the variables for different datasets.
   num_classes = _DATASETS_INFORMATION[dataset_name].num_classes
   ignore_label = _DATASETS_INFORMATION[dataset_name].ignore_label
+  label_weights = _DATASETS_INFORMATION[dataset_name].label_weights
 
   file_pattern = _FILE_PATTERN
   file_pattern = os.path.join(dataset_dir, file_pattern % split_name)
@@ -194,5 +200,6 @@ def get_dataset(dataset_name, split_name, dataset_dir):
       items_to_descriptions=_ITEMS_TO_DESCRIPTIONS,
       ignore_label=ignore_label,
       num_classes=num_classes,
+      label_weights=label_weights,
       name=dataset_name,
       multi_label=True)

--- a/research/deeplab/train.py
+++ b/research/deeplab/train.py
@@ -167,7 +167,7 @@ flags.DEFINE_string('train_split', 'train',
 flags.DEFINE_string('dataset_dir', None, 'Where the dataset reside.')
 
 
-def _build_deeplab(inputs_queue, outputs_to_num_classes, ignore_label):
+def _build_deeplab(inputs_queue, outputs_to_num_classes, label_weights, ignore_label):
   """Builds a clone of DeepLab.
 
   Args:
@@ -218,7 +218,7 @@ def _build_deeplab(inputs_queue, outputs_to_num_classes, ignore_label):
         samples[common.LABEL],
         num_classes,
         ignore_label,
-        loss_weight=1.0,
+        label_weights=label_weights,
         upsample_logits=FLAGS.upsample_logits,
         scope=output)
 
@@ -272,9 +272,13 @@ def main(unused_argv):
 
       # Define the model and create clones.
       model_fn = _build_deeplab
-      model_args = (inputs_queue, {
-          common.OUTPUT_TYPE: dataset.num_classes
-      }, dataset.ignore_label)
+      model_args = (
+          inputs_queue,
+          {
+              common.OUTPUT_TYPE: dataset.num_classes
+          },
+          dataset.label_weights,
+          dataset.ignore_label)
       clones = model_deploy.create_clones(config, model_fn, args=model_args)
 
       # Gather update_ops from the first clone. These contain, for example,


### PR DESCRIPTION
This pull request adds support for specifying class weights as below,

```
_CUSTOM_SEG_INFORMATION = DatasetDescriptor(
    splits_to_sizes={
        'train': 8643,
        'trainval': 10803,
        'val': 2160,
    },
    num_classes=5,
    ignore_label=255,
    label_weights=[1.0, 5.0, 30.0, 10.0, 5.0],
)
```

Please have a look and let me know if any change required.