### PR TITLE
change python2 style print to python3 style

### DIFF
--- a/research/object_detection/dataset_tools/oid_hierarchical_labels_expansion.py
+++ b/research/object_detection/dataset_tools/oid_hierarchical_labels_expansion.py
@@ -154,7 +154,7 @@ def main(parsed_args):
   if parsed_args.annotation_type == 2:
     labels_file = True
   elif parsed_args.annotation_type != 1:
-    print '--annotation_type expected value is 1 or 2.'
+    print('--annotation_type expected value is 1 or 2.')
     return -1
   with open(parsed_args.input_annotations, 'r') as source:
     with open(parsed_args.output_annotations, 'w') as target:

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -681,7 +681,7 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       _, num_classes, num_anchors, _ = self._create_model(
           random_example_sampling=True,
           use_keras=use_keras)
-    print num_classes, num_anchors
+    print(num_classes, num_anchors)
 
     def graph_fn(preprocessed_tensor, groundtruth_boxes1, groundtruth_boxes2,
                  groundtruth_classes1, groundtruth_classes2):


### PR DESCRIPTION
By doing this, we can also use python3 to run object_detection scripts without running error.

Signed-off-by: Pei Zhang <changpei1982@gmail.com>