### PR TITLE
Add eval_only flag as optional base flag.

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -430,29 +430,33 @@ def resnet_main(
 
   total_training_cycle = (flags_obj.train_epochs //
                           flags_obj.epochs_between_evals)
-  for cycle_index in range(total_training_cycle):
-    tf.logging.info('Starting a training cycle: %d/%d',
-                    cycle_index, total_training_cycle)
-
-    classifier.train(input_fn=input_fn_train, hooks=train_hooks,
-                     max_steps=flags_obj.max_train_steps)
-
-    tf.logging.info('Starting to evaluate.')
-
-    # flags_obj.max_train_steps is generally associated with testing and
-    # profiling. As a result it is frequently called with synthetic data, which
-    # will iterate forever. Passing steps=flags_obj.max_train_steps allows the
-    # eval (which is generally unimportant in those circumstances) to terminate.
-    # Note that eval will run for max_train_steps each loop, regardless of the
-    # global_step count.
-    eval_results = classifier.evaluate(input_fn=input_fn_eval,
-                                       steps=flags_obj.max_train_steps)
-
+  if flags_obj.eval_only:
+    eval_results = classifier.evaluate(input_fn=input_fn_eval)
     benchmark_logger.log_evaluation_result(eval_results)
+  else:
+    for cycle_index in range(total_training_cycle):
+      tf.logging.info('Starting a training cycle: %d/%d',
+                      cycle_index, total_training_cycle)
 
-    if model_helpers.past_stop_threshold(
-        flags_obj.stop_threshold, eval_results['accuracy']):
-      break
+      classifier.train(input_fn=input_fn_train, hooks=train_hooks,
+                       max_steps=flags_obj.max_train_steps)
+
+      tf.logging.info('Starting to evaluate.')
+
+      # flags_obj.max_train_steps is generally associated with testing and
+      # profiling. As a result it is frequently called with synthetic data,
+      # which will iterate forever. Passing steps=flags_obj.max_train_steps
+      # allows the eval (which is generally unimportant in those circumstances)
+      # to terminate. Note that eval will run for max_train_steps each loop,
+      # regardless of the global_step count.
+      eval_results = classifier.evaluate(input_fn=input_fn_eval,
+                                         steps=flags_obj.max_train_steps)
+
+      benchmark_logger.log_evaluation_result(eval_results)
+
+      if model_helpers.past_stop_threshold(
+          flags_obj.stop_threshold, eval_results['accuracy']):
+        break
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.

--- a/official/utils/flags/_base.py
+++ b/official/utils/flags/_base.py
@@ -27,7 +27,7 @@ from official.utils.logs import hooks_helper
 
 def define_base(data_dir=True, model_dir=True, clean=True, train_epochs=True,
                 epochs_between_evals=True, stop_threshold=True, batch_size=True,
-                num_gpu=True, hooks=True, export_dir=True):
+                num_gpu=True, hooks=True, export_dir=True, eval_only=False):
   """Register base flags.
 
   Args:
@@ -41,6 +41,7 @@ def define_base(data_dir=True, model_dir=True, clean=True, train_epochs=True,
     num_gpu: Create a flag to specify the number of GPUs used.
     hooks: Create a flag to specify hooks for logging.
     export_dir: Create a flag to specify where a SavedModel should be exported.
+    eval_only: Create a flag to specify that only eval is to be done.
 
   Returns:
     A list of flags for core.py to marks as key flags.
@@ -127,6 +128,12 @@ def define_base(data_dir=True, model_dir=True, clean=True, train_epochs=True,
                        "See the README for more details and relevant links.")
     )
     key_flags.append("export_dir")
+
+  if eval_only:
+    flags.DEFINE_boolean(
+        name="eval_only", default=False,
+        help=help_wrap("If set, only eval will be run on model_dir."))
+    key_flags.append("eval_only")
 
   return key_flags
 


### PR DESCRIPTION
I can can see where this flag might not fit into base.  

I only half care about this as a feature but I did it and found it useful.  If there is an easy way to make this work and fit with your philogphy that is great.  If not, moving on.

Side Note:
I really think it should eval either all the checkpoints in the dir or really better and more concise let you specify a specific checkpoint rather than the model directory.  I didn't try it so I am look like a fool but I suspect it works like tf_cnn_bench does and it uses some util class to find which checkpoint to load, what we did is if the path contains what looks like a checkpoint file then don't guess just us it.  