### PR TITLE
ResNet synthetic data performance enhancement.

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -135,9 +135,9 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None):
   )
 
 
-def get_synth_input_fn():
+def get_synth_input_fn(dtype):
   return resnet_run_loop.get_synth_input_fn(
-      _HEIGHT, _WIDTH, _NUM_CHANNELS, _NUM_CLASSES)
+      _HEIGHT, _WIDTH, _NUM_CHANNELS, _NUM_CLASSES, dtype=dtype)
 
 
 ###############################################################################
@@ -243,8 +243,9 @@ def run_cifar(flags_obj):
   Args:
     flags_obj: An object containing parsed flag values.
   """
-  input_function = (flags_obj.use_synthetic_data and get_synth_input_fn()
-                    or input_fn)
+  input_function = (flags_obj.use_synthetic_data and
+                    get_synth_input_fn(flags_core.get_tf_dtype(flags_obj)) or
+                    input_fn)
   resnet_run_loop.resnet_main(
       flags_obj, cifar10_model_fn, input_function, DATASET_NAME,
       shape=[_HEIGHT, _WIDTH, _NUM_CHANNELS])

--- a/official/resnet/cifar10_test.py
+++ b/official/resnet/cifar10_test.py
@@ -77,9 +77,9 @@ class BaseTest(tf.test.TestCase):
           self.assertAllClose(pixel, np.array([-1.225, 0., 1.225]), rtol=1e-3)
 
   def cifar10_model_fn_helper(self, mode, resnet_version, dtype):
-    input_fn = cifar10_main.get_synth_input_fn()
+    input_fn = cifar10_main.get_synth_input_fn(dtype)
     dataset = input_fn(True, '', _BATCH_SIZE)
-    iterator = dataset.make_one_shot_iterator()
+    iterator = dataset.make_initializable_iterator()
     features, labels = iterator.get_next()
     spec = cifar10_main.cifar10_model_fn(
         features, labels, mode, {

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -196,9 +196,10 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None):
   )
 
 
-def get_synth_input_fn():
+def get_synth_input_fn(dtype):
   return resnet_run_loop.get_synth_input_fn(
-      _DEFAULT_IMAGE_SIZE, _DEFAULT_IMAGE_SIZE, _NUM_CHANNELS, _NUM_CLASSES)
+      _DEFAULT_IMAGE_SIZE, _DEFAULT_IMAGE_SIZE, _NUM_CHANNELS, _NUM_CLASSES,
+      dtype=dtype)
 
 
 ###############################################################################
@@ -331,8 +332,9 @@ def run_imagenet(flags_obj):
   Args:
     flags_obj: An object containing parsed flag values.
   """
-  input_function = (flags_obj.use_synthetic_data and get_synth_input_fn()
-                    or input_fn)
+  input_function = (flags_obj.use_synthetic_data and
+                    get_synth_input_fn(flags_core.get_tf_dtype(flags_obj)) or
+                    input_fn)
 
   resnet_run_loop.resnet_main(
       flags_obj, imagenet_model_fn, input_function, DATASET_NAME,

--- a/official/resnet/imagenet_test.py
+++ b/official/resnet/imagenet_test.py
@@ -191,9 +191,9 @@ class BaseTest(tf.test.TestCase):
     """Tests that the EstimatorSpec is given the appropriate arguments."""
     tf.train.create_global_step()
 
-    input_fn = imagenet_main.get_synth_input_fn()
+    input_fn = imagenet_main.get_synth_input_fn(dtype)
     dataset = input_fn(True, '', _BATCH_SIZE)
-    iterator = dataset.make_one_shot_iterator()
+    iterator = dataset.make_initializable_iterator()
     features, labels = iterator.get_next()
     spec = imagenet_main.imagenet_model_fn(
         features, labels, mode, {

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -112,8 +112,10 @@ def get_synth_input_fn(height, width, num_channels, num_classes,
                        dtype=tf.float32):
   """Returns an input function that returns a dataset with random data.
 
-  This input_fn removed all aspects of the input pipeline other than the
-  host to device copy. This is useful in debugging input pipeline performance.
+  This input_fn returns a data set that iterates over a set of random data and
+  bypasses all preprocessing, e.g. jpeg decode and copy. The host to device
+  copy is still included. This used to find the upper throughput bound when
+  tunning the full input pipeline.
 
   Args:
     height: Integer height that will be used to create a fake image tensor.


### PR DESCRIPTION
All numbers are form a DGX-1 with V100s

tl;dr; I improved synthetic data performance from ~4,800 images/sec to 5,500 images/sec  14.6% speedup on ResNetV1 FP16 maybe more with smaller models.

The current Synthetic data has a couple problems.  1) the dtype is set to float32 and is then cast on the GPU (which is something that needs changed for real data a well but is less problematic and I will do a PR for next) no matter what 2) it does not seem to have prefetch.  Both of these combine for a situation where real data is faster than synthetic data:  Real data ~5,200 images/sec ResNet V1 and ~4,800 images/sec synthetic data.  

During my testing I found:

- Change current code to tf.float16 and leave the tf.cast gets 5,273 images/sec
- Change current code to tf.float16 and remove tf.cast gest 5,329 images/sec.  I have doubts the unneeded cast has any cost in this scenario and could have been noise.  
- Change the input_fn to my solution based on tf_cnn_benchmarks  5,534 images/sec

This solution still has the host to device copy, which I believe can only be removed with a custom dataset and I have some doubt it is worth it in the near-term.  

For followup work is to move the tf.cast to fp16 for real data as part of the input pipeline and then removing the tf.cast in resnet_run_loop had a small but seemingly consistent improvement.  It also seems more valid and keeps work off the GPU.  
