### PR TITLE
changed the prediction label data type from int64 to int32

### DIFF
--- a/research/deeplab/model.py
+++ b/research/deeplab/model.py
@@ -53,6 +53,7 @@ Alan L. Yuille (* equal contribution)
 """
 import tensorflow as tf
 from deeplab.core import feature_extractor
+from tensorflow.python.framework import dtypes
 
 slim = tf.contrib.slim
 
@@ -181,7 +182,7 @@ def predict_labels(images, model_options, image_pyramid=None):
         scales_to_logits[MERGED_LOGITS_SCOPE],
         tf.shape(images)[1:3],
         align_corners=True)
-    predictions[output] = tf.argmax(logits, 3)
+    predictions[output] = tf.argmax(logits, 3, output_type=dtypes.int32)
 
   return predictions
 


### PR DESCRIPTION
As the number of classes (which is generally less than 200) should perfectly fit in `int32`, there is no need to use an `int64` data type for prediction labels. 

Also, this change should fix this [issue](https://github.com/tensorflow/models/issues/4278) while using the model in **tflite** or `toco`.

Didn't use `uint8` instead of `int32`, because **argmax** expects only `int32` or `int64` datatype.