### PR TITLE
Rename Inception V2 to BN-Inception.

### DIFF
--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -248,7 +248,7 @@ crops at multiple scales.
 Model | TF-Slim File | Checkpoint | Top-1 Accuracy| Top-5 Accuracy |
 :----:|:------------:|:----------:|:-------:|:--------:|
 [Inception V1](http://arxiv.org/abs/1409.4842v1)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v1.py)|[inception_v1_2016_08_28.tar.gz](http://download.tensorflow.org/models/inception_v1_2016_08_28.tar.gz)|69.8|89.6|
-[Inception V2](http://arxiv.org/abs/1502.03167)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v2.py)|[inception_v2_2016_08_28.tar.gz](http://download.tensorflow.org/models/inception_v2_2016_08_28.tar.gz)|73.9|91.8|
+[BN-Inception](http://arxiv.org/abs/1502.03167)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v2.py)|[inception_v2_2016_08_28.tar.gz](http://download.tensorflow.org/models/inception_v2_2016_08_28.tar.gz)|73.9|91.8|
 [Inception V3](http://arxiv.org/abs/1512.00567)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v3.py)|[inception_v3_2016_08_28.tar.gz](http://download.tensorflow.org/models/inception_v3_2016_08_28.tar.gz)|78.0|93.9|
 [Inception V4](http://arxiv.org/abs/1602.07261)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v4.py)|[inception_v4_2016_09_09.tar.gz](http://download.tensorflow.org/models/inception_v4_2016_09_09.tar.gz)|80.2|95.2|
 [Inception-ResNet-v2](http://arxiv.org/abs/1602.07261)|[Code](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_resnet_v2.py)|[inception_resnet_v2_2016_08_30.tar.gz](http://download.tensorflow.org/models/inception_resnet_v2_2016_08_30.tar.gz)|80.4|95.3|


### PR DESCRIPTION
As discussed in https://github.com/tensorflow/models/issues/5054, I'm opening a initial PR. I've only edited the readme file, but further changes will be necessary.

The problem I'm addressing is that the link of Inception V2 in the readme file refers [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167). The implemented [network architecture](https://github.com/tensorflow/models/blob/master/research/slim/nets/inception_v2.py) has the same output sizes as in the paper (p. 11), so I think that the reference to the paper is correct. It is named BN-Inception.

Inception V2 (with V3) was introduced in [Rethinking the Inception Architecture for Computer Vision](https://arxiv.org/abs/1512.00567) and it has a different network architecture compared to the implemented one (see p. 6).

Therefore I think that the name of the network architecture in the repository should be changed from Inception V2 to BN-Inception.