### PR TITLE
Update the runtime version in bash script

### DIFF
--- a/research/object_detection/g3doc/running_pets.md
+++ b/research/object_detection/g3doc/running_pets.md
@@ -216,7 +216,7 @@ To start training and evaluation, execute the following command from the
 ```bash
 # From tensorflow/models/research/
 gcloud ml-engine jobs submit training `whoami`_object_detection_pets_`date +%m_%d_%Y_%H_%M_%S` \
-    --runtime-version 1.8 \
+    --runtime-version 1.9 \
     --job-dir=gs://${YOUR_GCS_BUCKET}/model_dir \
     --packages dist/object_detection-0.1.tar.gz,slim/dist/slim-0.1.tar.gz,/tmp/pycocotools/pycocotools-2.0.tar.gz \
     --module-name object_detection.model_main \


### PR DESCRIPTION
The bash script to submit training job for pets detection has runtime-version of 1.8. This will trigger `TypeError: non_max_suppression() got an unexpected keyword argument 'score_threshold'` on the Google Cloud since 1.8 and older does not support this keyword argument. Therefore, update this runtime version to 1.9, which is the most recent runtime version that is published on June 27, 2018. 

See 
https://github.com/tensorflow/models/issues/5056
https://cloud.google.com/ml-engine/docs/tensorflow/runtime-version-list