### PR TITLE
Fix spurious "did not start correctly" error.

### DIFF
--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -502,6 +502,12 @@ def make_train_input_fn(ncf_dataset):
   # type: (NCFDataset) -> (typing.Callable, str, int)
   """Construct training input_fn for the current epoch."""
 
+  if not tf.gfile.Exists(ncf_dataset.cache_paths.subproc_alive):
+    # The generation subprocess must have been alive at some point, because we
+    # earlier checked that the subproc_alive file existed.
+    raise ValueError("Generation subprocess unexpectedly died. Data will not "
+                     "be available; exiting to avoid waiting forever.")
+
   train_epoch_dir = ncf_dataset.cache_paths.train_epoch_dir
   while not tf.gfile.Exists(train_epoch_dir):
     tf.logging.info("Waiting for {} to exist.".format(train_epoch_dir))

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -115,11 +115,6 @@ class BaseTest(tf.test.TestCase):
         batch_size=BATCH_SIZE, eval_batch_size=BATCH_SIZE, num_data_readers=2,
         num_neg=NUM_NEG)
 
-    for _ in range(30):
-      if tf.gfile.Exists(ncf_dataset.cache_paths.subproc_alive):
-        break
-      time.sleep(1)  # allow `alive` file to be written
-
     g = tf.Graph()
     with g.as_default():
       input_fn, record_dir, batch_count = \


### PR DESCRIPTION
The error "Generation subprocess did not start correctly" would occur if the async process started up after the main process checked for the subproc_alive file.