### PR TITLE
Changed import order for object_detection model_lib.py to allow for headless

### DIFF
--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -23,6 +23,7 @@ import os
 
 import tensorflow as tf
 
+from object_detection.utils import visualization_utils as vis_utils
 from object_detection import eval_util
 from object_detection import inputs
 from object_detection.builders import graph_rewriter_builder
@@ -33,7 +34,6 @@ from object_detection.utils import config_util
 from object_detection.utils import label_map_util
 from object_detection.utils import shape_utils
 from object_detection.utils import variables_helper
-from object_detection.utils import visualization_utils as vis_utils
 
 # A map of names to methods that help build the model.
 MODEL_BUILD_UTIL_MAP = {


### PR DESCRIPTION
Moved object_detection vis_utils import in model_lib.py above eval_utils as matplotlib import has to be set to Agg to allow for headless. (current import order meant that matplotlib was not set correctly for headless).