### PR TITLE
Update data_download.py

### DIFF
--- a/official/boosted_trees/data_download.py
+++ b/official/boosted_trees/data_download.py
@@ -47,7 +47,7 @@ NPZ_FILE = "HIGGS.csv.gz.npz"  # numpy compressed file to contain "data" array.
 
 def _download_higgs_data_and_save_npz(data_dir):
   """Download higgs data and store as a numpy compressed file."""
-  input_url = os.path.join(URL_ROOT, INPUT_FILE)
+  input_url = URL_ROOT + "/%s" % INPUT_FILE
   np_filename = os.path.join(data_dir, NPZ_FILE)
   if tf.gfile.Exists(np_filename):
     raise ValueError("data_dir already has the processed data file: {}".format(


### PR DESCRIPTION
Url format doesn't depend on OS, shouldn't use os.path.join, otherwise will generate wrong format on windows, such as 
https://archive.ics.uci.edu/ml/machine-learning-databases/00280\HIGGS.csv.gz, and cause 404 error.