### PR TITLE
 Fixed TensorFlow version check in object_detection_tutorial.ipynb

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -54,8 +54,8 @@
         "sys.path.append(\"..\")\n",
         "from object_detection.utils import ops as utils_ops\n",
         "\n",
-        "if StrictVersion(tf.__version__) \u003c StrictVersion('1.4.0'):\n",
-        "  raise ImportError('Please upgrade your TensorFlow installation to v1.4.* or later!')\n"
+        "if StrictVersion(tf.__version__) \u003c StrictVersion('1.9.0'):\n",
+        "  raise ImportError('Please upgrade your TensorFlow installation to v1.9.* or later!')\n"
       ]
     },
     {

--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -36,6 +36,7 @@
       },
       "outputs": [],
       "source": [
+        "from distutils.version import StrictVersion\n",
         "import numpy as np\n",
         "import os\n",
         "import six.moves.urllib as urllib\n",
@@ -53,8 +54,8 @@
         "sys.path.append(\"..\")\n",
         "from object_detection.utils import ops as utils_ops\n",
         "\n",
-        "if tf.__version__ \u003c '1.4.0':\n",
-        "  raise ImportError('Please upgrade your tensorflow installation to v1.4.* or later!')\n"
+        "if StrictVersion(tf.__version__) \u003c StrictVersion('1.4.0'):\n",
+        "  raise ImportError('Please upgrade your TensorFlow installation to v1.4.* or later!')\n"
       ]
     },
     {


### PR DESCRIPTION
The Object_detection_tutorial is compatible with TensorFlow 1.10 but the check says that version 1.4 is newer than version 1.10. This change uses the StrictVersion check from [PEP-0386 ](https://www.python.org/dev/peps/pep-0386/) to ensure good version checks in the future.

Solves #5069, #3033

I have also changed `tensorflow` to `TensorFlow` in the error message. 