### PR TITLE
fix: fine_tune_batch_norm not match the train_batch_size

### DIFF
--- a/research/deeplab/local_test.sh
+++ b/research/deeplab/local_test.sh
@@ -86,7 +86,7 @@ python "${WORK_DIR}"/train.py \
   --train_crop_size=513 \
   --train_batch_size=4 \
   --training_number_of_steps="${NUM_ITERATIONS}" \
-  --fine_tune_batch_norm=true \
+  --fine_tune_batch_norm=false \
   --tf_initial_checkpoint="${INIT_FOLDER}/deeplabv3_pascal_train_aug/model.ckpt" \
   --train_logdir="${TRAIN_LOGDIR}" \
   --dataset_dir="${PASCAL_DATASET}"


### PR DESCRIPTION
 We should set  fine_tune_batch_norm to false while the  train_batch_size is 4  to avoid the OOM of  the limited resource at hand.The details can be found in the file of train.py:
>  Set to True if one wants to fine-tune the batch norm parameters in DeepLabv3.
    Set to False and use small batch size to save GPU memory.
    flags.DEFINE_boolean('fine_tune_batch_norm', False,
                     'Fine tune the batch norm parameters or not.')
