### PR TITLE
Update CIFAR-10 to default to ResNet-56 with updated lr and num epochs.

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -38,6 +38,7 @@ _RECORD_BYTES = _DEFAULT_IMAGE_BYTES + 1
 _NUM_CLASSES = 10
 _NUM_DATA_FILES = 5
 
+# TODO(tobyboyd): Change to best practice 45K(train)/5K(val)/10K(test) splits.
 _NUM_IMAGES = {
     'train': 50000,
     'validation': 10000,
@@ -190,14 +191,14 @@ class Cifar10Model(resnet_model.Model):
 def cifar10_model_fn(features, labels, mode, params):
   """Model function for CIFAR-10."""
   features = tf.reshape(features, [-1, _HEIGHT, _WIDTH, _NUM_CHANNELS])
-
+  # Learning rate schedule follows arXiv:1512.03385 for ResNet-56 and under.
   learning_rate_fn = resnet_run_loop.learning_rate_with_decay(
       batch_size=params['batch_size'], batch_denom=128,
-      num_images=_NUM_IMAGES['train'], boundary_epochs=[100, 150, 200],
+      num_images=_NUM_IMAGES['train'], boundary_epochs=[91, 136, 182],
       decay_rates=[1, 0.1, 0.01, 0.001])
 
-  # We use a weight decay of 0.0002, which performs better
-  # than the 0.0001 that was originally suggested.
+  # Weight decay of 2e-4 diverges from 1e-4 decay used in the ResNet paper
+  # and seems more stable in testing. The difference was nominal for ResNet-56.
   weight_decay = 2e-4
 
   # Empirical testing showed that including batch_normalization variables
@@ -231,8 +232,8 @@ def define_cifar_flags():
   flags.adopt_module_key_flags(resnet_run_loop)
   flags_core.set_defaults(data_dir='/tmp/cifar10_data',
                           model_dir='/tmp/cifar10_model',
-                          resnet_size='32',
-                          train_epochs=250,
+                          resnet_size='56',
+                          train_epochs=182,
                           epochs_between_evals=10,
                           batch_size=128)
 


### PR DESCRIPTION
I updated the lr schedule to match the original ResNet paper.  The example is using 50K training images rather than the 45K used by the paper so the number of steps is different but the epochs is a close match.  I also changed the code to use use ResNet56 as the default from ResNet32 because it gets  93% and on a GTX-1080 the time to train is almost identical.  The paper trained for ~182 epochs, I found ~164 epochs was enough for the test but recognize 182 would be more official and did some runs of that length and the results end up similar.  If top_1 is not 93% at 164 it will not be better at 182.  I also did not find a need to lower the learning rate, which was not in the original paper, again as was occurring in the previous defaults.  

This also **reduces the training time by 40-50%** by fixing lr and default num_epochs to train.

I ran FP16 and FP32 tests that I think we could also include them in the README.

max (mean +/- std) over 5 runs single V100 bs=128
   * FP32: .9344 (.9312 +/- .002)
   * FP16 (mixed-precision): .9344 (.9312 +/- .002)

Commands:
**FP32**
```bash
python -m official.resnet.cifar10_main --data_dir=/data/cifar10 --hooks ExamplesPerSecondHook --num_gpus=1 --batch_size=128 --resnet_size=56 --model_dir=/tmp/resnet-56_fp32 --dtype=fp32 --train_epochs=164
```
**FP16 (mixed-precision)**
```bash
python -m official.resnet.cifar10_main --data_dir=/data/cifar10 --hooks ExamplesPerSecondHook --num_gpus=1 --batch_size=128 --resnet_size=56 --model_dir=/tmp/resnet-56_fp16 --dtype=fp16 --train_epochs=164
```

There is not a huge performance improvement for FP16 due to the very small size of the data and minimal compute required per step.



