### PR TITLE
Text classification tutorial clarification

### DIFF
--- a/samples/core/tutorials/keras/basic_text_classification.ipynb
+++ b/samples/core/tutorials/keras/basic_text_classification.ipynb
@@ -378,7 +378,7 @@
         "\n",
         "* One-hot-encode the arrays to convert them into vectors of 0s and 1s. For example, the sequence  [3, 5] would become a 10,000-dimensional vector that is all zeros except for indices 3 and 5, which are ones. Then, make this the first layer in our network—a Dense layer—that can handle floating point vector data. This approach is memory intensive, though, requiring a `num_words * num_reviews` size matrix.\n",
         "\n",
-        "* Alternatively, we can pad the arrays so they all have the same length, then create an integer tensor of shape `num_examples * max_length`. We can use an embedding layer capable of handling this shape as the first layer in our network.\n",
+        "* Alternatively, we can pad the arrays so they all have the same length, then create an integer tensor of shape `max_length * num_reviews`. We can use an embedding layer capable of handling this shape as the first layer in our network.\n",
         "\n",
         "In this tutorial, we will use the second approach. \n",
         "\n",


### PR DESCRIPTION
Rename "num_examples" to "num_reviews" to be consistent with the "one-hot-encode" size description: "num_words * num_reviews".