### PR TITLE
Docs: Add plt.show() method

### DIFF
--- a/samples/core/tutorials/keras/basic_classification.ipynb
+++ b/samples/core/tutorials/keras/basic_classification.ipynb
@@ -416,7 +416,8 @@
         "plt.figure()\n",
         "plt.imshow(train_images[0])\n",
         "plt.colorbar()\n",
-        "plt.grid(False)"
+        "plt.grid(False)\n",
+        "plt.show()"
       ],
       "execution_count": 0,
       "outputs": []
@@ -481,7 +482,8 @@
         "    plt.yticks([])\n",
         "    plt.grid(False)\n",
         "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
-        "    plt.xlabel(class_names[train_labels[i]])"
+        "    plt.xlabel(class_names[train_labels[i]])\n",
+        "plt.show()"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Hello good people of tensorflow models, 

Change:
Adding missing method call `plt.show()` in the 'basic classification' example. 

Reason: 
It can be confusing for those who are running the examples without a Jupyter notebook.