### PR TITLE
Fix python 3 compatibility problem in ObjectDetectionEvaluator.evalua…

### DIFF
--- a/research/object_detection/utils/object_detection_evaluation.py
+++ b/research/object_detection/utils/object_detection_evaluation.py
@@ -307,6 +307,8 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
           category_name = unicode(category_name, 'utf-8')
         except TypeError:
           pass
+        except NameError:
+          pass
         category_name = unicodedata.normalize(
             'NFKD', category_name).encode('ascii', 'ignore')
         display_name = (


### PR DESCRIPTION
…te()

unicode() doesn't exist in python 3, and when executed, a NameError exception is thrown.