### PR TITLE
Allow .png images in load_image_into_numpy_array

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -297,6 +297,8 @@
       "source": [
         "def load_image_into_numpy_array(image):\n",
         "  (im_width, im_height) = image.size\n",
+        "  if image.format == 'PNG':\n",
+        "      image = image.convert('RGB')\n",
         "  return np.array(image.getdata()).reshape(\n",
         "      (im_height, im_width, 3)).astype(np.uint8)"
       ]


### PR DESCRIPTION
In object detection, load_image_into_numpy_array(image) raises ValueError when the given image is png format.