### PR TITLE
StringIO is not supported in python3

### DIFF
--- a/research/attention_ocr/python/datasets/unittest_utils.py
+++ b/research/attention_ocr/python/datasets/unittest_utils.py
@@ -15,7 +15,10 @@
 
 """Functions to make unit testing easier."""
 
-import StringIO
+try:
+  import StringIO
+except ImportError:
+  from io import StringIO
 import numpy as np
 from PIL import Image as PILImage
 import tensorflow as tf


### PR DESCRIPTION
putting `import StrinIO` in try-except block with `except ImportError` ensures that the code runs in python2 and python3

Author: Pinaki Nath Chowdhury <pinakinathc@gmail.com>