### PR TITLE
Release iNaturalist Species-trained models, refactor of evaluation, box predictor for object detection.

### DIFF
--- a/research/object_detection/README.md
+++ b/research/object_detection/README.md
@@ -99,6 +99,16 @@ reporting an issue.
 
 ## Release information
 
+### Sep 17, 2018
+
+We have released Faster R-CNN detectors with ResNet-50 / ResNet-101 feature
+extractors trained on the [iNaturalist Species Detection Dataset](https://github.com/visipedia/inat_comp/blob/master/2017/README.md#bounding-boxes).
+The models are trained on the training split of the iNaturalist data for 4M
+iterations, they achieve 55% and 58% mean AP@.5 over 2854 classes respectively.
+For more details please refer to this [paper](https://arxiv.org/abs/1707.06642).
+
+<b>Thanks to contributors</b>: Chen Sun
+
 ### July 13, 2018
 
 There are many new updates in this release, extending the functionality and

--- a/research/object_detection/builders/box_predictor_builder.py
+++ b/research/object_detection/builders/box_predictor_builder.py
@@ -15,33 +15,35 @@
 
 """Function to build box predictor from configuration."""
 
+from absl import logging
+
 from object_detection.predictors import convolutional_box_predictor
+from object_detection.predictors import convolutional_keras_box_predictor
 from object_detection.predictors import mask_rcnn_box_predictor
 from object_detection.predictors import rfcn_box_predictor
 from object_detection.predictors.heads import box_head
 from object_detection.predictors.heads import class_head
+from object_detection.predictors.heads import keras_box_head
+from object_detection.predictors.heads import keras_class_head
+from object_detection.predictors.heads import keras_mask_head
 from object_detection.predictors.heads import mask_head
 from object_detection.protos import box_predictor_pb2
 
 
-def build_convolutional_box_predictor(
-    is_training,
-    num_classes,
-    conv_hyperparams_fn,
-    min_depth,
-    max_depth,
-    num_layers_before_predictor,
-    use_dropout,
-    dropout_keep_prob,
-    kernel_size,
-    box_code_size,
-    apply_sigmoid_to_scores=False,
-    class_prediction_bias_init=0.0,
-    use_depthwise=False,
-    predict_instance_masks=False,
-    mask_height=7,
-    mask_width=7,
-    masks_are_class_agnostic=False):
+def build_convolutional_box_predictor(is_training,
+                                      num_classes,
+                                      conv_hyperparams_fn,
+                                      min_depth,
+                                      max_depth,
+                                      num_layers_before_predictor,
+                                      use_dropout,
+                                      dropout_keep_prob,
+                                      kernel_size,
+                                      box_code_size,
+                                      apply_sigmoid_to_scores=False,
+                                      class_prediction_bias_init=0.0,
+                                      use_depthwise=False,
+                                      mask_head_config=None):
   """Builds the ConvolutionalBoxPredictor from the arguments.
 
   Args:
@@ -66,18 +68,14 @@ def build_convolutional_box_predictor(
       then the kernel size is automatically set to be
       min(feature_width, feature_height).
     box_code_size: Size of encoding for each box.
-    apply_sigmoid_to_scores: if True, apply the sigmoid on the output
+    apply_sigmoid_to_scores: If True, apply the sigmoid on the output
       class_predictions.
-    class_prediction_bias_init: constant value to initialize bias of the last
+    class_prediction_bias_init: Constant value to initialize bias of the last
       conv2d layer before class prediction.
     use_depthwise: Whether to use depthwise convolutions for prediction
       steps. Default is False.
-    predict_instance_masks: If True, will add a third stage mask prediction
-      to the returned class.
-    mask_height: Desired output mask height. The default value is 7.
-    mask_width: Desired output mask width. The default value is 7.
-    masks_are_class_agnostic: Boolean determining if the mask-head is
-      class-agnostic or not.
+    mask_head_config: An optional MaskHead object containing configs for mask
+      head construction.
 
   Returns:
     A ConvolutionalBoxPredictor class.
@@ -97,7 +95,10 @@ def build_convolutional_box_predictor(
       class_prediction_bias_init=class_prediction_bias_init,
       use_depthwise=use_depthwise)
   other_heads = {}
-  if predict_instance_masks:
+  if mask_head_config is not None:
+    if not mask_head_config.masks_are_class_agnostic:
+      logging.warning('Note that class specific mask prediction for SSD '
+                      'models is memory consuming.')
     other_heads[convolutional_box_predictor.MASK_PREDICTIONS] = (
         mask_head.ConvolutionalMaskHead(
             is_training=is_training,
@@ -106,9 +107,9 @@ def build_convolutional_box_predictor(
             dropout_keep_prob=dropout_keep_prob,
             kernel_size=kernel_size,
             use_depthwise=use_depthwise,
-            mask_height=mask_height,
-            mask_width=mask_width,
-            masks_are_class_agnostic=masks_are_class_agnostic))
+            mask_height=mask_head_config.mask_height,
+            mask_width=mask_head_config.mask_width,
+            masks_are_class_agnostic=mask_head_config.masks_are_class_agnostic))
   return convolutional_box_predictor.ConvolutionalBoxPredictor(
       is_training=is_training,
       num_classes=num_classes,
@@ -119,6 +120,139 @@ def build_convolutional_box_predictor(
       num_layers_before_predictor=num_layers_before_predictor,
       min_depth=min_depth,
       max_depth=max_depth)
+
+
+def build_convolutional_keras_box_predictor(is_training,
+                                            num_classes,
+                                            conv_hyperparams,
+                                            freeze_batchnorm,
+                                            inplace_batchnorm_update,
+                                            num_predictions_per_location_list,
+                                            min_depth,
+                                            max_depth,
+                                            num_layers_before_predictor,
+                                            use_dropout,
+                                            dropout_keep_prob,
+                                            kernel_size,
+                                            box_code_size,
+                                            class_prediction_bias_init=0.0,
+                                            use_depthwise=False,
+                                            mask_head_config=None,
+                                            name='BoxPredictor'):
+  """Builds the ConvolutionalBoxPredictor from the arguments.
+
+  Args:
+    is_training: Indicates whether the BoxPredictor is in training mode.
+    num_classes: Number of classes.
+    conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+      containing hyperparameters for convolution ops.
+    freeze_batchnorm: Whether to freeze batch norm parameters during
+      training or not. When training with a small batch size (e.g. 1), it is
+      desirable to freeze batch norm update and use pretrained batch norm
+      params.
+    inplace_batchnorm_update: Whether to update batch norm moving average
+      values inplace. When this is false train op must add a control
+      dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+      batch norm statistics.
+    num_predictions_per_location_list: A list of integers representing the
+      number of box predictions to be made per spatial location for each
+      feature map.
+    min_depth: Minimum feature depth prior to predicting box encodings
+      and class predictions.
+    max_depth: Maximum feature depth prior to predicting box encodings
+      and class predictions. If max_depth is set to 0, no additional
+      feature map will be inserted before location and class predictions.
+    num_layers_before_predictor: Number of the additional conv layers before
+      the predictor.
+    use_dropout: Option to use dropout or not.  Note that a single dropout
+      op is applied here prior to both box and class predictions, which stands
+      in contrast to the ConvolutionalBoxPredictor below.
+    dropout_keep_prob: Keep probability for dropout.
+      This is only used if use_dropout is True.
+    kernel_size: Size of final convolution kernel.  If the
+      spatial resolution of the feature map is smaller than the kernel size,
+      then the kernel size is automatically set to be
+      min(feature_width, feature_height).
+    box_code_size: Size of encoding for each box.
+    class_prediction_bias_init: constant value to initialize bias of the last
+      conv2d layer before class prediction.
+    use_depthwise: Whether to use depthwise convolutions for prediction
+      steps. Default is False.
+    mask_head_config: An optional MaskHead object containing configs for mask
+      head construction.
+    name: A string name scope to assign to the box predictor. If `None`, Keras
+      will auto-generate one from the class name.
+
+  Returns:
+    A ConvolutionalBoxPredictor class.
+  """
+  box_prediction_heads = []
+  class_prediction_heads = []
+  mask_prediction_heads = []
+  other_heads = {}
+  if mask_head_config is not None:
+    other_heads[convolutional_box_predictor.MASK_PREDICTIONS] = \
+      mask_prediction_heads
+
+  for stack_index, num_predictions_per_location in enumerate(
+      num_predictions_per_location_list):
+    box_prediction_heads.append(
+        keras_box_head.ConvolutionalBoxHead(
+            is_training=is_training,
+            box_code_size=box_code_size,
+            kernel_size=kernel_size,
+            conv_hyperparams=conv_hyperparams,
+            freeze_batchnorm=freeze_batchnorm,
+            num_predictions_per_location=num_predictions_per_location,
+            use_depthwise=use_depthwise,
+            name='ConvolutionalBoxHead_%d' % stack_index))
+    class_prediction_heads.append(
+        keras_class_head.ConvolutionalClassHead(
+            is_training=is_training,
+            num_classes=num_classes,
+            use_dropout=use_dropout,
+            dropout_keep_prob=dropout_keep_prob,
+            kernel_size=kernel_size,
+            conv_hyperparams=conv_hyperparams,
+            freeze_batchnorm=freeze_batchnorm,
+            num_predictions_per_location=num_predictions_per_location,
+            class_prediction_bias_init=class_prediction_bias_init,
+            use_depthwise=use_depthwise,
+            name='ConvolutionalClassHead_%d' % stack_index))
+    if mask_head_config is not None:
+      if not mask_head_config.masks_are_class_agnostic:
+        logging.warning('Note that class specific mask prediction for SSD '
+                        'models is memory consuming.')
+      mask_prediction_heads.append(
+          keras_mask_head.ConvolutionalMaskHead(
+              is_training=is_training,
+              num_classes=num_classes,
+              use_dropout=use_dropout,
+              dropout_keep_prob=dropout_keep_prob,
+              kernel_size=kernel_size,
+              conv_hyperparams=conv_hyperparams,
+              freeze_batchnorm=freeze_batchnorm,
+              num_predictions_per_location=num_predictions_per_location,
+              use_depthwise=use_depthwise,
+              mask_height=mask_head_config.mask_height,
+              mask_width=mask_head_config.mask_width,
+              masks_are_class_agnostic=mask_head_config.
+              masks_are_class_agnostic,
+              name='ConvolutionalMaskHead_%d' % stack_index))
+
+  return convolutional_keras_box_predictor.ConvolutionalBoxPredictor(
+      is_training=is_training,
+      num_classes=num_classes,
+      box_prediction_heads=box_prediction_heads,
+      class_prediction_heads=class_prediction_heads,
+      other_heads=other_heads,
+      conv_hyperparams=conv_hyperparams,
+      num_layers_before_predictor=num_layers_before_predictor,
+      min_depth=min_depth,
+      max_depth=max_depth,
+      freeze_batchnorm=freeze_batchnorm,
+      inplace_batchnorm_update=inplace_batchnorm_update,
+      name=name)
 
 
 def build_weight_shared_convolutional_box_predictor(
@@ -134,10 +268,8 @@ def build_weight_shared_convolutional_box_predictor(
     dropout_keep_prob=0.8,
     share_prediction_tower=False,
     apply_batch_norm=True,
-    predict_instance_masks=False,
-    mask_height=7,
-    mask_width=7,
-    masks_are_class_agnostic=False):
+    use_depthwise=False,
+    mask_head_config=None):
   """Builds and returns a WeightSharedConvolutionalBoxPredictor class.
 
   Args:
@@ -161,12 +293,9 @@ def build_weight_shared_convolutional_box_predictor(
       prediction and class prediction heads.
     apply_batch_norm: Whether to apply batch normalization to conv layers in
       this predictor.
-    predict_instance_masks: If True, will add a third stage mask prediction
-      to the returned class.
-    mask_height: Desired output mask height. The default value is 7.
-    mask_width: Desired output mask width. The default value is 7.
-    masks_are_class_agnostic: Boolean determining if the mask-head is
-      class-agnostic or not.
+    use_depthwise: Whether to use depthwise separable conv2d instead of conv2d.
+    mask_head_config: An optional MaskHead object containing configs for mask
+      head construction.
 
   Returns:
     A WeightSharedConvolutionalBoxPredictor class.
@@ -174,25 +303,29 @@ def build_weight_shared_convolutional_box_predictor(
   box_prediction_head = box_head.WeightSharedConvolutionalBoxHead(
       box_code_size=box_code_size,
       kernel_size=kernel_size,
-      class_prediction_bias_init=class_prediction_bias_init)
+      use_depthwise=use_depthwise)
   class_prediction_head = (
       class_head.WeightSharedConvolutionalClassHead(
           num_classes=num_classes,
           kernel_size=kernel_size,
           class_prediction_bias_init=class_prediction_bias_init,
           use_dropout=use_dropout,
-          dropout_keep_prob=dropout_keep_prob))
+          dropout_keep_prob=dropout_keep_prob,
+          use_depthwise=use_depthwise))
   other_heads = {}
-  if predict_instance_masks:
+  if mask_head_config is not None:
+    if not mask_head_config.masks_are_class_agnostic:
+      logging.warning('Note that class specific mask prediction for SSD '
+                      'models is memory consuming.')
     other_heads[convolutional_box_predictor.MASK_PREDICTIONS] = (
         mask_head.WeightSharedConvolutionalMaskHead(
             num_classes=num_classes,
             kernel_size=kernel_size,
             use_dropout=use_dropout,
             dropout_keep_prob=dropout_keep_prob,
-            mask_height=mask_height,
-            mask_width=mask_width,
-            masks_are_class_agnostic=masks_are_class_agnostic))
+            mask_height=mask_head_config.mask_height,
+            mask_width=mask_head_config.mask_width,
+            masks_are_class_agnostic=mask_head_config.masks_are_class_agnostic))
   return convolutional_box_predictor.WeightSharedConvolutionalBoxPredictor(
       is_training=is_training,
       num_classes=num_classes,
@@ -204,7 +337,8 @@ def build_weight_shared_convolutional_box_predictor(
       num_layers_before_predictor=num_layers_before_predictor,
       kernel_size=kernel_size,
       apply_batch_norm=apply_batch_norm,
-      share_prediction_tower=share_prediction_tower)
+      share_prediction_tower=share_prediction_tower,
+      use_depthwise=use_depthwise)
 
 
 def build_mask_rcnn_box_predictor(is_training,
@@ -324,6 +458,9 @@ def build(argscope_fn, box_predictor_config, is_training, num_classes):
     config_box_predictor = box_predictor_config.convolutional_box_predictor
     conv_hyperparams_fn = argscope_fn(config_box_predictor.conv_hyperparams,
                                       is_training)
+    mask_head_config = (
+        config_box_predictor.mask_head
+        if config_box_predictor.HasField('mask_head') else None)
     return build_convolutional_box_predictor(
         is_training=is_training,
         num_classes=num_classes,
@@ -339,7 +476,8 @@ def build(argscope_fn, box_predictor_config, is_training, num_classes):
         apply_sigmoid_to_scores=config_box_predictor.apply_sigmoid_to_scores,
         class_prediction_bias_init=(
             config_box_predictor.class_prediction_bias_init),
-        use_depthwise=config_box_predictor.use_depthwise)
+        use_depthwise=config_box_predictor.use_depthwise,
+        mask_head_config=mask_head_config)
 
   if  box_predictor_oneof == 'weight_shared_convolutional_box_predictor':
     config_box_predictor = (
@@ -348,6 +486,9 @@ def build(argscope_fn, box_predictor_config, is_training, num_classes):
                                       is_training)
     apply_batch_norm = config_box_predictor.conv_hyperparams.HasField(
         'batch_norm')
+    mask_head_config = (
+        config_box_predictor.mask_head
+        if config_box_predictor.HasField('mask_head') else None)
     return build_weight_shared_convolutional_box_predictor(
         is_training=is_training,
         num_classes=num_classes,
@@ -362,7 +503,9 @@ def build(argscope_fn, box_predictor_config, is_training, num_classes):
         use_dropout=config_box_predictor.use_dropout,
         dropout_keep_prob=config_box_predictor.dropout_keep_probability,
         share_prediction_tower=config_box_predictor.share_prediction_tower,
-        apply_batch_norm=apply_batch_norm)
+        apply_batch_norm=apply_batch_norm,
+        use_depthwise=config_box_predictor.use_depthwise,
+        mask_head_config=mask_head_config)
 
   if box_predictor_oneof == 'mask_rcnn_box_predictor':
     config_box_predictor = box_predictor_config.mask_rcnn_box_predictor

--- a/research/object_detection/builders/dataset_builder.py
+++ b/research/object_detection/builders/dataset_builder.py
@@ -132,6 +132,8 @@ def build(input_reader_config, batch_size=None, transform_input_data_fn=None):
     dataset = read_dataset(
         functools.partial(tf.data.TFRecordDataset, buffer_size=8 * 1000 * 1000),
         config.input_path[:], input_reader_config)
+    if input_reader_config.sample_1_of_n_examples > 1:
+      dataset = dataset.shard(input_reader_config.sample_1_of_n_examples, 0)
     # TODO(rathodv): make batch size a required argument once the old binaries
     # are deleted.
     if batch_size:

--- a/research/object_detection/builders/hyperparams_builder_test.py
+++ b/research/object_detection/builders/hyperparams_builder_test.py
@@ -460,6 +460,11 @@ class HyperparamsBuilderTest(tf.test.TestCase):
     keras_config = hyperparams_builder.KerasLayerHyperparams(
         conv_hyperparams_proto)
     self.assertEqual(keras_config.params()['activation'], None)
+    self.assertEqual(
+        keras_config.params(include_activation=True)['activation'], None)
+    activation_layer = keras_config.build_activation_layer()
+    self.assertTrue(isinstance(activation_layer, tf.keras.layers.Lambda))
+    self.assertEqual(activation_layer.function, tf.identity)
 
   def test_use_relu_activation(self):
     conv_hyperparams_text_proto = """
@@ -497,7 +502,12 @@ class HyperparamsBuilderTest(tf.test.TestCase):
     text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams_proto)
     keras_config = hyperparams_builder.KerasLayerHyperparams(
         conv_hyperparams_proto)
-    self.assertEqual(keras_config.params()['activation'], tf.nn.relu)
+    self.assertEqual(keras_config.params()['activation'], None)
+    self.assertEqual(
+        keras_config.params(include_activation=True)['activation'], tf.nn.relu)
+    activation_layer = keras_config.build_activation_layer()
+    self.assertTrue(isinstance(activation_layer, tf.keras.layers.Lambda))
+    self.assertEqual(activation_layer.function, tf.nn.relu)
 
   def test_use_relu_6_activation(self):
     conv_hyperparams_text_proto = """
@@ -535,7 +545,12 @@ class HyperparamsBuilderTest(tf.test.TestCase):
     text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams_proto)
     keras_config = hyperparams_builder.KerasLayerHyperparams(
         conv_hyperparams_proto)
-    self.assertEqual(keras_config.params()['activation'], tf.nn.relu6)
+    self.assertEqual(keras_config.params()['activation'], None)
+    self.assertEqual(
+        keras_config.params(include_activation=True)['activation'], tf.nn.relu6)
+    activation_layer = keras_config.build_activation_layer()
+    self.assertTrue(isinstance(activation_layer, tf.keras.layers.Lambda))
+    self.assertEqual(activation_layer.function, tf.nn.relu6)
 
   def test_override_activation_keras(self):
     conv_hyperparams_text_proto = """

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 
 """A function to build a DetectionModel from configuration."""
+
 import functools
+
 from object_detection.builders import anchor_generator_builder
 from object_detection.builders import box_coder_builder
 from object_detection.builders import box_predictor_builder
@@ -25,6 +27,7 @@ from object_detection.builders import matcher_builder
 from object_detection.builders import post_processing_builder
 from object_detection.builders import region_similarity_calculator_builder as sim_calc
 from object_detection.core import balanced_positive_negative_sampler as sampler
+from object_detection.core import post_processing
 from object_detection.core import target_assigner
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.meta_architectures import rfcn_meta_arch
@@ -43,10 +46,10 @@ from object_detection.models.ssd_mobilenet_v1_feature_extractor import SSDMobile
 from object_detection.models.ssd_mobilenet_v1_fpn_feature_extractor import SSDMobileNetV1FpnFeatureExtractor
 from object_detection.models.ssd_mobilenet_v1_ppn_feature_extractor import SSDMobileNetV1PpnFeatureExtractor
 from object_detection.models.ssd_mobilenet_v2_feature_extractor import SSDMobileNetV2FeatureExtractor
+from object_detection.models.ssd_mobilenet_v2_fpn_feature_extractor import SSDMobileNetV2FpnFeatureExtractor
 from object_detection.predictors import rfcn_box_predictor
 from object_detection.protos import model_pb2
 from object_detection.utils import ops
-
 
 # A map of names to SSD feature extractors.
 SSD_FEATURE_EXTRACTOR_CLASS_MAP = {
@@ -56,6 +59,7 @@ SSD_FEATURE_EXTRACTOR_CLASS_MAP = {
     'ssd_mobilenet_v1_fpn': SSDMobileNetV1FpnFeatureExtractor,
     'ssd_mobilenet_v1_ppn': SSDMobileNetV1PpnFeatureExtractor,
     'ssd_mobilenet_v2': SSDMobileNetV2FeatureExtractor,
+    'ssd_mobilenet_v2_fpn': SSDMobileNetV2FpnFeatureExtractor,
     'ssd_resnet50_v1_fpn': ssd_resnet_v1_fpn.SSDResnet50V1FpnFeatureExtractor,
     'ssd_resnet101_v1_fpn': ssd_resnet_v1_fpn.SSDResnet101V1FpnFeatureExtractor,
     'ssd_resnet152_v1_fpn': ssd_resnet_v1_fpn.SSDResnet152V1FpnFeatureExtractor,
@@ -170,8 +174,12 @@ def _build_ssd_feature_extractor(feature_extractor_config, is_training,
 
   if feature_extractor_config.HasField('fpn'):
     kwargs.update({
-        'fpn_min_level': feature_extractor_config.fpn.min_level,
-        'fpn_max_level': feature_extractor_config.fpn.max_level,
+        'fpn_min_level':
+            feature_extractor_config.fpn.min_level,
+        'fpn_max_level':
+            feature_extractor_config.fpn.max_level,
+        'additional_layer_depth':
+            feature_extractor_config.fpn.additional_layer_depth,
     })
 
   return feature_extractor_class(**kwargs)
@@ -240,25 +248,24 @@ def _build_ssd_model(ssd_config, is_training, add_summaries,
         desired_negative_sampling_ratio=ssd_config.
         desired_negative_sampling_ratio)
 
-  return ssd_meta_arch.SSDMetaArch(
-      is_training,
-      anchor_generator,
-      ssd_box_predictor,
-      box_coder,
-      feature_extractor,
-      matcher,
-      region_similarity_calculator,
-      encode_background_as_zeros,
-      negative_class_weight,
-      image_resizer_fn,
-      non_max_suppression_fn,
-      score_conversion_fn,
-      classification_loss,
-      localization_loss,
-      classification_weight,
-      localization_weight,
-      normalize_loss_by_num_matches,
-      hard_example_miner,
+  ssd_meta_arch_fn = ssd_meta_arch.SSDMetaArch
+
+  return ssd_meta_arch_fn(
+      is_training=is_training,
+      anchor_generator=anchor_generator,
+      box_predictor=ssd_box_predictor,
+      box_coder=box_coder,
+      feature_extractor=feature_extractor,
+      encode_background_as_zeros=encode_background_as_zeros,
+      image_resizer_fn=image_resizer_fn,
+      non_max_suppression_fn=non_max_suppression_fn,
+      score_conversion_fn=score_conversion_fn,
+      classification_loss=classification_loss,
+      localization_loss=localization_loss,
+      classification_loss_weight=classification_weight,
+      localization_loss_weight=localization_weight,
+      normalize_loss_by_num_matches=normalize_loss_by_num_matches,
+      hard_example_miner=hard_example_miner,
       target_assigner_instance=target_assigner_instance,
       add_summaries=add_summaries,
       normalize_loc_loss_by_codesize=normalize_loc_loss_by_codesize,
@@ -350,12 +357,27 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       frcnn_config.first_stage_box_predictor_kernel_size)
   first_stage_box_predictor_depth = frcnn_config.first_stage_box_predictor_depth
   first_stage_minibatch_size = frcnn_config.first_stage_minibatch_size
+  # TODO(bhattad): When eval is supported using static shapes, add separate
+  # use_static_shapes_for_trainig and use_static_shapes_for_evaluation.
+  use_static_shapes = frcnn_config.use_static_shapes and is_training
   first_stage_sampler = sampler.BalancedPositiveNegativeSampler(
       positive_fraction=frcnn_config.first_stage_positive_balance_fraction,
-      is_static=frcnn_config.use_static_balanced_label_sampler)
-  first_stage_nms_score_threshold = frcnn_config.first_stage_nms_score_threshold
-  first_stage_nms_iou_threshold = frcnn_config.first_stage_nms_iou_threshold
+      is_static=frcnn_config.use_static_balanced_label_sampler and is_training)
   first_stage_max_proposals = frcnn_config.first_stage_max_proposals
+  if (frcnn_config.first_stage_nms_iou_threshold < 0 or
+      frcnn_config.first_stage_nms_iou_threshold > 1.0):
+    raise ValueError('iou_threshold not in [0, 1.0].')
+  if (is_training and frcnn_config.second_stage_batch_size >
+      first_stage_max_proposals):
+    raise ValueError('second_stage_batch_size should be no greater than '
+                     'first_stage_max_proposals.')
+  first_stage_non_max_suppression_fn = functools.partial(
+      post_processing.batch_multiclass_non_max_suppression,
+      score_thresh=frcnn_config.first_stage_nms_score_threshold,
+      iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
+      max_size_per_class=frcnn_config.first_stage_max_proposals,
+      max_total_size=frcnn_config.first_stage_max_proposals,
+      use_static_shapes=use_static_shapes and is_training)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight
@@ -376,7 +398,7 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
   second_stage_batch_size = frcnn_config.second_stage_batch_size
   second_stage_sampler = sampler.BalancedPositiveNegativeSampler(
       positive_fraction=frcnn_config.second_stage_balance_fraction,
-      is_static=frcnn_config.use_static_balanced_label_sampler)
+      is_static=frcnn_config.use_static_balanced_label_sampler and is_training)
   (second_stage_non_max_suppression_fn, second_stage_score_conversion_fn
   ) = post_processing_builder.build(frcnn_config.second_stage_post_processing)
   second_stage_localization_loss_weight = (
@@ -396,7 +418,9 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
         second_stage_classification_loss_weight,
         second_stage_localization_loss_weight)
 
-  use_matmul_crop_and_resize = (frcnn_config.use_matmul_crop_and_resize)
+  crop_and_resize_fn = (
+      ops.matmul_crop_and_resize if frcnn_config.use_matmul_crop_and_resize
+      else ops.native_crop_and_resize)
   clip_anchors_to_image = (
       frcnn_config.clip_anchors_to_image)
 
@@ -416,8 +440,7 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       'first_stage_box_predictor_depth': first_stage_box_predictor_depth,
       'first_stage_minibatch_size': first_stage_minibatch_size,
       'first_stage_sampler': first_stage_sampler,
-      'first_stage_nms_score_threshold': first_stage_nms_score_threshold,
-      'first_stage_nms_iou_threshold': first_stage_nms_iou_threshold,
+      'first_stage_non_max_suppression_fn': first_stage_non_max_suppression_fn,
       'first_stage_max_proposals': first_stage_max_proposals,
       'first_stage_localization_loss_weight': first_stage_loc_loss_weight,
       'first_stage_objectness_loss_weight': first_stage_obj_loss_weight,
@@ -435,8 +458,10 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       second_stage_classification_loss_weight,
       'hard_example_miner': hard_example_miner,
       'add_summaries': add_summaries,
-      'use_matmul_crop_and_resize': use_matmul_crop_and_resize,
-      'clip_anchors_to_image': clip_anchors_to_image
+      'crop_and_resize_fn': crop_and_resize_fn,
+      'clip_anchors_to_image': clip_anchors_to_image,
+      'use_static_shapes': use_static_shapes,
+      'resize_masks': frcnn_config.resize_masks
   }
 
   if isinstance(second_stage_box_predictor,

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -50,6 +50,11 @@ from object_detection.models.ssd_mobilenet_v2_fpn_feature_extractor import SSDMo
 from object_detection.predictors import rfcn_box_predictor
 from object_detection.protos import model_pb2
 from object_detection.utils import ops
+# BEGIN GOOGLE-INTERNAL
+# TODO(lzc): move ssd_mask_meta_arch to third party when it has decent
+# performance relative to a comparable Mask R-CNN model (b/112561592).
+from google3.image.understanding.object_detection.meta_architectures import ssd_mask_meta_arch
+# END GOOGLE-INTERNAL
 
 # A map of names to SSD feature extractors.
 SSD_FEATURE_EXTRACTOR_CLASS_MAP = {
@@ -249,6 +254,23 @@ def _build_ssd_model(ssd_config, is_training, add_summaries,
         desired_negative_sampling_ratio)
 
   ssd_meta_arch_fn = ssd_meta_arch.SSDMetaArch
+  # BEGIN GOOGLE-INTERNAL
+  # TODO(lzc): move ssd_mask_meta_arch to third party when it has decent
+  # performance relative to a comparable Mask R-CNN model (b/112561592).
+  predictor_config = ssd_config.box_predictor
+  predict_instance_masks = False
+  if predictor_config.WhichOneof(
+      'box_predictor_oneof') == 'convolutional_box_predictor':
+    predict_instance_masks = (
+        predictor_config.convolutional_box_predictor.HasField('mask_head'))
+  elif predictor_config.WhichOneof(
+      'box_predictor_oneof') == 'weight_shared_convolutional_box_predictor':
+    predict_instance_masks = (
+        predictor_config.weight_shared_convolutional_box_predictor.HasField(
+            'mask_head'))
+  if predict_instance_masks:
+    ssd_meta_arch_fn = ssd_mask_meta_arch.SSDMaskMetaArch
+  # END GOOGLE-INTERNAL
 
   return ssd_meta_arch_fn(
       is_training=is_training,

--- a/research/object_detection/builders/model_builder_test.py
+++ b/research/object_detection/builders/model_builder_test.py
@@ -15,6 +15,8 @@
 
 """Tests for object_detection.models.model_builder."""
 
+from absl.testing import parameterized
+
 import tensorflow as tf
 
 from google.protobuf import text_format
@@ -36,6 +38,7 @@ from object_detection.models.ssd_mobilenet_v1_feature_extractor import SSDMobile
 from object_detection.models.ssd_mobilenet_v1_fpn_feature_extractor import SSDMobileNetV1FpnFeatureExtractor
 from object_detection.models.ssd_mobilenet_v1_ppn_feature_extractor import SSDMobileNetV1PpnFeatureExtractor
 from object_detection.models.ssd_mobilenet_v2_feature_extractor import SSDMobileNetV2FeatureExtractor
+from object_detection.models.ssd_mobilenet_v2_fpn_feature_extractor import SSDMobileNetV2FpnFeatureExtractor
 from object_detection.protos import model_pb2
 
 FRCNN_RESNET_FEAT_MAPS = {
@@ -66,7 +69,7 @@ SSD_RESNET_V1_PPN_FEAT_MAPS = {
 }
 
 
-class ModelBuilderTest(tf.test.TestCase):
+class ModelBuilderTest(tf.test.TestCase, parameterized.TestCase):
 
   def create_model(self, model_config):
     """Builds a DetectionModel based on the model config.
@@ -160,6 +163,7 @@ class ModelBuilderTest(tf.test.TestCase):
             'minimum_negative_sampling': 10,
             'desired_negative_sampling_ratio': 2
         })
+
 
   def test_create_ssd_inception_v3_model_from_config(self):
     model_text_proto = """
@@ -712,6 +716,170 @@ class ModelBuilderTest(tf.test.TestCase):
     self.assertTrue(model._normalize_loc_loss_by_codesize)
     self.assertTrue(model._target_assigner._weight_regression_loss_by_score)
 
+  def test_create_ssd_mobilenet_v2_fpn_model_from_config(self):
+    model_text_proto = """
+      ssd {
+        freeze_batchnorm: true
+        inplace_batchnorm_update: true
+        feature_extractor {
+          type: 'ssd_mobilenet_v2_fpn'
+          fpn {
+            min_level: 3
+            max_level: 7
+          }
+          conv_hyperparams {
+            regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+          }
+        }
+        box_coder {
+          faster_rcnn_box_coder {
+          }
+        }
+        matcher {
+          argmax_matcher {
+          }
+        }
+        similarity_calculator {
+          iou_similarity {
+          }
+        }
+        anchor_generator {
+          ssd_anchor_generator {
+            aspect_ratios: 1.0
+          }
+        }
+        image_resizer {
+          fixed_shape_resizer {
+            height: 320
+            width: 320
+          }
+        }
+        box_predictor {
+          convolutional_box_predictor {
+            conv_hyperparams {
+              regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+            }
+          }
+        }
+        normalize_loc_loss_by_codesize: true
+        loss {
+          classification_loss {
+            weighted_softmax {
+            }
+          }
+          localization_loss {
+            weighted_smooth_l1 {
+            }
+          }
+        }
+      }"""
+    model_proto = model_pb2.DetectionModel()
+    text_format.Merge(model_text_proto, model_proto)
+    model = self.create_model(model_proto)
+    self.assertIsInstance(model, ssd_meta_arch.SSDMetaArch)
+    self.assertIsInstance(model._feature_extractor,
+                          SSDMobileNetV2FpnFeatureExtractor)
+    self.assertTrue(model._normalize_loc_loss_by_codesize)
+    self.assertTrue(model._freeze_batchnorm)
+    self.assertTrue(model._inplace_batchnorm_update)
+
+  def test_create_ssd_mobilenet_v2_fpnlite_model_from_config(self):
+    model_text_proto = """
+      ssd {
+        freeze_batchnorm: true
+        inplace_batchnorm_update: true
+        feature_extractor {
+          type: 'ssd_mobilenet_v2_fpn'
+          use_depthwise: true
+          fpn {
+            min_level: 3
+            max_level: 7
+            additional_layer_depth: 128
+          }
+          conv_hyperparams {
+            regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+          }
+        }
+        box_coder {
+          faster_rcnn_box_coder {
+          }
+        }
+        matcher {
+          argmax_matcher {
+          }
+        }
+        similarity_calculator {
+          iou_similarity {
+          }
+        }
+        anchor_generator {
+          ssd_anchor_generator {
+            aspect_ratios: 1.0
+          }
+        }
+        image_resizer {
+          fixed_shape_resizer {
+            height: 320
+            width: 320
+          }
+        }
+        box_predictor {
+          convolutional_box_predictor {
+            conv_hyperparams {
+              regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+            }
+          }
+        }
+        normalize_loc_loss_by_codesize: true
+        loss {
+          classification_loss {
+            weighted_softmax {
+            }
+          }
+          localization_loss {
+            weighted_smooth_l1 {
+            }
+          }
+        }
+      }"""
+    model_proto = model_pb2.DetectionModel()
+    text_format.Merge(model_text_proto, model_proto)
+    model = self.create_model(model_proto)
+    self.assertIsInstance(model, ssd_meta_arch.SSDMetaArch)
+    self.assertIsInstance(model._feature_extractor,
+                          SSDMobileNetV2FpnFeatureExtractor)
+    self.assertTrue(model._normalize_loc_loss_by_codesize)
+    self.assertTrue(model._freeze_batchnorm)
+    self.assertTrue(model._inplace_batchnorm_update)
+
   def test_create_embedded_ssd_mobilenet_v1_model_from_config(self):
     model_text_proto = """
       ssd {
@@ -845,13 +1013,19 @@ class ModelBuilderTest(tf.test.TestCase):
       }"""
     model_proto = model_pb2.DetectionModel()
     text_format.Merge(model_text_proto, model_proto)
+
     for extractor_type, extractor_class in FRCNN_RESNET_FEAT_MAPS.items():
       model_proto.faster_rcnn.feature_extractor.type = extractor_type
       model = model_builder.build(model_proto, is_training=True)
       self.assertIsInstance(model, faster_rcnn_meta_arch.FasterRCNNMetaArch)
       self.assertIsInstance(model._feature_extractor, extractor_class)
 
-  def test_create_faster_rcnn_resnet101_with_mask_prediction_enabled(self):
+  @parameterized.parameters(
+      {'use_matmul_crop_and_resize': False},
+      {'use_matmul_crop_and_resize': True},
+  )
+  def test_create_faster_rcnn_resnet101_with_mask_prediction_enabled(
+      self, use_matmul_crop_and_resize):
     model_text_proto = """
       faster_rcnn {
         num_classes: 3
@@ -924,6 +1098,8 @@ class ModelBuilderTest(tf.test.TestCase):
       }"""
     model_proto = model_pb2.DetectionModel()
     text_format.Merge(model_text_proto, model_proto)
+    model_proto.faster_rcnn.use_matmul_crop_and_resize = (
+        use_matmul_crop_and_resize)
     model = model_builder.build(model_proto, is_training=True)
     self.assertAlmostEqual(model._second_stage_mask_loss_weight, 3.0)
 

--- a/research/object_detection/builders/model_builder_test.py
+++ b/research/object_detection/builders/model_builder_test.py
@@ -40,6 +40,11 @@ from object_detection.models.ssd_mobilenet_v1_ppn_feature_extractor import SSDMo
 from object_detection.models.ssd_mobilenet_v2_feature_extractor import SSDMobileNetV2FeatureExtractor
 from object_detection.models.ssd_mobilenet_v2_fpn_feature_extractor import SSDMobileNetV2FpnFeatureExtractor
 from object_detection.protos import model_pb2
+# BEGIN GOOGLE-INTERNAL
+# TODO(lzc): move ssd_mask_meta_arch to third party when it has decent
+# performance relative to a comparable Mask R-CNN model (b/112561592).
+from google3.image.understanding.object_detection.meta_architectures import ssd_mask_meta_arch
+# END GOOGLE-INTERNAL
 
 FRCNN_RESNET_FEAT_MAPS = {
     'faster_rcnn_resnet50':
@@ -164,6 +169,161 @@ class ModelBuilderTest(tf.test.TestCase, parameterized.TestCase):
             'desired_negative_sampling_ratio': 2
         })
 
+  # BEGIN GOOGLE-INTERNAL
+  # TODO(lzc): move ssd_mask_meta_arch to third party when it has decent
+  # performance relative to a comparable Mask R-CNN model (b/112561592).
+  def test_create_ssd_conv_predictor_model_with_mask(self):
+    model_text_proto = """
+      ssd {
+        feature_extractor {
+          type: 'ssd_inception_v2'
+          conv_hyperparams {
+            regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+          }
+          override_base_feature_extractor_hyperparams: true
+        }
+        box_coder {
+          faster_rcnn_box_coder {
+          }
+        }
+        matcher {
+          argmax_matcher {
+          }
+        }
+        similarity_calculator {
+          iou_similarity {
+          }
+        }
+        anchor_generator {
+          ssd_anchor_generator {
+            aspect_ratios: 1.0
+          }
+        }
+        image_resizer {
+          fixed_shape_resizer {
+            height: 320
+            width: 320
+          }
+        }
+        box_predictor {
+          convolutional_box_predictor {
+            mask_head {
+            }
+            conv_hyperparams {
+              regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+            }
+          }
+        }
+        loss {
+          classification_loss {
+            weighted_softmax {
+            }
+          }
+          localization_loss {
+            weighted_smooth_l1 {
+            }
+          }
+        }
+        use_expected_classification_loss_under_sampling: true
+        minimum_negative_sampling: 10
+        desired_negative_sampling_ratio: 2
+      }"""
+    model_proto = model_pb2.DetectionModel()
+    text_format.Merge(model_text_proto, model_proto)
+    model = self.create_model(model_proto)
+    self.assertIsInstance(model, ssd_mask_meta_arch.SSDMaskMetaArch)
+
+  def test_create_ssd_weight_shared_predictor_model_with_mask(self):
+    model_text_proto = """
+      ssd {
+        feature_extractor {
+          type: 'ssd_inception_v2'
+          conv_hyperparams {
+            regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                truncated_normal_initializer {
+                }
+              }
+          }
+          override_base_feature_extractor_hyperparams: true
+        }
+        box_coder {
+          faster_rcnn_box_coder {
+          }
+        }
+        matcher {
+          argmax_matcher {
+          }
+        }
+        similarity_calculator {
+          iou_similarity {
+          }
+        }
+        anchor_generator {
+          ssd_anchor_generator {
+            aspect_ratios: 1.0
+          }
+        }
+        image_resizer {
+          fixed_shape_resizer {
+            height: 320
+            width: 320
+          }
+        }
+        box_predictor {
+          weight_shared_convolutional_box_predictor {
+            mask_head {
+            }
+            depth: 32
+            conv_hyperparams {
+              regularizer {
+                l2_regularizer {
+                }
+              }
+              initializer {
+                random_normal_initializer {
+                }
+              }
+            }
+            num_layers_before_predictor: 1
+          }
+        }
+        loss {
+          classification_loss {
+            weighted_softmax {
+            }
+          }
+          localization_loss {
+            weighted_smooth_l1 {
+            }
+          }
+        }
+        use_expected_classification_loss_under_sampling: true
+        minimum_negative_sampling: 10
+        desired_negative_sampling_ratio: 2
+      }"""
+    model_proto = model_pb2.DetectionModel()
+    text_format.Merge(model_text_proto, model_proto)
+    model = self.create_model(model_proto)
+    self.assertIsInstance(model, ssd_mask_meta_arch.SSDMaskMetaArch)
+  # END GOOGLE-INTERNAL
 
   def test_create_ssd_inception_v3_model_from_config(self):
     model_text_proto = """

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -84,7 +84,8 @@ def _build_non_max_suppressor(nms_config):
       score_thresh=nms_config.score_threshold,
       iou_thresh=nms_config.iou_threshold,
       max_size_per_class=nms_config.max_detections_per_class,
-      max_total_size=nms_config.max_total_detections)
+      max_total_size=nms_config.max_total_detections,
+      use_static_shapes=nms_config.use_static_shapes)
   return non_max_suppressor_fn
 
 

--- a/research/object_detection/core/balanced_positive_negative_sampler_test.py
+++ b/research/object_detection/core/balanced_positive_negative_sampler_test.py
@@ -24,7 +24,7 @@ from object_detection.utils import test_case
 
 class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
 
-  def _test_subsample_all_examples(self, is_static=False):
+  def test_subsample_all_examples_dynamic(self):
     numpy_labels = np.random.permutation(300)
     indicator = tf.constant(np.ones(300) == 1)
     numpy_labels = (numpy_labels - 200) > 0
@@ -32,8 +32,7 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
     labels = tf.constant(numpy_labels)
 
     sampler = (
-        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
-            is_static=is_static))
+        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler())
     is_sampled = sampler.subsample(indicator, 64, labels)
     with self.test_session() as sess:
       is_sampled = sess.run(is_sampled)
@@ -42,13 +41,26 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
       self.assertTrue(sum(np.logical_and(
           np.logical_not(numpy_labels), is_sampled)) == 32)
 
-  def test_subsample_all_examples_dynamic(self):
-    self._test_subsample_all_examples()
-
   def test_subsample_all_examples_static(self):
-    self._test_subsample_all_examples(is_static=True)
+    numpy_labels = np.random.permutation(300)
+    indicator = np.array(np.ones(300) == 1, np.bool)
+    numpy_labels = (numpy_labels - 200) > 0
 
-  def _test_subsample_selection(self, is_static=False):
+    labels = np.array(numpy_labels, np.bool)
+
+    def graph_fn(indicator, labels):
+      sampler = (
+          balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
+              is_static=True))
+      return sampler.subsample(indicator, 64, labels)
+
+    is_sampled = self.execute(graph_fn, [indicator, labels])
+    self.assertTrue(sum(is_sampled) == 64)
+    self.assertTrue(sum(np.logical_and(numpy_labels, is_sampled)) == 32)
+    self.assertTrue(sum(np.logical_and(
+        np.logical_not(numpy_labels), is_sampled)) == 32)
+
+  def test_subsample_selection_dynamic(self):
     # Test random sampling when only some examples can be sampled:
     # 100 samples, 20 positives, 10 positives cannot be sampled
     numpy_labels = np.arange(100)
@@ -59,8 +71,7 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
     labels = tf.constant(numpy_labels)
 
     sampler = (
-        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
-            is_static=is_static))
+        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler())
     is_sampled = sampler.subsample(indicator, 64, labels)
     with self.test_session() as sess:
       is_sampled = sess.run(is_sampled)
@@ -71,13 +82,30 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
       self.assertAllEqual(is_sampled, np.logical_and(is_sampled,
                                                      numpy_indicator))
 
-  def test_subsample_selection_dynamic(self):
-    self._test_subsample_selection()
-
   def test_subsample_selection_static(self):
-    self._test_subsample_selection(is_static=True)
+    # Test random sampling when only some examples can be sampled:
+    # 100 samples, 20 positives, 10 positives cannot be sampled.
+    numpy_labels = np.arange(100)
+    numpy_indicator = numpy_labels < 90
+    indicator = np.array(numpy_indicator, np.bool)
+    numpy_labels = (numpy_labels - 80) >= 0
 
-  def _test_subsample_selection_larger_batch_size(self, is_static=False):
+    labels = np.array(numpy_labels, np.bool)
+
+    def graph_fn(indicator, labels):
+      sampler = (
+          balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
+              is_static=True))
+      return sampler.subsample(indicator, 64, labels)
+
+    is_sampled = self.execute(graph_fn, [indicator, labels])
+    self.assertTrue(sum(is_sampled) == 64)
+    self.assertTrue(sum(np.logical_and(numpy_labels, is_sampled)) == 10)
+    self.assertTrue(sum(np.logical_and(
+        np.logical_not(numpy_labels), is_sampled)) == 54)
+    self.assertAllEqual(is_sampled, np.logical_and(is_sampled, numpy_indicator))
+
+  def test_subsample_selection_larger_batch_size_dynamic(self):
     # Test random sampling when total number of examples that can be sampled are
     # less than batch size:
     # 100 samples, 50 positives, 40 positives cannot be sampled, batch size 64.
@@ -89,8 +117,7 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
     labels = tf.constant(numpy_labels)
 
     sampler = (
-        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
-            is_static=is_static))
+        balanced_positive_negative_sampler.BalancedPositiveNegativeSampler())
     is_sampled = sampler.subsample(indicator, 64, labels)
     with self.test_session() as sess:
       is_sampled = sess.run(is_sampled)
@@ -101,11 +128,31 @@ class BalancedPositiveNegativeSamplerTest(test_case.TestCase):
       self.assertAllEqual(is_sampled, np.logical_and(is_sampled,
                                                      numpy_indicator))
 
-  def test_subsample_selection_larger_batch_size_dynamic(self):
-    self._test_subsample_selection_larger_batch_size()
-
   def test_subsample_selection_larger_batch_size_static(self):
-    self._test_subsample_selection_larger_batch_size(is_static=True)
+    # Test random sampling when total number of examples that can be sampled are
+    # less than batch size:
+    # 100 samples, 50 positives, 40 positives cannot be sampled, batch size 64.
+    # It should still return 64 samples, with 4 of them that couldn't have been
+    # sampled.
+    numpy_labels = np.arange(100)
+    numpy_indicator = numpy_labels < 60
+    indicator = np.array(numpy_indicator, np.bool)
+    numpy_labels = (numpy_labels - 50) >= 0
+
+    labels = np.array(numpy_labels, np.bool)
+
+    def graph_fn(indicator, labels):
+      sampler = (
+          balanced_positive_negative_sampler.BalancedPositiveNegativeSampler(
+              is_static=True))
+      return sampler.subsample(indicator, 64, labels)
+
+    is_sampled = self.execute(graph_fn, [indicator, labels])
+    self.assertTrue(sum(is_sampled) == 64)
+    self.assertTrue(sum(np.logical_and(numpy_labels, is_sampled)) >= 10)
+    self.assertTrue(
+        sum(np.logical_and(np.logical_not(numpy_labels), is_sampled)) >= 50)
+    self.assertTrue(sum(np.logical_and(is_sampled, numpy_indicator)) == 60)
 
   def test_subsample_selection_no_batch_size(self):
     # Test random sampling when only some examples can be sampled:

--- a/research/object_detection/core/box_list_ops.py
+++ b/research/object_detection/core/box_list_ops.py
@@ -26,6 +26,7 @@ BoxList are retained unless documented otherwise.
 import tensorflow as tf
 
 from object_detection.core import box_list
+from object_detection.utils import ops
 from object_detection.utils import shape_utils
 
 
@@ -420,7 +421,8 @@ def sq_dist(boxlist1, boxlist2, scope=None):
     return sqnorm1 + tf.transpose(sqnorm2) - 2.0 * innerprod
 
 
-def boolean_mask(boxlist, indicator, fields=None, scope=None):
+def boolean_mask(boxlist, indicator, fields=None, scope=None,
+                 use_static_shapes=False, indicator_sum=None):
   """Select boxes from BoxList according to indicator and return new BoxList.
 
   `boolean_mask` returns the subset of boxes that are marked as "True" by the
@@ -436,6 +438,10 @@ def boolean_mask(boxlist, indicator, fields=None, scope=None):
       all fields are gathered from.  Pass an empty fields list to only gather
       the box coordinates.
     scope: name scope.
+    use_static_shapes: Whether to use an implementation with static shape
+      gurantees.
+    indicator_sum: An integer containing the sum of `indicator` vector. Only
+      required if `use_static_shape` is True.
 
   Returns:
     subboxlist: a BoxList corresponding to the subset of the input BoxList
@@ -448,18 +454,36 @@ def boolean_mask(boxlist, indicator, fields=None, scope=None):
       raise ValueError('indicator should have rank 1')
     if indicator.dtype != tf.bool:
       raise ValueError('indicator should be a boolean tensor')
-    subboxlist = box_list.BoxList(tf.boolean_mask(boxlist.get(), indicator))
-    if fields is None:
-      fields = boxlist.get_extra_fields()
-    for field in fields:
-      if not boxlist.has_field(field):
-        raise ValueError('boxlist must contain all specified fields')
-      subfieldlist = tf.boolean_mask(boxlist.get_field(field), indicator)
-      subboxlist.add_field(field, subfieldlist)
-    return subboxlist
+    if use_static_shapes:
+      if not (indicator_sum and isinstance(indicator_sum, int)):
+        raise ValueError('`indicator_sum` must be a of type int')
+      selected_positions = tf.to_float(indicator)
+      indexed_positions = tf.cast(
+          tf.multiply(
+              tf.cumsum(selected_positions), selected_positions),
+          dtype=tf.int32)
+      one_hot_selector = tf.one_hot(
+          indexed_positions - 1, indicator_sum, dtype=tf.float32)
+      sampled_indices = tf.cast(
+          tf.tensordot(
+              tf.to_float(tf.range(tf.shape(indicator)[0])),
+              one_hot_selector,
+              axes=[0, 0]),
+          dtype=tf.int32)
+      return gather(boxlist, sampled_indices, use_static_shapes=True)
+    else:
+      subboxlist = box_list.BoxList(tf.boolean_mask(boxlist.get(), indicator))
+      if fields is None:
+        fields = boxlist.get_extra_fields()
+      for field in fields:
+        if not boxlist.has_field(field):
+          raise ValueError('boxlist must contain all specified fields')
+        subfieldlist = tf.boolean_mask(boxlist.get_field(field), indicator)
+        subboxlist.add_field(field, subfieldlist)
+      return subboxlist
 
 
-def gather(boxlist, indices, fields=None, scope=None):
+def gather(boxlist, indices, fields=None, scope=None, use_static_shapes=False):
   """Gather boxes from BoxList according to indices and return new BoxList.
 
   By default, `gather` returns boxes corresponding to the input index list, as
@@ -474,6 +498,8 @@ def gather(boxlist, indices, fields=None, scope=None):
       all fields are gathered from.  Pass an empty fields list to only gather
       the box coordinates.
     scope: name scope.
+    use_static_shapes: Whether to use an implementation with static shape
+      gurantees.
 
   Returns:
     subboxlist: a BoxList corresponding to the subset of the input BoxList
@@ -487,13 +513,17 @@ def gather(boxlist, indices, fields=None, scope=None):
       raise ValueError('indices should have rank 1')
     if indices.dtype != tf.int32 and indices.dtype != tf.int64:
       raise ValueError('indices should be an int32 / int64 tensor')
-    subboxlist = box_list.BoxList(tf.gather(boxlist.get(), indices))
+    gather_op = tf.gather
+    if use_static_shapes:
+      gather_op = ops.matmul_gather_on_zeroth_axis
+    subboxlist = box_list.BoxList(gather_op(boxlist.get(), indices))
     if fields is None:
       fields = boxlist.get_extra_fields()
+    fields += ['boxes']
     for field in fields:
       if not boxlist.has_field(field):
         raise ValueError('boxlist must contain all specified fields')
-      subfieldlist = tf.gather(boxlist.get_field(field), indices)
+      subfieldlist = gather_op(boxlist.get_field(field), indices)
       subboxlist.add_field(field, subfieldlist)
     return subboxlist
 
@@ -585,10 +615,7 @@ def sort_by_field(boxlist, field, order=SortOrder.descend, scope=None):
         ['Incorrect field size: actual vs expected.', num_entries, num_boxes])
 
     with tf.control_dependencies([length_assert]):
-      # TODO(derekjchow): Remove with tf.device when top_k operation runs
-      # correctly on GPU.
-      with tf.device('/cpu:0'):
-        _, sorted_indices = tf.nn.top_k(field_to_sort, num_boxes, sorted=True)
+      _, sorted_indices = tf.nn.top_k(field_to_sort, num_boxes, sorted=True)
 
     if order == SortOrder.ascend:
       sorted_indices = tf.reverse_v2(sorted_indices, [0])
@@ -1059,3 +1086,51 @@ def get_minimal_coverage_box(boxlist,
         tf.greater_equal(num_boxes, 1),
         true_fn=lambda: coverage_box(boxlist.get()),
         false_fn=lambda: default_box)
+
+
+def sample_boxes_by_jittering(boxlist,
+                              num_boxes_to_sample,
+                              stddev=0.1,
+                              scope=None):
+  """Samples num_boxes_to_sample boxes by jittering around boxlist boxes.
+
+  It is possible that this function might generate boxes with size 0. The larger
+  the stddev, this is more probable. For a small stddev of 0.1 this probability
+  is very small.
+
+  Args:
+    boxlist: A boxlist containing N boxes in normalized coordinates.
+    num_boxes_to_sample: A positive integer containing the number of boxes to
+      sample.
+    stddev: Standard deviation. This is used to draw random offsets for the
+      box corners from a normal distribution. The offset is multiplied by the
+      box size so will be larger in terms of pixels for larger boxes.
+    scope: Name scope.
+
+  Returns:
+    sampled_boxlist: A boxlist containing num_boxes_to_sample boxes in
+      normalized coordinates.
+  """
+  with tf.name_scope(scope, 'SampleBoxesByJittering'):
+    num_boxes = boxlist.num_boxes()
+    box_indices = tf.random_uniform(
+        [num_boxes_to_sample],
+        minval=0,
+        maxval=num_boxes,
+        dtype=tf.int32)
+    sampled_boxes = tf.gather(boxlist.get(), box_indices)
+    sampled_boxes_height = sampled_boxes[:, 2] - sampled_boxes[:, 0]
+    sampled_boxes_width = sampled_boxes[:, 3] - sampled_boxes[:, 1]
+    rand_miny_gaussian = tf.random_normal([num_boxes_to_sample], stddev=stddev)
+    rand_minx_gaussian = tf.random_normal([num_boxes_to_sample], stddev=stddev)
+    rand_maxy_gaussian = tf.random_normal([num_boxes_to_sample], stddev=stddev)
+    rand_maxx_gaussian = tf.random_normal([num_boxes_to_sample], stddev=stddev)
+    miny = rand_miny_gaussian * sampled_boxes_height + sampled_boxes[:, 0]
+    minx = rand_minx_gaussian * sampled_boxes_width + sampled_boxes[:, 1]
+    maxy = rand_maxy_gaussian * sampled_boxes_height + sampled_boxes[:, 2]
+    maxx = rand_maxx_gaussian * sampled_boxes_width + sampled_boxes[:, 3]
+    maxy = tf.maximum(miny, maxy)
+    maxx = tf.maximum(minx, maxx)
+    sampled_boxes = tf.stack([miny, minx, maxy, maxx], axis=1)
+    sampled_boxes = tf.maximum(tf.minimum(sampled_boxes, 1.0), 0.0)
+    return box_list.BoxList(sampled_boxes)

--- a/research/object_detection/core/box_predictor.py
+++ b/research/object_detection/core/box_predictor.py
@@ -138,7 +138,7 @@ class KerasBoxPredictor(tf.keras.Model):
   """Keras-based BoxPredictor."""
 
   def __init__(self, is_training, num_classes, freeze_batchnorm,
-               inplace_batchnorm_update):
+               inplace_batchnorm_update, name=None):
     """Constructor.
 
     Args:
@@ -155,8 +155,10 @@ class KerasBoxPredictor(tf.keras.Model):
         values inplace. When this is false train op must add a control
         dependency on tf.graphkeys.UPDATE_OPS collection in order to update
         batch norm statistics.
+      name: A string name scope to assign to the model. If `None`, Keras
+        will auto-generate one from the class name.
     """
-    super(KerasBoxPredictor, self).__init__()
+    super(KerasBoxPredictor, self).__init__(name=name)
 
     self._is_training = is_training
     self._num_classes = num_classes
@@ -171,7 +173,7 @@ class KerasBoxPredictor(tf.keras.Model):
   def num_classes(self):
     return self._num_classes
 
-  def call(self, image_features, scope=None, **kwargs):
+  def call(self, image_features, **kwargs):
     """Computes encoded object locations and corresponding confidences.
 
     Takes a list of high level image feature maps as input and produces a list
@@ -181,9 +183,8 @@ class KerasBoxPredictor(tf.keras.Model):
     Args:
       image_features: A list of float tensors of shape [batch_size, height_i,
       width_i, channels_i] containing features for a batch of images.
-      scope: Variable and Op scope name.
       **kwargs: Additional keyword arguments for specific implementations of
-              BoxPredictor.
+            BoxPredictor.
 
     Returns:
       A dictionary containing at least the following tensors.

--- a/research/object_detection/core/model.py
+++ b/research/object_detection/core/model.py
@@ -84,7 +84,8 @@ class DetectionModel(object):
 
     Args:
       field: a string key, options are
-        fields.BoxListFields.{boxes,classes,masks,keypoints}
+        fields.BoxListFields.{boxes,classes,masks,keypoints} or
+        fields.InputDataFields.is_annotated.
 
     Returns:
       a list of tensors holding groundtruth information (see also
@@ -94,7 +95,8 @@ class DetectionModel(object):
       RuntimeError: if the field has not been provided via provide_groundtruth.
     """
     if field not in self._groundtruth_lists:
-      raise RuntimeError('Groundtruth tensor %s has not been provided', field)
+      raise RuntimeError('Groundtruth tensor {} has not been provided'.format(
+          field))
     return self._groundtruth_lists[field]
 
   def groundtruth_has_field(self, field):
@@ -102,7 +104,8 @@ class DetectionModel(object):
 
     Args:
       field: a string key, options are
-        fields.BoxListFields.{boxes,classes,masks,keypoints}
+        fields.BoxListFields.{boxes,classes,masks,keypoints} or
+        fields.InputDataFields.is_annotated.
 
     Returns:
       True if the groundtruth includes the given field, False otherwise.
@@ -238,7 +241,8 @@ class DetectionModel(object):
                           groundtruth_masks_list=None,
                           groundtruth_keypoints_list=None,
                           groundtruth_weights_list=None,
-                          groundtruth_is_crowd_list=None):
+                          groundtruth_is_crowd_list=None,
+                          is_annotated_list=None):
     """Provide groundtruth tensors.
 
     Args:
@@ -263,6 +267,8 @@ class DetectionModel(object):
         [num_boxes] containing weights for groundtruth boxes.
       groundtruth_is_crowd_list: A list of 1-D tf.bool tensors of shape
         [num_boxes] containing is_crowd annotations
+      is_annotated_list: A list of scalar tf.bool tensors indicating whether
+        images have been labeled or not.
     """
     self._groundtruth_lists[fields.BoxListFields.boxes] = groundtruth_boxes_list
     self._groundtruth_lists[
@@ -279,6 +285,9 @@ class DetectionModel(object):
     if groundtruth_is_crowd_list:
       self._groundtruth_lists[
           fields.BoxListFields.is_crowd] = groundtruth_is_crowd_list
+    if is_annotated_list:
+      self._groundtruth_lists[
+          fields.InputDataFields.is_annotated] = is_annotated_list
 
   @abstractmethod
   def restore_map(self, fine_tune_checkpoint_type='detection'):

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -33,6 +33,7 @@ def multiclass_non_max_suppression(boxes,
                                    change_coordinate_frame=False,
                                    masks=None,
                                    boundaries=None,
+                                   pad_to_max_output_size=False,
                                    additional_fields=None,
                                    scope=None):
   """Multi-class version of non maximum suppression.
@@ -55,7 +56,8 @@ def multiclass_non_max_suppression(boxes,
       number of classes or 1 depending on whether a separate box is predicted
       per class.
     scores: A [k, num_classes] float32 tensor containing the scores for each of
-      the k detections.
+      the k detections. The scores have to be non-negative when
+      pad_to_max_output_size is True.
     score_thresh: scalar threshold for score (low scoring boxes are removed).
     iou_thresh: scalar threshold for IOU (new boxes that have high IOU overlap
       with previously selected boxes are removed).
@@ -74,6 +76,8 @@ def multiclass_non_max_suppression(boxes,
     boundaries: (optional) a [k, q, boundary_height, boundary_width] float32
       tensor containing box boundaries. `q` can be either number of classes or 1
       depending on whether a separate boundary is predicted per class.
+    pad_to_max_output_size: If true, the output nmsed boxes are padded to be of
+      length `max_size_per_class`. Defaults to false.
     additional_fields: (optional) If not None, a dictionary that maps keys to
       tensors whose first dimensions are all of size `k`. After non-maximum
       suppression, all tensors corresponding to the selected boxes will be
@@ -81,9 +85,12 @@ def multiclass_non_max_suppression(boxes,
     scope: name scope.
 
   Returns:
-    a BoxList holding M boxes with a rank-1 scores field representing
+    A tuple of sorted_boxes and num_valid_nms_boxes. The sorted_boxes is a
+      BoxList holds M boxes with a rank-1 scores field representing
       corresponding scores for each box with scores sorted in decreasing order
-      and a rank-1 classes field representing a class label for each box.
+      and a rank-1 classes field representing a class label for each box. The
+      num_valid_nms_boxes is a 0-D integer tensor representing the number of
+      valid elements in `BoxList`, with the valid elements appearing first.
 
   Raises:
     ValueError: if iou_thresh is not in [0, 1] or if input boxlist does not have
@@ -113,6 +120,7 @@ def multiclass_non_max_suppression(boxes,
     num_classes = scores.get_shape()[1]
 
     selected_boxes_list = []
+    num_valid_nms_boxes_cumulative = tf.constant(0)
     per_class_boxes_list = tf.unstack(boxes, axis=1)
     if masks is not None:
       per_class_masks_list = tf.unstack(masks, axis=1)
@@ -140,16 +148,40 @@ def multiclass_non_max_suppression(boxes,
         for key, tensor in additional_fields.items():
           boxlist_and_class_scores.add_field(key, tensor)
 
-      max_selection_size = tf.minimum(max_size_per_class,
-                                      boxlist_and_class_scores.num_boxes())
-      selected_indices = tf.image.non_max_suppression(
-          boxlist_and_class_scores.get(),
-          boxlist_and_class_scores.get_field(fields.BoxListFields.scores),
-          max_selection_size,
-          iou_threshold=iou_thresh,
-          score_threshold=score_thresh)
+      if pad_to_max_output_size:
+        max_selection_size = max_size_per_class
+        selected_indices, num_valid_nms_boxes = (
+            tf.image.non_max_suppression_padded(
+                boxlist_and_class_scores.get(),
+                boxlist_and_class_scores.get_field(fields.BoxListFields.scores),
+                max_selection_size,
+                iou_threshold=iou_thresh,
+                score_threshold=score_thresh,
+                pad_to_max_output_size=True))
+      else:
+        max_selection_size = tf.minimum(max_size_per_class,
+                                        boxlist_and_class_scores.num_boxes())
+        selected_indices = tf.image.non_max_suppression(
+            boxlist_and_class_scores.get(),
+            boxlist_and_class_scores.get_field(fields.BoxListFields.scores),
+            max_selection_size,
+            iou_threshold=iou_thresh,
+            score_threshold=score_thresh)
+        num_valid_nms_boxes = tf.shape(selected_indices)[0]
+        selected_indices = tf.concat(
+            [selected_indices,
+             tf.zeros(max_selection_size-num_valid_nms_boxes, tf.int32)], 0)
       nms_result = box_list_ops.gather(boxlist_and_class_scores,
                                        selected_indices)
+      # Make the scores -1 for invalid boxes.
+      valid_nms_boxes_indx = tf.less(
+          tf.range(max_selection_size), num_valid_nms_boxes)
+      nms_scores = nms_result.get_field(fields.BoxListFields.scores)
+      nms_result.add_field(fields.BoxListFields.scores,
+                           tf.where(valid_nms_boxes_indx,
+                                    nms_scores, -1*tf.ones(max_selection_size)))
+      num_valid_nms_boxes_cumulative += num_valid_nms_boxes
+
       nms_result.add_field(
           fields.BoxListFields.classes, (tf.zeros_like(
               nms_result.get_field(fields.BoxListFields.scores)) + class_idx))
@@ -158,16 +190,43 @@ def multiclass_non_max_suppression(boxes,
     sorted_boxes = box_list_ops.sort_by_field(selected_boxes,
                                               fields.BoxListFields.scores)
     if clip_window is not None:
-      sorted_boxes = box_list_ops.clip_to_window(sorted_boxes, clip_window)
+      # When pad_to_max_output_size is False, it prunes the boxes with zero
+      # area.
+      sorted_boxes = box_list_ops.clip_to_window(
+          sorted_boxes,
+          clip_window,
+          filter_nonoverlapping=not pad_to_max_output_size)
+      # Set the scores of boxes with zero area to -1 to keep the default
+      # behaviour of pruning out zero area boxes.
+      sorted_boxes_size = tf.shape(sorted_boxes.get())[0]
+      non_zero_box_area = tf.cast(box_list_ops.area(sorted_boxes), tf.bool)
+      sorted_boxes_scores = tf.where(
+          non_zero_box_area,
+          sorted_boxes.get_field(fields.BoxListFields.scores),
+          -1*tf.ones(sorted_boxes_size))
+      sorted_boxes.add_field(fields.BoxListFields.scores, sorted_boxes_scores)
+      num_valid_nms_boxes_cumulative = tf.reduce_sum(
+          tf.cast(tf.greater_equal(sorted_boxes_scores, 0), tf.int32))
+      sorted_boxes = box_list_ops.sort_by_field(sorted_boxes,
+                                                fields.BoxListFields.scores)
       if change_coordinate_frame:
         sorted_boxes = box_list_ops.change_coordinate_frame(
             sorted_boxes, clip_window)
+
     if max_total_size:
       max_total_size = tf.minimum(max_total_size,
                                   sorted_boxes.num_boxes())
       sorted_boxes = box_list_ops.gather(sorted_boxes,
                                          tf.range(max_total_size))
-    return sorted_boxes
+      num_valid_nms_boxes_cumulative = tf.where(
+          max_total_size > num_valid_nms_boxes_cumulative,
+          num_valid_nms_boxes_cumulative, max_total_size)
+    # Select only the valid boxes if pad_to_max_output_size is False.
+    if not pad_to_max_output_size:
+      sorted_boxes = box_list_ops.gather(
+          sorted_boxes, tf.range(num_valid_nms_boxes_cumulative))
+
+    return sorted_boxes, num_valid_nms_boxes_cumulative
 
 
 def batch_multiclass_non_max_suppression(boxes,
@@ -182,6 +241,7 @@ def batch_multiclass_non_max_suppression(boxes,
                                          masks=None,
                                          additional_fields=None,
                                          scope=None,
+                                         use_static_shapes=False,
                                          parallel_iterations=32):
   """Multi-class version of non maximum suppression that operates on a batch.
 
@@ -195,7 +255,8 @@ def batch_multiclass_non_max_suppression(boxes,
         otherwise, if `q` is equal to number of classes, class-specific boxes
         are used.
     scores: A [batch_size, num_anchors, num_classes] float32 tensor containing
-      the scores for each of the `num_anchors` detections.
+      the scores for each of the `num_anchors` detections. The scores have to be
+      non-negative when use_static_shapes is set True.
     score_thresh: scalar threshold for score (low scoring boxes are removed).
     iou_thresh: scalar threshold for IOU (new boxes that have high IOU overlap
       with previously selected boxes are removed).
@@ -221,6 +282,9 @@ def batch_multiclass_non_max_suppression(boxes,
     additional_fields: (optional) If not None, a dictionary that maps keys to
       tensors whose dimensions are [batch_size, num_anchors, ...].
     scope: tf scope name.
+    use_static_shapes: If true, the output nmsed boxes are padded to be of
+      length `max_size_per_class` and it doesn't clip boxes to max_total_size.
+      Defaults to false.
     parallel_iterations: (optional) number of batch items to process in
       parallel.
 
@@ -276,7 +340,7 @@ def batch_multiclass_non_max_suppression(boxes,
     # If masks aren't provided, create dummy masks so we can only have one copy
     # of _single_image_nms_fn and discard the dummy masks after map_fn.
     if masks is None:
-      masks_shape = tf.stack([batch_size, num_anchors, 1, 0, 0])
+      masks_shape = tf.stack([batch_size, num_anchors, q, 1, 1])
       masks = tf.zeros(masks_shape)
 
     if clip_window is None:
@@ -365,7 +429,7 @@ def batch_multiclass_non_max_suppression(boxes,
                        tf.stack([per_image_num_valid_boxes] +
                                 (additional_field_dim - 1) * [-1])),
               [-1] + [dim.value for dim in additional_field_shape[1:]])
-      nmsed_boxlist = multiclass_non_max_suppression(
+      nmsed_boxlist, num_valid_nms_boxes = multiclass_non_max_suppression(
           per_image_boxes,
           per_image_scores,
           score_thresh,
@@ -375,16 +439,19 @@ def batch_multiclass_non_max_suppression(boxes,
           clip_window=per_image_clip_window,
           change_coordinate_frame=change_coordinate_frame,
           masks=per_image_masks,
+          pad_to_max_output_size=use_static_shapes,
           additional_fields=per_image_additional_fields)
-      padded_boxlist = box_list_ops.pad_or_clip_box_list(nmsed_boxlist,
-                                                         max_total_size)
-      num_detections = nmsed_boxlist.num_boxes()
-      nmsed_boxes = padded_boxlist.get()
-      nmsed_scores = padded_boxlist.get_field(fields.BoxListFields.scores)
-      nmsed_classes = padded_boxlist.get_field(fields.BoxListFields.classes)
-      nmsed_masks = padded_boxlist.get_field(fields.BoxListFields.masks)
+
+      if not use_static_shapes:
+        nmsed_boxlist = box_list_ops.pad_or_clip_box_list(
+            nmsed_boxlist, max_total_size)
+      num_detections = num_valid_nms_boxes
+      nmsed_boxes = nmsed_boxlist.get()
+      nmsed_scores = nmsed_boxlist.get_field(fields.BoxListFields.scores)
+      nmsed_classes = nmsed_boxlist.get_field(fields.BoxListFields.classes)
+      nmsed_masks = nmsed_boxlist.get_field(fields.BoxListFields.masks)
       nmsed_additional_fields = [
-          padded_boxlist.get_field(key) for key in per_image_additional_fields
+          nmsed_boxlist.get_field(key) for key in per_image_additional_fields
       ]
       return ([nmsed_boxes, nmsed_scores, nmsed_classes, nmsed_masks] +
               nmsed_additional_fields + [num_detections])

--- a/research/object_detection/core/post_processing_test.py
+++ b/research/object_detection/core/post_processing_test.py
@@ -18,9 +18,10 @@ import numpy as np
 import tensorflow as tf
 from object_detection.core import post_processing
 from object_detection.core import standard_fields as fields
+from object_detection.utils import test_case
 
 
-class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
+class MulticlassNonMaxSuppressionTest(test_case.TestCase):
 
   def test_multiclass_nms_select_with_shared_boxes(self):
     boxes = tf.constant([[[0, 0, 1, 1]],
@@ -46,7 +47,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.95, .9, .85, .3]
     exp_nms_classes = [0, 0, 1, 0]
 
-    nms = post_processing.multiclass_non_max_suppression(
+    nms, _ = post_processing.multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh, max_output_size)
     with self.test_session() as sess:
       nms_corners_output, nms_scores_output, nms_classes_output = sess.run(
@@ -55,6 +56,8 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
       self.assertAllClose(nms_corners_output, exp_nms_corners)
       self.assertAllClose(nms_scores_output, exp_nms_scores)
       self.assertAllClose(nms_classes_output, exp_nms_classes)
+
+  # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
 
   def test_multiclass_nms_select_with_shared_boxes_given_keypoints(self):
     boxes = tf.constant([[[0, 0, 1, 1]],
@@ -87,10 +90,13 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
         tf.reshape(tf.constant([3, 0, 6, 5], dtype=tf.float32), [4, 1, 1]),
         [1, num_keypoints, 2])
 
-    nms = post_processing.multiclass_non_max_suppression(
-        boxes, scores, score_thresh, iou_thresh, max_output_size,
-        additional_fields={
-            fields.BoxListFields.keypoints: keypoints})
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes,
+        scores,
+        score_thresh,
+        iou_thresh,
+        max_output_size,
+        additional_fields={fields.BoxListFields.keypoints: keypoints})
 
     with self.test_session() as sess:
       (nms_corners_output,
@@ -145,10 +151,15 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_keypoint_heatmaps = np.ones(
         (4, heatmap_height, heatmap_width, num_keypoints), dtype=np.float32)
 
-    nms = post_processing.multiclass_non_max_suppression(
-        boxes, scores, score_thresh, iou_thresh, max_output_size,
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes,
+        scores,
+        score_thresh,
+        iou_thresh,
+        max_output_size,
         additional_fields={
-            fields.BoxListFields.keypoint_heatmaps: keypoint_heatmaps})
+            fields.BoxListFields.keypoint_heatmaps: keypoint_heatmaps
+        })
 
     with self.test_session() as sess:
       (nms_corners_output,
@@ -208,8 +219,12 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.95, .9, .85, .3]
     exp_nms_classes = [0, 0, 1, 0]
 
-    nms = post_processing.multiclass_non_max_suppression(
-        boxes, scores, score_thresh, iou_thresh, max_output_size,
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes,
+        scores,
+        score_thresh,
+        iou_thresh,
+        max_output_size,
         additional_fields={coarse_boxes_key: coarse_boxes})
 
     with self.test_session() as sess:
@@ -260,11 +275,8 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
         tf.reshape(tf.constant([3, 0, 6, 5], dtype=tf.float32), [4, 1, 1]),
         [1, mask_height, mask_width])
 
-    nms = post_processing.multiclass_non_max_suppression(boxes, scores,
-                                                         score_thresh,
-                                                         iou_thresh,
-                                                         max_output_size,
-                                                         masks=masks)
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes, scores, score_thresh, iou_thresh, max_output_size, masks=masks)
     with self.test_session() as sess:
       (nms_corners_output,
        nms_scores_output,
@@ -293,8 +305,12 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.9]
     exp_nms_classes = [0]
 
-    nms = post_processing.multiclass_non_max_suppression(
-        boxes, scores, score_thresh, iou_thresh, max_output_size,
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes,
+        scores,
+        score_thresh,
+        iou_thresh,
+        max_output_size,
         clip_window=clip_window)
     with self.test_session() as sess:
       nms_corners_output, nms_scores_output, nms_classes_output = sess.run(
@@ -317,9 +333,14 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.9]
     exp_nms_classes = [0]
 
-    nms = post_processing.multiclass_non_max_suppression(
-        boxes, scores, score_thresh, iou_thresh, max_output_size,
-        clip_window=clip_window, change_coordinate_frame=True)
+    nms, _ = post_processing.multiclass_non_max_suppression(
+        boxes,
+        scores,
+        score_thresh,
+        iou_thresh,
+        max_output_size,
+        clip_window=clip_window,
+        change_coordinate_frame=True)
     with self.test_session() as sess:
       nms_corners_output, nms_scores_output, nms_classes_output = sess.run(
           [nms.get(), nms.get_field(fields.BoxListFields.scores),
@@ -351,7 +372,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.95, .9, .85]
     exp_nms_classes = [0, 0, 1]
 
-    nms = post_processing.multiclass_non_max_suppression(
+    nms, _ = post_processing.multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh, max_size_per_class)
     with self.test_session() as sess:
       nms_corners_output, nms_scores_output, nms_classes_output = sess.run(
@@ -384,7 +405,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.95, .9]
     exp_nms_classes = [0, 0]
 
-    nms = post_processing.multiclass_non_max_suppression(
+    nms, _ = post_processing.multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh, max_size_per_class,
         max_total_size)
     with self.test_session() as sess:
@@ -412,7 +433,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms = [[0, 10, 1, 11],
                [0, 0, 1, 1],
                [0, 100, 1, 101]]
-    nms = post_processing.multiclass_non_max_suppression(
+    nms, _ = post_processing.multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh, max_output_size)
     with self.test_session() as sess:
       nms_output = sess.run(nms.get())
@@ -443,7 +464,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
     exp_nms_scores = [.95, .9, .85, .3]
     exp_nms_classes = [0, 0, 1, 0]
 
-    nms = post_processing.multiclass_non_max_suppression(
+    nms, _ = post_processing.multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh, max_output_size)
     with self.test_session() as sess:
       nms_corners_output, nms_scores_output, nms_classes_output = sess.run(
@@ -1055,6 +1076,7 @@ class MulticlassNonMaxSuppressionTest(tf.test.TestCase):
                             exp_nms_additional_fields[key])
       self.assertAllClose(num_detections, [1, 1])
 
+  # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/core/post_processing_test.py
+++ b/research/object_detection/core/post_processing_test.py
@@ -58,6 +58,55 @@ class MulticlassNonMaxSuppressionTest(test_case.TestCase):
       self.assertAllClose(nms_classes_output, exp_nms_classes)
 
   # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
+  # BEGIN GOOGLE-INTERNAL
+  def test_multiclass_nms_select_with_shared_boxes_pad_to_max_output_size(self):
+    boxes = np.array([[[0, 0, 1, 1]],
+                      [[0, 0.1, 1, 1.1]],
+                      [[0, -0.1, 1, 0.9]],
+                      [[0, 10, 1, 11]],
+                      [[0, 10.1, 1, 11.1]],
+                      [[0, 100, 1, 101]],
+                      [[0, 1000, 1, 1002]],
+                      [[0, 1000, 1, 1002.1]]], np.float32)
+    scores = np.array([[.9, 0.01], [.75, 0.05],
+                       [.6, 0.01], [.95, 0],
+                       [.5, 0.01], [.3, 0.01],
+                       [.01, .85], [.01, .5]], np.float32)
+    score_thresh = 0.1
+    iou_thresh = .5
+    max_size_per_class = 4
+    max_output_size = 5
+
+    exp_nms_corners = [[0, 10, 1, 11],
+                       [0, 0, 1, 1],
+                       [0, 1000, 1, 1002],
+                       [0, 100, 1, 101]]
+    exp_nms_scores = [.95, .9, .85, .3]
+    exp_nms_classes = [0, 0, 1, 0]
+
+    def graph_fn(boxes, scores):
+      nms, num_valid_nms_boxes = post_processing.multiclass_non_max_suppression(
+          boxes,
+          scores,
+          score_thresh,
+          iou_thresh,
+          max_size_per_class,
+          max_total_size=max_output_size,
+          pad_to_max_output_size=True)
+      return [nms.get(), nms.get_field(fields.BoxListFields.scores),
+              nms.get_field(fields.BoxListFields.classes), num_valid_nms_boxes]
+
+    [nms_corners_output, nms_scores_output, nms_classes_output,
+     num_valid_nms_boxes] = self.execute(graph_fn, [boxes, scores])
+
+    self.assertEqual(num_valid_nms_boxes, 4)
+    self.assertAllClose(nms_corners_output[0:num_valid_nms_boxes],
+                        exp_nms_corners)
+    self.assertAllClose(nms_scores_output[0:num_valid_nms_boxes],
+                        exp_nms_scores)
+    self.assertAllClose(nms_classes_output[0:num_valid_nms_boxes],
+                        exp_nms_classes)
+  # END GOOGLE-INTERNAL
 
   def test_multiclass_nms_select_with_shared_boxes_given_keypoints(self):
     boxes = tf.constant([[[0, 0, 1, 1]],
@@ -1077,6 +1126,61 @@ class MulticlassNonMaxSuppressionTest(test_case.TestCase):
       self.assertAllClose(num_detections, [1, 1])
 
   # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
+  # BEGIN GOOGLE-INTERNAL
+  def test_batch_multiclass_nms_with_use_static_shapes(self):
+    boxes = np.array([[[[0, 0, 1, 1], [0, 0, 4, 5]],
+                       [[0, 0.1, 1, 1.1], [0, 0.1, 2, 1.1]],
+                       [[0, -0.1, 1, 0.9], [0, -0.1, 1, 0.9]],
+                       [[0, 10, 1, 11], [0, 10, 1, 11]]],
+                      [[[0, 10.1, 1, 11.1], [0, 10.1, 1, 11.1]],
+                       [[0, 100, 1, 101], [0, 100, 1, 101]],
+                       [[0, 1000, 1, 1002], [0, 999, 2, 1004]],
+                       [[0, 1000, 1, 1002.1], [0, 999, 2, 1002.7]]]],
+                     np.float32)
+    scores = np.array([[[.9, 0.01], [.75, 0.05],
+                        [.6, 0.01], [.95, 0]],
+                       [[.5, 0.01], [.3, 0.01],
+                        [.01, .85], [.01, .5]]],
+                      np.float32)
+    clip_window = np.array([[0., 0., 5., 5.],
+                            [0., 0., 200., 200.]],
+                           np.float32)
+    score_thresh = 0.1
+    iou_thresh = .5
+    max_output_size = 4
+
+    exp_nms_corners = np.array([[[0, 0, 1, 1],
+                                 [0, 0, 0, 0],
+                                 [0, 0, 0, 0],
+                                 [0, 0, 0, 0]],
+                                [[0, 10.1, 1, 11.1],
+                                 [0, 100, 1, 101],
+                                 [0, 0, 0, 0],
+                                 [0, 0, 0, 0]]])
+    exp_nms_scores = np.array([[.9, 0., 0., 0.],
+                               [.5, .3, 0, 0]])
+    exp_nms_classes = np.array([[0, 0, 0, 0],
+                                [0, 0, 0, 0]])
+
+    def graph_fn(boxes, scores, clip_window):
+      (nmsed_boxes, nmsed_scores, nmsed_classes, _, _, num_detections
+      ) = post_processing.batch_multiclass_non_max_suppression(
+          boxes, scores, score_thresh, iou_thresh,
+          max_size_per_class=max_output_size, clip_window=clip_window,
+          use_static_shapes=True)
+      return nmsed_boxes, nmsed_scores, nmsed_classes, num_detections
+
+    (nmsed_boxes, nmsed_scores, nmsed_classes,
+     num_detections) = self.execute(graph_fn, [boxes, scores, clip_window])
+    for i in range(len(num_detections)):
+      self.assertAllClose(nmsed_boxes[i, 0:num_detections[i]],
+                          exp_nms_corners[i, 0:num_detections[i]])
+      self.assertAllClose(nmsed_scores[i, 0:num_detections[i]],
+                          exp_nms_scores[i, 0:num_detections[i]])
+      self.assertAllClose(nmsed_classes[i, 0:num_detections[i]],
+                          exp_nms_classes[i, 0:num_detections[i]])
+    self.assertAllClose(num_detections, [1, 2])
+  # END GOOGLE-INTERNAL
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/core/preprocessor.py
+++ b/research/object_detection/core/preprocessor.py
@@ -810,7 +810,7 @@ def random_image_scale(image,
     image = tf.image.resize_images(
         image, [image_newysize, image_newxsize], align_corners=True)
     result.append(image)
-    if masks:
+    if masks is not None:
       masks = tf.image.resize_nearest_neighbor(
           masks, [image_newysize, image_newxsize], align_corners=True)
       result.append(masks)

--- a/research/object_detection/core/preprocessor.py
+++ b/research/object_detection/core/preprocessor.py
@@ -2969,7 +2969,8 @@ def get_default_func_arg_map(include_label_scores=False,
   """
   groundtruth_label_scores = None
   if include_label_scores:
-    groundtruth_label_scores = (fields.InputDataFields.groundtruth_label_scores)
+    groundtruth_label_scores = (
+        fields.InputDataFields.groundtruth_confidences)
 
   multiclass_scores = None
   if include_multiclass_scores:

--- a/research/object_detection/core/preprocessor_cache.py
+++ b/research/object_detection/core/preprocessor_cache.py
@@ -67,7 +67,7 @@ class PreprocessorCache(object):
 
   def clear(self):
     """Resets cache."""
-    self._history = {}
+    self._history = defaultdict(dict)
 
   def get(self, function_id, key):
     """Gets stored value given a function id and key.

--- a/research/object_detection/core/preprocessor_test.py
+++ b/research/object_detection/core/preprocessor_test.py
@@ -1615,7 +1615,7 @@ class PreprocessorTest(tf.test.TestCase):
     tensor_dict = {
         fields.InputDataFields.groundtruth_boxes: boxes,
         fields.InputDataFields.groundtruth_classes: labels,
-        fields.InputDataFields.groundtruth_label_scores: label_scores
+        fields.InputDataFields.groundtruth_confidences: label_scores
     }
 
     preprocessing_options = [
@@ -1630,7 +1630,7 @@ class PreprocessorTest(tf.test.TestCase):
     retained_labels = retained_tensor_dict[
         fields.InputDataFields.groundtruth_classes]
     retained_label_scores = retained_tensor_dict[
-        fields.InputDataFields.groundtruth_label_scores]
+        fields.InputDataFields.groundtruth_confidences]
 
     with self.test_session() as sess:
       (retained_boxes_, retained_labels_,
@@ -1655,7 +1655,7 @@ class PreprocessorTest(tf.test.TestCase):
     tensor_dict = {
         fields.InputDataFields.groundtruth_boxes: boxes,
         fields.InputDataFields.groundtruth_classes: labels,
-        fields.InputDataFields.groundtruth_label_scores: label_scores,
+        fields.InputDataFields.groundtruth_confidences: label_scores,
         fields.InputDataFields.groundtruth_instance_masks: masks
     }
 
@@ -1687,7 +1687,7 @@ class PreprocessorTest(tf.test.TestCase):
     tensor_dict = {
         fields.InputDataFields.groundtruth_boxes: boxes,
         fields.InputDataFields.groundtruth_classes: labels,
-        fields.InputDataFields.groundtruth_label_scores: label_scores,
+        fields.InputDataFields.groundtruth_confidences: label_scores,
         fields.InputDataFields.groundtruth_keypoints: keypoints
     }
 
@@ -2784,7 +2784,7 @@ class PreprocessorTest(tf.test.TestCase):
     }
     if include_label_scores:
       label_scores = self.createTestLabelScores()
-      tensor_dict[fields.InputDataFields.groundtruth_label_scores] = (
+      tensor_dict[fields.InputDataFields.groundtruth_confidences] = (
           label_scores)
     if include_multiclass_scores:
       multiclass_scores = self.createTestMultiClassScores()

--- a/research/object_detection/core/standard_fields.py
+++ b/research/object_detection/core/standard_fields.py
@@ -60,6 +60,7 @@ class InputDataFields(object):
     groundtruth_label_scores: groundtruth label scores.
     groundtruth_weights: groundtruth weight factor for bounding boxes.
     num_groundtruth_boxes: number of groundtruth boxes.
+    is_annotated: whether an image has been labeled or not.
     true_image_shapes: true shapes of images in the resized images, as resized
       images can be padded with zeros.
     multiclass_scores: the label score per class for each box.
@@ -88,6 +89,7 @@ class InputDataFields(object):
   groundtruth_label_scores = 'groundtruth_label_scores'
   groundtruth_weights = 'groundtruth_weights'
   num_groundtruth_boxes = 'num_groundtruth_boxes'
+  is_annotated = 'is_annotated'
   true_image_shape = 'true_image_shape'
   multiclass_scores = 'multiclass_scores'
 

--- a/research/object_detection/core/standard_fields.py
+++ b/research/object_detection/core/standard_fields.py
@@ -40,8 +40,10 @@ class InputDataFields(object):
     source_id: source of the original image.
     filename: original filename of the dataset (without common path).
     groundtruth_image_classes: image-level class labels.
+    groundtruth_image_confidences: image-level class confidences.
     groundtruth_boxes: coordinates of the ground truth boxes in the image.
     groundtruth_classes: box-level class labels.
+    groundtruth_confidences: box-level class confidences.
     groundtruth_label_types: box-level label types (e.g. explicit negative).
     groundtruth_is_crowd: [DEPRECATED, use groundtruth_group_of instead]
       is the groundtruth a single object or a crowd.
@@ -72,8 +74,10 @@ class InputDataFields(object):
   source_id = 'source_id'
   filename = 'filename'
   groundtruth_image_classes = 'groundtruth_image_classes'
+  groundtruth_image_confidences = 'groundtruth_image_confidences'
   groundtruth_boxes = 'groundtruth_boxes'
   groundtruth_classes = 'groundtruth_classes'
+  groundtruth_confidences = 'groundtruth_confidences'
   groundtruth_label_types = 'groundtruth_label_types'
   groundtruth_is_crowd = 'groundtruth_is_crowd'
   groundtruth_area = 'groundtruth_area'

--- a/research/object_detection/core/target_assigner_test.py
+++ b/research/object_detection/core/target_assigner_test.py
@@ -495,8 +495,7 @@ class TargetAssignerTest(test_case.TestCase):
           priors,
           boxes,
           groundtruth_labels,
-          unmatched_class_label=unmatched_class_label,
-          num_valid_rows=3)
+          unmatched_class_label=unmatched_class_label)
 
   def test_raises_error_on_invalid_groundtruth_labels(self):
     similarity_calc = region_similarity_calculator.NegSqDistSimilarity()
@@ -520,8 +519,7 @@ class TargetAssignerTest(test_case.TestCase):
           priors,
           boxes,
           groundtruth_labels,
-          unmatched_class_label=unmatched_class_label,
-          num_valid_rows=3)
+          unmatched_class_label=unmatched_class_label)
 
 
 class BatchTargetAssignerTest(test_case.TestCase):

--- a/research/object_detection/data/fgvc_2854_classes_label_map.pbtxt
+++ b/research/object_detection/data/fgvc_2854_classes_label_map.pbtxt
@@ -1,0 +1,14270 @@
+item {
+  name: "147457"
+  id: 1
+  display_name: "Nicrophorus tomentosus"
+}
+item {
+  name: "81923"
+  id: 2
+  display_name: "Halyomorpha halys"
+}
+item {
+  name: "7"
+  id: 3
+  display_name: "Aramus guarauna"
+}
+item {
+  name: "201041"
+  id: 4
+  display_name: "Rupornis magnirostris"
+}
+item {
+  name: "65551"
+  id: 5
+  display_name: "Hyla eximia"
+}
+item {
+  name: "106516"
+  id: 6
+  display_name: "Nannothemis bella"
+}
+item {
+  name: "154287"
+  id: 7
+  display_name: "Acalymma vittatum"
+}
+item {
+  name: "32798"
+  id: 8
+  display_name: "Ramphotyphlops braminus"
+}
+item {
+  name: "8229"
+  id: 9
+  display_name: "Cyanocitta cristata"
+}
+item {
+  name: "73766"
+  id: 10
+  display_name: "Drymarchon melanurus"
+}
+item {
+  name: "409639"
+  id: 11
+  display_name: "Aenetus virescens"
+}
+item {
+  name: "8234"
+  id: 12
+  display_name: "Cyanocitta stelleri"
+}
+item {
+  name: "228593"
+  id: 13
+  display_name: "Polygrammate hebraeicum"
+}
+item {
+  name: "53"
+  id: 14
+  display_name: "Balearica regulorum"
+}
+item {
+  name: "57399"
+  id: 15
+  display_name: "Fistularia commersonii"
+}
+item {
+  name: "81979"
+  id: 16
+  display_name: "Syritta pipiens"
+}
+item {
+  name: "73788"
+  id: 17
+  display_name: "Plestiodon fasciatus"
+}
+item {
+  name: "73790"
+  id: 18
+  display_name: "Plestiodon inexpectatus"
+}
+item {
+  name: "16447"
+  id: 19
+  display_name: "Pyrocephalus rubinus"
+}
+item {
+  name: "73792"
+  id: 20
+  display_name: "Plestiodon laticeps"
+}
+item {
+  name: "49219"
+  id: 21
+  display_name: "Anguilla rostrata"
+}
+item {
+  name: "73797"
+  id: 22
+  display_name: "Plestiodon obsoletus"
+}
+item {
+  name: "73803"
+  id: 23
+  display_name: "Plestiodon tetragrammus"
+}
+item {
+  name: "122956"
+  id: 24
+  display_name: "Syntomoides imaon"
+}
+item {
+  name: "82003"
+  id: 25
+  display_name: "Arion ater"
+}
+item {
+  name: "32854"
+  id: 26
+  display_name: "Chamaeleo dilepis"
+}
+item {
+  name: "42341"
+  id: 27
+  display_name: "Tragelaphus scriptus"
+}
+item {
+  name: "82018"
+  id: 28
+  display_name: "Taeniopoda eques"
+}
+item {
+  name: "57443"
+  id: 29
+  display_name: "Libellula quadrimaculata"
+}
+item {
+  name: "4885"
+  id: 30
+  display_name: "Recurvirostra americana"
+}
+item {
+  name: "178403"
+  id: 31
+  display_name: "Phalaenophana pyramusalis"
+}
+item {
+  name: "135027"
+  id: 32
+  display_name: "Agalychnis dacnicolor"
+}
+item {
+  name: "49262"
+  id: 33
+  display_name: "Haemulon sciurus"
+}
+item {
+  name: "98417"
+  id: 34
+  display_name: "Cordulegaster diastatops"
+}
+item {
+  name: "57458"
+  id: 35
+  display_name: "Ladona julia"
+}
+item {
+  name: "115"
+  id: 36
+  display_name: "Ardeotis kori"
+}
+item {
+  name: "49269"
+  id: 37
+  display_name: "Diodon holocanthus"
+}
+item {
+  name: "57463"
+  id: 38
+  display_name: "Papilio canadensis"
+}
+item {
+  name: "82043"
+  id: 39
+  display_name: "Monochamus scutellatus"
+}
+item {
+  name: "147580"
+  id: 40
+  display_name: "Ceratotherium simum simum"
+}
+item {
+  name: "98430"
+  id: 41
+  display_name: "Cordulia shurtleffii"
+}
+item {
+  name: "8319"
+  id: 42
+  display_name: "Pica nuttalli"
+}
+item {
+  name: "43712"
+  id: 43
+  display_name: "Dasyprocta punctata"
+}
+item {
+  name: "8335"
+  id: 44
+  display_name: "Perisoreus canadensis"
+}
+item {
+  name: "508048"
+  id: 45
+  display_name: "Antigone canadensis"
+}
+item {
+  name: "49297"
+  id: 46
+  display_name: "Aetobatus narinari"
+}
+item {
+  name: "82069"
+  id: 47
+  display_name: "Phyciodes pulchella"
+}
+item {
+  name: "73149"
+  id: 48
+  display_name: "Parkesia noveboracensis"
+}
+item {
+  name: "180379"
+  id: 49
+  display_name: "Ardea herodias occidentalis"
+}
+item {
+  name: "73884"
+  id: 50
+  display_name: "Pantherophis emoryi"
+}
+item {
+  name: "106653"
+  id: 51
+  display_name: "Nehalennia irene"
+}
+item {
+  name: "73887"
+  id: 52
+  display_name: "Pantherophis guttatus"
+}
+item {
+  name: "73888"
+  id: 53
+  display_name: "Pantherophis obsoletus"
+}
+item {
+  name: "162"
+  id: 54
+  display_name: "Porzana carolina"
+}
+item {
+  name: "245925"
+  id: 55
+  display_name: "Siproeta stelenes biplagiata"
+}
+item {
+  name: "117302"
+  id: 56
+  display_name: "Physalia physalis"
+}
+item {
+  name: "57516"
+  id: 57
+  display_name: "Bombus terrestris"
+}
+item {
+  name: "204995"
+  id: 58
+  display_name: "Anas platyrhynchos diazi"
+}
+item {
+  name: "49348"
+  id: 59
+  display_name: "Hyles lineata"
+}
+item {
+  name: "82117"
+  id: 60
+  display_name: "Dolomedes tenebrosus"
+}
+item {
+  name: "114891"
+  id: 61
+  display_name: "Varanus salvator"
+}
+item {
+  name: "319695"
+  id: 62
+  display_name: "Epilachna mexicana"
+}
+item {
+  name: "41168"
+  id: 63
+  display_name: "Desmodus rotundus"
+}
+item {
+  name: "13688"
+  id: 64
+  display_name: "Motacilla cinerea"
+}
+item {
+  name: "57556"
+  id: 65
+  display_name: "Papio ursinus"
+}
+item {
+  name: "16598"
+  id: 66
+  display_name: "Empidonax difficilis"
+}
+item {
+  name: "16602"
+  id: 67
+  display_name: "Empidonax minimus"
+}
+item {
+  name: "16604"
+  id: 68
+  display_name: "Empidonax fulvifrons"
+}
+item {
+  name: "409181"
+  id: 69
+  display_name: "Trite planiceps"
+}
+item {
+  name: "82144"
+  id: 70
+  display_name: "Hemileuca eglanterina"
+}
+item {
+  name: "16611"
+  id: 71
+  display_name: "Empidonax traillii"
+}
+item {
+  name: "82153"
+  id: 72
+  display_name: "Ceratomia undulosa"
+}
+item {
+  name: "82155"
+  id: 73
+  display_name: "Bittacomorpha clavipes"
+}
+item {
+  name: "205036"
+  id: 74
+  display_name: "Xanthorhoe lacustrata"
+}
+item {
+  name: "16624"
+  id: 75
+  display_name: "Empidonax hammondii"
+}
+item {
+  name: "16625"
+  id: 76
+  display_name: "Empidonax occidentalis"
+}
+item {
+  name: "243"
+  id: 77
+  display_name: "Rallus limicola"
+}
+item {
+  name: "41"
+  id: 78
+  display_name: "Grus grus"
+}
+item {
+  name: "49402"
+  id: 79
+  display_name: "Abudefduf saxatilis"
+}
+item {
+  name: "58550"
+  id: 80
+  display_name: "Callophrys niphon"
+}
+item {
+  name: "205055"
+  id: 81
+  display_name: "Zopherus nodulosus haldemani"
+}
+item {
+  name: "82177"
+  id: 82
+  display_name: "Hermetia illucens"
+}
+item {
+  name: "9601"
+  id: 83
+  display_name: "Quiscalus major"
+}
+item {
+  name: "7101"
+  id: 84
+  display_name: "Branta leucopsis"
+}
+item {
+  name: "8470"
+  id: 85
+  display_name: "Cyanocorax yucatanicus"
+}
+item {
+  name: "74009"
+  id: 86
+  display_name: "Zamenis longissimus"
+}
+item {
+  name: "8474"
+  id: 87
+  display_name: "Cyanocorax yncas"
+}
+item {
+  name: "82204"
+  id: 88
+  display_name: "Nadata gibbosa"
+}
+item {
+  name: "123168"
+  id: 89
+  display_name: "Ensatina eschscholtzii xanthoptica"
+}
+item {
+  name: "82210"
+  id: 90
+  display_name: "Heterocampa biundata"
+}
+item {
+  name: "48284"
+  id: 91
+  display_name: "Oniscus asellus"
+}
+item {
+  name: "4146"
+  id: 92
+  display_name: "Oceanites oceanicus"
+}
+item {
+  name: "82225"
+  id: 93
+  display_name: "Lophocampa caryae"
+}
+item {
+  name: "9609"
+  id: 94
+  display_name: "Quiscalus niger"
+}
+item {
+  name: "65849"
+  id: 95
+  display_name: "Incilius nebulifer"
+}
+item {
+  name: "207583"
+  id: 96
+  display_name: "Miomantis caffra"
+}
+item {
+  name: "491839"
+  id: 97
+  display_name: "Pyrausta insequalis"
+}
+item {
+  name: "74048"
+  id: 98
+  display_name: "Alces americanus"
+}
+item {
+  name: "57665"
+  id: 99
+  display_name: "Cotinis mutabilis"
+}
+item {
+  name: "65860"
+  id: 100
+  display_name: "Incilius valliceps"
+}
+item {
+  name: "52911"
+  id: 101
+  display_name: "Dolichovespula maculata"
+}
+item {
+  name: "8524"
+  id: 102
+  display_name: "Psilorhinus morio"
+}
+item {
+  name: "49491"
+  id: 103
+  display_name: "Thalassoma bifasciatum"
+}
+item {
+  name: "41301"
+  id: 104
+  display_name: "Tadarida brasiliensis"
+}
+item {
+  name: "57687"
+  id: 105
+  display_name: "Xylocopa varipuncta"
+}
+item {
+  name: "57689"
+  id: 106
+  display_name: "Bombus vosnesenskii"
+}
+item {
+  name: "57690"
+  id: 107
+  display_name: "Bombus sonorus"
+}
+item {
+  name: "33118"
+  id: 108
+  display_name: "Basiliscus vittatus"
+}
+item {
+  name: "205151"
+  id: 109
+  display_name: "Phlogophora meticulosa"
+}
+item {
+  name: "49504"
+  id: 110
+  display_name: "Callinectes sapidus"
+}
+item {
+  name: "16737"
+  id: 111
+  display_name: "Megarynchus pitangua"
+}
+item {
+  name: "357"
+  id: 112
+  display_name: "Gallinula tenebrosa"
+}
+item {
+  name: "82278"
+  id: 113
+  display_name: "Ameiurus melas"
+}
+item {
+  name: "82279"
+  id: 114
+  display_name: "Automeris io"
+}
+item {
+  name: "505478"
+  id: 115
+  display_name: "Gallus gallus domesticus"
+}
+item {
+  name: "33135"
+  id: 116
+  display_name: "Crotaphytus collaris"
+}
+item {
+  name: "41328"
+  id: 117
+  display_name: "Lavia frons"
+}
+item {
+  name: "196979"
+  id: 118
+  display_name: "Anaxyrus boreas halophilus"
+}
+item {
+  name: "44902"
+  id: 119
+  display_name: "Sigmodon hispidus"
+}
+item {
+  name: "1428"
+  id: 120
+  display_name: "Numida meleagris"
+}
+item {
+  name: "119153"
+  id: 121
+  display_name: "Junco hyemalis caniceps"
+}
+item {
+  name: "49539"
+  id: 122
+  display_name: "Pisaster brevispinus"
+}
+item {
+  name: "328068"
+  id: 123
+  display_name: "Belocaulus angustipes"
+}
+item {
+  name: "120214"
+  id: 124
+  display_name: "Clostera albosigma"
+}
+item {
+  name: "16779"
+  id: 125
+  display_name: "Tyrannus vociferans"
+}
+item {
+  name: "16782"
+  id: 126
+  display_name: "Tyrannus tyrannus"
+}
+item {
+  name: "16783"
+  id: 127
+  display_name: "Tyrannus forficatus"
+}
+item {
+  name: "16784"
+  id: 128
+  display_name: "Tyrannus crassirostris"
+}
+item {
+  name: "57745"
+  id: 129
+  display_name: "Linckia laevigata"
+}
+item {
+  name: "205202"
+  id: 130
+  display_name: "Ecliptopera silaceata"
+}
+item {
+  name: "205203"
+  id: 131
+  display_name: "Dyspteris abortivaria"
+}
+item {
+  name: "16791"
+  id: 132
+  display_name: "Tyrannus verticalis"
+}
+item {
+  name: "16793"
+  id: 133
+  display_name: "Tyrannus savana"
+}
+item {
+  name: "205213"
+  id: 134
+  display_name: "Caripeta divisata"
+}
+item {
+  name: "49566"
+  id: 135
+  display_name: "Cicindela sexguttata"
+}
+item {
+  name: "491935"
+  id: 136
+  display_name: "Thylacodes squamigerus"
+}
+item {
+  name: "205216"
+  id: 137
+  display_name: "Cerma cerintha"
+}
+item {
+  name: "39665"
+  id: 138
+  display_name: "Caretta caretta"
+}
+item {
+  name: "147881"
+  id: 139
+  display_name: "Trichechus manatus latirostris"
+}
+item {
+  name: "28743"
+  id: 140
+  display_name: "Salvadora hexalepis"
+}
+item {
+  name: "205231"
+  id: 141
+  display_name: "Idaea dimidiata"
+}
+item {
+  name: "205233"
+  id: 142
+  display_name: "Iridopsis larvaria"
+}
+item {
+  name: "205235"
+  id: 143
+  display_name: "Leuconycta diphteroides"
+}
+item {
+  name: "436"
+  id: 144
+  display_name: "Gallirallus australis"
+}
+item {
+  name: "205238"
+  id: 145
+  display_name: "Metanema inatomaria"
+}
+item {
+  name: "49591"
+  id: 146
+  display_name: "Lepomis macrochirus"
+}
+item {
+  name: "229817"
+  id: 147
+  display_name: "Raphia frater"
+}
+item {
+  name: "49594"
+  id: 148
+  display_name: "Pomoxis nigromaculatus"
+}
+item {
+  name: "65979"
+  id: 149
+  display_name: "Lithobates catesbeianus"
+}
+item {
+  name: "49596"
+  id: 150
+  display_name: "Salvelinus fontinalis"
+}
+item {
+  name: "65982"
+  id: 151
+  display_name: "Lithobates clamitans"
+}
+item {
+  name: "8649"
+  id: 152
+  display_name: "Calocitta formosa"
+}
+item {
+  name: "8650"
+  id: 153
+  display_name: "Calocitta colliei"
+}
+item {
+  name: "82379"
+  id: 154
+  display_name: "Hemaris thysbe"
+}
+item {
+  name: "49614"
+  id: 155
+  display_name: "Lepomis gibbosus"
+}
+item {
+  name: "63028"
+  id: 156
+  display_name: "Hypercompe scribonia"
+}
+item {
+  name: "39672"
+  id: 157
+  display_name: "Eretmochelys imbricata"
+}
+item {
+  name: "66003"
+  id: 158
+  display_name: "Lithobates pipiens"
+}
+item {
+  name: "197077"
+  id: 159
+  display_name: "Vanessa kershawi"
+}
+item {
+  name: "473"
+  id: 160
+  display_name: "Fulica americana"
+}
+item {
+  name: "147930"
+  id: 161
+  display_name: "Rabidosa rabida"
+}
+item {
+  name: "147931"
+  id: 162
+  display_name: "Panoquina ocola"
+}
+item {
+  name: "66012"
+  id: 163
+  display_name: "Lithobates sylvaticus"
+}
+item {
+  name: "8671"
+  id: 164
+  display_name: "Pachyramphus aglaiae"
+}
+item {
+  name: "41440"
+  id: 165
+  display_name: "Phocoena phocoena"
+}
+item {
+  name: "27388"
+  id: 166
+  display_name: "Carphophis amoenus"
+}
+item {
+  name: "82418"
+  id: 167
+  display_name: "Cicindela punctulata"
+}
+item {
+  name: "25078"
+  id: 168
+  display_name: "Gastrophryne carolinensis"
+}
+item {
+  name: "82425"
+  id: 169
+  display_name: "Cicindela repanda"
+}
+item {
+  name: "143446"
+  id: 170
+  display_name: "Paonias myops"
+}
+item {
+  name: "41478"
+  id: 171
+  display_name: "Eschrichtius robustus"
+}
+item {
+  name: "5200"
+  id: 172
+  display_name: "Buteo lagopus"
+}
+item {
+  name: "148908"
+  id: 173
+  display_name: "Chrysodeixis includens"
+}
+item {
+  name: "41482"
+  id: 174
+  display_name: "Tursiops truncatus"
+}
+item {
+  name: "6914"
+  id: 175
+  display_name: "Cygnus atratus"
+}
+item {
+  name: "464301"
+  id: 176
+  display_name: "Philesturnus rufusater"
+}
+item {
+  name: "129226"
+  id: 177
+  display_name: "Chytolita morbidalis"
+}
+item {
+  name: "180759"
+  id: 178
+  display_name: "Aphonopelma iodius"
+}
+item {
+  name: "135318"
+  id: 179
+  display_name: "Apantesis phalerata"
+}
+item {
+  name: "49699"
+  id: 180
+  display_name: "Pisaster ochraceus"
+}
+item {
+  name: "49700"
+  id: 181
+  display_name: "Coluber lateralis lateralis"
+}
+item {
+  name: "61532"
+  id: 182
+  display_name: "Propylea quatuordecimpunctata"
+}
+item {
+  name: "4368"
+  id: 183
+  display_name: "Larus marinus"
+}
+item {
+  name: "41521"
+  id: 184
+  display_name: "Orcinus orca"
+}
+item {
+  name: "49716"
+  id: 185
+  display_name: "Paonias excaecata"
+}
+item {
+  name: "41526"
+  id: 186
+  display_name: "Delphinus delphis"
+}
+item {
+  name: "49723"
+  id: 187
+  display_name: "Pugettia producta"
+}
+item {
+  name: "16956"
+  id: 188
+  display_name: "Pitangus sulphuratus"
+}
+item {
+  name: "210607"
+  id: 189
+  display_name: "Diastictis fracturalis"
+}
+item {
+  name: "148030"
+  id: 190
+  display_name: "Equus asinus"
+}
+item {
+  name: "6924"
+  id: 191
+  display_name: "Anas rubripes"
+}
+item {
+  name: "30844"
+  id: 192
+  display_name: "Bothriechis schlegelii"
+}
+item {
+  name: "123628"
+  id: 193
+  display_name: "Argynnis paphia"
+}
+item {
+  name: "131676"
+  id: 194
+  display_name: "Anthus novaeseelandiae novaeseelandiae"
+}
+item {
+  name: "41566"
+  id: 195
+  display_name: "Megaptera novaeangliae"
+}
+item {
+  name: "49759"
+  id: 196
+  display_name: "Pyrgus oileus"
+}
+item {
+  name: "49761"
+  id: 197
+  display_name: "Anartia jatrophae"
+}
+item {
+  name: "49766"
+  id: 198
+  display_name: "Heliconius charithonia"
+}
+item {
+  name: "33383"
+  id: 199
+  display_name: "Coleonyx brevis"
+}
+item {
+  name: "33384"
+  id: 200
+  display_name: "Coleonyx elegans"
+}
+item {
+  name: "312764"
+  id: 201
+  display_name: "Euptoieta hegesia meridiania"
+}
+item {
+  name: "82538"
+  id: 202
+  display_name: "Vanessa gonerilla"
+}
+item {
+  name: "33387"
+  id: 203
+  display_name: "Coleonyx variegatus"
+}
+item {
+  name: "56082"
+  id: 204
+  display_name: "Aeshna canadensis"
+}
+item {
+  name: "17008"
+  id: 205
+  display_name: "Sayornis phoebe"
+}
+item {
+  name: "200808"
+  id: 206
+  display_name: "Sceloporus graciosus vandenburgianus"
+}
+item {
+  name: "17013"
+  id: 207
+  display_name: "Sayornis nigricans"
+}
+item {
+  name: "122381"
+  id: 208
+  display_name: "Cupido comyntas"
+}
+item {
+  name: "123516"
+  id: 209
+  display_name: "Mydas clavatus"
+}
+item {
+  name: "8834"
+  id: 210
+  display_name: "Tityra semifasciata"
+}
+item {
+  name: "146199"
+  id: 211
+  display_name: "Lampropeltis californiae"
+}
+item {
+  name: "17858"
+  id: 212
+  display_name: "Dryocopus lineatus"
+}
+item {
+  name: "334616"
+  id: 213
+  display_name: "Battus philenor hirsuta"
+}
+item {
+  name: "82582"
+  id: 214
+  display_name: "Labidomera clivicollis"
+}
+item {
+  name: "204699"
+  id: 215
+  display_name: "Pseudothyatira cymatophoroides"
+}
+item {
+  name: "41638"
+  id: 216
+  display_name: "Ursus americanus"
+}
+item {
+  name: "27420"
+  id: 217
+  display_name: "Desmognathus fuscus"
+}
+item {
+  name: "81584"
+  id: 218
+  display_name: "Anisota virginiensis"
+}
+item {
+  name: "49848"
+  id: 219
+  display_name: "Navanax inermis"
+}
+item {
+  name: "143476"
+  id: 220
+  display_name: "Calledapteryx dryopterata"
+}
+item {
+  name: "41663"
+  id: 221
+  display_name: "Procyon lotor"
+}
+item {
+  name: "49857"
+  id: 222
+  display_name: "Aplysia vaccaria"
+}
+item {
+  name: "41673"
+  id: 223
+  display_name: "Nasua narica"
+}
+item {
+  name: "41676"
+  id: 224
+  display_name: "Bassariscus astutus"
+}
+item {
+  name: "27427"
+  id: 225
+  display_name: "Aneides lugubris"
+}
+item {
+  name: "418530"
+  id: 226
+  display_name: "Porphyrio melanotus"
+}
+item {
+  name: "311419"
+  id: 227
+  display_name: "Neobernaya spadicea"
+}
+item {
+  name: "113502"
+  id: 228
+  display_name: "Sympetrum costiferum"
+}
+item {
+  name: "66278"
+  id: 229
+  display_name: "Oophaga pumilio"
+}
+item {
+  name: "6951"
+  id: 230
+  display_name: "Anas bahamensis"
+}
+item {
+  name: "213740"
+  id: 231
+  display_name: "Antaeotricha schlaegeri"
+}
+item {
+  name: "143485"
+  id: 232
+  display_name: "Xanthorhoe ferrugata"
+}
+item {
+  name: "120275"
+  id: 233
+  display_name: "Euphyia intermediata"
+}
+item {
+  name: "48035"
+  id: 234
+  display_name: "Strongylocentrotus purpuratus"
+}
+item {
+  name: "41728"
+  id: 235
+  display_name: "Mirounga angustirostris"
+}
+item {
+  name: "41733"
+  id: 236
+  display_name: "Halichoerus grypus"
+}
+item {
+  name: "41740"
+  id: 237
+  display_name: "Zalophus californianus"
+}
+item {
+  name: "118914"
+  id: 238
+  display_name: "Echinargus isola"
+}
+item {
+  name: "4936"
+  id: 239
+  display_name: "Egretta novaehollandiae"
+}
+item {
+  name: "131862"
+  id: 240
+  display_name: "Typocerus velutinus"
+}
+item {
+  name: "55401"
+  id: 241
+  display_name: "Pieris brassicae"
+}
+item {
+  name: "41752"
+  id: 242
+  display_name: "Arctocephalus forsteri"
+}
+item {
+  name: "41755"
+  id: 243
+  display_name: "Eumetopias jubatus"
+}
+item {
+  name: "123676"
+  id: 244
+  display_name: "Anas crecca carolinensis"
+}
+item {
+  name: "41763"
+  id: 245
+  display_name: "Phocarctos hookeri"
+}
+item {
+  name: "181034"
+  id: 246
+  display_name: "Cervus elaphus canadensis"
+}
+item {
+  name: "49964"
+  id: 247
+  display_name: "Ginglymostoma cirratum"
+}
+item {
+  name: "213809"
+  id: 248
+  display_name: "Anticarsia gemmatalis"
+}
+item {
+  name: "49972"
+  id: 249
+  display_name: "Battus philenor"
+}
+item {
+  name: "205623"
+  id: 250
+  display_name: "Microstylum morosum"
+}
+item {
+  name: "336697"
+  id: 251
+  display_name: "Arctia villica"
+}
+item {
+  name: "41789"
+  id: 252
+  display_name: "Taxidea taxus"
+}
+item {
+  name: "48724"
+  id: 253
+  display_name: "Phidiana hiltoni"
+}
+item {
+  name: "123713"
+  id: 254
+  display_name: "Neoscona oaxacensis"
+}
+item {
+  name: "33602"
+  id: 255
+  display_name: "Tarentola mauritanica"
+}
+item {
+  name: "846"
+  id: 256
+  display_name: "Alectoris chukar"
+}
+item {
+  name: "41808"
+  id: 257
+  display_name: "Mustela erminea"
+}
+item {
+  name: "50001"
+  id: 258
+  display_name: "Terrapene carolina carolina"
+}
+item {
+  name: "41810"
+  id: 259
+  display_name: "Mustela frenata"
+}
+item {
+  name: "82774"
+  id: 260
+  display_name: "Oryctes nasicornis"
+}
+item {
+  name: "41815"
+  id: 261
+  display_name: "Mustela nivalis"
+}
+item {
+  name: "4239"
+  id: 262
+  display_name: "Tachybaptus dominicus"
+}
+item {
+  name: "344926"
+  id: 263
+  display_name: "Artemisiospiza belli"
+}
+item {
+  name: "82792"
+  id: 264
+  display_name: "Celastrina neglecta"
+}
+item {
+  name: "41841"
+  id: 265
+  display_name: "Meles meles"
+}
+item {
+  name: "882"
+  id: 266
+  display_name: "Gallus gallus"
+}
+item {
+  name: "125758"
+  id: 267
+  display_name: "Mercenaria mercenaria"
+}
+item {
+  name: "9081"
+  id: 268
+  display_name: "Cardinalis sinuatus"
+}
+item {
+  name: "9083"
+  id: 269
+  display_name: "Cardinalis cardinalis"
+}
+item {
+  name: "9092"
+  id: 270
+  display_name: "Melospiza lincolnii"
+}
+item {
+  name: "4246"
+  id: 271
+  display_name: "Podilymbus podiceps"
+}
+item {
+  name: "9096"
+  id: 272
+  display_name: "Melospiza georgiana"
+}
+item {
+  name: "906"
+  id: 273
+  display_name: "Meleagris gallopavo"
+}
+item {
+  name: "50059"
+  id: 274
+  display_name: "Limacia cockerelli"
+}
+item {
+  name: "394124"
+  id: 275
+  display_name: "Orthodera novaezealandiae"
+}
+item {
+  name: "82832"
+  id: 276
+  display_name: "Cosmopepla lintneriana"
+}
+item {
+  name: "913"
+  id: 277
+  display_name: "Meleagris ocellata"
+}
+item {
+  name: "41877"
+  id: 278
+  display_name: "Conepatus leuconotus"
+}
+item {
+  name: "196419"
+  id: 279
+  display_name: "Euborellia annulipes"
+}
+item {
+  name: "50071"
+  id: 280
+  display_name: "Erynnis horatius"
+}
+item {
+  name: "41880"
+  id: 281
+  display_name: "Mephitis mephitis"
+}
+item {
+  name: "50073"
+  id: 282
+  display_name: "Dryas iulia"
+}
+item {
+  name: "173793"
+  id: 283
+  display_name: "Diphthera festiva"
+}
+item {
+  name: "41886"
+  id: 284
+  display_name: "Crocuta crocuta"
+}
+item {
+  name: "30683"
+  id: 285
+  display_name: "Agkistrodon contortrix contortrix"
+}
+item {
+  name: "931"
+  id: 286
+  display_name: "Lagopus lagopus"
+}
+item {
+  name: "41901"
+  id: 287
+  display_name: "Herpestes javanicus"
+}
+item {
+  name: "143517"
+  id: 288
+  display_name: "Biston betularia"
+}
+item {
+  name: "9139"
+  id: 289
+  display_name: "Spizella atrogularis"
+}
+item {
+  name: "8350"
+  id: 290
+  display_name: "Pyrrhocorax graculus"
+}
+item {
+  name: "9144"
+  id: 291
+  display_name: "Spizella breweri"
+}
+item {
+  name: "12936"
+  id: 292
+  display_name: "Sialia currucoides"
+}
+item {
+  name: "9152"
+  id: 293
+  display_name: "Spizella pusilla"
+}
+item {
+  name: "68229"
+  id: 294
+  display_name: "Tramea carolina"
+}
+item {
+  name: "6987"
+  id: 295
+  display_name: "Anas superciliosa"
+}
+item {
+  name: "9156"
+  id: 296
+  display_name: "Passerella iliaca"
+}
+item {
+  name: "202315"
+  id: 297
+  display_name: "Romaleon antennarium"
+}
+item {
+  name: "4257"
+  id: 298
+  display_name: "Phoenicopterus ruber"
+}
+item {
+  name: "25545"
+  id: 299
+  display_name: "Rana aurora"
+}
+item {
+  name: "15282"
+  id: 300
+  display_name: "Sylvia atricapilla"
+}
+item {
+  name: "103927"
+  id: 301
+  display_name: "Ladona deplanata"
+}
+item {
+  name: "17356"
+  id: 302
+  display_name: "Vireo bellii"
+}
+item {
+  name: "26765"
+  id: 303
+  display_name: "Ambystoma mavortium"
+}
+item {
+  name: "205777"
+  id: 304
+  display_name: "Plectrodera scalator"
+}
+item {
+  name: "17362"
+  id: 305
+  display_name: "Vireo plumbeus"
+}
+item {
+  name: "99283"
+  id: 306
+  display_name: "Didymops transversa"
+}
+item {
+  name: "17364"
+  id: 307
+  display_name: "Vireo philadelphicus"
+}
+item {
+  name: "17365"
+  id: 308
+  display_name: "Vireo flavifrons"
+}
+item {
+  name: "17366"
+  id: 309
+  display_name: "Vireo olivaceus"
+}
+item {
+  name: "9182"
+  id: 310
+  display_name: "Zonotrichia querula"
+}
+item {
+  name: "17375"
+  id: 311
+  display_name: "Vireo huttoni"
+}
+item {
+  name: "9184"
+  id: 312
+  display_name: "Zonotrichia albicollis"
+}
+item {
+  name: "9185"
+  id: 313
+  display_name: "Zonotrichia atricapilla"
+}
+item {
+  name: "50147"
+  id: 314
+  display_name: "Celithemis eponina"
+}
+item {
+  name: "47585"
+  id: 315
+  display_name: "Crassostrea virginica"
+}
+item {
+  name: "9195"
+  id: 316
+  display_name: "Emberiza citrinella"
+}
+item {
+  name: "41964"
+  id: 317
+  display_name: "Panthera leo"
+}
+item {
+  name: "6994"
+  id: 318
+  display_name: "Bucephala islandica"
+}
+item {
+  name: "52506"
+  id: 319
+  display_name: "Adalia bipunctata"
+}
+item {
+  name: "9201"
+  id: 320
+  display_name: "Emberiza schoeniclus"
+}
+item {
+  name: "17394"
+  id: 321
+  display_name: "Vireo gilvus"
+}
+item {
+  name: "25591"
+  id: 322
+  display_name: "Rana temporaria"
+}
+item {
+  name: "41976"
+  id: 323
+  display_name: "Lynx rufus"
+}
+item {
+  name: "214015"
+  id: 324
+  display_name: "Apoda y-inversum"
+}
+item {
+  name: "50176"
+  id: 325
+  display_name: "Enallagma vesperum"
+}
+item {
+  name: "99331"
+  id: 326
+  display_name: "Diplacodes trivialis"
+}
+item {
+  name: "50181"
+  id: 327
+  display_name: "Loxosceles reclusa"
+}
+item {
+  name: "74758"
+  id: 328
+  display_name: "Neovison vison"
+}
+item {
+  name: "123912"
+  id: 329
+  display_name: "Charaxes jasius"
+}
+item {
+  name: "41997"
+  id: 330
+  display_name: "Leopardus pardalis"
+}
+item {
+  name: "123920"
+  id: 331
+  display_name: "Dorcus parallelipipedus"
+}
+item {
+  name: "132334"
+  id: 332
+  display_name: "Urbanus procne"
+}
+item {
+  name: "123922"
+  id: 333
+  display_name: "Abudefduf sordidus"
+}
+item {
+  name: "9236"
+  id: 334
+  display_name: "Serinus serinus"
+}
+item {
+  name: "42007"
+  id: 335
+  display_name: "Puma concolor"
+}
+item {
+  name: "9240"
+  id: 336
+  display_name: "Serinus mozambicus"
+}
+item {
+  name: "148506"
+  id: 337
+  display_name: "Melanis pixe"
+}
+item {
+  name: "58399"
+  id: 338
+  display_name: "Urosalpinx cinerea"
+}
+item {
+  name: "312353"
+  id: 339
+  display_name: "Leptophobia aripa elodia"
+}
+item {
+  name: "148517"
+  id: 340
+  display_name: "Heliopetes laviana"
+}
+item {
+  name: "73905"
+  id: 341
+  display_name: "Phrynosoma cornutum"
+}
+item {
+  name: "39772"
+  id: 342
+  display_name: "Chrysemys picta marginata"
+}
+item {
+  name: "25646"
+  id: 343
+  display_name: "Rana boylii"
+}
+item {
+  name: "62984"
+  id: 344
+  display_name: "Aedes albopictus"
+}
+item {
+  name: "123959"
+  id: 345
+  display_name: "Ensatina eschscholtzii oregonensis"
+}
+item {
+  name: "1081"
+  id: 346
+  display_name: "Lophura leucomelanos"
+}
+item {
+  name: "39775"
+  id: 347
+  display_name: "Chrysemys picta picta"
+}
+item {
+  name: "42046"
+  id: 348
+  display_name: "Canis mesomelas"
+}
+item {
+  name: "42048"
+  id: 349
+  display_name: "Canis lupus"
+}
+item {
+  name: "42051"
+  id: 350
+  display_name: "Canis latrans"
+}
+item {
+  name: "9284"
+  id: 351
+  display_name: "Euphonia elegantissima"
+}
+item {
+  name: "25669"
+  id: 352
+  display_name: "Rana dalmatina"
+}
+item {
+  name: "9287"
+  id: 353
+  display_name: "Euphonia hirundinacea"
+}
+item {
+  name: "9291"
+  id: 354
+  display_name: "Euphonia affinis"
+}
+item {
+  name: "222284"
+  id: 355
+  display_name: "Iridopsis defectaria"
+}
+item {
+  name: "74832"
+  id: 356
+  display_name: "Papio anubis"
+}
+item {
+  name: "148563"
+  id: 357
+  display_name: "Myscelia ethusa"
+}
+item {
+  name: "42069"
+  id: 358
+  display_name: "Vulpes vulpes"
+}
+item {
+  name: "9743"
+  id: 359
+  display_name: "Agelaius tricolor"
+}
+item {
+  name: "42076"
+  id: 360
+  display_name: "Urocyon cinereoargenteus"
+}
+item {
+  name: "509025"
+  id: 361
+  display_name: "Momotus lessonii"
+}
+item {
+  name: "17506"
+  id: 362
+  display_name: "Zosterops japonicus"
+}
+item {
+  name: "4283"
+  id: 363
+  display_name: "Phalacrocorax pelagicus"
+}
+item {
+  name: "58469"
+  id: 364
+  display_name: "Thorybes pylades"
+}
+item {
+  name: "9319"
+  id: 365
+  display_name: "Icterus cucullatus"
+}
+item {
+  name: "58473"
+  id: 366
+  display_name: "Erynnis icelus"
+}
+item {
+  name: "58475"
+  id: 367
+  display_name: "Erynnis juvenalis"
+}
+item {
+  name: "42093"
+  id: 368
+  display_name: "Lycaon pictus"
+}
+item {
+  name: "58478"
+  id: 369
+  display_name: "Erynnis baptisiae"
+}
+item {
+  name: "9328"
+  id: 370
+  display_name: "Icterus graduacauda"
+}
+item {
+  name: "58481"
+  id: 371
+  display_name: "Ancyloxypha numitor"
+}
+item {
+  name: "132210"
+  id: 372
+  display_name: "Deloyala guttata"
+}
+item {
+  name: "58484"
+  id: 373
+  display_name: "Thymelicus lineola"
+}
+item {
+  name: "13701"
+  id: 374
+  display_name: "Motacilla aguimp"
+}
+item {
+  name: "410743"
+  id: 375
+  display_name: "Anas superciliosa \303\227 platyrhynchos"
+}
+item {
+  name: "9336"
+  id: 376
+  display_name: "Icterus pustulatus"
+}
+item {
+  name: "9339"
+  id: 377
+  display_name: "Icterus gularis"
+}
+item {
+  name: "124031"
+  id: 378
+  display_name: "Agrius convolvuli"
+}
+item {
+  name: "42113"
+  id: 379
+  display_name: "Pecari tajacu"
+}
+item {
+  name: "132227"
+  id: 380
+  display_name: "Lethe appalachia"
+}
+item {
+  name: "113516"
+  id: 381
+  display_name: "Sympetrum madidum"
+}
+item {
+  name: "58509"
+  id: 382
+  display_name: "Anatrytone logan"
+}
+item {
+  name: "83086"
+  id: 383
+  display_name: "Eurytides marcellus"
+}
+item {
+  name: "58511"
+  id: 384
+  display_name: "Poanes viator"
+}
+item {
+  name: "83090"
+  id: 385
+  display_name: "Epimecis hortaria"
+}
+item {
+  name: "115859"
+  id: 386
+  display_name: "Micrurus tener tener"
+}
+item {
+  name: "129902"
+  id: 387
+  display_name: "Camponotus pennsylvanicus"
+}
+item {
+  name: "42134"
+  id: 388
+  display_name: "Sus scrofa"
+}
+item {
+  name: "58519"
+  id: 389
+  display_name: "Pompeius verna"
+}
+item {
+  name: "205977"
+  id: 390
+  display_name: "Coccinella undecimpunctata"
+}
+item {
+  name: "58523"
+  id: 391
+  display_name: "Papilio polyxenes"
+}
+item {
+  name: "58525"
+  id: 392
+  display_name: "Papilio troilus"
+}
+item {
+  name: "410783"
+  id: 393
+  display_name: "Hypoblemum albovittatum"
+}
+item {
+  name: "9376"
+  id: 394
+  display_name: "Carduelis cannabina"
+}
+item {
+  name: "58531"
+  id: 395
+  display_name: "Colias philodice"
+}
+item {
+  name: "50340"
+  id: 396
+  display_name: "Hylephila phyleus"
+}
+item {
+  name: "42149"
+  id: 397
+  display_name: "Hippopotamus amphibius"
+}
+item {
+  name: "50342"
+  id: 398
+  display_name: "Erythrodiplax umbrata"
+}
+item {
+  name: "12883"
+  id: 399
+  display_name: "Catharus minimus"
+}
+item {
+  name: "28557"
+  id: 400
+  display_name: "Storeria occipitomaculata"
+}
+item {
+  name: "199"
+  id: 401
+  display_name: "Amaurornis phoenicurus"
+}
+item {
+  name: "58541"
+  id: 402
+  display_name: "Satyrium liparops"
+}
+item {
+  name: "58543"
+  id: 403
+  display_name: "Callophrys augustinus"
+}
+item {
+  name: "42161"
+  id: 404
+  display_name: "Dama dama"
+}
+item {
+  name: "61508"
+  id: 405
+  display_name: "Ischnura elegans"
+}
+item {
+  name: "1204"
+  id: 406
+  display_name: "Pavo cristatus"
+}
+item {
+  name: "42166"
+  id: 407
+  display_name: "Axis axis"
+}
+item {
+  name: "146797"
+  id: 408
+  display_name: "Platynota idaeusalis"
+}
+item {
+  name: "58556"
+  id: 409
+  display_name: "Celastrina ladon"
+}
+item {
+  name: "367477"
+  id: 410
+  display_name: "Rallus crepitans"
+}
+item {
+  name: "58561"
+  id: 411
+  display_name: "Libytheana carinenta"
+}
+item {
+  name: "58563"
+  id: 412
+  display_name: "Speyeria aphrodite"
+}
+item {
+  name: "58564"
+  id: 413
+  display_name: "Boloria bellona"
+}
+item {
+  name: "413489"
+  id: 414
+  display_name: "Nestor meridionalis septentrionalis"
+}
+item {
+  name: "42184"
+  id: 415
+  display_name: "Capreolus capreolus"
+}
+item {
+  name: "9419"
+  id: 416
+  display_name: "Pipilo chlorurus"
+}
+item {
+  name: "9420"
+  id: 417
+  display_name: "Pipilo maculatus"
+}
+item {
+  name: "9424"
+  id: 418
+  display_name: "Pipilo erythrophthalmus"
+}
+item {
+  name: "99539"
+  id: 419
+  display_name: "Dorocordulia libera"
+}
+item {
+  name: "58580"
+  id: 420
+  display_name: "Polygonia progne"
+}
+item {
+  name: "58581"
+  id: 421
+  display_name: "Nymphalis vaualbum"
+}
+item {
+  name: "42199"
+  id: 422
+  display_name: "Rangifer tarandus"
+}
+item {
+  name: "58586"
+  id: 423
+  display_name: "Limenitis archippus"
+}
+item {
+  name: "58587"
+  id: 424
+  display_name: "Asterocampa clyton"
+}
+item {
+  name: "42206"
+  id: 425
+  display_name: "Cervus elaphus"
+}
+item {
+  name: "312543"
+  id: 426
+  display_name: "Anartia jatrophae luteipicta"
+}
+item {
+  name: "204094"
+  id: 427
+  display_name: "Cairina moschata domestica"
+}
+item {
+  name: "4304"
+  id: 428
+  display_name: "Phalacrocorax varius"
+}
+item {
+  name: "42210"
+  id: 429
+  display_name: "Cervus nippon"
+}
+item {
+  name: "17638"
+  id: 430
+  display_name: "Picoides dorsalis"
+}
+item {
+  name: "132330"
+  id: 431
+  display_name: "Chlosyne janais"
+}
+item {
+  name: "58603"
+  id: 432
+  display_name: "Megisto cymela"
+}
+item {
+  name: "42220"
+  id: 433
+  display_name: "Odocoileus hemionus"
+}
+item {
+  name: "17645"
+  id: 434
+  display_name: "Picoides nuttallii"
+}
+item {
+  name: "58606"
+  id: 435
+  display_name: "Cercyonis pegala"
+}
+item {
+  name: "42223"
+  id: 436
+  display_name: "Odocoileus virginianus"
+}
+item {
+  name: "58609"
+  id: 437
+  display_name: "Lepisosteus osseus"
+}
+item {
+  name: "17650"
+  id: 438
+  display_name: "Picoides scalaris"
+}
+item {
+  name: "132339"
+  id: 439
+  display_name: "Anthanassa texana"
+}
+item {
+  name: "58612"
+  id: 440
+  display_name: "Carassius auratus"
+}
+item {
+  name: "1406"
+  id: 441
+  display_name: "Callipepla gambelii"
+}
+item {
+  name: "9462"
+  id: 442
+  display_name: "Pyrrhula pyrrhula"
+}
+item {
+  name: "4308"
+  id: 443
+  display_name: "Phalacrocorax brasilianus"
+}
+item {
+  name: "17660"
+  id: 444
+  display_name: "Picoides pubescens"
+}
+item {
+  name: "1280"
+  id: 445
+  display_name: "Colinus virginianus"
+}
+item {
+  name: "129920"
+  id: 446
+  display_name: "Calliostoma ligatum"
+}
+item {
+  name: "58627"
+  id: 447
+  display_name: "Perca flavescens"
+}
+item {
+  name: "148742"
+  id: 448
+  display_name: "Hamadryas februa"
+}
+item {
+  name: "39809"
+  id: 449
+  display_name: "Terrapene ornata ornata"
+}
+item {
+  name: "115979"
+  id: 450
+  display_name: "Plestiodon skiltonianus skiltonianus"
+}
+item {
+  name: "9484"
+  id: 451
+  display_name: "Sporophila torqueola"
+}
+item {
+  name: "17678"
+  id: 452
+  display_name: "Picoides villosus"
+}
+item {
+  name: "3862"
+  id: 453
+  display_name: "Calidris pusilla"
+}
+item {
+  name: "70421"
+  id: 454
+  display_name: "Acris blanchardi"
+}
+item {
+  name: "124183"
+  id: 455
+  display_name: "Phlogophora periculosa"
+}
+item {
+  name: "124184"
+  id: 456
+  display_name: "Plodia interpunctella"
+}
+item {
+  name: "99609"
+  id: 457
+  display_name: "Dromogomphus spinosus"
+}
+item {
+  name: "99610"
+  id: 458
+  display_name: "Dromogomphus spoliatus"
+}
+item {
+  name: "17694"
+  id: 459
+  display_name: "Picoides arcticus"
+}
+item {
+  name: "113521"
+  id: 460
+  display_name: "Sympetrum pallipes"
+}
+item {
+  name: "320801"
+  id: 461
+  display_name: "Aspidoscelis tesselata"
+}
+item {
+  name: "7047"
+  id: 462
+  display_name: "Aythya marila"
+}
+item {
+  name: "4317"
+  id: 463
+  display_name: "Phaethon aethereus"
+}
+item {
+  name: "81606"
+  id: 464
+  display_name: "Littorina littorea"
+}
+item {
+  name: "99891"
+  id: 465
+  display_name: "Enallagma aspersum"
+}
+item {
+  name: "9528"
+  id: 466
+  display_name: "Sturnella magna"
+}
+item {
+  name: "99641"
+  id: 467
+  display_name: "Dythemis fugax"
+}
+item {
+  name: "99644"
+  id: 468
+  display_name: "Dythemis nigrescens"
+}
+item {
+  name: "39818"
+  id: 469
+  display_name: "Terrapene carolina triunguis"
+}
+item {
+  name: "99647"
+  id: 470
+  display_name: "Dythemis velox"
+}
+item {
+  name: "148800"
+  id: 471
+  display_name: "Chioides albofasciatus"
+}
+item {
+  name: "19339"
+  id: 472
+  display_name: "Melopsittacus undulatus"
+}
+item {
+  name: "47509"
+  id: 473
+  display_name: "Diaulula sandiegensis"
+}
+item {
+  name: "148810"
+  id: 474
+  display_name: "Anaea aidea"
+}
+item {
+  name: "123070"
+  id: 475
+  display_name: "Capra hircus"
+}
+item {
+  name: "7054"
+  id: 476
+  display_name: "Aythya affinis"
+}
+item {
+  name: "99897"
+  id: 477
+  display_name: "Enallagma civile"
+}
+item {
+  name: "42328"
+  id: 478
+  display_name: "Kobus ellipsiprymnus"
+}
+item {
+  name: "48328"
+  id: 479
+  display_name: "Aurelia aurita"
+}
+item {
+  name: "132445"
+  id: 480
+  display_name: "Conchylodes ovulalis"
+}
+item {
+  name: "215271"
+  id: 481
+  display_name: "Bleptina caradrinalis"
+}
+item {
+  name: "83297"
+  id: 482
+  display_name: "Scarus rubroviolaceus"
+}
+item {
+  name: "42347"
+  id: 483
+  display_name: "Rupicapra rupicapra"
+}
+item {
+  name: "7058"
+  id: 484
+  display_name: "Aythya novaeseelandiae"
+}
+item {
+  name: "52457"
+  id: 485
+  display_name: "Chaetodon auriga"
+}
+item {
+  name: "1392"
+  id: 486
+  display_name: "Cyrtonyx montezumae"
+}
+item {
+  name: "4328"
+  id: 487
+  display_name: "Pelecanus occidentalis"
+}
+item {
+  name: "7647"
+  id: 488
+  display_name: "Cinclus cinclus"
+}
+item {
+  name: "148856"
+  id: 489
+  display_name: "Anteos clorinde"
+}
+item {
+  name: "7060"
+  id: 490
+  display_name: "Chen rossii"
+}
+item {
+  name: "58750"
+  id: 491
+  display_name: "Nomophila nearctica"
+}
+item {
+  name: "1409"
+  id: 492
+  display_name: "Callipepla californica"
+}
+item {
+  name: "9602"
+  id: 493
+  display_name: "Quiscalus quiscula"
+}
+item {
+  name: "296326"
+  id: 494
+  display_name: "Oncopeltus sexmaculatus"
+}
+item {
+  name: "9607"
+  id: 495
+  display_name: "Quiscalus mexicanus"
+}
+item {
+  name: "319724"
+  id: 496
+  display_name: "Euphoria kernii"
+}
+item {
+  name: "1419"
+  id: 497
+  display_name: "Callipepla squamata"
+}
+item {
+  name: "148883"
+  id: 498
+  display_name: "Eantis tamenund"
+}
+item {
+  name: "42391"
+  id: 499
+  display_name: "Ovis canadensis"
+}
+item {
+  name: "107937"
+  id: 500
+  display_name: "Orthemis discolor"
+}
+item {
+  name: "42405"
+  id: 501
+  display_name: "Syncerus caffer"
+}
+item {
+  name: "42408"
+  id: 502
+  display_name: "Bison bison"
+}
+item {
+  name: "116137"
+  id: 503
+  display_name: "Sceloporus cowlesi"
+}
+item {
+  name: "326296"
+  id: 504
+  display_name: "Bufo bufo"
+}
+item {
+  name: "148907"
+  id: 505
+  display_name: "Cydia latiferreana"
+}
+item {
+  name: "42414"
+  id: 506
+  display_name: "Oreamnos americanus"
+}
+item {
+  name: "116143"
+  id: 507
+  display_name: "Sceloporus tristichus"
+}
+item {
+  name: "99912"
+  id: 508
+  display_name: "Enallagma geminatum"
+}
+item {
+  name: "226889"
+  id: 509
+  display_name: "Pangrapta decoralis"
+}
+item {
+  name: "42429"
+  id: 510
+  display_name: "Antilocapra americana"
+}
+item {
+  name: "17855"
+  id: 511
+  display_name: "Dryocopus pileatus"
+}
+item {
+  name: "107974"
+  id: 512
+  display_name: "Orthetrum sabina"
+}
+item {
+  name: "56225"
+  id: 513
+  display_name: "Polygonia c-album"
+}
+item {
+  name: "67016"
+  id: 514
+  display_name: "Rana draytonii"
+}
+item {
+  name: "132553"
+  id: 515
+  display_name: "Strymon istapa"
+}
+item {
+  name: "73155"
+  id: 516
+  display_name: "Passerina caerulea"
+}
+item {
+  name: "26074"
+  id: 517
+  display_name: "Crocodylus moreletii"
+}
+item {
+  name: "171903"
+  id: 518
+  display_name: "Oligyra orbiculata"
+}
+item {
+  name: "26085"
+  id: 519
+  display_name: "Crocodylus acutus"
+}
+item {
+  name: "143613"
+  id: 520
+  display_name: "Homophoberia apicosa"
+}
+item {
+  name: "5715"
+  id: 521
+  display_name: "Amazilia beryllina"
+}
+item {
+  name: "9721"
+  id: 522
+  display_name: "Geothlypis trichas"
+}
+item {
+  name: "154446"
+  id: 523
+  display_name: "Lambdina fiscellaria"
+}
+item {
+  name: "236841"
+  id: 524
+  display_name: "Lichanura orcutti"
+}
+item {
+  name: "20737"
+  id: 525
+  display_name: "Trogon melanocephalus"
+}
+item {
+  name: "124431"
+  id: 526
+  display_name: "Cycloneda sanguinea"
+}
+item {
+  name: "124432"
+  id: 527
+  display_name: "Deroceras reticulatum"
+}
+item {
+  name: "39566"
+  id: 528
+  display_name: "Apalone ferox"
+}
+item {
+  name: "149017"
+  id: 529
+  display_name: "Chlorochlamys chloroleucaria"
+}
+item {
+  name: "15281"
+  id: 530
+  display_name: "Sylvia communis"
+}
+item {
+  name: "312873"
+  id: 531
+  display_name: "Anartia fatima fatima"
+}
+item {
+  name: "9771"
+  id: 532
+  display_name: "Pinicola enucleator"
+}
+item {
+  name: "39858"
+  id: 533
+  display_name: "Graptemys geographica"
+}
+item {
+  name: "26159"
+  id: 534
+  display_name: "Alligator mississippiensis"
+}
+item {
+  name: "304690"
+  id: 535
+  display_name: "Naupactus cervinus"
+}
+item {
+  name: "124467"
+  id: 536
+  display_name: "Pseudosphinx tetrio"
+}
+item {
+  name: "99892"
+  id: 537
+  display_name: "Enallagma basidens"
+}
+item {
+  name: "99895"
+  id: 538
+  display_name: "Enallagma carunculatum"
+}
+item {
+  name: "67129"
+  id: 539
+  display_name: "Rhinella marina"
+}
+item {
+  name: "83515"
+  id: 540
+  display_name: "Oxybelis aeneus"
+}
+item {
+  name: "81681"
+  id: 541
+  display_name: "Campaea perlata"
+}
+item {
+  name: "99901"
+  id: 542
+  display_name: "Enallagma cyathigerum"
+}
+item {
+  name: "99911"
+  id: 543
+  display_name: "Enallagma exsulans"
+}
+item {
+  name: "9800"
+  id: 544
+  display_name: "Coccothraustes vespertinus"
+}
+item {
+  name: "9801"
+  id: 545
+  display_name: "Coccothraustes coccothraustes"
+}
+item {
+  name: "154551"
+  id: 546
+  display_name: "Leptoglossus zonatus"
+}
+item {
+  name: "9807"
+  id: 547
+  display_name: "Vermivora chrysoptera"
+}
+item {
+  name: "61157"
+  id: 548
+  display_name: "Trichodes ornatus"
+}
+item {
+  name: "99924"
+  id: 549
+  display_name: "Enallagma signatum"
+}
+item {
+  name: "1626"
+  id: 550
+  display_name: "Opisthocomus hoazin"
+}
+item {
+  name: "132704"
+  id: 551
+  display_name: "Setophaga coronata coronata"
+}
+item {
+  name: "119056"
+  id: 552
+  display_name: "Centruroides vittatus"
+}
+item {
+  name: "50786"
+  id: 553
+  display_name: "Vanessa annabella"
+}
+item {
+  name: "60347"
+  id: 554
+  display_name: "Pituophis catenifer sayi"
+}
+item {
+  name: "9833"
+  id: 555
+  display_name: "Diglossa baritula"
+}
+item {
+  name: "132718"
+  id: 556
+  display_name: "Scathophaga stercoraria"
+}
+item {
+  name: "132719"
+  id: 557
+  display_name: "Calopteron reticulatum"
+}
+item {
+  name: "116340"
+  id: 558
+  display_name: "Dreissena polymorpha"
+}
+item {
+  name: "134078"
+  id: 559
+  display_name: "Scoliopteryx libatrix"
+}
+item {
+  name: "9850"
+  id: 560
+  display_name: "Saltator coerulescens"
+}
+item {
+  name: "117695"
+  id: 561
+  display_name: "Cucumaria miniata"
+}
+item {
+  name: "9854"
+  id: 562
+  display_name: "Saltator atriceps"
+}
+item {
+  name: "132736"
+  id: 563
+  display_name: "Urola nivalis"
+}
+item {
+  name: "34435"
+  id: 564
+  display_name: "Hemidactylus turcicus"
+}
+item {
+  name: "9864"
+  id: 565
+  display_name: "Sicalis flaveola"
+}
+item {
+  name: "7106"
+  id: 566
+  display_name: "Aix galericulata"
+}
+item {
+  name: "485010"
+  id: 567
+  display_name: "Chinavia hilaris"
+}
+item {
+  name: "132764"
+  id: 568
+  display_name: "Junco hyemalis hyemalis"
+}
+item {
+  name: "367558"
+  id: 569
+  display_name: "Eupsittula canicularis"
+}
+item {
+  name: "370351"
+  id: 570
+  display_name: "Microcarbo melanoleucos"
+}
+item {
+  name: "50867"
+  id: 571
+  display_name: "Argiope bruennichi"
+}
+item {
+  name: "67252"
+  id: 572
+  display_name: "Trachycephalus typhonius"
+}
+item {
+  name: "132789"
+  id: 573
+  display_name: "Clepsis peritana"
+}
+item {
+  name: "9915"
+  id: 574
+  display_name: "Piranga rubra"
+}
+item {
+  name: "50880"
+  id: 575
+  display_name: "Limenitis lorquini"
+}
+item {
+  name: "9921"
+  id: 576
+  display_name: "Piranga olivacea"
+}
+item {
+  name: "100034"
+  id: 577
+  display_name: "Epiaeschna heros"
+}
+item {
+  name: "9924"
+  id: 578
+  display_name: "Piranga flava"
+}
+item {
+  name: "42339"
+  id: 579
+  display_name: "Tragelaphus strepsiceros"
+}
+item {
+  name: "50892"
+  id: 580
+  display_name: "Euphydryas chalcedona"
+}
+item {
+  name: "130348"
+  id: 581
+  display_name: "Dione moneta"
+}
+item {
+  name: "394966"
+  id: 582
+  display_name: "Phaulacridium marginale"
+}
+item {
+  name: "9943"
+  id: 583
+  display_name: "Amphispiza bilineata"
+}
+item {
+  name: "4388"
+  id: 584
+  display_name: "Larus dominicanus"
+}
+item {
+  name: "1758"
+  id: 585
+  display_name: "Piaya cayana"
+}
+item {
+  name: "50913"
+  id: 586
+  display_name: "Hyalophora euryalus"
+}
+item {
+  name: "9958"
+  id: 587
+  display_name: "Aimophila ruficeps"
+}
+item {
+  name: "59115"
+  id: 588
+  display_name: "Gambusia affinis"
+}
+item {
+  name: "64346"
+  id: 589
+  display_name: "Natrix tessellata"
+}
+item {
+  name: "59119"
+  id: 590
+  display_name: "Pontia protodice"
+}
+item {
+  name: "18160"
+  id: 591
+  display_name: "Melanerpes lewis"
+}
+item {
+  name: "18161"
+  id: 592
+  display_name: "Melanerpes uropygialis"
+}
+item {
+  name: "50931"
+  id: 593
+  display_name: "Strymon melinus"
+}
+item {
+  name: "59124"
+  id: 594
+  display_name: "Anthocharis sara"
+}
+item {
+  name: "59127"
+  id: 595
+  display_name: "Lycaena helloides"
+}
+item {
+  name: "59128"
+  id: 596
+  display_name: "Atlides halesus"
+}
+item {
+  name: "67324"
+  id: 597
+  display_name: "Eurema daira"
+}
+item {
+  name: "9981"
+  id: 598
+  display_name: "Passerculus sandwichensis"
+}
+item {
+  name: "59134"
+  id: 599
+  display_name: "Satyrium sylvinus"
+}
+item {
+  name: "67327"
+  id: 600
+  display_name: "Schistocerca obscura"
+}
+item {
+  name: "67328"
+  id: 601
+  display_name: "Pholcus phalangioides"
+}
+item {
+  name: "59138"
+  id: 602
+  display_name: "Satyrium saepium"
+}
+item {
+  name: "132867"
+  id: 603
+  display_name: "Microtia elva"
+}
+item {
+  name: "18181"
+  id: 604
+  display_name: "Melanerpes pucherani"
+}
+item {
+  name: "7486"
+  id: 605
+  display_name: "Salpinctes obsoletus"
+}
+item {
+  name: "108303"
+  id: 606
+  display_name: "Paltothemis lineatipes"
+}
+item {
+  name: "59152"
+  id: 607
+  display_name: "Leptotes marina"
+}
+item {
+  name: "132881"
+  id: 608
+  display_name: "Catocala ultronia"
+}
+item {
+  name: "143662"
+  id: 609
+  display_name: "Orthosoma brunneum"
+}
+item {
+  name: "59164"
+  id: 610
+  display_name: "Plebejus icarioides"
+}
+item {
+  name: "18205"
+  id: 611
+  display_name: "Melanerpes carolinus"
+}
+item {
+  name: "18206"
+  id: 612
+  display_name: "Melanerpes chrysogenys"
+}
+item {
+  name: "83744"
+  id: 613
+  display_name: "Amblyomma americanum"
+}
+item {
+  name: "18209"
+  id: 614
+  display_name: "Melanerpes formicivorus"
+}
+item {
+  name: "116517"
+  id: 615
+  display_name: "Caiman crocodilus"
+}
+item {
+  name: "59176"
+  id: 616
+  display_name: "Phyciodes mylitta"
+}
+item {
+  name: "59182"
+  id: 617
+  display_name: "Euphydryas editha"
+}
+item {
+  name: "43997"
+  id: 618
+  display_name: "Myocastor coypus"
+}
+item {
+  name: "59185"
+  id: 619
+  display_name: "Coenonympha tullia"
+}
+item {
+  name: "59187"
+  id: 620
+  display_name: "Erynnis propertius"
+}
+item {
+  name: "59188"
+  id: 621
+  display_name: "Erynnis funeralis"
+}
+item {
+  name: "59189"
+  id: 622
+  display_name: "Erynnis tristis"
+}
+item {
+  name: "59190"
+  id: 623
+  display_name: "Heliopetes ericetorum"
+}
+item {
+  name: "34615"
+  id: 624
+  display_name: "Gekko gecko"
+}
+item {
+  name: "42808"
+  id: 625
+  display_name: "Trichosurus vulpecula"
+}
+item {
+  name: "59194"
+  id: 626
+  display_name: "Ochlodes sylvanoides"
+}
+item {
+  name: "59195"
+  id: 627
+  display_name: "Lerodea eufala"
+}
+item {
+  name: "18236"
+  id: 628
+  display_name: "Colaptes auratus"
+}
+item {
+  name: "10045"
+  id: 629
+  display_name: "Basileuterus rufifrons"
+}
+item {
+  name: "59202"
+  id: 630
+  display_name: "Larus michahellis"
+}
+item {
+  name: "10053"
+  id: 631
+  display_name: "Ramphocelus passerinii"
+}
+item {
+  name: "19975"
+  id: 632
+  display_name: "Athene cunicularia"
+}
+item {
+  name: "82231"
+  id: 633
+  display_name: "Periplaneta americana"
+}
+item {
+  name: "67409"
+  id: 634
+  display_name: "Gobiesox maeandricus"
+}
+item {
+  name: "83795"
+  id: 635
+  display_name: "Cipangopaludina chinensis"
+}
+item {
+  name: "59220"
+  id: 636
+  display_name: "Branta hutchinsii"
+}
+item {
+  name: "10069"
+  id: 637
+  display_name: "Fringilla montifringilla"
+}
+item {
+  name: "10070"
+  id: 638
+  display_name: "Fringilla coelebs"
+}
+item {
+  name: "83802"
+  id: 639
+  display_name: "Megacyllene robiniae"
+}
+item {
+  name: "83804"
+  id: 640
+  display_name: "Dynastes tityus"
+}
+item {
+  name: "51039"
+  id: 641
+  display_name: "Cepaea hortensis"
+}
+item {
+  name: "68062"
+  id: 642
+  display_name: "Menemerus bivittatus"
+}
+item {
+  name: "47527"
+  id: 643
+  display_name: "Ostracion meleagris"
+}
+item {
+  name: "67435"
+  id: 644
+  display_name: "Urbanus proteus"
+}
+item {
+  name: "10094"
+  id: 645
+  display_name: "Junco hyemalis"
+}
+item {
+  name: "67440"
+  id: 646
+  display_name: "Utetheisa ornatrix"
+}
+item {
+  name: "100210"
+  id: 647
+  display_name: "Epitheca canis"
+}
+item {
+  name: "1907"
+  id: 648
+  display_name: "Cuculus canorus"
+}
+item {
+  name: "100215"
+  id: 649
+  display_name: "Epitheca princeps"
+}
+item {
+  name: "27826"
+  id: 650
+  display_name: "Taricha granulosa"
+}
+item {
+  name: "129147"
+  id: 651
+  display_name: "Ammophila procera"
+}
+item {
+  name: "10111"
+  id: 652
+  display_name: "Junco phaeonotus"
+}
+item {
+  name: "83844"
+  id: 653
+  display_name: "Oxyopes salticus"
+}
+item {
+  name: "144107"
+  id: 654
+  display_name: "Tetracis crocallata"
+}
+item {
+  name: "51097"
+  id: 655
+  display_name: "Papilio zelicaon"
+}
+item {
+  name: "10138"
+  id: 656
+  display_name: "Ammodramus nelsoni"
+}
+item {
+  name: "10139"
+  id: 657
+  display_name: "Ammodramus savannarum"
+}
+item {
+  name: "10147"
+  id: 658
+  display_name: "Ammodramus maritimus"
+}
+item {
+  name: "59300"
+  id: 659
+  display_name: "Anagrapha falcifera"
+}
+item {
+  name: "51110"
+  id: 660
+  display_name: "Xylocopa virginica"
+}
+item {
+  name: "1960"
+  id: 661
+  display_name: "Coccyzus erythropthalmus"
+}
+item {
+  name: "42652"
+  id: 662
+  display_name: "Didelphis virginiana"
+}
+item {
+  name: "428606"
+  id: 663
+  display_name: "Heraclides rumiko"
+}
+item {
+  name: "127303"
+  id: 664
+  display_name: "Callophrys henrici"
+}
+item {
+  name: "1964"
+  id: 665
+  display_name: "Coccyzus minor"
+}
+item {
+  name: "1965"
+  id: 666
+  display_name: "Coccyzus americanus"
+}
+item {
+  name: "8520"
+  id: 667
+  display_name: "Nucifraga columbiana"
+}
+item {
+  name: "116658"
+  id: 668
+  display_name: "Siphanta acuta"
+}
+item {
+  name: "1972"
+  id: 669
+  display_name: "Crotophaga sulcirostris"
+}
+item {
+  name: "10168"
+  id: 670
+  display_name: "Pooecetes gramineus"
+}
+item {
+  name: "53893"
+  id: 671
+  display_name: "Chlosyne palla"
+}
+item {
+  name: "10173"
+  id: 672
+  display_name: "Arremonops rufivirgatus"
+}
+item {
+  name: "1986"
+  id: 673
+  display_name: "Geococcyx californianus"
+}
+item {
+  name: "1987"
+  id: 674
+  display_name: "Geococcyx velox"
+}
+item {
+  name: "116680"
+  id: 675
+  display_name: "Tabanus atratus"
+}
+item {
+  name: "116681"
+  id: 676
+  display_name: "Atteva aurea"
+}
+item {
+  name: "124875"
+  id: 677
+  display_name: "Spodoptera litura"
+}
+item {
+  name: "26575"
+  id: 678
+  display_name: "Diadophis punctatus"
+}
+item {
+  name: "10199"
+  id: 679
+  display_name: "Coereba flaveola"
+}
+item {
+  name: "26591"
+  id: 680
+  display_name: "Diadophis punctatus edwardsii"
+}
+item {
+  name: "59360"
+  id: 681
+  display_name: "Neverita duplicata"
+}
+item {
+  name: "68263"
+  id: 682
+  display_name: "Papilio multicaudata"
+}
+item {
+  name: "26598"
+  id: 683
+  display_name: "Diadophis punctatus amabilis"
+}
+item {
+  name: "42983"
+  id: 684
+  display_name: "Phascolarctos cinereus"
+}
+item {
+  name: "67560"
+  id: 685
+  display_name: "Adelpha californica"
+}
+item {
+  name: "10224"
+  id: 686
+  display_name: "Passerina ciris"
+}
+item {
+  name: "2038"
+  id: 687
+  display_name: "Alectura lathami"
+}
+item {
+  name: "10232"
+  id: 688
+  display_name: "Passerina leclancherii"
+}
+item {
+  name: "10234"
+  id: 689
+  display_name: "Passerina amoena"
+}
+item {
+  name: "10243"
+  id: 690
+  display_name: "Icteria virens"
+}
+item {
+  name: "2052"
+  id: 691
+  display_name: "Crax rubra"
+}
+item {
+  name: "94551"
+  id: 692
+  display_name: "Argia immunda"
+}
+item {
+  name: "2062"
+  id: 693
+  display_name: "Penelope purpurascens"
+}
+item {
+  name: "204490"
+  id: 694
+  display_name: "Copsychus malabaricus"
+}
+item {
+  name: "10257"
+  id: 695
+  display_name: "Paroaria capitata"
+}
+item {
+  name: "51221"
+  id: 696
+  display_name: "Procambarus clarkii"
+}
+item {
+  name: "10262"
+  id: 697
+  display_name: "Cyanerpes cyaneus"
+}
+item {
+  name: "508249"
+  id: 698
+  display_name: "Microcarbo melanoleucos brevirostris"
+}
+item {
+  name: "18460"
+  id: 699
+  display_name: "Sphyrapicus thyroideus"
+}
+item {
+  name: "10271"
+  id: 700
+  display_name: "Pheucticus ludovicianus"
+}
+item {
+  name: "18464"
+  id: 701
+  display_name: "Sphyrapicus ruber"
+}
+item {
+  name: "10274"
+  id: 702
+  display_name: "Pheucticus melanocephalus"
+}
+item {
+  name: "18467"
+  id: 703
+  display_name: "Sphyrapicus nuchalis"
+}
+item {
+  name: "100391"
+  id: 704
+  display_name: "Erythrodiplax berenice"
+}
+item {
+  name: "2089"
+  id: 705
+  display_name: "Ortalis poliocephala"
+}
+item {
+  name: "2090"
+  id: 706
+  display_name: "Ortalis vetula"
+}
+item {
+  name: "8038"
+  id: 707
+  display_name: "Corvus albus"
+}
+item {
+  name: "67629"
+  id: 708
+  display_name: "Oligocottus maculosus"
+}
+item {
+  name: "10286"
+  id: 709
+  display_name: "Mniotilta varia"
+}
+item {
+  name: "10288"
+  id: 710
+  display_name: "Volatinia jacarina"
+}
+item {
+  name: "100403"
+  id: 711
+  display_name: "Erythrodiplax minuscula"
+}
+item {
+  name: "84023"
+  id: 712
+  display_name: "Amorpha juglandis"
+}
+item {
+  name: "84024"
+  id: 713
+  display_name: "Galasa nigrinodis"
+}
+item {
+  name: "10297"
+  id: 714
+  display_name: "Thraupis palmarum"
+}
+item {
+  name: "67642"
+  id: 715
+  display_name: "Pantherophis spiloides"
+}
+item {
+  name: "67653"
+  id: 716
+  display_name: "Phoebis agarithe"
+}
+item {
+  name: "84038"
+  id: 717
+  display_name: "Haploa lecontei"
+}
+item {
+  name: "26695"
+  id: 718
+  display_name: "Scaphiopus holbrookii"
+}
+item {
+  name: "84040"
+  id: 719
+  display_name: "Chauliognathus marginatus"
+}
+item {
+  name: "51275"
+  id: 720
+  display_name: "Pentatoma rufipes"
+}
+item {
+  name: "2124"
+  id: 721
+  display_name: "Momotus mexicanus"
+}
+item {
+  name: "26702"
+  id: 722
+  display_name: "Spea hammondii"
+}
+item {
+  name: "10325"
+  id: 723
+  display_name: "Euphagus cyanocephalus"
+}
+item {
+  name: "43102"
+  id: 724
+  display_name: "Sylvilagus palustris"
+}
+item {
+  name: "49509"
+  id: 725
+  display_name: "Lutjanus griseus"
+}
+item {
+  name: "116834"
+  id: 726
+  display_name: "Cacatua galerita"
+}
+item {
+  name: "127188"
+  id: 727
+  display_name: "Junco hyemalis oreganus"
+}
+item {
+  name: "26725"
+  id: 728
+  display_name: "Ambystoma jeffersonianum"
+}
+item {
+  name: "43111"
+  id: 729
+  display_name: "Sylvilagus floridanus"
+}
+item {
+  name: "43112"
+  id: 730
+  display_name: "Sylvilagus bachmani"
+}
+item {
+  name: "67691"
+  id: 731
+  display_name: "Lophocampa maculata"
+}
+item {
+  name: "51311"
+  id: 732
+  display_name: "Urbanus dorantes"
+}
+item {
+  name: "67700"
+  id: 733
+  display_name: "Caracolus caracolla"
+}
+item {
+  name: "43128"
+  id: 734
+  display_name: "Lepus europaeus"
+}
+item {
+  name: "26745"
+  id: 735
+  display_name: "Ambystoma texanum"
+}
+item {
+  name: "67706"
+  id: 736
+  display_name: "Argiope argentata"
+}
+item {
+  name: "26747"
+  id: 737
+  display_name: "Ambystoma gracile"
+}
+item {
+  name: "67708"
+  id: 738
+  display_name: "Argiope trifasciata"
+}
+item {
+  name: "26749"
+  id: 739
+  display_name: "Ambystoma tigrinum"
+}
+item {
+  name: "4896"
+  id: 740
+  display_name: "Pluvialis fulva"
+}
+item {
+  name: "10369"
+  id: 741
+  display_name: "Molothrus aeneus"
+}
+item {
+  name: "26754"
+  id: 742
+  display_name: "Ambystoma macrodactylum"
+}
+item {
+  name: "10373"
+  id: 743
+  display_name: "Molothrus ater"
+}
+item {
+  name: "2185"
+  id: 744
+  display_name: "Merops pusillus"
+}
+item {
+  name: "84109"
+  id: 745
+  display_name: "Pisaurina mira"
+}
+item {
+  name: "67726"
+  id: 746
+  display_name: "Aeshna palmata"
+}
+item {
+  name: "2191"
+  id: 747
+  display_name: "Merops apiaster"
+}
+item {
+  name: "67731"
+  id: 748
+  display_name: "Anax junius"
+}
+item {
+  name: "198804"
+  id: 749
+  display_name: "Satyrium titus"
+}
+item {
+  name: "51349"
+  id: 750
+  display_name: "Pyrgus communis"
+}
+item {
+  name: "18584"
+  id: 751
+  display_name: "Pteroglossus torquatus"
+}
+item {
+  name: "67737"
+  id: 752
+  display_name: "Rhionaeschna multicolor"
+}
+item {
+  name: "198812"
+  id: 753
+  display_name: "Lethe anthedon"
+}
+item {
+  name: "321697"
+  id: 754
+  display_name: "Melanchroia chephise"
+}
+item {
+  name: "198821"
+  id: 755
+  display_name: "Pieris oleracea"
+}
+item {
+  name: "26790"
+  id: 756
+  display_name: "Ambystoma maculatum"
+}
+item {
+  name: "10411"
+  id: 757
+  display_name: "Loxia curvirostra"
+}
+item {
+  name: "133295"
+  id: 758
+  display_name: "Melitaea didyma"
+}
+item {
+  name: "67760"
+  id: 759
+  display_name: "Popillia japonica"
+}
+item {
+  name: "43188"
+  id: 760
+  display_name: "Ochotona princeps"
+}
+item {
+  name: "2229"
+  id: 761
+  display_name: "Merops orientalis"
+}
+item {
+  name: "10423"
+  id: 762
+  display_name: "Loxia leucoptera"
+}
+item {
+  name: "67771"
+  id: 763
+  display_name: "Leptoglossus occidentalis"
+}
+item {
+  name: "84162"
+  id: 764
+  display_name: "Chrysochus auratus"
+}
+item {
+  name: "26822"
+  id: 765
+  display_name: "Dicamptodon tenebrosus"
+}
+item {
+  name: "26823"
+  id: 766
+  display_name: "Dicamptodon ensatus"
+}
+item {
+  name: "51402"
+  id: 767
+  display_name: "Megalops atlanticus"
+}
+item {
+  name: "67725"
+  id: 768
+  display_name: "Aeshna interrupta"
+}
+item {
+  name: "411858"
+  id: 769
+  display_name: "Vanessa gonerilla gonerilla"
+}
+item {
+  name: "26835"
+  id: 770
+  display_name: "Drymobius margaritiferus"
+}
+item {
+  name: "84185"
+  id: 771
+  display_name: "Megalopyge opercularis"
+}
+item {
+  name: "2266"
+  id: 772
+  display_name: "Coracias garrulus"
+}
+item {
+  name: "141531"
+  id: 773
+  display_name: "Lethe eurydice"
+}
+item {
+  name: "2269"
+  id: 774
+  display_name: "Coracias caudatus"
+}
+item {
+  name: "133346"
+  id: 775
+  display_name: "Melittia cucurbitae"
+}
+item {
+  name: "2275"
+  id: 776
+  display_name: "Coracias benghalensis"
+}
+item {
+  name: "84196"
+  id: 777
+  display_name: "Pontania californica"
+}
+item {
+  name: "10470"
+  id: 778
+  display_name: "Xanthocephalus xanthocephalus"
+}
+item {
+  name: "10479"
+  id: 779
+  display_name: "Chondestes grammacus"
+}
+item {
+  name: "51440"
+  id: 780
+  display_name: "Pituophis catenifer catenifer"
+}
+item {
+  name: "54087"
+  id: 781
+  display_name: "Pieris napi"
+}
+item {
+  name: "59635"
+  id: 782
+  display_name: "Phragmatopoma californica"
+}
+item {
+  name: "10487"
+  id: 783
+  display_name: "Dolichonyx oryzivorus"
+}
+item {
+  name: "67835"
+  id: 784
+  display_name: "Danaus chrysippus"
+}
+item {
+  name: "59644"
+  id: 785
+  display_name: "Pantherophis alleghaniensis"
+}
+item {
+  name: "59646"
+  id: 786
+  display_name: "Pantherophis bairdi"
+}
+item {
+  name: "116999"
+  id: 787
+  display_name: "Pandion haliaetus"
+}
+item {
+  name: "117002"
+  id: 788
+  display_name: "Phainopepla nitens"
+}
+item {
+  name: "16770"
+  id: 789
+  display_name: "Tyrannus couchii"
+}
+item {
+  name: "84239"
+  id: 790
+  display_name: "Callophrys gryneus"
+}
+item {
+  name: "104553"
+  id: 791
+  display_name: "Leucorrhinia proxima"
+}
+item {
+  name: "117016"
+  id: 792
+  display_name: "Phylloscopus collybita"
+}
+item {
+  name: "49540"
+  id: 793
+  display_name: "Gasteracantha cancriformis"
+}
+item {
+  name: "59675"
+  id: 794
+  display_name: "Pyrrharctia isabella"
+}
+item {
+  name: "469277"
+  id: 795
+  display_name: "Neotibicen superbus"
+}
+item {
+  name: "236973"
+  id: 796
+  display_name: "Circus cyaneus hudsonius"
+}
+item {
+  name: "59683"
+  id: 797
+  display_name: "Porpita porpita"
+}
+item {
+  name: "26916"
+  id: 798
+  display_name: "Contia tenuis"
+}
+item {
+  name: "51493"
+  id: 799
+  display_name: "Trimerotropis pallidipennis"
+}
+item {
+  name: "51495"
+  id: 800
+  display_name: "Anthocharis cardamines"
+}
+item {
+  name: "133416"
+  id: 801
+  display_name: "Phoebis philea"
+}
+item {
+  name: "8583"
+  id: 802
+  display_name: "Grallina cyanoleuca"
+}
+item {
+  name: "395569"
+  id: 803
+  display_name: "Prionoplus reticularis"
+}
+item {
+  name: "59698"
+  id: 804
+  display_name: "Velella velella"
+}
+item {
+  name: "141626"
+  id: 805
+  display_name: "Lygaeus turcicus"
+}
+item {
+  name: "84286"
+  id: 806
+  display_name: "Diapheromera femorata"
+}
+item {
+  name: "117059"
+  id: 807
+  display_name: "Plectrophenax nivalis"
+}
+item {
+  name: "133447"
+  id: 808
+  display_name: "Crambus agitatellus"
+}
+item {
+  name: "133448"
+  id: 809
+  display_name: "Climaciella brunnea"
+}
+item {
+  name: "51534"
+  id: 810
+  display_name: "Leptotes cassius"
+}
+item {
+  name: "205197"
+  id: 811
+  display_name: "Eutrapela clemataria"
+}
+item {
+  name: "51536"
+  id: 812
+  display_name: "Ascia monuste"
+}
+item {
+  name: "10585"
+  id: 813
+  display_name: "Calamospiza melanocorys"
+}
+item {
+  name: "49552"
+  id: 814
+  display_name: "Scutigera coleoptrata"
+}
+item {
+  name: "51555"
+  id: 815
+  display_name: "Sympetrum illotum"
+}
+item {
+  name: "51557"
+  id: 816
+  display_name: "Bombylius major"
+}
+item {
+  name: "117095"
+  id: 817
+  display_name: "Regulus calendula"
+}
+item {
+  name: "117097"
+  id: 818
+  display_name: "Regulus ignicapilla"
+}
+item {
+  name: "117099"
+  id: 819
+  display_name: "Regulus regulus"
+}
+item {
+  name: "117100"
+  id: 820
+  display_name: "Regulus satrapa"
+}
+item {
+  name: "84333"
+  id: 821
+  display_name: "Eudryas grata"
+}
+item {
+  name: "215409"
+  id: 822
+  display_name: "Bradybaena similaris"
+}
+item {
+  name: "16787"
+  id: 823
+  display_name: "Tyrannus melancholicus"
+}
+item {
+  name: "46225"
+  id: 824
+  display_name: "Tamias dorsalis"
+}
+item {
+  name: "59774"
+  id: 825
+  display_name: "Pachydiplax longipennis"
+}
+item {
+  name: "59776"
+  id: 826
+  display_name: "Perithemis tenera"
+}
+item {
+  name: "119014"
+  id: 827
+  display_name: "Argia fumipennis violacea"
+}
+item {
+  name: "4326"
+  id: 828
+  display_name: "Pelecanus conspicillatus"
+}
+item {
+  name: "18833"
+  id: 829
+  display_name: "Aulacorhynchus prasinus"
+}
+item {
+  name: "43411"
+  id: 830
+  display_name: "Ateles geoffroyi"
+}
+item {
+  name: "141725"
+  id: 831
+  display_name: "Nezara viridula"
+}
+item {
+  name: "51614"
+  id: 832
+  display_name: "Eurema hecabe"
+}
+item {
+  name: "125343"
+  id: 833
+  display_name: "Crepidula fornicata"
+}
+item {
+  name: "2464"
+  id: 834
+  display_name: "Todiramphus sanctus"
+}
+item {
+  name: "43432"
+  id: 835
+  display_name: "Cebus capucinus"
+}
+item {
+  name: "43436"
+  id: 836
+  display_name: "Alouatta palliata"
+}
+item {
+  name: "43439"
+  id: 837
+  display_name: "Alouatta pigra"
+}
+item {
+  name: "9357"
+  id: 838
+  display_name: "Icterus bullockii"
+}
+item {
+  name: "84403"
+  id: 839
+  display_name: "Phyllopalpus pulchellus"
+}
+item {
+  name: "10676"
+  id: 840
+  display_name: "Spiza americana"
+}
+item {
+  name: "16798"
+  id: 841
+  display_name: "Tyrannus dominicensis"
+}
+item {
+  name: "141752"
+  id: 842
+  display_name: "Biblis hyperia"
+}
+item {
+  name: "4512"
+  id: 843
+  display_name: "Chlidonias niger"
+}
+item {
+  name: "43460"
+  id: 844
+  display_name: "Macaca mulatta"
+}
+item {
+  name: "51654"
+  id: 845
+  display_name: "Junonia almana"
+}
+item {
+  name: "51659"
+  id: 846
+  display_name: "Anthopleura xanthogrammica"
+}
+item {
+  name: "84428"
+  id: 847
+  display_name: "Drepana arcuata"
+}
+item {
+  name: "10702"
+  id: 848
+  display_name: "Oriturus superciliosus"
+}
+item {
+  name: "68047"
+  id: 849
+  display_name: "Psarocolius montezuma"
+}
+item {
+  name: "12707"
+  id: 850
+  display_name: "Turdus pilaris"
+}
+item {
+  name: "84437"
+  id: 851
+  display_name: "Nicrophorus orbicollis"
+}
+item {
+  name: "84438"
+  id: 852
+  display_name: "Platyprepia virginalis"
+}
+item {
+  name: "117209"
+  id: 853
+  display_name: "Notiomystis cincta"
+}
+item {
+  name: "343393"
+  id: 854
+  display_name: "Hypsopygia olinalis"
+}
+item {
+  name: "27101"
+  id: 855
+  display_name: "Eurycea longicauda"
+}
+item {
+  name: "117214"
+  id: 856
+  display_name: "Sagittarius serpentarius"
+}
+item {
+  name: "18911"
+  id: 857
+  display_name: "Psittacula krameri"
+}
+item {
+  name: "117218"
+  id: 858
+  display_name: "Verrucosa arenata"
+}
+item {
+  name: "117221"
+  id: 859
+  display_name: "Dasymutilla occidentalis"
+}
+item {
+  name: "35303"
+  id: 860
+  display_name: "Ctenosaura similis"
+}
+item {
+  name: "18920"
+  id: 861
+  display_name: "Platycercus eximius"
+}
+item {
+  name: "10729"
+  id: 862
+  display_name: "Protonotaria citrea"
+}
+item {
+  name: "35306"
+  id: 863
+  display_name: "Ctenosaura pectinata"
+}
+item {
+  name: "109650"
+  id: 864
+  display_name: "Platycnemis pennipes"
+}
+item {
+  name: "27120"
+  id: 865
+  display_name: "Eurycea bislineata"
+}
+item {
+  name: "27123"
+  id: 866
+  display_name: "Eurycea lucifuga"
+}
+item {
+  name: "51702"
+  id: 867
+  display_name: "Coccinella septempunctata"
+}
+item {
+  name: "2552"
+  id: 868
+  display_name: "Megaceryle torquata"
+}
+item {
+  name: "133625"
+  id: 869
+  display_name: "Zanclognatha jacchusalis"
+}
+item {
+  name: "18943"
+  id: 870
+  display_name: "Nestor meridionalis"
+}
+item {
+  name: "84481"
+  id: 871
+  display_name: "Calopteryx maculata"
+}
+item {
+  name: "35330"
+  id: 872
+  display_name: "Sauromalus ater"
+}
+item {
+  name: "27140"
+  id: 873
+  display_name: "Coluber constrictor priapus"
+}
+item {
+  name: "199179"
+  id: 874
+  display_name: "Polistes chinensis"
+}
+item {
+  name: "51724"
+  id: 875
+  display_name: "Mopalia lignosa"
+}
+item {
+  name: "27149"
+  id: 876
+  display_name: "Coluber constrictor constrictor"
+}
+item {
+  name: "35342"
+  id: 877
+  display_name: "Iguana iguana"
+}
+item {
+  name: "27153"
+  id: 878
+  display_name: "Coluber constrictor flaviventris"
+}
+item {
+  name: "35347"
+  id: 879
+  display_name: "Amblyrhynchus cristatus"
+}
+item {
+  name: "125461"
+  id: 880
+  display_name: "Ursus arctos horribilis"
+}
+item {
+  name: "84507"
+  id: 881
+  display_name: "Lygus lineolaris"
+}
+item {
+  name: "35356"
+  id: 882
+  display_name: "Dipsosaurus dorsalis"
+}
+item {
+  name: "51743"
+  id: 883
+  display_name: "Danaus gilippus"
+}
+item {
+  name: "18976"
+  id: 884
+  display_name: "Amazona viridigenalis"
+}
+item {
+  name: "125475"
+  id: 885
+  display_name: "Plusiodonta compressipalpis"
+}
+item {
+  name: "51748"
+  id: 886
+  display_name: "Danaus gilippus thersippus"
+}
+item {
+  name: "68137"
+  id: 887
+  display_name: "Chlorocebus pygerythrus"
+}
+item {
+  name: "133675"
+  id: 888
+  display_name: "Coenobita clypeatus"
+}
+item {
+  name: "215596"
+  id: 889
+  display_name: "Buprestis aurulenta"
+}
+item {
+  name: "117293"
+  id: 890
+  display_name: "Oecophylla smaragdina"
+}
+item {
+  name: "68142"
+  id: 891
+  display_name: "Prenolepis imparis"
+}
+item {
+  name: "27184"
+  id: 892
+  display_name: "Plethodon glutinosus"
+}
+item {
+  name: "27186"
+  id: 893
+  display_name: "Plethodon cinereus"
+}
+item {
+  name: "18995"
+  id: 894
+  display_name: "Amazona albifrons"
+}
+item {
+  name: "51765"
+  id: 895
+  display_name: "Poanes melane"
+}
+item {
+  name: "18998"
+  id: 896
+  display_name: "Amazona oratrix"
+}
+item {
+  name: "41396"
+  id: 897
+  display_name: "Rhynchonycteris naso"
+}
+item {
+  name: "27194"
+  id: 898
+  display_name: "Plethodon vehiculum"
+}
+item {
+  name: "51773"
+  id: 899
+  display_name: "Nathalis iole"
+}
+item {
+  name: "12908"
+  id: 900
+  display_name: "Saxicola rubetra"
+}
+item {
+  name: "68165"
+  id: 901
+  display_name: "Linepithema humile"
+}
+item {
+  name: "154721"
+  id: 902
+  display_name: "Brachygastra mellifica"
+}
+item {
+  name: "338504"
+  id: 903
+  display_name: "Xanthocnemis zealandica"
+}
+item {
+  name: "338505"
+  id: 904
+  display_name: "Melangyna novaezelandiae"
+}
+item {
+  name: "27093"
+  id: 905
+  display_name: "Eurycea cirrigera"
+}
+item {
+  name: "65975"
+  id: 906
+  display_name: "Lithobates berlandieri"
+}
+item {
+  name: "19020"
+  id: 907
+  display_name: "Ara militaris"
+}
+item {
+  name: "474210"
+  id: 908
+  display_name: "Spizelloides arborea"
+}
+item {
+  name: "205240"
+  id: 909
+  display_name: "Pantographa limata"
+}
+item {
+  name: "27226"
+  id: 910
+  display_name: "Plethodon albagula"
+}
+item {
+  name: "318545"
+  id: 911
+  display_name: "Coreus marginatus"
+}
+item {
+  name: "2662"
+  id: 912
+  display_name: "Ceryle rudis"
+}
+item {
+  name: "109161"
+  id: 913
+  display_name: "Perithemis intensa"
+}
+item {
+  name: "51824"
+  id: 914
+  display_name: "Calopteryx splendens"
+}
+item {
+  name: "27250"
+  id: 915
+  display_name: "Ensatina eschscholtzii"
+}
+item {
+  name: "2676"
+  id: 916
+  display_name: "Chloroceryle aenea"
+}
+item {
+  name: "2679"
+  id: 917
+  display_name: "Chloroceryle amazona"
+}
+item {
+  name: "84602"
+  id: 918
+  display_name: "Zale lunata"
+}
+item {
+  name: "133756"
+  id: 919
+  display_name: "Leptoglossus oppositus"
+}
+item {
+  name: "35453"
+  id: 920
+  display_name: "Zootoca vivipara"
+}
+item {
+  name: "84612"
+  id: 921
+  display_name: "Polyphylla decemlineata"
+}
+item {
+  name: "133765"
+  id: 922
+  display_name: "Eumenes fraternus"
+}
+item {
+  name: "68230"
+  id: 923
+  display_name: "Brachymesia gravida"
+}
+item {
+  name: "49601"
+  id: 924
+  display_name: "Mola mola"
+}
+item {
+  name: "68232"
+  id: 925
+  display_name: "Papilio palamedes"
+}
+item {
+  name: "68233"
+  id: 926
+  display_name: "Orthemis ferruginea"
+}
+item {
+  name: "68239"
+  id: 927
+  display_name: "Parnassius clodius"
+}
+item {
+  name: "68240"
+  id: 928
+  display_name: "Chlosyne lacinia"
+}
+item {
+  name: "68244"
+  id: 929
+  display_name: "Euptoieta claudia"
+}
+item {
+  name: "68249"
+  id: 930
+  display_name: "Dymasia dymas"
+}
+item {
+  name: "68251"
+  id: 931
+  display_name: "Limenitis weidemeyerii"
+}
+item {
+  name: "133790"
+  id: 932
+  display_name: "Chalybion californicum"
+}
+item {
+  name: "84644"
+  id: 933
+  display_name: "Phalangium opilio"
+}
+item {
+  name: "68262"
+  id: 934
+  display_name: "Polygonia faunus"
+}
+item {
+  name: "133799"
+  id: 935
+  display_name: "Xenox tigrinus"
+}
+item {
+  name: "68264"
+  id: 936
+  display_name: "Asterocampa celtis"
+}
+item {
+  name: "132892"
+  id: 937
+  display_name: "Anacridium aegyptium"
+}
+item {
+  name: "68268"
+  id: 938
+  display_name: "Euptoieta hegesia"
+}
+item {
+  name: "68269"
+  id: 939
+  display_name: "Aglais milberti"
+}
+item {
+  name: "43694"
+  id: 940
+  display_name: "Loxodonta africana"
+}
+item {
+  name: "59165"
+  id: 941
+  display_name: "Apodemia mormo"
+}
+item {
+  name: "68274"
+  id: 942
+  display_name: "Phyciodes phaon"
+}
+item {
+  name: "68275"
+  id: 943
+  display_name: "Battus polydamas"
+}
+item {
+  name: "84662"
+  id: 944
+  display_name: "Celastrina lucia"
+}
+item {
+  name: "16842"
+  id: 945
+  display_name: "Myiozetetes similis"
+}
+item {
+  name: "133826"
+  id: 946
+  display_name: "Zelus longipes"
+}
+item {
+  name: "14912"
+  id: 947
+  display_name: "Toxostoma curvirostre"
+}
+item {
+  name: "53708"
+  id: 948
+  display_name: "Pacifastacus leniusculus"
+}
+item {
+  name: "117452"
+  id: 949
+  display_name: "Sphinx kalmiae"
+}
+item {
+  name: "182997"
+  id: 950
+  display_name: "Megisto rubricata"
+}
+item {
+  name: "223965"
+  id: 951
+  display_name: "Lithacodia musta"
+}
+item {
+  name: "125663"
+  id: 952
+  display_name: "Kelletia kelletii"
+}
+item {
+  name: "125669"
+  id: 953
+  display_name: "Rumina decollata"
+}
+item {
+  name: "68328"
+  id: 954
+  display_name: "Oxythyrea funesta"
+}
+item {
+  name: "179324"
+  id: 955
+  display_name: "Dactylotum bicolor"
+}
+item {
+  name: "68330"
+  id: 956
+  display_name: "Arctia caja"
+}
+item {
+  name: "2548"
+  id: 957
+  display_name: "Megaceryle alcyon"
+}
+item {
+  name: "207600"
+  id: 958
+  display_name: "Thasus neocalifornicus"
+}
+item {
+  name: "207601"
+  id: 959
+  display_name: "Palpita quadristigmalis"
+}
+item {
+  name: "51954"
+  id: 960
+  display_name: "Sphecius speciosus"
+}
+item {
+  name: "207603"
+  id: 961
+  display_name: "Prolimacodes badia"
+}
+item {
+  name: "7294"
+  id: 962
+  display_name: "Eremophila alpestris"
+}
+item {
+  name: "19196"
+  id: 963
+  display_name: "Alisterus scapularis"
+}
+item {
+  name: "145194"
+  id: 964
+  display_name: "Cinnyris jugularis"
+}
+item {
+  name: "27390"
+  id: 965
+  display_name: "Desmognathus ochrophaeus"
+}
+item {
+  name: "207615"
+  id: 966
+  display_name: "Polistes apachus"
+}
+item {
+  name: "63275"
+  id: 967
+  display_name: "Tremex columba"
+}
+item {
+  name: "61910"
+  id: 968
+  display_name: "Orgyia antiqua"
+}
+item {
+  name: "199438"
+  id: 969
+  display_name: "Orgyia postica"
+}
+item {
+  name: "43794"
+  id: 970
+  display_name: "Castor canadensis"
+}
+item {
+  name: "84755"
+  id: 971
+  display_name: "Arion rufus"
+}
+item {
+  name: "51996"
+  id: 972
+  display_name: "Daphnis nerii"
+}
+item {
+  name: "194075"
+  id: 973
+  display_name: "Drymarchon melanurus erebennus"
+}
+item {
+  name: "133923"
+  id: 974
+  display_name: "Mermiria bivittata"
+}
+item {
+  name: "84778"
+  id: 975
+  display_name: "Leptinotarsa decemlineata"
+}
+item {
+  name: "11051"
+  id: 976
+  display_name: "Xiphorhynchus flavigaster"
+}
+item {
+  name: "121992"
+  id: 977
+  display_name: "Cervus elaphus roosevelti"
+}
+item {
+  name: "27459"
+  id: 978
+  display_name: "Batrachoseps attenuatus"
+}
+item {
+  name: "84806"
+  id: 979
+  display_name: "Acanalonia conica"
+}
+item {
+  name: "52043"
+  id: 980
+  display_name: "Spoladea recurvalis"
+}
+item {
+  name: "27468"
+  id: 981
+  display_name: "Batrachoseps major"
+}
+item {
+  name: "133966"
+  id: 982
+  display_name: "Lomographa vestaliata"
+}
+item {
+  name: "27474"
+  id: 983
+  display_name: "Batrachoseps nigriventris"
+}
+item {
+  name: "101204"
+  id: 984
+  display_name: "Gambusia holbrooki"
+}
+item {
+  name: "52055"
+  id: 985
+  display_name: "Crocothemis servilia"
+}
+item {
+  name: "4580"
+  id: 986
+  display_name: "Jacana jacana"
+}
+item {
+  name: "346970"
+  id: 987
+  display_name: "Callophrys dumetorum"
+}
+item {
+  name: "27486"
+  id: 988
+  display_name: "Pseudotriton ruber"
+}
+item {
+  name: "52075"
+  id: 989
+  display_name: "Atalopedes campestris"
+}
+item {
+  name: "27500"
+  id: 990
+  display_name: "Gyrinophilus porphyriticus"
+}
+item {
+  name: "73203"
+  id: 991
+  display_name: "Phalaropus fulicarius"
+}
+item {
+  name: "322417"
+  id: 992
+  display_name: "Limacus flavus"
+}
+item {
+  name: "40083"
+  id: 993
+  display_name: "Gopherus berlandieri"
+}
+item {
+  name: "68469"
+  id: 994
+  display_name: "Papilio demodocus"
+}
+item {
+  name: "2938"
+  id: 995
+  display_name: "Streptopelia turtur"
+}
+item {
+  name: "117633"
+  id: 996
+  display_name: "Mopalia muscosa"
+}
+item {
+  name: "117641"
+  id: 997
+  display_name: "Nucella lamellosa"
+}
+item {
+  name: "322443"
+  id: 998
+  display_name: "Thasus gigas"
+}
+item {
+  name: "68492"
+  id: 999
+  display_name: "Hemidactylus mabouia"
+}
+item {
+  name: "143853"
+  id: 1000
+  display_name: "Pica hudsonia"
+}
+item {
+  name: "144757"
+  id: 1001
+  display_name: "Corvus cornix"
+}
+item {
+  name: "117650"
+  id: 1002
+  display_name: "Mytilus edulis"
+}
+item {
+  name: "19349"
+  id: 1003
+  display_name: "Myiopsitta monachus"
+}
+item {
+  name: "2969"
+  id: 1004
+  display_name: "Streptopelia decaocto"
+}
+item {
+  name: "9919"
+  id: 1005
+  display_name: "Piranga ludoviciana"
+}
+item {
+  name: "5009"
+  id: 1006
+  display_name: "Ixobrychus exilis"
+}
+item {
+  name: "117666"
+  id: 1007
+  display_name: "Pleuroncodes planipes"
+}
+item {
+  name: "7603"
+  id: 1008
+  display_name: "Auriparus flaviceps"
+}
+item {
+  name: "117674"
+  id: 1009
+  display_name: "Ligia occidentalis"
+}
+item {
+  name: "145223"
+  id: 1010
+  display_name: "Geothlypis tolmiei"
+}
+item {
+  name: "60341"
+  id: 1011
+  display_name: "Lithobates sphenocephalus"
+}
+item {
+  name: "60342"
+  id: 1012
+  display_name: "Thamnophis proximus"
+}
+item {
+  name: "52155"
+  id: 1013
+  display_name: "Dermacentor variabilis"
+}
+item {
+  name: "60349"
+  id: 1014
+  display_name: "Scincella lateralis"
+}
+item {
+  name: "52158"
+  id: 1015
+  display_name: "Schistocerca nitens"
+}
+item {
+  name: "117696"
+  id: 1016
+  display_name: "Dendraster excentricus"
+}
+item {
+  name: "232391"
+  id: 1017
+  display_name: "Tetracha carolina"
+}
+item {
+  name: "3017"
+  id: 1018
+  display_name: "Columba livia"
+}
+item {
+  name: "145229"
+  id: 1019
+  display_name: "Setophaga citrina"
+}
+item {
+  name: "84950"
+  id: 1020
+  display_name: "Alypia octomaculata"
+}
+item {
+  name: "52188"
+  id: 1021
+  display_name: "Rhincodon typus"
+}
+item {
+  name: "494559"
+  id: 1022
+  display_name: "Polydrusus formosus"
+}
+item {
+  name: "145232"
+  id: 1023
+  display_name: "Setophaga cerulea"
+}
+item {
+  name: "3048"
+  id: 1024
+  display_name: "Columba palumbus"
+}
+item {
+  name: "9922"
+  id: 1025
+  display_name: "Piranga bidentata"
+}
+item {
+  name: "44026"
+  id: 1026
+  display_name: "Erethizon dorsatum"
+}
+item {
+  name: "61505"
+  id: 1027
+  display_name: "Manduca sexta"
+}
+item {
+  name: "84994"
+  id: 1028
+  display_name: "Acanthocephala declivis"
+}
+item {
+  name: "27652"
+  id: 1029
+  display_name: "Hemidactylium scutatum"
+}
+item {
+  name: "117767"
+  id: 1030
+  display_name: "Cervus elaphus nannodes"
+}
+item {
+  name: "494603"
+  id: 1031
+  display_name: "Hermissenda opalescens"
+}
+item {
+  name: "39819"
+  id: 1032
+  display_name: "Terrapene carolina bauri"
+}
+item {
+  name: "3093"
+  id: 1033
+  display_name: "Patagioenas leucocephala"
+}
+item {
+  name: "205316"
+  id: 1034
+  display_name: "Aidemona azteca"
+}
+item {
+  name: "216093"
+  id: 1035
+  display_name: "Caracolus marginella"
+}
+item {
+  name: "44062"
+  id: 1036
+  display_name: "Thomomys bottae"
+}
+item {
+  name: "85024"
+  id: 1037
+  display_name: "Heraclides cresphontes"
+}
+item {
+  name: "3108"
+  id: 1038
+  display_name: "Patagioenas fasciata"
+}
+item {
+  name: "213510"
+  id: 1039
+  display_name: "Anageshna primordialis"
+}
+item {
+  name: "85030"
+  id: 1040
+  display_name: "Crocothemis erythraea"
+}
+item {
+  name: "85034"
+  id: 1041
+  display_name: "Neoscona crucifera"
+}
+item {
+  name: "3117"
+  id: 1042
+  display_name: "Patagioenas flavirostris"
+}
+item {
+  name: "207924"
+  id: 1043
+  display_name: "Synchlora frondaria"
+}
+item {
+  name: "35900"
+  id: 1044
+  display_name: "Lacerta bilineata"
+}
+item {
+  name: "24382"
+  id: 1045
+  display_name: "Osteopilus septentrionalis"
+}
+item {
+  name: "145249"
+  id: 1046
+  display_name: "Setophaga discolor"
+}
+item {
+  name: "52297"
+  id: 1047
+  display_name: "Triakis semifasciata"
+}
+item {
+  name: "27726"
+  id: 1048
+  display_name: "Salamandra salamandra"
+}
+item {
+  name: "27727"
+  id: 1049
+  display_name: "Bogertophis subocularis"
+}
+item {
+  name: "143043"
+  id: 1050
+  display_name: "Cycnia tenera"
+}
+item {
+  name: "52313"
+  id: 1051
+  display_name: "Diodon hystrix"
+}
+item {
+  name: "143316"
+  id: 1052
+  display_name: "Schinia florida"
+}
+item {
+  name: "61968"
+  id: 1053
+  display_name: "Graphosoma lineatum"
+}
+item {
+  name: "502885"
+  id: 1054
+  display_name: "Lissachatina fulica"
+}
+item {
+  name: "71029"
+  id: 1055
+  display_name: "Crotalus cerastes cerastes"
+}
+item {
+  name: "207977"
+  id: 1056
+  display_name: "Aglais io"
+}
+item {
+  name: "19577"
+  id: 1057
+  display_name: "Chordeiles minor"
+}
+item {
+  name: "93312"
+  id: 1058
+  display_name: "Acropora palmata"
+}
+item {
+  name: "52354"
+  id: 1059
+  display_name: "Ambystoma laterale"
+}
+item {
+  name: "19587"
+  id: 1060
+  display_name: "Chordeiles acutipennis"
+}
+item {
+  name: "58585"
+  id: 1061
+  display_name: "Limenitis arthemis astyanax"
+}
+item {
+  name: "134277"
+  id: 1062
+  display_name: "Gastrophryne olivacea"
+}
+item {
+  name: "60551"
+  id: 1063
+  display_name: "Papilio glaucus"
+}
+item {
+  name: "3731"
+  id: 1064
+  display_name: "Platalea leucorodia"
+}
+item {
+  name: "232593"
+  id: 1065
+  display_name: "Thyris sepulchralis"
+}
+item {
+  name: "19609"
+  id: 1066
+  display_name: "Phalaenoptilus nuttallii"
+}
+item {
+  name: "126106"
+  id: 1067
+  display_name: "Haploa clymene"
+}
+item {
+  name: "27805"
+  id: 1068
+  display_name: "Notophthalmus viridescens"
+}
+item {
+  name: "199840"
+  id: 1069
+  display_name: "Haemorhous mexicanus"
+}
+item {
+  name: "199841"
+  id: 1070
+  display_name: "Haemorhous purpureus"
+}
+item {
+  name: "219719"
+  id: 1071
+  display_name: "Eudryas unio"
+}
+item {
+  name: "27818"
+  id: 1072
+  display_name: "Taricha torosa"
+}
+item {
+  name: "19627"
+  id: 1073
+  display_name: "Nyctidromus albicollis"
+}
+item {
+  name: "28750"
+  id: 1074
+  display_name: "Salvadora grahamiae lineata"
+}
+item {
+  name: "27824"
+  id: 1075
+  display_name: "Taricha rivularis"
+}
+item {
+  name: "146632"
+  id: 1076
+  display_name: "Toxomerus politus"
+}
+item {
+  name: "52402"
+  id: 1077
+  display_name: "Cetonia aurata"
+}
+item {
+  name: "18291"
+  id: 1078
+  display_name: "Campephilus guatemalensis"
+}
+item {
+  name: "60598"
+  id: 1079
+  display_name: "Ixodes scapularis"
+}
+item {
+  name: "199870"
+  id: 1080
+  display_name: "Pyralis farinalis"
+}
+item {
+  name: "60607"
+  id: 1081
+  display_name: "Limenitis arthemis"
+}
+item {
+  name: "205241"
+  id: 1082
+  display_name: "Plagodis phlogosaria"
+}
+item {
+  name: "14898"
+  id: 1083
+  display_name: "Toxostoma rufum"
+}
+item {
+  name: "126153"
+  id: 1084
+  display_name: "Amphion floridensis"
+}
+item {
+  name: "126155"
+  id: 1085
+  display_name: "Vespula germanica"
+}
+item {
+  name: "51392"
+  id: 1086
+  display_name: "Morone saxatilis"
+}
+item {
+  name: "3280"
+  id: 1087
+  display_name: "Leptotila verreauxi"
+}
+item {
+  name: "19670"
+  id: 1088
+  display_name: "Nyctibius jamaicensis"
+}
+item {
+  name: "6929"
+  id: 1089
+  display_name: "Anas penelope"
+}
+item {
+  name: "97738"
+  id: 1090
+  display_name: "Chromagrion conditum"
+}
+item {
+  name: "52449"
+  id: 1091
+  display_name: "Rhinecanthus rectangulus"
+}
+item {
+  name: "52451"
+  id: 1092
+  display_name: "Naso lituratus"
+}
+item {
+  name: "56529"
+  id: 1093
+  display_name: "Papilio machaon"
+}
+item {
+  name: "199913"
+  id: 1094
+  display_name: "Buteo plagiatus"
+}
+item {
+  name: "199914"
+  id: 1095
+  display_name: "Selasphorus calliope"
+}
+item {
+  name: "85227"
+  id: 1096
+  display_name: "Hemideina crassidens"
+}
+item {
+  name: "36076"
+  id: 1097
+  display_name: "Cophosaurus texanus"
+}
+item {
+  name: "36077"
+  id: 1098
+  display_name: "Cophosaurus texanus texanus"
+}
+item {
+  name: "208112"
+  id: 1099
+  display_name: "Palpita magniferalis"
+}
+item {
+  name: "85235"
+  id: 1100
+  display_name: "Deinacrida rugosa"
+}
+item {
+  name: "93429"
+  id: 1101
+  display_name: "Aeshna constricta"
+}
+item {
+  name: "36086"
+  id: 1102
+  display_name: "Callisaurus draconoides rhodostictus"
+}
+item {
+  name: "126204"
+  id: 1103
+  display_name: "Synchlora aerata"
+}
+item {
+  name: "93437"
+  id: 1104
+  display_name: "Aeshna mixta"
+}
+item {
+  name: "126207"
+  id: 1105
+  display_name: "Schizura unicornis"
+}
+item {
+  name: "126209"
+  id: 1106
+  display_name: "Metcalfa pruinosa"
+}
+item {
+  name: "126211"
+  id: 1107
+  display_name: "Poecilocapsus lineatus"
+}
+item {
+  name: "36100"
+  id: 1108
+  display_name: "Uta stansburiana elegans"
+}
+item {
+  name: "48342"
+  id: 1109
+  display_name: "Hemigrapsus nudus"
+}
+item {
+  name: "199942"
+  id: 1110
+  display_name: "Strategus aloeus"
+}
+item {
+  name: "126215"
+  id: 1111
+  display_name: "Monobia quadridens"
+}
+item {
+  name: "101640"
+  id: 1112
+  display_name: "Gomphaeschna furcillata"
+}
+item {
+  name: "126217"
+  id: 1113
+  display_name: "Pyrausta orphisalis"
+}
+item {
+  name: "36107"
+  id: 1114
+  display_name: "Urosaurus ornatus"
+}
+item {
+  name: "51940"
+  id: 1115
+  display_name: "Hemidactylus frenatus"
+}
+item {
+  name: "36121"
+  id: 1116
+  display_name: "Urosaurus graciosus"
+}
+item {
+  name: "19743"
+  id: 1117
+  display_name: "Megascops kennicottii"
+}
+item {
+  name: "68901"
+  id: 1118
+  display_name: "Salticus scenicus"
+}
+item {
+  name: "44326"
+  id: 1119
+  display_name: "Microtus californicus"
+}
+item {
+  name: "82481"
+  id: 1120
+  display_name: "Pieris marginalis"
+}
+item {
+  name: "474332"
+  id: 1121
+  display_name: "Porphyrio poliocephalus"
+}
+item {
+  name: "81674"
+  id: 1122
+  display_name: "Rivula propinqualis"
+}
+item {
+  name: "126252"
+  id: 1123
+  display_name: "Mastigoproctus giganteus"
+}
+item {
+  name: "36142"
+  id: 1124
+  display_name: "Sceloporus undulatus"
+}
+item {
+  name: "68911"
+  id: 1125
+  display_name: "Libellula needhami"
+}
+item {
+  name: "68912"
+  id: 1126
+  display_name: "Dysdera crocata"
+}
+item {
+  name: "42888"
+  id: 1127
+  display_name: "Macropus giganteus"
+}
+item {
+  name: "19765"
+  id: 1128
+  display_name: "Megascops asio"
+}
+item {
+  name: "68918"
+  id: 1129
+  display_name: "Poecilanthrax lucifer"
+}
+item {
+  name: "333705"
+  id: 1130
+  display_name: "Pantherophis obsoletus lindheimeri"
+}
+item {
+  name: "126267"
+  id: 1131
+  display_name: "Coleomegilla maculata"
+}
+item {
+  name: "101693"
+  id: 1132
+  display_name: "Gomphus vastus"
+}
+item {
+  name: "85221"
+  id: 1133
+  display_name: "Hemideina thoracica"
+}
+item {
+  name: "126276"
+  id: 1134
+  display_name: "Agrotis ipsilon"
+}
+item {
+  name: "85317"
+  id: 1135
+  display_name: "Eurosta solidaginis"
+}
+item {
+  name: "36169"
+  id: 1136
+  display_name: "Sceloporus spinosus"
+}
+item {
+  name: "60752"
+  id: 1137
+  display_name: "Hermeuptychia sosybius"
+}
+item {
+  name: "60754"
+  id: 1138
+  display_name: "Pyromorpha dimidiata"
+}
+item {
+  name: "126291"
+  id: 1139
+  display_name: "Prosapia bicincta"
+}
+item {
+  name: "52564"
+  id: 1140
+  display_name: "Anthopleura elegantissima"
+}
+item {
+  name: "126293"
+  id: 1141
+  display_name: "Prionoxystus robiniae"
+}
+item {
+  name: "120719"
+  id: 1142
+  display_name: "Pseudacris hypochondriaca"
+}
+item {
+  name: "36189"
+  id: 1143
+  display_name: "Sceloporus poinsettii"
+}
+item {
+  name: "52576"
+  id: 1144
+  display_name: "Uroctonus mordax"
+}
+item {
+  name: "36198"
+  id: 1145
+  display_name: "Sceloporus orcutti"
+}
+item {
+  name: "52584"
+  id: 1146
+  display_name: "Pantala hymenaea"
+}
+item {
+  name: "44395"
+  id: 1147
+  display_name: "Peromyscus leucopus"
+}
+item {
+  name: "36204"
+  id: 1148
+  display_name: "Sceloporus occidentalis"
+}
+item {
+  name: "52589"
+  id: 1149
+  display_name: "Coenonympha pamphilus"
+}
+item {
+  name: "3439"
+  id: 1150
+  display_name: "Zenaida auriculata"
+}
+item {
+  name: "36208"
+  id: 1151
+  display_name: "Sceloporus occidentalis bocourtii"
+}
+item {
+  name: "72936"
+  id: 1152
+  display_name: "Hymenolaimus malacorhynchos"
+}
+item {
+  name: "85362"
+  id: 1153
+  display_name: "Sphex ichneumoneus"
+}
+item {
+  name: "36217"
+  id: 1154
+  display_name: "Sceloporus merriami"
+}
+item {
+  name: "68993"
+  id: 1155
+  display_name: "Liometopum occidentale"
+}
+item {
+  name: "199916"
+  id: 1156
+  display_name: "Setophaga caerulescens"
+}
+item {
+  name: "52620"
+  id: 1157
+  display_name: "Cicindela oregona"
+}
+item {
+  name: "36243"
+  id: 1158
+  display_name: "Sceloporus jarrovii"
+}
+item {
+  name: "52628"
+  id: 1159
+  display_name: "Araneus diadematus"
+}
+item {
+  name: "180007"
+  id: 1160
+  display_name: "Otospermophilus beecheyi"
+}
+item {
+  name: "85408"
+  id: 1161
+  display_name: "Erythemis collocata"
+}
+item {
+  name: "36262"
+  id: 1162
+  display_name: "Sceloporus grammicus"
+}
+item {
+  name: "60839"
+  id: 1163
+  display_name: "Spilosoma virginica"
+}
+item {
+  name: "16968"
+  id: 1164
+  display_name: "Camptostoma imberbe"
+}
+item {
+  name: "4715"
+  id: 1165
+  display_name: "Caracara plancus"
+}
+item {
+  name: "313246"
+  id: 1166
+  display_name: "Olla v-nigrum"
+}
+item {
+  name: "126393"
+  id: 1167
+  display_name: "Stomolophus meleagris"
+}
+item {
+  name: "126397"
+  id: 1168
+  display_name: "Halysidota harrisii"
+}
+item {
+  name: "64221"
+  id: 1169
+  display_name: "Bipalium kewense"
+}
+item {
+  name: "28102"
+  id: 1170
+  display_name: "Virginia striatula"
+}
+item {
+  name: "150985"
+  id: 1171
+  display_name: "Planorbella trivolvis"
+}
+item {
+  name: "36306"
+  id: 1172
+  display_name: "Phrynosoma modestum"
+}
+item {
+  name: "36307"
+  id: 1173
+  display_name: "Phrynosoma orbiculare"
+}
+item {
+  name: "199929"
+  id: 1174
+  display_name: "Plagiometriona clavata"
+}
+item {
+  name: "3545"
+  id: 1175
+  display_name: "Columbina passerina"
+}
+item {
+  name: "36315"
+  id: 1176
+  display_name: "Phrynosoma hernandesi"
+}
+item {
+  name: "367556"
+  id: 1177
+  display_name: "Eupsittula nana"
+}
+item {
+  name: "371963"
+  id: 1178
+  display_name: "Lampropeltis multifasciata"
+}
+item {
+  name: "36339"
+  id: 1179
+  display_name: "Holbrookia propinqua"
+}
+item {
+  name: "36094"
+  id: 1180
+  display_name: "Uta stansburiana"
+}
+item {
+  name: "36343"
+  id: 1181
+  display_name: "Holbrookia maculata"
+}
+item {
+  name: "52766"
+  id: 1182
+  display_name: "Megaphasma denticrus"
+}
+item {
+  name: "18941"
+  id: 1183
+  display_name: "Nestor notabilis"
+}
+item {
+  name: "3580"
+  id: 1184
+  display_name: "Columbina talpacoti"
+}
+item {
+  name: "123690"
+  id: 1185
+  display_name: "Caranx melampygus"
+}
+item {
+  name: "52482"
+  id: 1186
+  display_name: "Episyrphus balteatus"
+}
+item {
+  name: "28762"
+  id: 1187
+  display_name: "Rhinocheilus lecontei"
+}
+item {
+  name: "3607"
+  id: 1188
+  display_name: "Geopelia striata"
+}
+item {
+  name: "52484"
+  id: 1189
+  display_name: "Celastrina echo"
+}
+item {
+  name: "61293"
+  id: 1190
+  display_name: "Thaumetopoea pityocampa"
+}
+item {
+  name: "19998"
+  id: 1191
+  display_name: "Athene noctua"
+}
+item {
+  name: "44575"
+  id: 1192
+  display_name: "Rattus rattus"
+}
+item {
+  name: "44576"
+  id: 1193
+  display_name: "Rattus norvegicus"
+}
+item {
+  name: "133250"
+  id: 1194
+  display_name: "Tettigonia viridissima"
+}
+item {
+  name: "52774"
+  id: 1195
+  display_name: "Bombus fervidus"
+}
+item {
+  name: "49756"
+  id: 1196
+  display_name: "Nephila clavipes"
+}
+item {
+  name: "52779"
+  id: 1197
+  display_name: "Bombus bimaculatus"
+}
+item {
+  name: "52782"
+  id: 1198
+  display_name: "Melissodes bimaculata"
+}
+item {
+  name: "126513"
+  id: 1199
+  display_name: "Larinioides cornutus"
+}
+item {
+  name: "69170"
+  id: 1200
+  display_name: "Hemigrapsus oregonensis"
+}
+item {
+  name: "1971"
+  id: 1201
+  display_name: "Crotophaga ani"
+}
+item {
+  name: "12942"
+  id: 1202
+  display_name: "Sialia sialis"
+}
+item {
+  name: "126532"
+  id: 1203
+  display_name: "Toxomerus geminatus"
+}
+item {
+  name: "216649"
+  id: 1204
+  display_name: "Chauliognathus pensylvanicus"
+}
+item {
+  name: "3734"
+  id: 1205
+  display_name: "Platalea alba"
+}
+item {
+  name: "216651"
+  id: 1206
+  display_name: "Chelinidea vittiger"
+}
+item {
+  name: "20044"
+  id: 1207
+  display_name: "Bubo virginianus"
+}
+item {
+  name: "11855"
+  id: 1208
+  display_name: "Petrochelidon fulva"
+}
+item {
+  name: "28246"
+  id: 1209
+  display_name: "Arizona elegans"
+}
+item {
+  name: "224855"
+  id: 1210
+  display_name: "Melipotis indomita"
+}
+item {
+  name: "11867"
+  id: 1211
+  display_name: "Progne subis"
+}
+item {
+  name: "126562"
+  id: 1212
+  display_name: "Setophaga coronata auduboni"
+}
+item {
+  name: "126568"
+  id: 1213
+  display_name: "Manduca rustica"
+}
+item {
+  name: "11882"
+  id: 1214
+  display_name: "Hirundo neoxena"
+}
+item {
+  name: "11901"
+  id: 1215
+  display_name: "Hirundo rustica"
+}
+item {
+  name: "52865"
+  id: 1216
+  display_name: "Tramea lacerata"
+}
+item {
+  name: "142978"
+  id: 1217
+  display_name: "Simyra insularis"
+}
+item {
+  name: "123499"
+  id: 1218
+  display_name: "Notophthalmus viridescens viridescens"
+}
+item {
+  name: "339592"
+  id: 1219
+  display_name: "Calidris virgata"
+}
+item {
+  name: "339593"
+  id: 1220
+  display_name: "Calidris pugnax"
+}
+item {
+  name: "44311"
+  id: 1221
+  display_name: "Microtus pennsylvanicus"
+}
+item {
+  name: "142988"
+  id: 1222
+  display_name: "Lerema accius"
+}
+item {
+  name: "142990"
+  id: 1223
+  display_name: "Autographa precationis"
+}
+item {
+  name: "142995"
+  id: 1224
+  display_name: "Hymenia perspectalis"
+}
+item {
+  name: "129423"
+  id: 1225
+  display_name: "Zelus luridus"
+}
+item {
+  name: "3733"
+  id: 1226
+  display_name: "Platalea regia"
+}
+item {
+  name: "470678"
+  id: 1227
+  display_name: "Cerithideopsis californica"
+}
+item {
+  name: "146713"
+  id: 1228
+  display_name: "Elaphria grata"
+}
+item {
+  name: "143002"
+  id: 1229
+  display_name: "Orthonama obstipata"
+}
+item {
+  name: "11931"
+  id: 1230
+  display_name: "Tachycineta thalassina"
+}
+item {
+  name: "143005"
+  id: 1231
+  display_name: "Costaconvexa centrostrigaria"
+}
+item {
+  name: "3743"
+  id: 1232
+  display_name: "Bostrychia hagedash"
+}
+item {
+  name: "143009"
+  id: 1233
+  display_name: "Ectropis crepuscularia"
+}
+item {
+  name: "36514"
+  id: 1234
+  display_name: "Anolis carolinensis"
+}
+item {
+  name: "143012"
+  id: 1235
+  display_name: "Zanclognatha pedipilalis"
+}
+item {
+  name: "11941"
+  id: 1236
+  display_name: "Riparia riparia"
+}
+item {
+  name: "52902"
+  id: 1237
+  display_name: "Palthis asopialis"
+}
+item {
+  name: "3751"
+  id: 1238
+  display_name: "Eudocimus albus"
+}
+item {
+  name: "52906"
+  id: 1239
+  display_name: "Chytonix palliatricula"
+}
+item {
+  name: "3756"
+  id: 1240
+  display_name: "Plegadis falcinellus"
+}
+item {
+  name: "3759"
+  id: 1241
+  display_name: "Plegadis chihi"
+}
+item {
+  name: "143024"
+  id: 1242
+  display_name: "Eusarca confusaria"
+}
+item {
+  name: "62067"
+  id: 1243
+  display_name: "Orthetrum cancellatum"
+}
+item {
+  name: "28340"
+  id: 1244
+  display_name: "Thamnophis sauritus"
+}
+item {
+  name: "28345"
+  id: 1245
+  display_name: "Thamnophis cyrtopsis"
+}
+item {
+  name: "143034"
+  id: 1246
+  display_name: "Hippodamia variegata"
+}
+item {
+  name: "28347"
+  id: 1247
+  display_name: "Thamnophis cyrtopsis ocellatus"
+}
+item {
+  name: "52925"
+  id: 1248
+  display_name: "Phyciodes tharos"
+}
+item {
+  name: "8010"
+  id: 1249
+  display_name: "Corvus corax"
+}
+item {
+  name: "11970"
+  id: 1250
+  display_name: "Stelgidopteryx serripennis"
+}
+item {
+  name: "28362"
+  id: 1251
+  display_name: "Thamnophis sirtalis"
+}
+item {
+  name: "3788"
+  id: 1252
+  display_name: "Sula dactylatra"
+}
+item {
+  name: "44749"
+  id: 1253
+  display_name: "Neotoma fuscipes"
+}
+item {
+  name: "52943"
+  id: 1254
+  display_name: "Trichodezia albovittata"
+}
+item {
+  name: "3793"
+  id: 1255
+  display_name: "Sula sula"
+}
+item {
+  name: "101667"
+  id: 1256
+  display_name: "Gomphus exilis"
+}
+item {
+  name: "3797"
+  id: 1257
+  display_name: "Sula leucogaster"
+}
+item {
+  name: "118486"
+  id: 1258
+  display_name: "Macaria aemulataria"
+}
+item {
+  name: "3801"
+  id: 1259
+  display_name: "Morus serrator"
+}
+item {
+  name: "28378"
+  id: 1260
+  display_name: "Thamnophis radix"
+}
+item {
+  name: "118492"
+  id: 1261
+  display_name: "Helicoverpa zea"
+}
+item {
+  name: "148793"
+  id: 1262
+  display_name: "Asterocampa leilia"
+}
+item {
+  name: "28384"
+  id: 1263
+  display_name: "Thamnophis proximus rubrilineatus"
+}
+item {
+  name: "257761"
+  id: 1264
+  display_name: "Phocides polybius"
+}
+item {
+  name: "28387"
+  id: 1265
+  display_name: "Thamnophis proximus orarius"
+}
+item {
+  name: "28390"
+  id: 1266
+  display_name: "Thamnophis marcianus"
+}
+item {
+  name: "118503"
+  id: 1267
+  display_name: "Darapsa myron"
+}
+item {
+  name: "3817"
+  id: 1268
+  display_name: "Eudyptula minor"
+}
+item {
+  name: "36135"
+  id: 1269
+  display_name: "Uma scoparia"
+}
+item {
+  name: "28396"
+  id: 1270
+  display_name: "Thamnophis hammondii"
+}
+item {
+  name: "28400"
+  id: 1271
+  display_name: "Thamnophis elegans elegans"
+}
+item {
+  name: "118513"
+  id: 1272
+  display_name: "Hypena scabra"
+}
+item {
+  name: "28403"
+  id: 1273
+  display_name: "Thamnophis elegans vagrans"
+}
+item {
+  name: "201342"
+  id: 1274
+  display_name: "Chalcoela iphitalis"
+}
+item {
+  name: "3831"
+  id: 1275
+  display_name: "Megadyptes antipodes"
+}
+item {
+  name: "126712"
+  id: 1276
+  display_name: "Corydalus cornutus"
+}
+item {
+  name: "30676"
+  id: 1277
+  display_name: "Agkistrodon piscivorus leucostoma"
+}
+item {
+  name: "3834"
+  id: 1278
+  display_name: "Scopus umbretta"
+}
+item {
+  name: "213631"
+  id: 1279
+  display_name: "Anicla infecta"
+}
+item {
+  name: "143105"
+  id: 1280
+  display_name: "Pleuroprucha insulsaria"
+}
+item {
+  name: "28418"
+  id: 1281
+  display_name: "Thamnophis atratus"
+}
+item {
+  name: "118531"
+  id: 1282
+  display_name: "Parallelia bistriaris"
+}
+item {
+  name: "145363"
+  id: 1283
+  display_name: "Troglodytes troglodytes"
+}
+item {
+  name: "3845"
+  id: 1284
+  display_name: "Calidris canutus"
+}
+item {
+  name: "12038"
+  id: 1285
+  display_name: "Lanius collurio"
+}
+item {
+  name: "143114"
+  id: 1286
+  display_name: "Phragmatobia fuliginosa"
+}
+item {
+  name: "3851"
+  id: 1287
+  display_name: "Calidris bairdii"
+}
+item {
+  name: "324226"
+  id: 1288
+  display_name: "Meleagris gallopavo intermedia"
+}
+item {
+  name: "143118"
+  id: 1289
+  display_name: "Pseudeustrotia carneola"
+}
+item {
+  name: "3855"
+  id: 1290
+  display_name: "Calidris mauri"
+}
+item {
+  name: "3856"
+  id: 1291
+  display_name: "Calidris maritima"
+}
+item {
+  name: "3857"
+  id: 1292
+  display_name: "Calidris alpina"
+}
+item {
+  name: "143124"
+  id: 1293
+  display_name: "Parapediasia teterrella"
+}
+item {
+  name: "143125"
+  id: 1294
+  display_name: "Hypena madefactalis"
+}
+item {
+  name: "3863"
+  id: 1295
+  display_name: "Calidris ferruginea"
+}
+item {
+  name: "118552"
+  id: 1296
+  display_name: "Felis catus"
+}
+item {
+  name: "3865"
+  id: 1297
+  display_name: "Calidris melanotos"
+}
+item {
+  name: "3869"
+  id: 1298
+  display_name: "Limnodromus griseus"
+}
+item {
+  name: "118558"
+  id: 1299
+  display_name: "Manduca quinquemaculata"
+}
+item {
+  name: "118559"
+  id: 1300
+  display_name: "Tetraopes tetrophthalmus"
+}
+item {
+  name: "12065"
+  id: 1301
+  display_name: "Malurus cyaneus"
+}
+item {
+  name: "3878"
+  id: 1302
+  display_name: "Tringa nebularia"
+}
+item {
+  name: "101681"
+  id: 1303
+  display_name: "Gomphus militaris"
+}
+item {
+  name: "413483"
+  id: 1304
+  display_name: "Todiramphus sanctus vagans"
+}
+item {
+  name: "3885"
+  id: 1305
+  display_name: "Tringa ochropus"
+}
+item {
+  name: "3888"
+  id: 1306
+  display_name: "Tringa glareola"
+}
+item {
+  name: "126770"
+  id: 1307
+  display_name: "Vulpes vulpes fulvus"
+}
+item {
+  name: "3892"
+  id: 1308
+  display_name: "Tringa melanoleuca"
+}
+item {
+  name: "3893"
+  id: 1309
+  display_name: "Tringa flavipes"
+}
+item {
+  name: "126775"
+  id: 1310
+  display_name: "Cervus elaphus nelsoni"
+}
+item {
+  name: "3896"
+  id: 1311
+  display_name: "Numenius arquata"
+}
+item {
+  name: "126777"
+  id: 1312
+  display_name: "Peucetia viridans"
+}
+item {
+  name: "3901"
+  id: 1313
+  display_name: "Numenius phaeopus"
+}
+item {
+  name: "32058"
+  id: 1314
+  display_name: "Elgaria multicarinata webbii"
+}
+item {
+  name: "413506"
+  id: 1315
+  display_name: "Phalacrocorax carbo novaehollandiae"
+}
+item {
+  name: "413508"
+  id: 1316
+  display_name: "Petroica macrocephala macrocephala"
+}
+item {
+  name: "413512"
+  id: 1317
+  display_name: "Petroica australis longipes"
+}
+item {
+  name: "61258"
+  id: 1318
+  display_name: "Junonia evarete"
+}
+item {
+  name: "28493"
+  id: 1319
+  display_name: "Tantilla nigriceps"
+}
+item {
+  name: "413522"
+  id: 1320
+  display_name: "Prosthemadera novaeseelandiae novaeseelandiae"
+}
+item {
+  name: "58506"
+  id: 1321
+  display_name: "Polites themistocles"
+}
+item {
+  name: "28505"
+  id: 1322
+  display_name: "Tantilla gracilis"
+}
+item {
+  name: "20315"
+  id: 1323
+  display_name: "Asio flammeus"
+}
+item {
+  name: "143196"
+  id: 1324
+  display_name: "Schinia arcigera"
+}
+item {
+  name: "413533"
+  id: 1325
+  display_name: "Rhipidura fuliginosa fuliginosa"
+}
+item {
+  name: "3936"
+  id: 1326
+  display_name: "Scolopax minor"
+}
+item {
+  name: "3938"
+  id: 1327
+  display_name: "Arenaria interpres"
+}
+item {
+  name: "3941"
+  id: 1328
+  display_name: "Arenaria melanocephala"
+}
+item {
+  name: "413543"
+  id: 1329
+  display_name: "Rhipidura fuliginosa placabilis"
+}
+item {
+  name: "3947"
+  id: 1330
+  display_name: "Limosa limosa"
+}
+item {
+  name: "3950"
+  id: 1331
+  display_name: "Limosa haemastica"
+}
+item {
+  name: "126269"
+  id: 1332
+  display_name: "Austrolestes colensonis"
+}
+item {
+  name: "3954"
+  id: 1333
+  display_name: "Limosa fedoa"
+}
+item {
+  name: "199998"
+  id: 1334
+  display_name: "Pedicia albivitta"
+}
+item {
+  name: "3959"
+  id: 1335
+  display_name: "Phalaropus lobatus"
+}
+item {
+  name: "3962"
+  id: 1336
+  display_name: "Bartramia longicauda"
+}
+item {
+  name: "199999"
+  id: 1337
+  display_name: "Callopistria mollissima"
+}
+item {
+  name: "104426"
+  id: 1338
+  display_name: "Lestes disjunctus"
+}
+item {
+  name: "126848"
+  id: 1339
+  display_name: "Delphinia picta"
+}
+item {
+  name: "3951"
+  id: 1340
+  display_name: "Limosa lapponica"
+}
+item {
+  name: "20356"
+  id: 1341
+  display_name: "Aegolius acadicus"
+}
+item {
+  name: "121792"
+  id: 1342
+  display_name: "Polistes carolina"
+}
+item {
+  name: "3978"
+  id: 1343
+  display_name: "Actitis hypoleucos"
+}
+item {
+  name: "53911"
+  id: 1344
+  display_name: "Cyprinus carpio"
+}
+item {
+  name: "135055"
+  id: 1345
+  display_name: "Bufotes balearicus"
+}
+item {
+  name: "19121"
+  id: 1346
+  display_name: "Trichoglossus haematodus"
+}
+item {
+  name: "28562"
+  id: 1347
+  display_name: "Storeria dekayi"
+}
+item {
+  name: "28563"
+  id: 1348
+  display_name: "Storeria dekayi texana"
+}
+item {
+  name: "20372"
+  id: 1349
+  display_name: "Surnia ulula"
+}
+item {
+  name: "135064"
+  id: 1350
+  display_name: "Bufotes viridis"
+}
+item {
+  name: "28570"
+  id: 1351
+  display_name: "Storeria dekayi dekayi"
+}
+item {
+  name: "61341"
+  id: 1352
+  display_name: "Narceus americanus"
+}
+item {
+  name: "7493"
+  id: 1353
+  display_name: "Polioptila caerulea"
+}
+item {
+  name: "29339"
+  id: 1354
+  display_name: "Natrix natrix"
+}
+item {
+  name: "9135"
+  id: 1355
+  display_name: "Spizella passerina"
+}
+item {
+  name: "126889"
+  id: 1356
+  display_name: "Toxomerus marginatus"
+}
+item {
+  name: "143274"
+  id: 1357
+  display_name: "Gluphisia septentrionis"
+}
+item {
+  name: "343021"
+  id: 1358
+  display_name: "Anguis fragilis"
+}
+item {
+  name: "14591"
+  id: 1359
+  display_name: "Pycnonotus jocosus"
+}
+item {
+  name: "10227"
+  id: 1360
+  display_name: "Passerina cyanea"
+}
+item {
+  name: "10228"
+  id: 1361
+  display_name: "Passerina versicolor"
+}
+item {
+  name: "61371"
+  id: 1362
+  display_name: "Panulirus interruptus"
+}
+item {
+  name: "143294"
+  id: 1363
+  display_name: "Colias croceus"
+}
+item {
+  name: "135104"
+  id: 1364
+  display_name: "Ichthyosaura alpestris"
+}
+item {
+  name: "83958"
+  id: 1365
+  display_name: "Phryganidia californica"
+}
+item {
+  name: "143302"
+  id: 1366
+  display_name: "Megapallifera mutabilis"
+}
+item {
+  name: "12231"
+  id: 1367
+  display_name: "Manorina melanocephala"
+}
+item {
+  name: "200661"
+  id: 1368
+  display_name: "Coluber constrictor mormon"
+}
+item {
+  name: "3681"
+  id: 1369
+  display_name: "Ocyphaps lophotes"
+}
+item {
+  name: "4773"
+  id: 1370
+  display_name: "Jabiru mycteria"
+}
+item {
+  name: "135140"
+  id: 1371
+  display_name: "Taricha sierrae"
+}
+item {
+  name: "28649"
+  id: 1372
+  display_name: "Sonora semiannulata"
+}
+item {
+  name: "53226"
+  id: 1373
+  display_name: "Boisea rubrolineata"
+}
+item {
+  name: "53227"
+  id: 1374
+  display_name: "Boisea trivittata"
+}
+item {
+  name: "14593"
+  id: 1375
+  display_name: "Pycnonotus cafer"
+}
+item {
+  name: "61428"
+  id: 1376
+  display_name: "Arion subfuscus"
+}
+item {
+  name: "333822"
+  id: 1377
+  display_name: "Anser cygnoides domesticus"
+}
+item {
+  name: "41641"
+  id: 1378
+  display_name: "Ursus arctos"
+}
+item {
+  name: "56602"
+  id: 1379
+  display_name: "Plebejus lupini"
+}
+item {
+  name: "55295"
+  id: 1380
+  display_name: "Grapsus grapsus"
+}
+item {
+  name: "36181"
+  id: 1381
+  display_name: "Sceloporus cyanogenys"
+}
+item {
+  name: "41708"
+  id: 1382
+  display_name: "Phoca vitulina"
+}
+item {
+  name: "118788"
+  id: 1383
+  display_name: "Desmia funeralis"
+}
+item {
+  name: "61445"
+  id: 1384
+  display_name: "Acanthocephala terminalis"
+}
+item {
+  name: "30721"
+  id: 1385
+  display_name: "Crotalus triseriatus"
+}
+item {
+  name: "180010"
+  id: 1386
+  display_name: "Callospermophilus lateralis"
+}
+item {
+  name: "53875"
+  id: 1387
+  display_name: "Ocypode quadrata"
+}
+item {
+  name: "18358"
+  id: 1388
+  display_name: "Picus viridis"
+}
+item {
+  name: "143390"
+  id: 1389
+  display_name: "Oxidus gracilis"
+}
+item {
+  name: "55785"
+  id: 1390
+  display_name: "Ochlodes agricola"
+}
+item {
+  name: "4141"
+  id: 1391
+  display_name: "Phoebastria nigripes"
+}
+item {
+  name: "20526"
+  id: 1392
+  display_name: "Struthio camelus"
+}
+item {
+  name: "32093"
+  id: 1393
+  display_name: "Boa constrictor"
+}
+item {
+  name: "4144"
+  id: 1394
+  display_name: "Phoebastria immutabilis"
+}
+item {
+  name: "74442"
+  id: 1395
+  display_name: "Hydrochoerus hydrochaeris"
+}
+item {
+  name: "61492"
+  id: 1396
+  display_name: "Chrysopilus thoracicus"
+}
+item {
+  name: "61495"
+  id: 1397
+  display_name: "Erythemis simplicicollis"
+}
+item {
+  name: "389177"
+  id: 1398
+  display_name: "Eriophora pustulosa"
+}
+item {
+  name: "61503"
+  id: 1399
+  display_name: "Ascalapha odorata"
+}
+item {
+  name: "118855"
+  id: 1400
+  display_name: "Calosoma scrutator"
+}
+item {
+  name: "61513"
+  id: 1401
+  display_name: "Adelges tsugae"
+}
+item {
+  name: "28749"
+  id: 1402
+  display_name: "Salvadora grahamiae"
+}
+item {
+  name: "143440"
+  id: 1403
+  display_name: "Ceratomia catalpae"
+}
+item {
+  name: "61523"
+  id: 1404
+  display_name: "Helix pomatia"
+}
+item {
+  name: "4180"
+  id: 1405
+  display_name: "Fulmarus glacialis"
+}
+item {
+  name: "143445"
+  id: 1406
+  display_name: "Pachysphinx modesta"
+}
+item {
+  name: "233560"
+  id: 1407
+  display_name: "Vespula squamosa"
+}
+item {
+  name: "126308"
+  id: 1408
+  display_name: "Marpesia chiron"
+}
+item {
+  name: "61536"
+  id: 1409
+  display_name: "Calopteryx virgo"
+}
+item {
+  name: "685"
+  id: 1410
+  display_name: "Francolinus pondicerianus"
+}
+item {
+  name: "60774"
+  id: 1411
+  display_name: "Psychomorpha epimenis"
+}
+item {
+  name: "135271"
+  id: 1412
+  display_name: "Amphibolips confluenta"
+}
+item {
+  name: "69736"
+  id: 1413
+  display_name: "Schistocerca americana"
+}
+item {
+  name: "69737"
+  id: 1414
+  display_name: "Xylophanes tersa"
+}
+item {
+  name: "6141"
+  id: 1415
+  display_name: "Cynanthus latirostris"
+}
+item {
+  name: "4205"
+  id: 1416
+  display_name: "Podiceps nigricollis"
+}
+item {
+  name: "69743"
+  id: 1417
+  display_name: "Wallengrenia otho"
+}
+item {
+  name: "4208"
+  id: 1418
+  display_name: "Podiceps cristatus"
+}
+item {
+  name: "4209"
+  id: 1419
+  display_name: "Podiceps auritus"
+}
+item {
+  name: "118901"
+  id: 1420
+  display_name: "Hyles gallii"
+}
+item {
+  name: "17871"
+  id: 1421
+  display_name: "Dendrocopos major"
+}
+item {
+  name: "143484"
+  id: 1422
+  display_name: "Blepharomastix ranalis"
+}
+item {
+  name: "4224"
+  id: 1423
+  display_name: "Podiceps grisegena"
+}
+item {
+  name: "200834"
+  id: 1424
+  display_name: "Sphenodon punctatus"
+}
+item {
+  name: "179995"
+  id: 1425
+  display_name: "Urocitellus beldingi"
+}
+item {
+  name: "322024"
+  id: 1426
+  display_name: "Apatura ilia"
+}
+item {
+  name: "44396"
+  id: 1427
+  display_name: "Peromyscus maniculatus"
+}
+item {
+  name: "4237"
+  id: 1428
+  display_name: "Tachybaptus ruficollis"
+}
+item {
+  name: "118930"
+  id: 1429
+  display_name: "Spodoptera ornithogalli"
+}
+item {
+  name: "118936"
+  id: 1430
+  display_name: "Euplagia quadripunctaria"
+}
+item {
+  name: "4804"
+  id: 1431
+  display_name: "Charadrius montanus"
+}
+item {
+  name: "127133"
+  id: 1432
+  display_name: "Hyphantria cunea"
+}
+item {
+  name: "143518"
+  id: 1433
+  display_name: "Prochoerodes lineola"
+}
+item {
+  name: "52592"
+  id: 1434
+  display_name: "Pararge aegeria"
+}
+item {
+  name: "36149"
+  id: 1435
+  display_name: "Sceloporus torquatus"
+}
+item {
+  name: "118951"
+  id: 1436
+  display_name: "Pterophylla camellifolia"
+}
+item {
+  name: "4265"
+  id: 1437
+  display_name: "Phalacrocorax auritus"
+}
+item {
+  name: "4270"
+  id: 1438
+  display_name: "Phalacrocorax carbo"
+}
+item {
+  name: "446640"
+  id: 1439
+  display_name: "Neomonachus schauinslandi"
+}
+item {
+  name: "118961"
+  id: 1440
+  display_name: "Conocephalus brevipennis"
+}
+item {
+  name: "28850"
+  id: 1441
+  display_name: "Regina septemvittata"
+}
+item {
+  name: "4277"
+  id: 1442
+  display_name: "Phalacrocorax penicillatus"
+}
+item {
+  name: "4234"
+  id: 1443
+  display_name: "Aechmophorus clarkii"
+}
+item {
+  name: "118967"
+  id: 1444
+  display_name: "Psyllobora vigintimaculata"
+}
+item {
+  name: "118968"
+  id: 1445
+  display_name: "Allograpta obliqua"
+}
+item {
+  name: "118970"
+  id: 1446
+  display_name: "Bombus impatiens"
+}
+item {
+  name: "123594"
+  id: 1447
+  display_name: "Anaxyrus americanus americanus"
+}
+item {
+  name: "69838"
+  id: 1448
+  display_name: "Cyanea capillata"
+}
+item {
+  name: "69844"
+  id: 1449
+  display_name: "Anthocharis midea"
+}
+item {
+  name: "48505"
+  id: 1450
+  display_name: "Junonia coenia"
+}
+item {
+  name: "151769"
+  id: 1451
+  display_name: "Diaphania hyalinata"
+}
+item {
+  name: "151770"
+  id: 1452
+  display_name: "Peridea angulosa"
+}
+item {
+  name: "53467"
+  id: 1453
+  display_name: "Leucauge venusta"
+}
+item {
+  name: "119013"
+  id: 1454
+  display_name: "Ctenucha virginica"
+}
+item {
+  name: "4327"
+  id: 1455
+  display_name: "Pelecanus onocrotalus"
+}
+item {
+  name: "143592"
+  id: 1456
+  display_name: "Spragueia leo"
+}
+item {
+  name: "200938"
+  id: 1457
+  display_name: "Diaethria anna"
+}
+item {
+  name: "4334"
+  id: 1458
+  display_name: "Pelecanus erythrorhynchos"
+}
+item {
+  name: "151794"
+  id: 1459
+  display_name: "Atta texana"
+}
+item {
+  name: "3454"
+  id: 1460
+  display_name: "Zenaida macroura"
+}
+item {
+  name: "4872"
+  id: 1461
+  display_name: "Vanellus miles"
+}
+item {
+  name: "4345"
+  id: 1462
+  display_name: "Larus occidentalis"
+}
+item {
+  name: "143610"
+  id: 1463
+  display_name: "Besma quercivoraria"
+}
+item {
+  name: "20733"
+  id: 1464
+  display_name: "Trogon massena"
+}
+item {
+  name: "143615"
+  id: 1465
+  display_name: "Udea rubigalis"
+}
+item {
+  name: "4352"
+  id: 1466
+  display_name: "Larus thayeri"
+}
+item {
+  name: "4353"
+  id: 1467
+  display_name: "Larus heermanni"
+}
+item {
+  name: "4354"
+  id: 1468
+  display_name: "Larus livens"
+}
+item {
+  name: "4356"
+  id: 1469
+  display_name: "Larus canus"
+}
+item {
+  name: "220826"
+  id: 1470
+  display_name: "Habrosyne scripta"
+}
+item {
+  name: "4361"
+  id: 1471
+  display_name: "Larus glaucoides"
+}
+item {
+  name: "4364"
+  id: 1472
+  display_name: "Larus delawarensis"
+}
+item {
+  name: "102672"
+  id: 1473
+  display_name: "Hetaerina titia"
+}
+item {
+  name: "20754"
+  id: 1474
+  display_name: "Trogon collaris"
+}
+item {
+  name: "479512"
+  id: 1475
+  display_name: "Acronicta fallax"
+}
+item {
+  name: "3460"
+  id: 1476
+  display_name: "Zenaida asiatica"
+}
+item {
+  name: "119066"
+  id: 1477
+  display_name: "Idia lubricalis"
+}
+item {
+  name: "119068"
+  id: 1478
+  display_name: "Apodemia virgulti"
+}
+item {
+  name: "4381"
+  id: 1479
+  display_name: "Larus fuscus"
+}
+item {
+  name: "4385"
+  id: 1480
+  display_name: "Larus californicus"
+}
+item {
+  name: "69922"
+  id: 1481
+  display_name: "Oncorhynchus nerka"
+}
+item {
+  name: "12580"
+  id: 1482
+  display_name: "Prosthemadera novaeseelandiae"
+}
+item {
+  name: "69925"
+  id: 1483
+  display_name: "Clinocardium nuttallii"
+}
+item {
+  name: "20781"
+  id: 1484
+  display_name: "Trogon elegans"
+}
+item {
+  name: "4399"
+  id: 1485
+  display_name: "Larus glaucescens"
+}
+item {
+  name: "94513"
+  id: 1486
+  display_name: "Archilestes grandis"
+}
+item {
+  name: "119090"
+  id: 1487
+  display_name: "Eremnophila aureonotata"
+}
+item {
+  name: "20787"
+  id: 1488
+  display_name: "Trogon citreolus"
+}
+item {
+  name: "69940"
+  id: 1489
+  display_name: "Hemiargus ceraunus"
+}
+item {
+  name: "61749"
+  id: 1490
+  display_name: "Lucanus cervus"
+}
+item {
+  name: "4415"
+  id: 1491
+  display_name: "Cepphus columba"
+}
+item {
+  name: "4832"
+  id: 1492
+  display_name: "Himantopus leucocephalus"
+}
+item {
+  name: "4418"
+  id: 1493
+  display_name: "Cepphus grylle"
+}
+item {
+  name: "12612"
+  id: 1494
+  display_name: "Anthornis melanura"
+}
+item {
+  name: "125627"
+  id: 1495
+  display_name: "Ellychnia corrusca"
+}
+item {
+  name: "201031"
+  id: 1496
+  display_name: "Leptoptilos crumenifer"
+}
+item {
+  name: "201032"
+  id: 1497
+  display_name: "Threskiornis moluccus"
+}
+item {
+  name: "60812"
+  id: 1498
+  display_name: "Lucanus capreolus"
+}
+item {
+  name: "10295"
+  id: 1499
+  display_name: "Thraupis episcopus"
+}
+item {
+  name: "209233"
+  id: 1500
+  display_name: "Equus caballus"
+}
+item {
+  name: "119122"
+  id: 1501
+  display_name: "Araneus trifolium"
+}
+item {
+  name: "201043"
+  id: 1502
+  display_name: "Geranoaetus albicaudatus"
+}
+item {
+  name: "61781"
+  id: 1503
+  display_name: "Ochlodes sylvanus"
+}
+item {
+  name: "49133"
+  id: 1504
+  display_name: "Vanessa atalanta"
+}
+item {
+  name: "94556"
+  id: 1505
+  display_name: "Argia lugens"
+}
+item {
+  name: "94557"
+  id: 1506
+  display_name: "Argia moesta"
+}
+item {
+  name: "61524"
+  id: 1507
+  display_name: "Forficula auricularia"
+}
+item {
+  name: "4449"
+  id: 1508
+  display_name: "Sterna paradisaea"
+}
+item {
+  name: "4450"
+  id: 1509
+  display_name: "Sterna hirundo"
+}
+item {
+  name: "348515"
+  id: 1510
+  display_name: "Nyctemera annulata"
+}
+item {
+  name: "110625"
+  id: 1511
+  display_name: "Progomphus obscurus"
+}
+item {
+  name: "94566"
+  id: 1512
+  display_name: "Argia plana"
+}
+item {
+  name: "4457"
+  id: 1513
+  display_name: "Sterna forsteri"
+}
+item {
+  name: "94571"
+  id: 1514
+  display_name: "Argia sedula"
+}
+item {
+  name: "61804"
+  id: 1515
+  display_name: "Olivella biplicata"
+}
+item {
+  name: "204532"
+  id: 1516
+  display_name: "Lanius excubitor"
+}
+item {
+  name: "29038"
+  id: 1517
+  display_name: "Pituophis deppei"
+}
+item {
+  name: "143728"
+  id: 1518
+  display_name: "Choristoneura rosaceana"
+}
+item {
+  name: "94577"
+  id: 1519
+  display_name: "Argia translata"
+}
+item {
+  name: "130451"
+  id: 1520
+  display_name: "Dione juno"
+}
+item {
+  name: "29044"
+  id: 1521
+  display_name: "Pituophis catenifer"
+}
+item {
+  name: "70005"
+  id: 1522
+  display_name: "Ilyanassa obsoleta"
+}
+item {
+  name: "143734"
+  id: 1523
+  display_name: "Eupithecia miserulata"
+}
+item {
+  name: "20856"
+  id: 1524
+  display_name: "Pharomachrus mocinno"
+}
+item {
+  name: "29049"
+  id: 1525
+  display_name: "Pituophis catenifer deserticola"
+}
+item {
+  name: "29052"
+  id: 1526
+  display_name: "Pituophis catenifer affinis"
+}
+item {
+  name: "29053"
+  id: 1527
+  display_name: "Pituophis catenifer annectens"
+}
+item {
+  name: "4478"
+  id: 1528
+  display_name: "Sterna striata"
+}
+item {
+  name: "407459"
+  id: 1529
+  display_name: "Dolomedes minor"
+}
+item {
+  name: "4489"
+  id: 1530
+  display_name: "Stercorarius parasiticus"
+}
+item {
+  name: "4491"
+  id: 1531
+  display_name: "Stercorarius pomarinus"
+}
+item {
+  name: "6969"
+  id: 1532
+  display_name: "Anas gracilis"
+}
+item {
+  name: "4494"
+  id: 1533
+  display_name: "Rissa tridactyla"
+}
+item {
+  name: "4496"
+  id: 1534
+  display_name: "Rynchops niger"
+}
+item {
+  name: "4501"
+  id: 1535
+  display_name: "Alca torda"
+}
+item {
+  name: "4504"
+  id: 1536
+  display_name: "Fratercula arctica"
+}
+item {
+  name: "4509"
+  id: 1537
+  display_name: "Fratercula cirrhata"
+}
+item {
+  name: "26693"
+  id: 1538
+  display_name: "Scaphiopus hurterii"
+}
+item {
+  name: "94624"
+  id: 1539
+  display_name: "Arigomphus submedianus"
+}
+item {
+  name: "94625"
+  id: 1540
+  display_name: "Arigomphus villosipes"
+}
+item {
+  name: "120720"
+  id: 1541
+  display_name: "Pseudacris sierra"
+}
+item {
+  name: "70057"
+  id: 1542
+  display_name: "Agrilus planipennis"
+}
+item {
+  name: "127402"
+  id: 1543
+  display_name: "Grammia virgo"
+}
+item {
+  name: "51271"
+  id: 1544
+  display_name: "Trachemys scripta elegans"
+}
+item {
+  name: "12716"
+  id: 1545
+  display_name: "Turdus merula"
+}
+item {
+  name: "12718"
+  id: 1546
+  display_name: "Turdus plumbeus"
+}
+item {
+  name: "12720"
+  id: 1547
+  display_name: "Turdus grayi"
+}
+item {
+  name: "63697"
+  id: 1548
+  display_name: "Metacarcinus magister"
+}
+item {
+  name: "12727"
+  id: 1549
+  display_name: "Turdus migratorius"
+}
+item {
+  name: "26698"
+  id: 1550
+  display_name: "Spea multiplicata"
+}
+item {
+  name: "12735"
+  id: 1551
+  display_name: "Turdus viscivorus"
+}
+item {
+  name: "26699"
+  id: 1552
+  display_name: "Spea bombifrons"
+}
+item {
+  name: "127431"
+  id: 1553
+  display_name: "Emmelina monodactyla"
+}
+item {
+  name: "4553"
+  id: 1554
+  display_name: "Cerorhinca monocerata"
+}
+item {
+  name: "12748"
+  id: 1555
+  display_name: "Turdus philomelos"
+}
+item {
+  name: "233933"
+  id: 1556
+  display_name: "Zale horrida"
+}
+item {
+  name: "1468"
+  id: 1557
+  display_name: "Galbula ruficauda"
+}
+item {
+  name: "111055"
+  id: 1558
+  display_name: "Pseudoleon superbus"
+}
+item {
+  name: "61908"
+  id: 1559
+  display_name: "Orgyia vetusta"
+}
+item {
+  name: "43086"
+  id: 1560
+  display_name: "Procavia capensis"
+}
+item {
+  name: "143830"
+  id: 1561
+  display_name: "Eumorpha vitis"
+}
+item {
+  name: "67663"
+  id: 1562
+  display_name: "Leptysma marginicollis"
+}
+item {
+  name: "127457"
+  id: 1563
+  display_name: "Idia americalis"
+}
+item {
+  name: "4578"
+  id: 1564
+  display_name: "Jacana spinosa"
+}
+item {
+  name: "127460"
+  id: 1565
+  display_name: "Idia aemula"
+}
+item {
+  name: "201192"
+  id: 1566
+  display_name: "Saxicola rubicola"
+}
+item {
+  name: "20969"
+  id: 1567
+  display_name: "Upupa epops"
+}
+item {
+  name: "94699"
+  id: 1568
+  display_name: "Aspidoscelis marmorata"
+}
+item {
+  name: "10322"
+  id: 1569
+  display_name: "Euphagus carolinus"
+}
+item {
+  name: "53743"
+  id: 1570
+  display_name: "Uca pugilator"
+}
+item {
+  name: "61256"
+  id: 1571
+  display_name: "Leptoglossus phyllopus"
+}
+item {
+  name: "29438"
+  id: 1572
+  display_name: "Coluber flagellum piceus"
+}
+item {
+  name: "53750"
+  id: 1573
+  display_name: "Lottia gigantea"
+}
+item {
+  name: "143865"
+  id: 1574
+  display_name: "Odocoileus hemionus hemionus"
+}
+item {
+  name: "143867"
+  id: 1575
+  display_name: "Protoboarmia porcelaria"
+}
+item {
+  name: "209405"
+  id: 1576
+  display_name: "Cenopis reticulatana"
+}
+item {
+  name: "49920"
+  id: 1577
+  display_name: "Nymphalis californica"
+}
+item {
+  name: "53762"
+  id: 1578
+  display_name: "Scolopendra polymorpha"
+}
+item {
+  name: "127492"
+  id: 1579
+  display_name: "Megalographa biloba"
+}
+item {
+  name: "62470"
+  id: 1580
+  display_name: "Limax maximus"
+}
+item {
+  name: "4621"
+  id: 1581
+  display_name: "Gavia pacifica"
+}
+item {
+  name: "14884"
+  id: 1582
+  display_name: "Mimus gilvus"
+}
+item {
+  name: "29200"
+  id: 1583
+  display_name: "Opheodrys aestivus"
+}
+item {
+  name: "201233"
+  id: 1584
+  display_name: "Passer italiae"
+}
+item {
+  name: "4626"
+  id: 1585
+  display_name: "Gavia immer"
+}
+item {
+  name: "4627"
+  id: 1586
+  display_name: "Gavia stellata"
+}
+item {
+  name: "12822"
+  id: 1587
+  display_name: "Oenanthe oenanthe"
+}
+item {
+  name: "4631"
+  id: 1588
+  display_name: "Fregata magnificens"
+}
+item {
+  name: "4636"
+  id: 1589
+  display_name: "Fregata minor"
+}
+item {
+  name: "70174"
+  id: 1590
+  display_name: "Hypolimnas bolina"
+}
+item {
+  name: "4643"
+  id: 1591
+  display_name: "Falco subbuteo"
+}
+item {
+  name: "4644"
+  id: 1592
+  display_name: "Falco mexicanus"
+}
+item {
+  name: "4645"
+  id: 1593
+  display_name: "Falco femoralis"
+}
+item {
+  name: "4647"
+  id: 1594
+  display_name: "Falco peregrinus"
+}
+item {
+  name: "119340"
+  id: 1595
+  display_name: "Amphipyra pyramidoides"
+}
+item {
+  name: "61997"
+  id: 1596
+  display_name: "Steatoda grossa"
+}
+item {
+  name: "70191"
+  id: 1597
+  display_name: "Ischnura ramburii"
+}
+item {
+  name: "53809"
+  id: 1598
+  display_name: "Phidippus audax"
+}
+item {
+  name: "143213"
+  id: 1599
+  display_name: "Frontinella communis"
+}
+item {
+  name: "4664"
+  id: 1600
+  display_name: "Falco rufigularis"
+}
+item {
+  name: "4665"
+  id: 1601
+  display_name: "Falco sparverius"
+}
+item {
+  name: "19893"
+  id: 1602
+  display_name: "Strix varia"
+}
+item {
+  name: "4672"
+  id: 1603
+  display_name: "Falco columbarius"
+}
+item {
+  name: "201281"
+  id: 1604
+  display_name: "Phyllodesma americana"
+}
+item {
+  name: "201282"
+  id: 1605
+  display_name: "Gallinula chloropus"
+}
+item {
+  name: "152131"
+  id: 1606
+  display_name: "Bagrada hilaris"
+}
+item {
+  name: "145276"
+  id: 1607
+  display_name: "Cardellina pusilla"
+}
+item {
+  name: "12878"
+  id: 1608
+  display_name: "Catharus ustulatus"
+}
+item {
+  name: "4690"
+  id: 1609
+  display_name: "Falco novaeseelandiae"
+}
+item {
+  name: "53843"
+  id: 1610
+  display_name: "Brephidium exilis"
+}
+item {
+  name: "36281"
+  id: 1611
+  display_name: "Sceloporus clarkii"
+}
+item {
+  name: "12890"
+  id: 1612
+  display_name: "Catharus guttatus"
+}
+item {
+  name: "62045"
+  id: 1613
+  display_name: "Lygaeus kalmii"
+}
+item {
+  name: "47075"
+  id: 1614
+  display_name: "Dasypus novemcinctus"
+}
+item {
+  name: "12901"
+  id: 1615
+  display_name: "Catharus fuscescens"
+}
+item {
+  name: "4714"
+  id: 1616
+  display_name: "Caracara cheriway"
+}
+item {
+  name: "53867"
+  id: 1617
+  display_name: "Erythemis plebeja"
+}
+item {
+  name: "62060"
+  id: 1618
+  display_name: "Palomena prasina"
+}
+item {
+  name: "53869"
+  id: 1619
+  display_name: "Ocypus olens"
+}
+item {
+  name: "4719"
+  id: 1620
+  display_name: "Herpetotheres cachinnans"
+}
+item {
+  name: "116840"
+  id: 1621
+  display_name: "Calcarius lapponicus"
+}
+item {
+  name: "4726"
+  id: 1622
+  display_name: "Milvago chimachima"
+}
+item {
+  name: "29304"
+  id: 1623
+  display_name: "Nerodia taxispilota"
+}
+item {
+  name: "29305"
+  id: 1624
+  display_name: "Nerodia sipedon"
+}
+item {
+  name: "29306"
+  id: 1625
+  display_name: "Nerodia sipedon sipedon"
+}
+item {
+  name: "142783"
+  id: 1626
+  display_name: "Myodocha serripes"
+}
+item {
+  name: "4733"
+  id: 1627
+  display_name: "Ciconia ciconia"
+}
+item {
+  name: "29310"
+  id: 1628
+  display_name: "Nerodia rhombifer"
+}
+item {
+  name: "201343"
+  id: 1629
+  display_name: "Lithacodes fasciola"
+}
+item {
+  name: "21121"
+  id: 1630
+  display_name: "Dendrobates auratus"
+}
+item {
+  name: "127618"
+  id: 1631
+  display_name: "Epirrhoe alternata"
+}
+item {
+  name: "43115"
+  id: 1632
+  display_name: "Sylvilagus audubonii"
+}
+item {
+  name: "29317"
+  id: 1633
+  display_name: "Nerodia fasciata"
+}
+item {
+  name: "4742"
+  id: 1634
+  display_name: "Mycteria americana"
+}
+item {
+  name: "53895"
+  id: 1635
+  display_name: "Stenopelmatus fuscus"
+}
+item {
+  name: "4744"
+  id: 1636
+  display_name: "Mycteria ibis"
+}
+item {
+  name: "12937"
+  id: 1637
+  display_name: "Sialia mexicana"
+}
+item {
+  name: "29322"
+  id: 1638
+  display_name: "Nerodia fasciata confluens"
+}
+item {
+  name: "29324"
+  id: 1639
+  display_name: "Nerodia clarkii clarkii"
+}
+item {
+  name: "29327"
+  id: 1640
+  display_name: "Nerodia cyclopion"
+}
+item {
+  name: "29328"
+  id: 1641
+  display_name: "Nerodia erythrogaster"
+}
+item {
+  name: "53905"
+  id: 1642
+  display_name: "Mantis religiosa"
+}
+item {
+  name: "4754"
+  id: 1643
+  display_name: "Ephippiorhynchus senegalensis"
+}
+item {
+  name: "127635"
+  id: 1644
+  display_name: "Plecia nearctica"
+}
+item {
+  name: "4756"
+  id: 1645
+  display_name: "Cathartes aura"
+}
+item {
+  name: "29334"
+  id: 1646
+  display_name: "Nerodia erythrogaster flavigaster"
+}
+item {
+  name: "12951"
+  id: 1647
+  display_name: "Myadestes townsendi"
+}
+item {
+  name: "4761"
+  id: 1648
+  display_name: "Cathartes burrovianus"
+}
+item {
+  name: "4763"
+  id: 1649
+  display_name: "Sarcoramphus papa"
+}
+item {
+  name: "4765"
+  id: 1650
+  display_name: "Coragyps atratus"
+}
+item {
+  name: "19890"
+  id: 1651
+  display_name: "Strix nebulosa"
+}
+item {
+  name: "26736"
+  id: 1652
+  display_name: "Ambystoma opacum"
+}
+item {
+  name: "66331"
+  id: 1653
+  display_name: "Pelophylax perezi"
+}
+item {
+  name: "4776"
+  id: 1654
+  display_name: "Anastomus lamelligerus"
+}
+item {
+  name: "4892"
+  id: 1655
+  display_name: "Pluvialis squatarola"
+}
+item {
+  name: "4778"
+  id: 1656
+  display_name: "Gymnogyps californianus"
+}
+item {
+  name: "12971"
+  id: 1657
+  display_name: "Muscicapa striata"
+}
+item {
+  name: "56776"
+  id: 1658
+  display_name: "Glaucopsyche lygdamus"
+}
+item {
+  name: "127669"
+  id: 1659
+  display_name: "Jadera haematoloma"
+}
+item {
+  name: "4793"
+  id: 1660
+  display_name: "Charadrius vociferus"
+}
+item {
+  name: "209594"
+  id: 1661
+  display_name: "Scantius aegyptius"
+}
+item {
+  name: "4795"
+  id: 1662
+  display_name: "Charadrius wilsonia"
+}
+item {
+  name: "48586"
+  id: 1663
+  display_name: "Cepaea nemoralis"
+}
+item {
+  name: "4798"
+  id: 1664
+  display_name: "Charadrius melodus"
+}
+item {
+  name: "12992"
+  id: 1665
+  display_name: "Phoenicurus phoenicurus"
+}
+item {
+  name: "45763"
+  id: 1666
+  display_name: "Ondatra zibethicus"
+}
+item {
+  name: "119492"
+  id: 1667
+  display_name: "Smerinthus cerisyi"
+}
+item {
+  name: "13000"
+  id: 1668
+  display_name: "Phoenicurus ochruros"
+}
+item {
+  name: "4811"
+  id: 1669
+  display_name: "Charadrius dubius"
+}
+item {
+  name: "64973"
+  id: 1670
+  display_name: "Anaxyrus cognatus"
+}
+item {
+  name: "2168"
+  id: 1671
+  display_name: "Eumomota superciliosa"
+}
+item {
+  name: "6980"
+  id: 1672
+  display_name: "Anas querquedula"
+}
+item {
+  name: "64975"
+  id: 1673
+  display_name: "Anaxyrus debilis"
+}
+item {
+  name: "43130"
+  id: 1674
+  display_name: "Lepus californicus"
+}
+item {
+  name: "67707"
+  id: 1675
+  display_name: "Argiope aurantia"
+}
+item {
+  name: "4836"
+  id: 1676
+  display_name: "Himantopus mexicanus"
+}
+item {
+  name: "4838"
+  id: 1677
+  display_name: "Haematopus bachmani"
+}
+item {
+  name: "43132"
+  id: 1678
+  display_name: "Lepus americanus"
+}
+item {
+  name: "144106"
+  id: 1679
+  display_name: "Pica pica"
+}
+item {
+  name: "4843"
+  id: 1680
+  display_name: "Haematopus ostralegus"
+}
+item {
+  name: "67709"
+  id: 1681
+  display_name: "Antrodiaetus riversi"
+}
+item {
+  name: "4848"
+  id: 1682
+  display_name: "Haematopus unicolor"
+}
+item {
+  name: "4857"
+  id: 1683
+  display_name: "Vanellus vanellus"
+}
+item {
+  name: "29435"
+  id: 1684
+  display_name: "Coluber flagellum testaceus"
+}
+item {
+  name: "119550"
+  id: 1685
+  display_name: "Feltia jaculifera"
+}
+item {
+  name: "4866"
+  id: 1686
+  display_name: "Vanellus spinosus"
+}
+item {
+  name: "4870"
+  id: 1687
+  display_name: "Vanellus armatus"
+}
+item {
+  name: "54024"
+  id: 1688
+  display_name: "Satyrium californica"
+}
+item {
+  name: "13071"
+  id: 1689
+  display_name: "Luscinia svecica"
+}
+item {
+  name: "3544"
+  id: 1690
+  display_name: "Columbina inca"
+}
+item {
+  name: "4883"
+  id: 1691
+  display_name: "Recurvirostra avosetta"
+}
+item {
+  name: "204701"
+  id: 1692
+  display_name: "Melanchra adjuncta"
+}
+item {
+  name: "56083"
+  id: 1693
+  display_name: "Armadillidium vulgare"
+}
+item {
+  name: "981"
+  id: 1694
+  display_name: "Phasianus colchicus"
+}
+item {
+  name: "4893"
+  id: 1695
+  display_name: "Pluvialis dominica"
+}
+item {
+  name: "103200"
+  id: 1696
+  display_name: "Hypsiglena jani"
+}
+item {
+  name: "127777"
+  id: 1697
+  display_name: "Vespula vulgaris"
+}
+item {
+  name: "7643"
+  id: 1698
+  display_name: "Cinclus mexicanus"
+}
+item {
+  name: "13094"
+  id: 1699
+  display_name: "Erithacus rubecula"
+}
+item {
+  name: "41777"
+  id: 1700
+  display_name: "Lontra canadensis"
+}
+item {
+  name: "64988"
+  id: 1701
+  display_name: "Anaxyrus terrestris"
+}
+item {
+  name: "18167"
+  id: 1702
+  display_name: "Melanerpes aurifrons"
+}
+item {
+  name: "54064"
+  id: 1703
+  display_name: "Polygonia comma"
+}
+item {
+  name: "209713"
+  id: 1704
+  display_name: "Phigalia titea"
+}
+item {
+  name: "54068"
+  id: 1705
+  display_name: "Boloria selene"
+}
+item {
+  name: "104585"
+  id: 1706
+  display_name: "Libellula semifasciata"
+}
+item {
+  name: "119608"
+  id: 1707
+  display_name: "Theba pisana"
+}
+item {
+  name: "4801"
+  id: 1708
+  display_name: "Charadrius hiaticula"
+}
+item {
+  name: "104586"
+  id: 1709
+  display_name: "Libellula vibrans"
+}
+item {
+  name: "4935"
+  id: 1710
+  display_name: "Egretta gularis"
+}
+item {
+  name: "4937"
+  id: 1711
+  display_name: "Egretta caerulea"
+}
+item {
+  name: "4938"
+  id: 1712
+  display_name: "Egretta tricolor"
+}
+item {
+  name: "4940"
+  id: 1713
+  display_name: "Egretta thula"
+}
+item {
+  name: "340813"
+  id: 1714
+  display_name: "Hyalymenus tarsatus"
+}
+item {
+  name: "4943"
+  id: 1715
+  display_name: "Egretta garzetta"
+}
+item {
+  name: "4947"
+  id: 1716
+  display_name: "Egretta sacra"
+}
+item {
+  name: "13141"
+  id: 1717
+  display_name: "Monticola solitarius"
+}
+item {
+  name: "4952"
+  id: 1718
+  display_name: "Ardea cocoi"
+}
+item {
+  name: "4954"
+  id: 1719
+  display_name: "Ardea cinerea"
+}
+item {
+  name: "67727"
+  id: 1720
+  display_name: "Aeshna umbrosa"
+}
+item {
+  name: "4956"
+  id: 1721
+  display_name: "Ardea herodias"
+}
+item {
+  name: "144223"
+  id: 1722
+  display_name: "Chlosyne theona"
+}
+item {
+  name: "201568"
+  id: 1723
+  display_name: "Diabrotica undecimpunctata undecimpunctata"
+}
+item {
+  name: "47383"
+  id: 1724
+  display_name: "Latrodectus geometricus"
+}
+item {
+  name: "119664"
+  id: 1725
+  display_name: "Cacyreus marshalli"
+}
+item {
+  name: "62321"
+  id: 1726
+  display_name: "Rutpela maculata"
+}
+item {
+  name: "217970"
+  id: 1727
+  display_name: "Cyclophora pendulinaria"
+}
+item {
+  name: "4981"
+  id: 1728
+  display_name: "Nycticorax nycticorax"
+}
+item {
+  name: "12714"
+  id: 1729
+  display_name: "Turdus rufopalliatus"
+}
+item {
+  name: "4994"
+  id: 1730
+  display_name: "Ardeola ralloides"
+}
+item {
+  name: "4999"
+  id: 1731
+  display_name: "Nyctanassa violacea"
+}
+item {
+  name: "37769"
+  id: 1732
+  display_name: "Plestiodon skiltonianus"
+}
+item {
+  name: "213826"
+  id: 1733
+  display_name: "Apamea amputatrix"
+}
+item {
+  name: "67736"
+  id: 1734
+  display_name: "Rhionaeschna californica"
+}
+item {
+  name: "155380"
+  id: 1735
+  display_name: "Andricus crystallinus"
+}
+item {
+  name: "144280"
+  id: 1736
+  display_name: "Aramides cajaneus"
+}
+item {
+  name: "5017"
+  id: 1737
+  display_name: "Bubulcus ibis"
+}
+item {
+  name: "5020"
+  id: 1738
+  display_name: "Butorides virescens"
+}
+item {
+  name: "144285"
+  id: 1739
+  display_name: "Porphyrio martinicus"
+}
+item {
+  name: "81729"
+  id: 1740
+  display_name: "Feniseca tarquinius"
+}
+item {
+  name: "127905"
+  id: 1741
+  display_name: "Bombus ternarius"
+}
+item {
+  name: "5034"
+  id: 1742
+  display_name: "Botaurus lentiginosus"
+}
+item {
+  name: "29330"
+  id: 1743
+  display_name: "Nerodia erythrogaster transversa"
+}
+item {
+  name: "5036"
+  id: 1744
+  display_name: "Cochlearius cochlearius"
+}
+item {
+  name: "46001"
+  id: 1745
+  display_name: "Sciurus vulgaris"
+}
+item {
+  name: "46005"
+  id: 1746
+  display_name: "Sciurus variegatoides"
+}
+item {
+  name: "127928"
+  id: 1747
+  display_name: "Autochton cellus"
+}
+item {
+  name: "340923"
+  id: 1748
+  display_name: "Scolypopa australis"
+}
+item {
+  name: "46017"
+  id: 1749
+  display_name: "Sciurus carolinensis"
+}
+item {
+  name: "46018"
+  id: 1750
+  display_name: "Sciurus aberti"
+}
+item {
+  name: "447427"
+  id: 1751
+  display_name: "Neverita lewisii"
+}
+item {
+  name: "46020"
+  id: 1752
+  display_name: "Sciurus niger"
+}
+item {
+  name: "5061"
+  id: 1753
+  display_name: "Anhinga novaehollandiae"
+}
+item {
+  name: "46023"
+  id: 1754
+  display_name: "Sciurus griseus"
+}
+item {
+  name: "122375"
+  id: 1755
+  display_name: "Carterocephalus palaemon"
+}
+item {
+  name: "5066"
+  id: 1756
+  display_name: "Anhinga rufa"
+}
+item {
+  name: "145289"
+  id: 1757
+  display_name: "Melozone fusca"
+}
+item {
+  name: "5074"
+  id: 1758
+  display_name: "Aquila chrysaetos"
+}
+item {
+  name: "49998"
+  id: 1759
+  display_name: "Thamnophis sirtalis infernalis"
+}
+item {
+  name: "13270"
+  id: 1760
+  display_name: "Hylocichla mustelina"
+}
+item {
+  name: "62423"
+  id: 1761
+  display_name: "Cimbex americana"
+}
+item {
+  name: "62424"
+  id: 1762
+  display_name: "Sitochroa palealis"
+}
+item {
+  name: "111578"
+  id: 1763
+  display_name: "Regina grahamii"
+}
+item {
+  name: "144207"
+  id: 1764
+  display_name: "Aphelocoma wollweberi"
+}
+item {
+  name: "62429"
+  id: 1765
+  display_name: "Pyronia tithonus"
+}
+item {
+  name: "47934"
+  id: 1766
+  display_name: "Libellula luctuosa"
+}
+item {
+  name: "50000"
+  id: 1767
+  display_name: "Clemmys guttata"
+}
+item {
+  name: "5097"
+  id: 1768
+  display_name: "Accipiter striatus"
+}
+item {
+  name: "119789"
+  id: 1769
+  display_name: "Cisseps fulvicollis"
+}
+item {
+  name: "5106"
+  id: 1770
+  display_name: "Accipiter nisus"
+}
+item {
+  name: "5108"
+  id: 1771
+  display_name: "Accipiter gentilis"
+}
+item {
+  name: "62456"
+  id: 1772
+  display_name: "Rhagonycha fulva"
+}
+item {
+  name: "4948"
+  id: 1773
+  display_name: "Egretta rufescens"
+}
+item {
+  name: "46082"
+  id: 1774
+  display_name: "Marmota marmota"
+}
+item {
+  name: "6990"
+  id: 1775
+  display_name: "Bucephala clangula"
+}
+item {
+  name: "4535"
+  id: 1776
+  display_name: "Anous stolidus"
+}
+item {
+  name: "46087"
+  id: 1777
+  display_name: "Marmota caligata"
+}
+item {
+  name: "72458"
+  id: 1778
+  display_name: "Actitis macularius"
+}
+item {
+  name: "4951"
+  id: 1779
+  display_name: "Ardea purpurea"
+}
+item {
+  name: "128012"
+  id: 1780
+  display_name: "Eumorpha fasciatus"
+}
+item {
+  name: "472078"
+  id: 1781
+  display_name: "Todiramphus chloris"
+}
+item {
+  name: "46095"
+  id: 1782
+  display_name: "Marmota monax"
+}
+item {
+  name: "34"
+  id: 1783
+  display_name: "Grus americana"
+}
+item {
+  name: "4835"
+  id: 1784
+  display_name: "Himantopus himantopus"
+}
+item {
+  name: "122374"
+  id: 1785
+  display_name: "Eurema mexicana"
+}
+item {
+  name: "19812"
+  id: 1786
+  display_name: "Glaucidium gnoma"
+}
+item {
+  name: "73823"
+  id: 1787
+  display_name: "Hierophis viridiflavus"
+}
+item {
+  name: "5168"
+  id: 1788
+  display_name: "Circus approximans"
+}
+item {
+  name: "143110"
+  id: 1789
+  display_name: "Hypagyrtis unipunctata"
+}
+item {
+  name: "65976"
+  id: 1790
+  display_name: "Lithobates blairi"
+}
+item {
+  name: "5173"
+  id: 1791
+  display_name: "Circus aeruginosus"
+}
+item {
+  name: "54327"
+  id: 1792
+  display_name: "Vespa crabro"
+}
+item {
+  name: "4273"
+  id: 1793
+  display_name: "Phalacrocorax sulcirostris"
+}
+item {
+  name: "5180"
+  id: 1794
+  display_name: "Buteo albonotatus"
+}
+item {
+  name: "103485"
+  id: 1795
+  display_name: "Ischnura denticollis"
+}
+item {
+  name: "62528"
+  id: 1796
+  display_name: "Butorides striata"
+}
+item {
+  name: "62529"
+  id: 1797
+  display_name: "Platalea ajaja"
+}
+item {
+  name: "5186"
+  id: 1798
+  display_name: "Buteo brachyurus"
+}
+item {
+  name: "103494"
+  id: 1799
+  display_name: "Ischnura hastata"
+}
+item {
+  name: "144455"
+  id: 1800
+  display_name: "Ardea alba"
+}
+item {
+  name: "103497"
+  id: 1801
+  display_name: "Ischnura perparva"
+}
+item {
+  name: "103498"
+  id: 1802
+  display_name: "Ischnura posita"
+}
+item {
+  name: "5196"
+  id: 1803
+  display_name: "Buteo swainsoni"
+}
+item {
+  name: "128079"
+  id: 1804
+  display_name: "Grammia ornata"
+}
+item {
+  name: "29777"
+  id: 1805
+  display_name: "Lampropeltis triangulum"
+}
+item {
+  name: "867"
+  id: 1806
+  display_name: "Alectoris rufa"
+}
+item {
+  name: "5206"
+  id: 1807
+  display_name: "Buteo lineatus"
+}
+item {
+  name: "29783"
+  id: 1808
+  display_name: "Lampropeltis triangulum triangulum"
+}
+item {
+  name: "122383"
+  id: 1809
+  display_name: "Plebejus melissa"
+}
+item {
+  name: "5212"
+  id: 1810
+  display_name: "Buteo jamaicensis"
+}
+item {
+  name: "81495"
+  id: 1811
+  display_name: "Libellula pulchella"
+}
+item {
+  name: "35003"
+  id: 1812
+  display_name: "Heloderma suspectum"
+}
+item {
+  name: "46180"
+  id: 1813
+  display_name: "Cynomys gunnisoni"
+}
+item {
+  name: "144485"
+  id: 1814
+  display_name: "Charadrius nivosus"
+}
+item {
+  name: "144490"
+  id: 1815
+  display_name: "Tringa incana"
+}
+item {
+  name: "144491"
+  id: 1816
+  display_name: "Tringa semipalmata"
+}
+item {
+  name: "25185"
+  id: 1817
+  display_name: "Hypopachus variolosus"
+}
+item {
+  name: "5231"
+  id: 1818
+  display_name: "Terathopius ecaudatus"
+}
+item {
+  name: "144496"
+  id: 1819
+  display_name: "Gallinago delicata"
+}
+item {
+  name: "5233"
+  id: 1820
+  display_name: "Buteogallus anthracinus"
+}
+item {
+  name: "211035"
+  id: 1821
+  display_name: "Speranza pustularia"
+}
+item {
+  name: "29813"
+  id: 1822
+  display_name: "Lampropeltis getula"
+}
+item {
+  name: "144502"
+  id: 1823
+  display_name: "Chroicocephalus philadelphia"
+}
+item {
+  name: "5242"
+  id: 1824
+  display_name: "Circaetus gallicus"
+}
+item {
+  name: "144507"
+  id: 1825
+  display_name: "Chroicocephalus novaehollandiae"
+}
+item {
+  name: "144510"
+  id: 1826
+  display_name: "Chroicocephalus ridibundus"
+}
+item {
+  name: "52757"
+  id: 1827
+  display_name: "Polistes fuscatus"
+}
+item {
+  name: "144514"
+  id: 1828
+  display_name: "Leucophaeus atricilla"
+}
+item {
+  name: "144515"
+  id: 1829
+  display_name: "Leucophaeus pipixcan"
+}
+item {
+  name: "46217"
+  id: 1830
+  display_name: "Tamias striatus"
+}
+item {
+  name: "144525"
+  id: 1831
+  display_name: "Onychoprion fuscatus"
+}
+item {
+  name: "46222"
+  id: 1832
+  display_name: "Tamias minimus"
+}
+item {
+  name: "144530"
+  id: 1833
+  display_name: "Sternula antillarum"
+}
+item {
+  name: "46230"
+  id: 1834
+  display_name: "Tamias merriami"
+}
+item {
+  name: "144537"
+  id: 1835
+  display_name: "Hydroprogne caspia"
+}
+item {
+  name: "144539"
+  id: 1836
+  display_name: "Thalasseus maximus"
+}
+item {
+  name: "144540"
+  id: 1837
+  display_name: "Thalasseus bergii"
+}
+item {
+  name: "5277"
+  id: 1838
+  display_name: "Elanus leucurus"
+}
+item {
+  name: "324766"
+  id: 1839
+  display_name: "Epicallima argenticinctella"
+}
+item {
+  name: "72486"
+  id: 1840
+  display_name: "Alopochen aegyptiaca"
+}
+item {
+  name: "62229"
+  id: 1841
+  display_name: "Ischnura cervula"
+}
+item {
+  name: "144550"
+  id: 1842
+  display_name: "Streptopelia senegalensis"
+}
+item {
+  name: "46256"
+  id: 1843
+  display_name: "Ammospermophilus harrisii"
+}
+item {
+  name: "94559"
+  id: 1844
+  display_name: "Argia nahuana"
+}
+item {
+  name: "46259"
+  id: 1845
+  display_name: "Tamiasciurus douglasii"
+}
+item {
+  name: "46260"
+  id: 1846
+  display_name: "Tamiasciurus hudsonicus"
+}
+item {
+  name: "119989"
+  id: 1847
+  display_name: "Stagmomantis carolina"
+}
+item {
+  name: "13494"
+  id: 1848
+  display_name: "Gerygone igata"
+}
+item {
+  name: "5305"
+  id: 1849
+  display_name: "Haliaeetus leucocephalus"
+}
+item {
+  name: "7596"
+  id: 1850
+  display_name: "Cistothorus platensis"
+}
+item {
+  name: "5308"
+  id: 1851
+  display_name: "Haliaeetus vocifer"
+}
+item {
+  name: "218301"
+  id: 1852
+  display_name: "Diacme elealis"
+}
+item {
+  name: "95422"
+  id: 1853
+  display_name: "Basiaeschna janata"
+}
+item {
+  name: "46272"
+  id: 1854
+  display_name: "Glaucomys volans"
+}
+item {
+  name: "120010"
+  id: 1855
+  display_name: "Polistes metricus"
+}
+item {
+  name: "144594"
+  id: 1856
+  display_name: "Bubo scandiacus"
+}
+item {
+  name: "52771"
+  id: 1857
+  display_name: "Gonepteryx rhamni"
+}
+item {
+  name: "144597"
+  id: 1858
+  display_name: "Ciccaba virgata"
+}
+item {
+  name: "890"
+  id: 1859
+  display_name: "Bonasa umbellus"
+}
+item {
+  name: "52773"
+  id: 1860
+  display_name: "Poanes zabulon"
+}
+item {
+  name: "120033"
+  id: 1861
+  display_name: "Lapara bombycoides"
+}
+item {
+  name: "5346"
+  id: 1862
+  display_name: "Busarellus nigricollis"
+}
+item {
+  name: "5349"
+  id: 1863
+  display_name: "Rostrhamus sociabilis"
+}
+item {
+  name: "36391"
+  id: 1864
+  display_name: "Anolis equestris"
+}
+item {
+  name: "46316"
+  id: 1865
+  display_name: "Trichechus manatus"
+}
+item {
+  name: "5267"
+  id: 1866
+  display_name: "Milvus milvus"
+}
+item {
+  name: "128241"
+  id: 1867
+  display_name: "Darapsa choerilus"
+}
+item {
+  name: "128242"
+  id: 1868
+  display_name: "Palthis angulalis"
+}
+item {
+  name: "5366"
+  id: 1869
+  display_name: "Gyps fulvus"
+}
+item {
+  name: "204512"
+  id: 1870
+  display_name: "Ficedula hypoleuca"
+}
+item {
+  name: "54526"
+  id: 1871
+  display_name: "Crassadoma gigantea"
+}
+item {
+  name: "144642"
+  id: 1872
+  display_name: "Momotus coeruliceps"
+}
+item {
+  name: "120070"
+  id: 1873
+  display_name: "Strongylocentrotus droebachiensis"
+}
+item {
+  name: "54538"
+  id: 1874
+  display_name: "Syngnathus leptorhynchus"
+}
+item {
+  name: "81746"
+  id: 1875
+  display_name: "Necrophila americana"
+}
+item {
+  name: "300301"
+  id: 1876
+  display_name: "Pseudomyrmex gracilis"
+}
+item {
+  name: "202003"
+  id: 1877
+  display_name: "Apiomerus spissipes"
+}
+item {
+  name: "41860"
+  id: 1878
+  display_name: "Enhydra lutris"
+}
+item {
+  name: "4817"
+  id: 1879
+  display_name: "Charadrius semipalmatus"
+}
+item {
+  name: "36145"
+  id: 1880
+  display_name: "Sceloporus variabilis"
+}
+item {
+  name: "202012"
+  id: 1881
+  display_name: "Steatoda capensis"
+}
+item {
+  name: "62749"
+  id: 1882
+  display_name: "Iphiclides podalirius"
+}
+item {
+  name: "5406"
+  id: 1883
+  display_name: "Haliastur indus"
+}
+item {
+  name: "62751"
+  id: 1884
+  display_name: "Andricus kingi"
+}
+item {
+  name: "5363"
+  id: 1885
+  display_name: "Gyps africanus"
+}
+item {
+  name: "5416"
+  id: 1886
+  display_name: "Ictinia mississippiensis"
+}
+item {
+  name: "62766"
+  id: 1887
+  display_name: "Issoria lathonia"
+}
+item {
+  name: "62768"
+  id: 1888
+  display_name: "Scolia dubia"
+}
+item {
+  name: "126206"
+  id: 1889
+  display_name: "Dissosteira carolina"
+}
+item {
+  name: "269875"
+  id: 1890
+  display_name: "Mallodon dasystomus"
+}
+item {
+  name: "155030"
+  id: 1891
+  display_name: "Limenitis reducta"
+}
+item {
+  name: "62345"
+  id: 1892
+  display_name: "Duttaphrynus melanostictus"
+}
+item {
+  name: "52519"
+  id: 1893
+  display_name: "Aeshna cyanea"
+}
+item {
+  name: "10001"
+  id: 1894
+  display_name: "Dives dives"
+}
+item {
+  name: "460365"
+  id: 1895
+  display_name: "Tegula funebralis"
+}
+item {
+  name: "13631"
+  id: 1896
+  display_name: "Baeolophus atricristatus"
+}
+item {
+  name: "13632"
+  id: 1897
+  display_name: "Baeolophus bicolor"
+}
+item {
+  name: "13633"
+  id: 1898
+  display_name: "Baeolophus inornatus"
+}
+item {
+  name: "9100"
+  id: 1899
+  display_name: "Melospiza melodia"
+}
+item {
+  name: "62796"
+  id: 1900
+  display_name: "Crotaphytus bicinctores"
+}
+item {
+  name: "62797"
+  id: 1901
+  display_name: "Gambelia wislizenii"
+}
+item {
+  name: "46009"
+  id: 1902
+  display_name: "Sciurus aureogaster"
+}
+item {
+  name: "112867"
+  id: 1903
+  display_name: "Sparisoma viride"
+}
+item {
+  name: "70997"
+  id: 1904
+  display_name: "Pelecinus polyturator"
+}
+item {
+  name: "62806"
+  id: 1905
+  display_name: "Mytilus californianus"
+}
+item {
+  name: "120156"
+  id: 1906
+  display_name: "Musca domestica"
+}
+item {
+  name: "136548"
+  id: 1907
+  display_name: "Euclea delphinii"
+}
+item {
+  name: "50065"
+  id: 1908
+  display_name: "Danaus eresimus"
+}
+item {
+  name: "43239"
+  id: 1909
+  display_name: "Tachyglossus aculeatus"
+}
+item {
+  name: "145303"
+  id: 1910
+  display_name: "Spinus spinus"
+}
+item {
+  name: "120183"
+  id: 1911
+  display_name: "Araneus marmoreus"
+}
+item {
+  name: "71032"
+  id: 1912
+  display_name: "Crotalus scutulatus scutulatus"
+}
+item {
+  name: "71034"
+  id: 1913
+  display_name: "Tenodera sinensis"
+}
+item {
+  name: "143121"
+  id: 1914
+  display_name: "Ochropleura implecta"
+}
+item {
+  name: "13695"
+  id: 1915
+  display_name: "Motacilla alba"
+}
+item {
+  name: "7458"
+  id: 1916
+  display_name: "Certhia americana"
+}
+item {
+  name: "38293"
+  id: 1917
+  display_name: "Lampropholis delicata"
+}
+item {
+  name: "144281"
+  id: 1918
+  display_name: "Bucorvus leadbeateri"
+}
+item {
+  name: "120217"
+  id: 1919
+  display_name: "Halysidota tessellaris"
+}
+item {
+  name: "226718"
+  id: 1920
+  display_name: "Otiorhynchus sulcatus"
+}
+item {
+  name: "464287"
+  id: 1921
+  display_name: "Anteaeolidiella oliviae"
+}
+item {
+  name: "226720"
+  id: 1922
+  display_name: "Oxychilus draparnaudi"
+}
+item {
+  name: "13729"
+  id: 1923
+  display_name: "Anthus pratensis"
+}
+item {
+  name: "13732"
+  id: 1924
+  display_name: "Anthus rubescens"
+}
+item {
+  name: "11930"
+  id: 1925
+  display_name: "Tachycineta albilinea"
+}
+item {
+  name: "71085"
+  id: 1926
+  display_name: "Varanus niloticus"
+}
+item {
+  name: "144814"
+  id: 1927
+  display_name: "Poecile carolinensis"
+}
+item {
+  name: "144815"
+  id: 1928
+  display_name: "Poecile atricapillus"
+}
+item {
+  name: "144816"
+  id: 1929
+  display_name: "Poecile gambeli"
+}
+item {
+  name: "144820"
+  id: 1930
+  display_name: "Poecile rufescens"
+}
+item {
+  name: "144823"
+  id: 1931
+  display_name: "Periparus ater"
+}
+item {
+  name: "10485"
+  id: 1932
+  display_name: "Chlorophanes spiza"
+}
+item {
+  name: "40523"
+  id: 1933
+  display_name: "Lasiurus cinereus"
+}
+item {
+  name: "47719"
+  id: 1934
+  display_name: "Datana ministra"
+}
+item {
+  name: "13770"
+  id: 1935
+  display_name: "Estrilda astrild"
+}
+item {
+  name: "144849"
+  id: 1936
+  display_name: "Cyanistes caeruleus"
+}
+item {
+  name: "218587"
+  id: 1937
+  display_name: "Discus rotundatus"
+}
+item {
+  name: "47105"
+  id: 1938
+  display_name: "Tamandua mexicana"
+}
+item {
+  name: "18463"
+  id: 1939
+  display_name: "Sphyrapicus varius"
+}
+item {
+  name: "11858"
+  id: 1940
+  display_name: "Petrochelidon pyrrhonota"
+}
+item {
+  name: "144882"
+  id: 1941
+  display_name: "Troglodytes pacificus"
+}
+item {
+  name: "144883"
+  id: 1942
+  display_name: "Troglodytes hiemalis"
+}
+item {
+  name: "153076"
+  id: 1943
+  display_name: "Nephelodes minians"
+}
+item {
+  name: "62978"
+  id: 1944
+  display_name: "Chlosyne nycteis"
+}
+item {
+  name: "128517"
+  id: 1945
+  display_name: "Catocala ilia"
+}
+item {
+  name: "153102"
+  id: 1946
+  display_name: "Dysphania militaris"
+}
+item {
+  name: "59651"
+  id: 1947
+  display_name: "Aquarius remigis"
+}
+item {
+  name: "13851"
+  id: 1948
+  display_name: "Passer montanus"
+}
+item {
+  name: "13858"
+  id: 1949
+  display_name: "Passer domesticus"
+}
+item {
+  name: "39742"
+  id: 1950
+  display_name: "Kinosternon flavescens"
+}
+item {
+  name: "506118"
+  id: 1951
+  display_name: "Aphelocoma californica"
+}
+item {
+  name: "5672"
+  id: 1952
+  display_name: "Amazilia yucatanensis"
+}
+item {
+  name: "5676"
+  id: 1953
+  display_name: "Amazilia tzacatl"
+}
+item {
+  name: "204503"
+  id: 1954
+  display_name: "Dicrurus adsimilis"
+}
+item {
+  name: "52785"
+  id: 1955
+  display_name: "Megachile sculpturalis"
+}
+item {
+  name: "126905"
+  id: 1956
+  display_name: "Harrisina americana"
+}
+item {
+  name: "55773"
+  id: 1957
+  display_name: "Promachus hinei"
+}
+item {
+  name: "84752"
+  id: 1958
+  display_name: "Microcentrum rhombifolium"
+}
+item {
+  name: "5698"
+  id: 1959
+  display_name: "Amazilia violiceps"
+}
+item {
+  name: "145539"
+  id: 1960
+  display_name: "Ovis canadensis nelsoni"
+}
+item {
+  name: "104004"
+  id: 1961
+  display_name: "Lampropeltis splendida"
+}
+item {
+  name: "13893"
+  id: 1962
+  display_name: "Lonchura punctulata"
+}
+item {
+  name: "63048"
+  id: 1963
+  display_name: "Nuttallina californica"
+}
+item {
+  name: "226901"
+  id: 1964
+  display_name: "Panopoda rufimargo"
+}
+item {
+  name: "194134"
+  id: 1965
+  display_name: "Anthanassa tulcis"
+}
+item {
+  name: "5049"
+  id: 1966
+  display_name: "Tigrisoma mexicanum"
+}
+item {
+  name: "407130"
+  id: 1967
+  display_name: "Porphyrio melanotus melanotus"
+}
+item {
+  name: "226910"
+  id: 1968
+  display_name: "Panthea furcilla"
+}
+item {
+  name: "130661"
+  id: 1969
+  display_name: "Catasticta nimbice"
+}
+item {
+  name: "120215"
+  id: 1970
+  display_name: "Bombus griseocollis"
+}
+item {
+  name: "144220"
+  id: 1971
+  display_name: "Melanitta americana"
+}
+item {
+  name: "9148"
+  id: 1972
+  display_name: "Spizella pallida"
+}
+item {
+  name: "320610"
+  id: 1973
+  display_name: "Sceloporus magister"
+}
+item {
+  name: "54900"
+  id: 1974
+  display_name: "Papilio polyxenes asterius"
+}
+item {
+  name: "36080"
+  id: 1975
+  display_name: "Callisaurus draconoides"
+}
+item {
+  name: "5758"
+  id: 1976
+  display_name: "Amazilia rutila"
+}
+item {
+  name: "3465"
+  id: 1977
+  display_name: "Zenaida aurita"
+}
+item {
+  name: "116461"
+  id: 1978
+  display_name: "Anolis sagrei"
+}
+item {
+  name: "61295"
+  id: 1979
+  display_name: "Aporia crataegi"
+}
+item {
+  name: "131673"
+  id: 1980
+  display_name: "Tetracis cachexiata"
+}
+item {
+  name: "63113"
+  id: 1981
+  display_name: "Blarina brevicauda"
+}
+item {
+  name: "26904"
+  id: 1982
+  display_name: "Coronella austriaca"
+}
+item {
+  name: "94575"
+  id: 1983
+  display_name: "Argia tibialis"
+}
+item {
+  name: "237166"
+  id: 1984
+  display_name: "Lycaena phlaeas hypophlaeas"
+}
+item {
+  name: "129305"
+  id: 1985
+  display_name: "Melanoplus bivittatus"
+}
+item {
+  name: "63128"
+  id: 1986
+  display_name: "Speyeria atlantis"
+}
+item {
+  name: "113514"
+  id: 1987
+  display_name: "Sympetrum internum"
+}
+item {
+  name: "48757"
+  id: 1988
+  display_name: "Echinothrix calamaris"
+}
+item {
+  name: "128670"
+  id: 1989
+  display_name: "Bombus vagans"
+}
+item {
+  name: "13988"
+  id: 1990
+  display_name: "Prunella modularis"
+}
+item {
+  name: "54951"
+  id: 1991
+  display_name: "Anartia fatima"
+}
+item {
+  name: "54952"
+  id: 1992
+  display_name: "Cardisoma guanhumi"
+}
+item {
+  name: "325295"
+  id: 1993
+  display_name: "Cydalima perspectalis"
+}
+item {
+  name: "63160"
+  id: 1994
+  display_name: "Celithemis elisa"
+}
+item {
+  name: "210615"
+  id: 1995
+  display_name: "Pyrausta volupialis"
+}
+item {
+  name: "472766"
+  id: 1996
+  display_name: "Falco tinnunculus"
+}
+item {
+  name: "29927"
+  id: 1997
+  display_name: "Heterodon nasicus"
+}
+item {
+  name: "145088"
+  id: 1998
+  display_name: "Ixoreus naevius"
+}
+item {
+  name: "6432"
+  id: 1999
+  display_name: "Archilochus colubris"
+}
+item {
+  name: "5827"
+  id: 2000
+  display_name: "Lampornis clemenciae"
+}
+item {
+  name: "15990"
+  id: 2001
+  display_name: "Myiarchus tuberculifer"
+}
+item {
+  name: "128712"
+  id: 2002
+  display_name: "Coccinella californica"
+}
+item {
+  name: "67559"
+  id: 2003
+  display_name: "Adelpha eulalia"
+}
+item {
+  name: "128719"
+  id: 2004
+  display_name: "Echinometra mathaei"
+}
+item {
+  name: "10247"
+  id: 2005
+  display_name: "Setophaga ruticilla"
+}
+item {
+  name: "202451"
+  id: 2006
+  display_name: "Copaeodes minima"
+}
+item {
+  name: "95958"
+  id: 2007
+  display_name: "Boyeria vinosa"
+}
+item {
+  name: "16016"
+  id: 2008
+  display_name: "Myiarchus tyrannulus"
+}
+item {
+  name: "36202"
+  id: 2009
+  display_name: "Sceloporus olivaceus"
+}
+item {
+  name: "95982"
+  id: 2010
+  display_name: "Brachymesia furcata"
+}
+item {
+  name: "126589"
+  id: 2011
+  display_name: "Calycopis isobeon"
+}
+item {
+  name: "120578"
+  id: 2012
+  display_name: "Micrathena sagittata"
+}
+item {
+  name: "194690"
+  id: 2013
+  display_name: "Pogonomyrmex barbatus"
+}
+item {
+  name: "120583"
+  id: 2014
+  display_name: "Parasteatoda tepidariorum"
+}
+item {
+  name: "202505"
+  id: 2015
+  display_name: "Zosterops lateralis"
+}
+item {
+  name: "38671"
+  id: 2016
+  display_name: "Aspidoscelis tigris"
+}
+item {
+  name: "38672"
+  id: 2017
+  display_name: "Aspidoscelis tigris stejnegeri"
+}
+item {
+  name: "9176"
+  id: 2018
+  display_name: "Zonotrichia leucophrys"
+}
+item {
+  name: "120596"
+  id: 2019
+  display_name: "Aphonopelma hentzi"
+}
+item {
+  name: "9744"
+  id: 2020
+  display_name: "Agelaius phoeniceus"
+}
+item {
+  name: "38684"
+  id: 2021
+  display_name: "Aspidoscelis tigris mundus"
+}
+item {
+  name: "62426"
+  id: 2022
+  display_name: "Aphantopus hyperantus"
+}
+item {
+  name: "30494"
+  id: 2023
+  display_name: "Micrurus tener"
+}
+item {
+  name: "58578"
+  id: 2024
+  display_name: "Euphydryas phaeton"
+}
+item {
+  name: "96036"
+  id: 2025
+  display_name: "Brechmorhoga mendax"
+}
+item {
+  name: "333608"
+  id: 2026
+  display_name: "Leukoma staminea"
+}
+item {
+  name: "38703"
+  id: 2027
+  display_name: "Aspidoscelis sexlineata sexlineata"
+}
+item {
+  name: "126600"
+  id: 2028
+  display_name: "Chortophaga viridifasciata"
+}
+item {
+  name: "63287"
+  id: 2029
+  display_name: "Megalorchestia californiana"
+}
+item {
+  name: "128824"
+  id: 2030
+  display_name: "Lucilia sericata"
+}
+item {
+  name: "104249"
+  id: 2031
+  display_name: "Lepisosteus oculatus"
+}
+item {
+  name: "203153"
+  id: 2032
+  display_name: "Parus major"
+}
+item {
+  name: "9183"
+  id: 2033
+  display_name: "Zonotrichia capensis"
+}
+item {
+  name: "82201"
+  id: 2034
+  display_name: "Hypena baltimoralis"
+}
+item {
+  name: "145217"
+  id: 2035
+  display_name: "Oreothlypis peregrina"
+}
+item {
+  name: "145218"
+  id: 2036
+  display_name: "Oreothlypis celata"
+}
+item {
+  name: "145221"
+  id: 2037
+  display_name: "Oreothlypis ruficapilla"
+}
+item {
+  name: "145224"
+  id: 2038
+  display_name: "Geothlypis philadelphia"
+}
+item {
+  name: "145225"
+  id: 2039
+  display_name: "Geothlypis formosa"
+}
+item {
+  name: "448331"
+  id: 2040
+  display_name: "Ambigolimax valentianus"
+}
+item {
+  name: "128845"
+  id: 2041
+  display_name: "Copestylum mexicanum"
+}
+item {
+  name: "145231"
+  id: 2042
+  display_name: "Setophaga tigrina"
+}
+item {
+  name: "145233"
+  id: 2043
+  display_name: "Setophaga americana"
+}
+item {
+  name: "145235"
+  id: 2044
+  display_name: "Setophaga magnolia"
+}
+item {
+  name: "145236"
+  id: 2045
+  display_name: "Setophaga castanea"
+}
+item {
+  name: "145237"
+  id: 2046
+  display_name: "Setophaga fusca"
+}
+item {
+  name: "145238"
+  id: 2047
+  display_name: "Setophaga petechia"
+}
+item {
+  name: "145240"
+  id: 2048
+  display_name: "Setophaga striata"
+}
+item {
+  name: "145242"
+  id: 2049
+  display_name: "Setophaga palmarum"
+}
+item {
+  name: "179855"
+  id: 2050
+  display_name: "Polites vibex"
+}
+item {
+  name: "145244"
+  id: 2051
+  display_name: "Setophaga pinus"
+}
+item {
+  name: "145245"
+  id: 2052
+  display_name: "Setophaga coronata"
+}
+item {
+  name: "145246"
+  id: 2053
+  display_name: "Setophaga dominica"
+}
+item {
+  name: "5987"
+  id: 2054
+  display_name: "Campylopterus hemileucurus"
+}
+item {
+  name: "17382"
+  id: 2055
+  display_name: "Vireo cassinii"
+}
+item {
+  name: "145254"
+  id: 2056
+  display_name: "Setophaga nigrescens"
+}
+item {
+  name: "145255"
+  id: 2057
+  display_name: "Setophaga townsendi"
+}
+item {
+  name: "145256"
+  id: 2058
+  display_name: "Setophaga occidentalis"
+}
+item {
+  name: "145257"
+  id: 2059
+  display_name: "Setophaga chrysoparia"
+}
+item {
+  name: "145258"
+  id: 2060
+  display_name: "Setophaga virens"
+}
+item {
+  name: "48786"
+  id: 2061
+  display_name: "Pollicipes polymerus"
+}
+item {
+  name: "36207"
+  id: 2062
+  display_name: "Sceloporus occidentalis longipes"
+}
+item {
+  name: "22392"
+  id: 2063
+  display_name: "Eleutherodactylus marnockii"
+}
+item {
+  name: "22393"
+  id: 2064
+  display_name: "Eleutherodactylus cystignathoides"
+}
+item {
+  name: "145275"
+  id: 2065
+  display_name: "Cardellina canadensis"
+}
+item {
+  name: "145277"
+  id: 2066
+  display_name: "Cardellina rubra"
+}
+item {
+  name: "7829"
+  id: 2067
+  display_name: "Aphelocoma coerulescens"
+}
+item {
+  name: "41963"
+  id: 2068
+  display_name: "Panthera pardus"
+}
+item {
+  name: "142998"
+  id: 2069
+  display_name: "Pyrausta acrionalis"
+}
+item {
+  name: "18204"
+  id: 2070
+  display_name: "Melanerpes erythrocephalus"
+}
+item {
+  name: "47425"
+  id: 2071
+  display_name: "Tonicella lineata"
+}
+item {
+  name: "148460"
+  id: 2072
+  display_name: "Charadra deridens"
+}
+item {
+  name: "145291"
+  id: 2073
+  display_name: "Emberiza calandra"
+}
+item {
+  name: "52523"
+  id: 2074
+  display_name: "Carcinus maenas"
+}
+item {
+  name: "46994"
+  id: 2075
+  display_name: "Scapanus latimanus"
+}
+item {
+  name: "114314"
+  id: 2076
+  display_name: "Tramea onusta"
+}
+item {
+  name: "145300"
+  id: 2077
+  display_name: "Acanthis flammea"
+}
+item {
+  name: "63382"
+  id: 2078
+  display_name: "Dermasterias imbricata"
+}
+item {
+  name: "126772"
+  id: 2079
+  display_name: "Ursus americanus californiensis"
+}
+item {
+  name: "145304"
+  id: 2080
+  display_name: "Spinus pinus"
+}
+item {
+  name: "10294"
+  id: 2081
+  display_name: "Thraupis abbas"
+}
+item {
+  name: "145308"
+  id: 2082
+  display_name: "Spinus psaltria"
+}
+item {
+  name: "145309"
+  id: 2083
+  display_name: "Spinus lawrencei"
+}
+item {
+  name: "145310"
+  id: 2084
+  display_name: "Spinus tristis"
+}
+item {
+  name: "3739"
+  id: 2085
+  display_name: "Threskiornis aethiopicus"
+}
+item {
+  name: "47014"
+  id: 2086
+  display_name: "Scalopus aquaticus"
+}
+item {
+  name: "4566"
+  id: 2087
+  display_name: "Gygis alba"
+}
+item {
+  name: "43335"
+  id: 2088
+  display_name: "Equus quagga"
+}
+item {
+  name: "41970"
+  id: 2089
+  display_name: "Panthera onca"
+}
+item {
+  name: "128950"
+  id: 2090
+  display_name: "Lycomorpha pholus"
+}
+item {
+  name: "11935"
+  id: 2091
+  display_name: "Tachycineta bicolor"
+}
+item {
+  name: "333759"
+  id: 2092
+  display_name: "Larus dominicanus dominicanus"
+}
+item {
+  name: "143008"
+  id: 2093
+  display_name: "Herpetogramma pertextalis"
+}
+item {
+  name: "235341"
+  id: 2094
+  display_name: "Coenonympha tullia california"
+}
+item {
+  name: "44705"
+  id: 2095
+  display_name: "Mus musculus"
+}
+item {
+  name: "145352"
+  id: 2096
+  display_name: "Lonchura oryzivora"
+}
+item {
+  name: "4840"
+  id: 2097
+  display_name: "Haematopus palliatus"
+}
+item {
+  name: "244845"
+  id: 2098
+  display_name: "Apiomerus californicus"
+}
+item {
+  name: "145360"
+  id: 2099
+  display_name: "Chloris chloris"
+}
+item {
+  name: "5112"
+  id: 2100
+  display_name: "Accipiter cooperii"
+}
+item {
+  name: "30675"
+  id: 2101
+  display_name: "Agkistrodon piscivorus"
+}
+item {
+  name: "341972"
+  id: 2102
+  display_name: "Crocodylus niloticus"
+}
+item {
+  name: "30677"
+  id: 2103
+  display_name: "Agkistrodon piscivorus conanti"
+}
+item {
+  name: "30678"
+  id: 2104
+  display_name: "Agkistrodon contortrix"
+}
+item {
+  name: "52900"
+  id: 2105
+  display_name: "Caenurgina crassiuscula"
+}
+item {
+  name: "30682"
+  id: 2106
+  display_name: "Agkistrodon contortrix laticinctus"
+}
+item {
+  name: "47067"
+  id: 2107
+  display_name: "Bradypus variegatus"
+}
+item {
+  name: "55260"
+  id: 2108
+  display_name: "Erythemis vesiculosa"
+}
+item {
+  name: "17402"
+  id: 2109
+  display_name: "Vireo solitarius"
+}
+item {
+  name: "6369"
+  id: 2110
+  display_name: "Selasphorus platycercus"
+}
+item {
+  name: "104416"
+  id: 2111
+  display_name: "Lestes alacer"
+}
+item {
+  name: "128993"
+  id: 2112
+  display_name: "Narceus annularus"
+}
+item {
+  name: "104422"
+  id: 2113
+  display_name: "Lestes congener"
+}
+item {
+  name: "227307"
+  id: 2114
+  display_name: "Patalene olyzonaria"
+}
+item {
+  name: "104429"
+  id: 2115
+  display_name: "Lestes dryas"
+}
+item {
+  name: "194542"
+  id: 2116
+  display_name: "Phyciodes graphica"
+}
+item {
+  name: "52904"
+  id: 2117
+  display_name: "Microcrambus elegans"
+}
+item {
+  name: "129363"
+  id: 2118
+  display_name: "Calephelis nemesis"
+}
+item {
+  name: "144506"
+  id: 2119
+  display_name: "Chroicocephalus scopulinus"
+}
+item {
+  name: "30713"
+  id: 2120
+  display_name: "Crotalus oreganus helleri"
+}
+item {
+  name: "47101"
+  id: 2121
+  display_name: "Choloepus hoffmanni"
+}
+item {
+  name: "210942"
+  id: 2122
+  display_name: "Caedicia simplex"
+}
+item {
+  name: "30719"
+  id: 2123
+  display_name: "Crotalus scutulatus"
+}
+item {
+  name: "30724"
+  id: 2124
+  display_name: "Crotalus ruber"
+}
+item {
+  name: "47110"
+  id: 2125
+  display_name: "Triopha maculata"
+}
+item {
+  name: "4235"
+  id: 2126
+  display_name: "Aechmophorus occidentalis"
+}
+item {
+  name: "30731"
+  id: 2127
+  display_name: "Crotalus molossus"
+}
+item {
+  name: "30733"
+  id: 2128
+  display_name: "Crotalus molossus nigrescens"
+}
+item {
+  name: "30735"
+  id: 2129
+  display_name: "Crotalus mitchellii"
+}
+item {
+  name: "30740"
+  id: 2130
+  display_name: "Crotalus lepidus"
+}
+item {
+  name: "30746"
+  id: 2131
+  display_name: "Crotalus horridus"
+}
+item {
+  name: "63518"
+  id: 2132
+  display_name: "Melanoplus differentialis"
+}
+item {
+  name: "30751"
+  id: 2133
+  display_name: "Crotalus cerastes"
+}
+item {
+  name: "126640"
+  id: 2134
+  display_name: "Caenurgina erechtea"
+}
+item {
+  name: "46086"
+  id: 2135
+  display_name: "Marmota flaviventris"
+}
+item {
+  name: "194599"
+  id: 2136
+  display_name: "Heliomata cycladata"
+}
+item {
+  name: "30764"
+  id: 2137
+  display_name: "Crotalus atrox"
+}
+item {
+  name: "204520"
+  id: 2138
+  display_name: "Hemiphaga novaeseelandiae"
+}
+item {
+  name: "128141"
+  id: 2139
+  display_name: "Crepidula adunca"
+}
+item {
+  name: "121183"
+  id: 2140
+  display_name: "Mythimna unipuncta"
+}
+item {
+  name: "40827"
+  id: 2141
+  display_name: "Eidolon helvum"
+}
+item {
+  name: "4571"
+  id: 2142
+  display_name: "Xema sabini"
+}
+item {
+  name: "211007"
+  id: 2143
+  display_name: "Nepytia canosaria"
+}
+item {
+  name: "47171"
+  id: 2144
+  display_name: "Flabellina iodinea"
+}
+item {
+  name: "211012"
+  id: 2145
+  display_name: "Maliattha synochitis"
+}
+item {
+  name: "30798"
+  id: 2146
+  display_name: "Bothrops asper"
+}
+item {
+  name: "47188"
+  id: 2147
+  display_name: "Pachygrapsus crassipes"
+}
+item {
+  name: "55387"
+  id: 2148
+  display_name: "Esox lucius"
+}
+item {
+  name: "58583"
+  id: 2149
+  display_name: "Limenitis arthemis arthemis"
+}
+item {
+  name: "104548"
+  id: 2150
+  display_name: "Leucorrhinia frigida"
+}
+item {
+  name: "104550"
+  id: 2151
+  display_name: "Leucorrhinia hudsonica"
+}
+item {
+  name: "104551"
+  id: 2152
+  display_name: "Leucorrhinia intacta"
+}
+item {
+  name: "47209"
+  id: 2153
+  display_name: "Hermissenda crassicornis"
+}
+item {
+  name: "55655"
+  id: 2154
+  display_name: "Lycaena phlaeas"
+}
+item {
+  name: "202861"
+  id: 2155
+  display_name: "Otala lactea"
+}
+item {
+  name: "143037"
+  id: 2156
+  display_name: "Lineodes integra"
+}
+item {
+  name: "47219"
+  id: 2157
+  display_name: "Apis mellifera"
+}
+item {
+  name: "24254"
+  id: 2158
+  display_name: "Pseudacris cadaverina"
+}
+item {
+  name: "47226"
+  id: 2159
+  display_name: "Papilio rutulus"
+}
+item {
+  name: "104572"
+  id: 2160
+  display_name: "Libellula comanche"
+}
+item {
+  name: "104574"
+  id: 2161
+  display_name: "Libellula croceipennis"
+}
+item {
+  name: "104575"
+  id: 2162
+  display_name: "Libellula cyanea"
+}
+item {
+  name: "145538"
+  id: 2163
+  display_name: "Ovis canadensis canadensis"
+}
+item {
+  name: "104580"
+  id: 2164
+  display_name: "Libellula incesta"
+}
+item {
+  name: "24257"
+  id: 2165
+  display_name: "Pseudacris streckeri"
+}
+item {
+  name: "53866"
+  id: 2166
+  display_name: "Calpodes ethlius"
+}
+item {
+  name: "18796"
+  id: 2167
+  display_name: "Ramphastos sulfuratus"
+}
+item {
+  name: "2413"
+  id: 2168
+  display_name: "Dacelo novaeguineae"
+}
+item {
+  name: "482"
+  id: 2169
+  display_name: "Fulica atra"
+}
+item {
+  name: "47251"
+  id: 2170
+  display_name: "Sphyraena barracuda"
+}
+item {
+  name: "358549"
+  id: 2171
+  display_name: "Hemaris diffinis"
+}
+item {
+  name: "81526"
+  id: 2172
+  display_name: "Crotalus viridis"
+}
+item {
+  name: "342169"
+  id: 2173
+  display_name: "Hirundo rustica erythrogaster"
+}
+item {
+  name: "39280"
+  id: 2174
+  display_name: "Leiocephalus carinatus"
+}
+item {
+  name: "47269"
+  id: 2175
+  display_name: "Dasyatis americana"
+}
+item {
+  name: "55467"
+  id: 2176
+  display_name: "Sabulodes aegrotata"
+}
+item {
+  name: "6316"
+  id: 2177
+  display_name: "Calypte costae"
+}
+item {
+  name: "6317"
+  id: 2178
+  display_name: "Calypte anna"
+}
+item {
+  name: "47280"
+  id: 2179
+  display_name: "Pterois volitans"
+}
+item {
+  name: "81608"
+  id: 2180
+  display_name: "Geukensia demissa"
+}
+item {
+  name: "121012"
+  id: 2181
+  display_name: "Euglandina rosea"
+}
+item {
+  name: "236980"
+  id: 2182
+  display_name: "Colaptes auratus cafer"
+}
+item {
+  name: "38673"
+  id: 2183
+  display_name: "Aspidoscelis tigris tigris"
+}
+item {
+  name: "3786"
+  id: 2184
+  display_name: "Sula nebouxii"
+}
+item {
+  name: "55487"
+  id: 2185
+  display_name: "Diabrotica undecimpunctata"
+}
+item {
+  name: "243904"
+  id: 2186
+  display_name: "Phrynosoma platyrhinos"
+}
+item {
+  name: "55489"
+  id: 2187
+  display_name: "Cycloneda munda"
+}
+item {
+  name: "204491"
+  id: 2188
+  display_name: "Copsychus saularis"
+}
+item {
+  name: "55492"
+  id: 2189
+  display_name: "Cycloneda polita"
+}
+item {
+  name: "129222"
+  id: 2190
+  display_name: "Heterophleps triguttaria"
+}
+item {
+  name: "129223"
+  id: 2191
+  display_name: "Pasiphila rectangulata"
+}
+item {
+  name: "28365"
+  id: 2192
+  display_name: "Thamnophis sirtalis sirtalis"
+}
+item {
+  name: "47316"
+  id: 2193
+  display_name: "Chaetodon lunula"
+}
+item {
+  name: "6359"
+  id: 2194
+  display_name: "Selasphorus sasin"
+}
+item {
+  name: "62500"
+  id: 2195
+  display_name: "Leptophobia aripa"
+}
+item {
+  name: "6363"
+  id: 2196
+  display_name: "Selasphorus rufus"
+}
+item {
+  name: "96480"
+  id: 2197
+  display_name: "Calopteryx aequabilis"
+}
+item {
+  name: "55521"
+  id: 2198
+  display_name: "Papilio eurymedon"
+}
+item {
+  name: "6371"
+  id: 2199
+  display_name: "Calothorax lucifer"
+}
+item {
+  name: "129263"
+  id: 2200
+  display_name: "Syrbula admirabilis"
+}
+item {
+  name: "28371"
+  id: 2201
+  display_name: "Thamnophis sirtalis fitchi"
+}
+item {
+  name: "243962"
+  id: 2202
+  display_name: "Charina bottae"
+}
+item {
+  name: "145659"
+  id: 2203
+  display_name: "Acronicta americana"
+}
+item {
+  name: "14588"
+  id: 2204
+  display_name: "Pycnonotus barbatus"
+}
+item {
+  name: "480298"
+  id: 2205
+  display_name: "Cornu aspersum"
+}
+item {
+  name: "51584"
+  id: 2206
+  display_name: "Melanitis leda"
+}
+item {
+  name: "243970"
+  id: 2207
+  display_name: "Larus glaucescens \303\227 occidentalis"
+}
+item {
+  name: "55556"
+  id: 2208
+  display_name: "Oncopeltus fasciatus"
+}
+item {
+  name: "506117"
+  id: 2209
+  display_name: "Aphelocoma woodhouseii"
+}
+item {
+  name: "63750"
+  id: 2210
+  display_name: "Anavitrinella pampinaria"
+}
+item {
+  name: "30983"
+  id: 2211
+  display_name: "Sistrurus miliarius"
+}
+item {
+  name: "211210"
+  id: 2212
+  display_name: "Holocnemus pluchei"
+}
+item {
+  name: "49587"
+  id: 2213
+  display_name: "Micropterus salmoides"
+}
+item {
+  name: "6417"
+  id: 2214
+  display_name: "Florisuga mellivora"
+}
+item {
+  name: "47381"
+  id: 2215
+  display_name: "Latrodectus mactans"
+}
+item {
+  name: "47382"
+  id: 2216
+  display_name: "Latrodectus hesperus"
+}
+item {
+  name: "4851"
+  id: 2217
+  display_name: "Haematopus finschi"
+}
+item {
+  name: "51588"
+  id: 2218
+  display_name: "Papilio polytes"
+}
+item {
+  name: "144431"
+  id: 2219
+  display_name: "Falcipennis canadensis"
+}
+item {
+  name: "118490"
+  id: 2220
+  display_name: "Haematopis grataria"
+}
+item {
+  name: "6433"
+  id: 2221
+  display_name: "Archilochus alexandri"
+}
+item {
+  name: "52956"
+  id: 2222
+  display_name: "Chaetodon capistratus"
+}
+item {
+  name: "203050"
+  id: 2223
+  display_name: "Junonia genoveva"
+}
+item {
+  name: "5170"
+  id: 2224
+  display_name: "Circus cyaneus"
+}
+item {
+  name: "84332"
+  id: 2225
+  display_name: "Panorpa nuptialis"
+}
+item {
+  name: "47414"
+  id: 2226
+  display_name: "Emerita analoga"
+}
+item {
+  name: "129335"
+  id: 2227
+  display_name: "Gibbifer californicus"
+}
+item {
+  name: "55610"
+  id: 2228
+  display_name: "Pyrrhocoris apterus"
+}
+item {
+  name: "58421"
+  id: 2229
+  display_name: "Phidippus johnsoni"
+}
+item {
+  name: "208608"
+  id: 2230
+  display_name: "Trachymela sloanei"
+}
+item {
+  name: "68138"
+  id: 2231
+  display_name: "Sympetrum corruptum"
+}
+item {
+  name: "129350"
+  id: 2232
+  display_name: "Photinus pyralis"
+}
+item {
+  name: "55625"
+  id: 2233
+  display_name: "Sympetrum striolatum"
+}
+item {
+  name: "55626"
+  id: 2234
+  display_name: "Pieris rapae"
+}
+item {
+  name: "203084"
+  id: 2235
+  display_name: "Ardea alba modesta"
+}
+item {
+  name: "129362"
+  id: 2236
+  display_name: "Zerene cesonia"
+}
+item {
+  name: "55638"
+  id: 2237
+  display_name: "Anania hortulata"
+}
+item {
+  name: "148537"
+  id: 2238
+  display_name: "Astraptes fulgerator"
+}
+item {
+  name: "55640"
+  id: 2239
+  display_name: "Celastrina argiolus"
+}
+item {
+  name: "55641"
+  id: 2240
+  display_name: "Polyommatus icarus"
+}
+item {
+  name: "16028"
+  id: 2241
+  display_name: "Myiarchus crinitus"
+}
+item {
+  name: "55643"
+  id: 2242
+  display_name: "Araschnia levana"
+}
+item {
+  name: "121180"
+  id: 2243
+  display_name: "Megastraea undosa"
+}
+item {
+  name: "47454"
+  id: 2244
+  display_name: "Triopha catalinae"
+}
+item {
+  name: "28389"
+  id: 2245
+  display_name: "Thamnophis ordinoides"
+}
+item {
+  name: "68139"
+  id: 2246
+  display_name: "Sympetrum vicinum"
+}
+item {
+  name: "55651"
+  id: 2247
+  display_name: "Autographa gamma"
+}
+item {
+  name: "55653"
+  id: 2248
+  display_name: "Maniola jurtina"
+}
+item {
+  name: "84369"
+  id: 2249
+  display_name: "Libellula forensis"
+}
+item {
+  name: "47135"
+  id: 2250
+  display_name: "Badumna longinqua"
+}
+item {
+  name: "48213"
+  id: 2251
+  display_name: "Ariolimax californicus"
+}
+item {
+  name: "121196"
+  id: 2252
+  display_name: "Acanthurus coeruleus"
+}
+item {
+  name: "47469"
+  id: 2253
+  display_name: "Doris montereyensis"
+}
+item {
+  name: "5181"
+  id: 2254
+  display_name: "Buteo regalis"
+}
+item {
+  name: "47472"
+  id: 2255
+  display_name: "Acanthodoris lutea"
+}
+item {
+  name: "129415"
+  id: 2256
+  display_name: "Copaeodes aurantiaca"
+}
+item {
+  name: "47505"
+  id: 2257
+  display_name: "Geitodoris heathi"
+}
+item {
+  name: "28398"
+  id: 2258
+  display_name: "Thamnophis elegans"
+}
+item {
+  name: "6553"
+  id: 2259
+  display_name: "Aeronautes saxatalis"
+}
+item {
+  name: "47516"
+  id: 2260
+  display_name: "Oncorhynchus mykiss"
+}
+item {
+  name: "6557"
+  id: 2261
+  display_name: "Chaetura vauxi"
+}
+item {
+  name: "47518"
+  id: 2262
+  display_name: "Salmo trutta"
+}
+item {
+  name: "55711"
+  id: 2263
+  display_name: "Ladona depressa"
+}
+item {
+  name: "55719"
+  id: 2264
+  display_name: "Eristalis tenax"
+}
+item {
+  name: "6571"
+  id: 2265
+  display_name: "Chaetura pelagica"
+}
+item {
+  name: "119881"
+  id: 2266
+  display_name: "Chrysochus cobaltinus"
+}
+item {
+  name: "145239"
+  id: 2267
+  display_name: "Setophaga pensylvanica"
+}
+item {
+  name: "154043"
+  id: 2268
+  display_name: "Bombus huntii"
+}
+item {
+  name: "41955"
+  id: 2269
+  display_name: "Acinonyx jubatus"
+}
+item {
+  name: "55746"
+  id: 2270
+  display_name: "Misumena vatia"
+}
+item {
+  name: "12024"
+  id: 2271
+  display_name: "Lanius ludovicianus"
+}
+item {
+  name: "5063"
+  id: 2272
+  display_name: "Anhinga anhinga"
+}
+item {
+  name: "59892"
+  id: 2273
+  display_name: "Prionus californicus"
+}
+item {
+  name: "52986"
+  id: 2274
+  display_name: "Largus californicus"
+}
+item {
+  name: "204454"
+  id: 2275
+  display_name: "Acridotheres tristis"
+}
+item {
+  name: "14816"
+  id: 2276
+  display_name: "Sitta pygmaea"
+}
+item {
+  name: "148560"
+  id: 2277
+  display_name: "Mestra amymone"
+}
+item {
+  name: "4585"
+  id: 2278
+  display_name: "Actophilornis africanus"
+}
+item {
+  name: "47590"
+  id: 2279
+  display_name: "Phloeodes diabolicus"
+}
+item {
+  name: "14823"
+  id: 2280
+  display_name: "Sitta canadensis"
+}
+item {
+  name: "14824"
+  id: 2281
+  display_name: "Sitta europaea"
+}
+item {
+  name: "14825"
+  id: 2282
+  display_name: "Sitta pusilla"
+}
+item {
+  name: "67598"
+  id: 2283
+  display_name: "Solenopsis invicta"
+}
+item {
+  name: "6638"
+  id: 2284
+  display_name: "Apus apus"
+}
+item {
+  name: "301557"
+  id: 2285
+  display_name: "Euphoria basalis"
+}
+item {
+  name: "132070"
+  id: 2286
+  display_name: "Phaneroptera nana"
+}
+item {
+  name: "14850"
+  id: 2287
+  display_name: "Sturnus vulgaris"
+}
+item {
+  name: "62550"
+  id: 2288
+  display_name: "Seiurus aurocapilla"
+}
+item {
+  name: "64006"
+  id: 2289
+  display_name: "Corbicula fluminea"
+}
+item {
+  name: "204545"
+  id: 2290
+  display_name: "Motacilla flava"
+}
+item {
+  name: "47632"
+  id: 2291
+  display_name: "Katharina tunicata"
+}
+item {
+  name: "325309"
+  id: 2292
+  display_name: "Chortophaga viridifasciata viridifasciata"
+}
+item {
+  name: "104993"
+  id: 2293
+  display_name: "Macrodiplax balteata"
+}
+item {
+  name: "17408"
+  id: 2294
+  display_name: "Vireo griseus"
+}
+item {
+  name: "14895"
+  id: 2295
+  display_name: "Toxostoma longirostre"
+}
+item {
+  name: "47664"
+  id: 2296
+  display_name: "Henricia leviuscula"
+}
+item {
+  name: "31281"
+  id: 2297
+  display_name: "Calotes versicolor"
+}
+item {
+  name: "119086"
+  id: 2298
+  display_name: "Agrius cingulata"
+}
+item {
+  name: "3849"
+  id: 2299
+  display_name: "Calidris alba"
+}
+item {
+  name: "14906"
+  id: 2300
+  display_name: "Toxostoma redivivum"
+}
+item {
+  name: "144479"
+  id: 2301
+  display_name: "Gallinula galeata"
+}
+item {
+  name: "3850"
+  id: 2302
+  display_name: "Calidris himantopus"
+}
+item {
+  name: "117520"
+  id: 2303
+  display_name: "Enhydra lutris nereis"
+}
+item {
+  name: "51491"
+  id: 2304
+  display_name: "Myliobatis californica"
+}
+item {
+  name: "121612"
+  id: 2305
+  display_name: "Estigmene acrea"
+}
+item {
+  name: "105034"
+  id: 2306
+  display_name: "Macromia illinoiensis"
+}
+item {
+  name: "6498"
+  id: 2307
+  display_name: "Eugenes fulgens"
+}
+item {
+  name: "46179"
+  id: 2308
+  display_name: "Cynomys ludovicianus"
+}
+item {
+  name: "105049"
+  id: 2309
+  display_name: "Macromia taeniolata"
+}
+item {
+  name: "94045"
+  id: 2310
+  display_name: "Anax longipes"
+}
+item {
+  name: "143119"
+  id: 2311
+  display_name: "Galgula partita"
+}
+item {
+  name: "9317"
+  id: 2312
+  display_name: "Icterus wagleri"
+}
+item {
+  name: "122704"
+  id: 2313
+  display_name: "Nucella ostrina"
+}
+item {
+  name: "146709"
+  id: 2314
+  display_name: "Grylloprociphilus imbricator"
+}
+item {
+  name: "9318"
+  id: 2315
+  display_name: "Icterus parisorum"
+}
+item {
+  name: "85333"
+  id: 2316
+  display_name: "Micrathena gracilis"
+}
+item {
+  name: "126737"
+  id: 2317
+  display_name: "Anania funebris"
+}
+item {
+  name: "49053"
+  id: 2318
+  display_name: "Cryptochiton stelleri"
+}
+item {
+  name: "47721"
+  id: 2319
+  display_name: "Parastichopus californicus"
+}
+item {
+  name: "34050"
+  id: 2320
+  display_name: "Phelsuma laticauda"
+}
+item {
+  name: "154219"
+  id: 2321
+  display_name: "Notarctia proxima"
+}
+item {
+  name: "51781"
+  id: 2322
+  display_name: "Tyria jacobaeae"
+}
+item {
+  name: "24230"
+  id: 2323
+  display_name: "Acris crepitans"
+}
+item {
+  name: "146032"
+  id: 2324
+  display_name: "Coluber flagellum"
+}
+item {
+  name: "146033"
+  id: 2325
+  display_name: "Coluber flagellum flagellum"
+}
+item {
+  name: "244340"
+  id: 2326
+  display_name: "Hordnia atropunctata"
+}
+item {
+  name: "146037"
+  id: 2327
+  display_name: "Coluber taeniatus"
+}
+item {
+  name: "244344"
+  id: 2328
+  display_name: "Scopula rubraria"
+}
+item {
+  name: "47737"
+  id: 2329
+  display_name: "Harpaphe haydeniana"
+}
+item {
+  name: "5227"
+  id: 2330
+  display_name: "Buteo platypterus"
+}
+item {
+  name: "39556"
+  id: 2331
+  display_name: "Apalone spinifera"
+}
+item {
+  name: "39560"
+  id: 2332
+  display_name: "Apalone spinifera emoryi"
+}
+item {
+  name: "318836"
+  id: 2333
+  display_name: "Gallinago gallinago"
+}
+item {
+  name: "105098"
+  id: 2334
+  display_name: "Magicicada septendecim"
+}
+item {
+  name: "96907"
+  id: 2335
+  display_name: "Celithemis fasciata"
+}
+item {
+  name: "9325"
+  id: 2336
+  display_name: "Icterus spurius"
+}
+item {
+  name: "3864"
+  id: 2337
+  display_name: "Calidris minutilla"
+}
+item {
+  name: "14995"
+  id: 2338
+  display_name: "Dumetella carolinensis"
+}
+item {
+  name: "424597"
+  id: 2339
+  display_name: "Porphyrio hochstetteri"
+}
+item {
+  name: "47768"
+  id: 2340
+  display_name: "Doriopsilla albopunctata"
+}
+item {
+  name: "498116"
+  id: 2341
+  display_name: "Aeolidia papillosa"
+}
+item {
+  name: "244378"
+  id: 2342
+  display_name: "Mallophora fautrix"
+}
+item {
+  name: "3866"
+  id: 2343
+  display_name: "Calidris fuscicollis"
+}
+item {
+  name: "47776"
+  id: 2344
+  display_name: "Ariolimax columbianus"
+}
+item {
+  name: "144497"
+  id: 2345
+  display_name: "Phalaropus tricolor"
+}
+item {
+  name: "39824"
+  id: 2346
+  display_name: "Pseudemys nelsoni"
+}
+item {
+  name: "236979"
+  id: 2347
+  display_name: "Colaptes auratus auratus"
+}
+item {
+  name: "55990"
+  id: 2348
+  display_name: "Podarcis muralis"
+}
+item {
+  name: "244407"
+  id: 2349
+  display_name: "Zelus renardii"
+}
+item {
+  name: "47802"
+  id: 2350
+  display_name: "Lymantria dispar"
+}
+item {
+  name: "15035"
+  id: 2351
+  display_name: "Melanotis caerulescens"
+}
+item {
+  name: "51658"
+  id: 2352
+  display_name: "Anthopleura artemisia"
+}
+item {
+  name: "121534"
+  id: 2353
+  display_name: "Oreta rosea"
+}
+item {
+  name: "73504"
+  id: 2354
+  display_name: "Tiaris olivaceus"
+}
+item {
+  name: "15045"
+  id: 2355
+  display_name: "Oreoscoptes montanus"
+}
+item {
+  name: "3873"
+  id: 2356
+  display_name: "Limnodromus scolopaceus"
+}
+item {
+  name: "47673"
+  id: 2357
+  display_name: "Pycnopodia helianthoides"
+}
+item {
+  name: "47817"
+  id: 2358
+  display_name: "Libellula saturata"
+}
+item {
+  name: "56644"
+  id: 2359
+  display_name: "Polygonia satyrus"
+}
+item {
+  name: "47826"
+  id: 2360
+  display_name: "Cancer productus"
+}
+item {
+  name: "3875"
+  id: 2361
+  display_name: "Tringa solitaria"
+}
+item {
+  name: "39782"
+  id: 2362
+  display_name: "Trachemys scripta"
+}
+item {
+  name: "143140"
+  id: 2363
+  display_name: "Cyllopsis gemma"
+}
+item {
+  name: "29818"
+  id: 2364
+  display_name: "Lampropeltis holbrooki"
+}
+item {
+  name: "56293"
+  id: 2365
+  display_name: "Macroglossum stellatarum"
+}
+item {
+  name: "154340"
+  id: 2366
+  display_name: "Gryllodes sigillatus"
+}
+item {
+  name: "14801"
+  id: 2367
+  display_name: "Sitta carolinensis"
+}
+item {
+  name: "121578"
+  id: 2368
+  display_name: "Ovis aries"
+}
+item {
+  name: "3879"
+  id: 2369
+  display_name: "Tringa totanus"
+}
+item {
+  name: "6893"
+  id: 2370
+  display_name: "Dendrocygna autumnalis"
+}
+item {
+  name: "154353"
+  id: 2371
+  display_name: "Sunira bicolorago"
+}
+item {
+  name: "6898"
+  id: 2372
+  display_name: "Dendrocygna viduata"
+}
+item {
+  name: "6899"
+  id: 2373
+  display_name: "Dendrocygna bicolor"
+}
+item {
+  name: "9342"
+  id: 2374
+  display_name: "Icterus abeillei"
+}
+item {
+  name: "39670"
+  id: 2375
+  display_name: "Lepidochelys olivacea"
+}
+item {
+  name: "4867"
+  id: 2376
+  display_name: "Vanellus chilensis"
+}
+item {
+  name: "39677"
+  id: 2377
+  display_name: "Dermochelys coriacea"
+}
+item {
+  name: "113407"
+  id: 2378
+  display_name: "Stylurus plagiatus"
+}
+item {
+  name: "39682"
+  id: 2379
+  display_name: "Chelydra serpentina"
+}
+item {
+  name: "6915"
+  id: 2380
+  display_name: "Cygnus buccinator"
+}
+item {
+  name: "6916"
+  id: 2381
+  display_name: "Cygnus cygnus"
+}
+item {
+  name: "6917"
+  id: 2382
+  display_name: "Cygnus columbianus"
+}
+item {
+  name: "29825"
+  id: 2383
+  display_name: "Lampropeltis calligaster calligaster"
+}
+item {
+  name: "6921"
+  id: 2384
+  display_name: "Cygnus olor"
+}
+item {
+  name: "146186"
+  id: 2385
+  display_name: "Intellagama lesueurii"
+}
+item {
+  name: "9346"
+  id: 2386
+  display_name: "Icterus galbula"
+}
+item {
+  name: "126765"
+  id: 2387
+  display_name: "Plutella xylostella"
+}
+item {
+  name: "71154"
+  id: 2388
+  display_name: "Aphis nerii"
+}
+item {
+  name: "6930"
+  id: 2389
+  display_name: "Anas platyrhynchos"
+}
+item {
+  name: "6933"
+  id: 2390
+  display_name: "Anas acuta"
+}
+item {
+  name: "39703"
+  id: 2391
+  display_name: "Sternotherus odoratus"
+}
+item {
+  name: "6937"
+  id: 2392
+  display_name: "Anas crecca"
+}
+item {
+  name: "64287"
+  id: 2393
+  display_name: "Lottia digitalis"
+}
+item {
+  name: "6944"
+  id: 2394
+  display_name: "Anas cyanoptera"
+}
+item {
+  name: "39713"
+  id: 2395
+  display_name: "Kinosternon subrubrum"
+}
+item {
+  name: "26691"
+  id: 2396
+  display_name: "Scaphiopus couchii"
+}
+item {
+  name: "6948"
+  id: 2397
+  display_name: "Anas fulvigula"
+}
+item {
+  name: "6953"
+  id: 2398
+  display_name: "Anas discors"
+}
+item {
+  name: "47914"
+  id: 2399
+  display_name: "Eumorpha pandorus"
+}
+item {
+  name: "47916"
+  id: 2400
+  display_name: "Actias luna"
+}
+item {
+  name: "6957"
+  id: 2401
+  display_name: "Anas strepera"
+}
+item {
+  name: "47919"
+  id: 2402
+  display_name: "Antheraea polyphemus"
+}
+item {
+  name: "119953"
+  id: 2403
+  display_name: "Hypoprepia fucosa"
+}
+item {
+  name: "6961"
+  id: 2404
+  display_name: "Anas clypeata"
+}
+item {
+  name: "134119"
+  id: 2405
+  display_name: "Anisomorpha buprestoides"
+}
+item {
+  name: "51678"
+  id: 2406
+  display_name: "Coenagrion puella"
+}
+item {
+  name: "72502"
+  id: 2407
+  display_name: "Anas chlorotis"
+}
+item {
+  name: "49060"
+  id: 2408
+  display_name: "Epiactis prolifera"
+}
+item {
+  name: "42122"
+  id: 2409
+  display_name: "Phacochoerus africanus"
+}
+item {
+  name: "58507"
+  id: 2410
+  display_name: "Poanes hobomok"
+}
+item {
+  name: "121669"
+  id: 2411
+  display_name: "Stenopus hispidus"
+}
+item {
+  name: "8143"
+  id: 2412
+  display_name: "Rhipidura leucophrys"
+}
+item {
+  name: "6985"
+  id: 2413
+  display_name: "Anas americana"
+}
+item {
+  name: "6993"
+  id: 2414
+  display_name: "Bucephala albeola"
+}
+item {
+  name: "121682"
+  id: 2415
+  display_name: "Tetraclita rubescens"
+}
+item {
+  name: "6996"
+  id: 2416
+  display_name: "Mergus serrator"
+}
+item {
+  name: "113498"
+  id: 2417
+  display_name: "Sympetrum ambiguum"
+}
+item {
+  name: "39771"
+  id: 2418
+  display_name: "Chrysemys picta"
+}
+item {
+  name: "7004"
+  id: 2419
+  display_name: "Mergus merganser"
+}
+item {
+  name: "39773"
+  id: 2420
+  display_name: "Chrysemys picta bellii"
+}
+item {
+  name: "113503"
+  id: 2421
+  display_name: "Sympetrum danae"
+}
+item {
+  name: "113507"
+  id: 2422
+  display_name: "Sympetrum fonscolombii"
+}
+item {
+  name: "154469"
+  id: 2423
+  display_name: "Isa textula"
+}
+item {
+  name: "47975"
+  id: 2424
+  display_name: "Argia apicalis"
+}
+item {
+  name: "7018"
+  id: 2425
+  display_name: "Anser anser"
+}
+item {
+  name: "7019"
+  id: 2426
+  display_name: "Anser albifrons"
+}
+item {
+  name: "47980"
+  id: 2427
+  display_name: "Speyeria cybele"
+}
+item {
+  name: "58514"
+  id: 2428
+  display_name: "Euphyes vestris"
+}
+item {
+  name: "113519"
+  id: 2429
+  display_name: "Sympetrum obtrusum"
+}
+item {
+  name: "7024"
+  id: 2430
+  display_name: "Somateria mollissima"
+}
+item {
+  name: "39793"
+  id: 2431
+  display_name: "Trachemys scripta scripta"
+}
+item {
+  name: "367475"
+  id: 2432
+  display_name: "Rallus obsoletus"
+}
+item {
+  name: "121716"
+  id: 2433
+  display_name: "Uresiphita reversalis"
+}
+item {
+  name: "113525"
+  id: 2434
+  display_name: "Sympetrum sanguineum"
+}
+item {
+  name: "113526"
+  id: 2435
+  display_name: "Sympetrum semicinctum"
+}
+item {
+  name: "18921"
+  id: 2436
+  display_name: "Platycercus elegans"
+}
+item {
+  name: "7032"
+  id: 2437
+  display_name: "Melanitta fusca"
+}
+item {
+  name: "5268"
+  id: 2438
+  display_name: "Milvus migrans"
+}
+item {
+  name: "144536"
+  id: 2439
+  display_name: "Gelochelidon nilotica"
+}
+item {
+  name: "413503"
+  id: 2440
+  display_name: "Ninox novaeseelandiae novaeseelandiae"
+}
+item {
+  name: "7036"
+  id: 2441
+  display_name: "Melanitta perspicillata"
+}
+item {
+  name: "64382"
+  id: 2442
+  display_name: "Lissotriton vulgaris"
+}
+item {
+  name: "39807"
+  id: 2443
+  display_name: "Terrapene ornata"
+}
+item {
+  name: "39808"
+  id: 2444
+  display_name: "Terrapene ornata luteola"
+}
+item {
+  name: "7044"
+  id: 2445
+  display_name: "Aythya collaris"
+}
+item {
+  name: "7045"
+  id: 2446
+  display_name: "Aythya ferina"
+}
+item {
+  name: "7046"
+  id: 2447
+  display_name: "Aythya fuligula"
+}
+item {
+  name: "146314"
+  id: 2448
+  display_name: "Opheodrys vernalis"
+}
+item {
+  name: "3906"
+  id: 2449
+  display_name: "Numenius americanus"
+}
+item {
+  name: "39823"
+  id: 2450
+  display_name: "Pseudemys gorzugi"
+}
+item {
+  name: "178991"
+  id: 2451
+  display_name: "Sypharochiton pelliserpentis"
+}
+item {
+  name: "7061"
+  id: 2452
+  display_name: "Chen caerulescens"
+}
+item {
+  name: "39830"
+  id: 2453
+  display_name: "Pseudemys concinna"
+}
+item {
+  name: "127490"
+  id: 2454
+  display_name: "Parrhasius m-album"
+}
+item {
+  name: "15256"
+  id: 2455
+  display_name: "Chamaea fasciata"
+}
+item {
+  name: "39836"
+  id: 2456
+  display_name: "Malaclemys terrapin"
+}
+item {
+  name: "133764"
+  id: 2457
+  display_name: "Trichopoda pennipes"
+}
+item {
+  name: "334753"
+  id: 2458
+  display_name: "Hypselonotus punctiventris"
+}
+item {
+  name: "58611"
+  id: 2459
+  display_name: "Amia calva"
+}
+item {
+  name: "56240"
+  id: 2460
+  display_name: "Argia vivida"
+}
+item {
+  name: "7089"
+  id: 2461
+  display_name: "Branta canadensis"
+}
+item {
+  name: "146354"
+  id: 2462
+  display_name: "Phrynosoma blainvillii"
+}
+item {
+  name: "56243"
+  id: 2463
+  display_name: "Plebejus acmon"
+}
+item {
+  name: "144542"
+  id: 2464
+  display_name: "Thalasseus elegans"
+}
+item {
+  name: "121783"
+  id: 2465
+  display_name: "Lithobates clamitans melanota"
+}
+item {
+  name: "39865"
+  id: 2466
+  display_name: "Glyptemys insculpta"
+}
+item {
+  name: "39867"
+  id: 2467
+  display_name: "Emys orbicularis"
+}
+item {
+  name: "7104"
+  id: 2468
+  display_name: "Branta sandvicensis"
+}
+item {
+  name: "50336"
+  id: 2469
+  display_name: "Siproeta stelenes"
+}
+item {
+  name: "7056"
+  id: 2470
+  display_name: "Aythya americana"
+}
+item {
+  name: "7107"
+  id: 2471
+  display_name: "Aix sponsa"
+}
+item {
+  name: "7109"
+  id: 2472
+  display_name: "Lophodytes cucullatus"
+}
+item {
+  name: "7111"
+  id: 2473
+  display_name: "Histrionicus histrionicus"
+}
+item {
+  name: "367562"
+  id: 2474
+  display_name: "Aratinga nenday"
+}
+item {
+  name: "39885"
+  id: 2475
+  display_name: "Emydoidea blandingii"
+}
+item {
+  name: "367566"
+  id: 2476
+  display_name: "Psittacara holochlorus"
+}
+item {
+  name: "143181"
+  id: 2477
+  display_name: "Marimatha nigrofimbria"
+}
+item {
+  name: "7120"
+  id: 2478
+  display_name: "Cairina moschata"
+}
+item {
+  name: "7122"
+  id: 2479
+  display_name: "Netta rufina"
+}
+item {
+  name: "130003"
+  id: 2480
+  display_name: "Phaeoura quernaria"
+}
+item {
+  name: "367572"
+  id: 2481
+  display_name: "Psittacara erythrogenys"
+}
+item {
+  name: "17009"
+  id: 2482
+  display_name: "Sayornis saya"
+}
+item {
+  name: "154582"
+  id: 2483
+  display_name: "Ennomos magnaria"
+}
+item {
+  name: "58532"
+  id: 2484
+  display_name: "Colias eurytheme"
+}
+item {
+  name: "121821"
+  id: 2485
+  display_name: "Sceliphron caementarium"
+}
+item {
+  name: "48094"
+  id: 2486
+  display_name: "Dryocampa rubicunda"
+}
+item {
+  name: "7057"
+  id: 2487
+  display_name: "Aythya valisineria"
+}
+item {
+  name: "17646"
+  id: 2488
+  display_name: "Picoides albolarvatus"
+}
+item {
+  name: "201551"
+  id: 2489
+  display_name: "Procyon lotor lotor"
+}
+item {
+  name: "58534"
+  id: 2490
+  display_name: "Lycaena hyllus"
+}
+item {
+  name: "73553"
+  id: 2491
+  display_name: "Vermivora cyanoptera"
+}
+item {
+  name: "359401"
+  id: 2492
+  display_name: "Exomala orientalis"
+}
+item {
+  name: "8018"
+  id: 2493
+  display_name: "Corvus caurinus"
+}
+item {
+  name: "490478"
+  id: 2494
+  display_name: "Tegula brunnea"
+}
+item {
+  name: "20307"
+  id: 2495
+  display_name: "Asio otus"
+}
+item {
+  name: "227466"
+  id: 2496
+  display_name: "Peridea ferruginea"
+}
+item {
+  name: "122172"
+  id: 2497
+  display_name: "Pyrisitia lisa"
+}
+item {
+  name: "133631"
+  id: 2498
+  display_name: "Polites peckius"
+}
+item {
+  name: "8021"
+  id: 2499
+  display_name: "Corvus brachyrhynchos"
+}
+item {
+  name: "7170"
+  id: 2500
+  display_name: "Clangula hyemalis"
+}
+item {
+  name: "58539"
+  id: 2501
+  display_name: "Satyrium calanus"
+}
+item {
+  name: "27137"
+  id: 2502
+  display_name: "Coluber constrictor"
+}
+item {
+  name: "7176"
+  id: 2503
+  display_name: "Chenonetta jubata"
+}
+item {
+  name: "42157"
+  id: 2504
+  display_name: "Giraffa camelopardalis"
+}
+item {
+  name: "144541"
+  id: 2505
+  display_name: "Thalasseus sandvicensis"
+}
+item {
+  name: "23572"
+  id: 2506
+  display_name: "Litoria aurea"
+}
+item {
+  name: "354820"
+  id: 2507
+  display_name: "Patiriella regularis"
+}
+item {
+  name: "55887"
+  id: 2508
+  display_name: "Andricus quercuscalifornicus"
+}
+item {
+  name: "46255"
+  id: 2509
+  display_name: "Ammospermophilus leucurus"
+}
+item {
+  name: "334341"
+  id: 2510
+  display_name: "Oryctolagus cuniculus domesticus"
+}
+item {
+  name: "144560"
+  id: 2511
+  display_name: "Eolophus roseicapilla"
+}
+item {
+  name: "94043"
+  id: 2512
+  display_name: "Anax imperator"
+}
+item {
+  name: "425004"
+  id: 2513
+  display_name: "Dryas iulia moderata"
+}
+item {
+  name: "269359"
+  id: 2514
+  display_name: "Cactophagus spinolae"
+}
+item {
+  name: "72755"
+  id: 2515
+  display_name: "Colaptes rubiginosus"
+}
+item {
+  name: "319123"
+  id: 2516
+  display_name: "Meleagris gallopavo silvestris"
+}
+item {
+  name: "130846"
+  id: 2517
+  display_name: "Lyssa zampa"
+}
+item {
+  name: "203831"
+  id: 2518
+  display_name: "Nemoria bistriaria"
+}
+item {
+  name: "367678"
+  id: 2519
+  display_name: "Ptiliogonys cinereus"
+}
+item {
+  name: "5301"
+  id: 2520
+  display_name: "Elanoides forficatus"
+}
+item {
+  name: "9398"
+  id: 2521
+  display_name: "Carduelis carduelis"
+}
+item {
+  name: "143201"
+  id: 2522
+  display_name: "Coryphista meadii"
+}
+item {
+  name: "104419"
+  id: 2523
+  display_name: "Lestes australis"
+}
+item {
+  name: "367693"
+  id: 2524
+  display_name: "Cassiculus melanicterus"
+}
+item {
+  name: "143452"
+  id: 2525
+  display_name: "Deidamia inscriptum"
+}
+item {
+  name: "466003"
+  id: 2526
+  display_name: "Romalea microptera"
+}
+item {
+  name: "84494"
+  id: 2527
+  display_name: "Paraphidippus aurantius"
+}
+item {
+  name: "203866"
+  id: 2528
+  display_name: "Rabdophaga strobiloides"
+}
+item {
+  name: "72797"
+  id: 2529
+  display_name: "Dendragapus fuliginosus"
+}
+item {
+  name: "7266"
+  id: 2530
+  display_name: "Psaltriparus minimus"
+}
+item {
+  name: "120920"
+  id: 2531
+  display_name: "Odocoileus virginianus clavium"
+}
+item {
+  name: "7278"
+  id: 2532
+  display_name: "Aegithalos caudatus"
+}
+item {
+  name: "30681"
+  id: 2533
+  display_name: "Agkistrodon contortrix mokasen"
+}
+item {
+  name: "413547"
+  id: 2534
+  display_name: "Zosterops lateralis lateralis"
+}
+item {
+  name: "48262"
+  id: 2535
+  display_name: "Apatelodes torrefacta"
+}
+item {
+  name: "121993"
+  id: 2536
+  display_name: "Lampides boeticus"
+}
+item {
+  name: "48267"
+  id: 2537
+  display_name: "Crotalus oreganus oreganus"
+}
+item {
+  name: "48268"
+  id: 2538
+  display_name: "Crotalus oreganus"
+}
+item {
+  name: "147309"
+  id: 2539
+  display_name: "Feltia herilis"
+}
+item {
+  name: "146413"
+  id: 2540
+  display_name: "Sceloporus consobrinus"
+}
+item {
+  name: "326764"
+  id: 2541
+  display_name: "Cyprinus carpio haematopterus"
+}
+item {
+  name: "5315"
+  id: 2542
+  display_name: "Haliaeetus leucogaster"
+}
+item {
+  name: "4519"
+  id: 2543
+  display_name: "Uria aalge"
+}
+item {
+  name: "40085"
+  id: 2544
+  display_name: "Gopherus polyphemus"
+}
+item {
+  name: "23702"
+  id: 2545
+  display_name: "Agalychnis callidryas"
+}
+item {
+  name: "210116"
+  id: 2546
+  display_name: "Tringa semipalmata inornatus"
+}
+item {
+  name: "40092"
+  id: 2547
+  display_name: "Stigmochelys pardalis"
+}
+item {
+  name: "59931"
+  id: 2548
+  display_name: "Acanthurus triostegus"
+}
+item {
+  name: "48292"
+  id: 2549
+  display_name: "Philoscia muscorum"
+}
+item {
+  name: "146601"
+  id: 2550
+  display_name: "Scolopendra heros"
+}
+item {
+  name: "244906"
+  id: 2551
+  display_name: "Panchlora nivea"
+}
+item {
+  name: "48302"
+  id: 2552
+  display_name: "Limulus polyphemus"
+}
+item {
+  name: "180008"
+  id: 2553
+  display_name: "Otospermophilus variegatus"
+}
+item {
+  name: "7347"
+  id: 2554
+  display_name: "Alauda arvensis"
+}
+item {
+  name: "43459"
+  id: 2555
+  display_name: "Macaca fascicularis"
+}
+item {
+  name: "113846"
+  id: 2556
+  display_name: "Telebasis salva"
+}
+item {
+  name: "7356"
+  id: 2557
+  display_name: "Galerida cristata"
+}
+item {
+  name: "64705"
+  id: 2558
+  display_name: "Delichon urbicum"
+}
+item {
+  name: "145932"
+  id: 2559
+  display_name: "Aspidoscelis hyperythra beldingi"
+}
+item {
+  name: "72912"
+  id: 2560
+  display_name: "Helmitheros vermivorum"
+}
+item {
+  name: "69805"
+  id: 2561
+  display_name: "Octogomphus specularis"
+}
+item {
+  name: "129572"
+  id: 2562
+  display_name: "Aphomia sociella"
+}
+item {
+  name: "31964"
+  id: 2563
+  display_name: "Barisia imbricata"
+}
+item {
+  name: "244625"
+  id: 2564
+  display_name: "Halmus chalybeus"
+}
+item {
+  name: "58576"
+  id: 2565
+  display_name: "Phyciodes cocyta"
+}
+item {
+  name: "72931"
+  id: 2566
+  display_name: "Hylocharis leucotis"
+}
+item {
+  name: "104449"
+  id: 2567
+  display_name: "Lestes rectangularis"
+}
+item {
+  name: "14886"
+  id: 2568
+  display_name: "Mimus polyglottos"
+}
+item {
+  name: "23783"
+  id: 2569
+  display_name: "Hyla versicolor"
+}
+item {
+  name: "23784"
+  id: 2570
+  display_name: "Hyla plicata"
+}
+item {
+  name: "8575"
+  id: 2571
+  display_name: "Gymnorhina tibicen"
+}
+item {
+  name: "2599"
+  id: 2572
+  display_name: "Alcedo atthis"
+}
+item {
+  name: "61152"
+  id: 2573
+  display_name: "Pyrrhosoma nymphula"
+}
+item {
+  name: "58579"
+  id: 2574
+  display_name: "Polygonia interrogationis"
+}
+item {
+  name: "31993"
+  id: 2575
+  display_name: "Ophisaurus attenuatus attenuatus"
+}
+item {
+  name: "53985"
+  id: 2576
+  display_name: "Odocoileus hemionus californicus"
+}
+item {
+  name: "144549"
+  id: 2577
+  display_name: "Streptopelia chinensis"
+}
+item {
+  name: "105730"
+  id: 2578
+  display_name: "Micrathyria hagenii"
+}
+item {
+  name: "7428"
+  id: 2579
+  display_name: "Bombycilla cedrorum"
+}
+item {
+  name: "7429"
+  id: 2580
+  display_name: "Bombycilla garrulus"
+}
+item {
+  name: "50391"
+  id: 2581
+  display_name: "Polygonia gracilis"
+}
+item {
+  name: "7067"
+  id: 2582
+  display_name: "Tadorna tadorna"
+}
+item {
+  name: "413513"
+  id: 2583
+  display_name: "Petroica australis australis"
+}
+item {
+  name: "39469"
+  id: 2584
+  display_name: "Varanus varius"
+}
+item {
+  name: "58479"
+  id: 2585
+  display_name: "Pholisora catullus"
+}
+item {
+  name: "127929"
+  id: 2586
+  display_name: "Achalarus lyciades"
+}
+item {
+  name: "48403"
+  id: 2587
+  display_name: "Gasterosteus aculeatus"
+}
+item {
+  name: "18990"
+  id: 2588
+  display_name: "Amazona autumnalis"
+}
+item {
+  name: "1241"
+  id: 2589
+  display_name: "Dendragapus obscurus"
+}
+item {
+  name: "228634"
+  id: 2590
+  display_name: "Ponometia erastrioides"
+}
+item {
+  name: "64806"
+  id: 2591
+  display_name: "Pelophylax"
+}
+item {
+  name: "51761"
+  id: 2592
+  display_name: "Hetaerina americana"
+}
+item {
+  name: "7464"
+  id: 2593
+  display_name: "Catherpes mexicanus"
+}
+item {
+  name: "318761"
+  id: 2594
+  display_name: "Sceloporus uniformis"
+}
+item {
+  name: "7068"
+  id: 2595
+  display_name: "Tadorna ferruginea"
+}
+item {
+  name: "204077"
+  id: 2596
+  display_name: "Achyra rantalis"
+}
+item {
+  name: "7470"
+  id: 2597
+  display_name: "Campylorhynchus brunneicapillus"
+}
+item {
+  name: "32048"
+  id: 2598
+  display_name: "Gerrhonotus infernalis"
+}
+item {
+  name: "204081"
+  id: 2599
+  display_name: "Pyrausta laticlavia"
+}
+item {
+  name: "7476"
+  id: 2600
+  display_name: "Campylorhynchus rufinucha"
+}
+item {
+  name: "32055"
+  id: 2601
+  display_name: "Elgaria multicarinata"
+}
+item {
+  name: "244276"
+  id: 2602
+  display_name: "Rhipidura fuliginosa"
+}
+item {
+  name: "144187"
+  id: 2603
+  display_name: "Pyrisitia proterpia"
+}
+item {
+  name: "32059"
+  id: 2604
+  display_name: "Elgaria multicarinata multicarinata"
+}
+item {
+  name: "32061"
+  id: 2605
+  display_name: "Elgaria kingii"
+}
+item {
+  name: "146750"
+  id: 2606
+  display_name: "Lascoria ambigualis"
+}
+item {
+  name: "32064"
+  id: 2607
+  display_name: "Elgaria coerulea"
+}
+item {
+  name: "23873"
+  id: 2608
+  display_name: "Hyla squirella"
+}
+item {
+  name: "48450"
+  id: 2609
+  display_name: "Peltodoris nobilis"
+}
+item {
+  name: "64146"
+  id: 2610
+  display_name: "Fissurella volcano"
+}
+item {
+  name: "48259"
+  id: 2611
+  display_name: "Pelidnota punctata"
+}
+item {
+  name: "122185"
+  id: 2612
+  display_name: "Pantherophis alleghaniensis quadrivittata"
+}
+item {
+  name: "7498"
+  id: 2613
+  display_name: "Polioptila melanura"
+}
+item {
+  name: "56652"
+  id: 2614
+  display_name: "Haliotis rufescens"
+}
+item {
+  name: "122191"
+  id: 2615
+  display_name: "Pelecanus occidentalis carolinensis"
+}
+item {
+  name: "73041"
+  id: 2616
+  display_name: "Melozone aberti"
+}
+item {
+  name: "199381"
+  id: 2617
+  display_name: "Homalodisca vitripennis"
+}
+item {
+  name: "73044"
+  id: 2618
+  display_name: "Melozone crissalis"
+}
+item {
+  name: "83290"
+  id: 2619
+  display_name: "Zanclus cornutus"
+}
+item {
+  name: "7513"
+  id: 2620
+  display_name: "Thryothorus ludovicianus"
+}
+item {
+  name: "28559"
+  id: 2621
+  display_name: "Storeria occipitomaculata occipitomaculata"
+}
+item {
+  name: "24255"
+  id: 2622
+  display_name: "Pseudacris maculata"
+}
+item {
+  name: "130398"
+  id: 2623
+  display_name: "Melanargia galathea"
+}
+item {
+  name: "29925"
+  id: 2624
+  display_name: "Heterodon platirhinos"
+}
+item {
+  name: "48484"
+  id: 2625
+  display_name: "Harmonia axyridis"
+}
+item {
+  name: "122214"
+  id: 2626
+  display_name: "Odontotaenius disjunctus"
+}
+item {
+  name: "39484"
+  id: 2627
+  display_name: "Xantusia vigilis"
+}
+item {
+  name: "73919"
+  id: 2628
+  display_name: "Podarcis sicula"
+}
+item {
+  name: "154553"
+  id: 2629
+  display_name: "Leptoglossus clypealis"
+}
+item {
+  name: "23922"
+  id: 2630
+  display_name: "Hyla intermedia"
+}
+item {
+  name: "122228"
+  id: 2631
+  display_name: "Acharia stimulea"
+}
+item {
+  name: "108344"
+  id: 2632
+  display_name: "Pantala flavescens"
+}
+item {
+  name: "118538"
+  id: 2633
+  display_name: "Cotinis nitida"
+}
+item {
+  name: "23930"
+  id: 2634
+  display_name: "Hyla chrysoscelis"
+}
+item {
+  name: "23933"
+  id: 2635
+  display_name: "Hyla arenicolor"
+}
+item {
+  name: "122238"
+  id: 2636
+  display_name: "Porcellio scaber"
+}
+item {
+  name: "479803"
+  id: 2637
+  display_name: "Dioprosopa clavata"
+}
+item {
+  name: "5355"
+  id: 2638
+  display_name: "Parabuteo unicinctus"
+}
+item {
+  name: "146822"
+  id: 2639
+  display_name: "Texola elada"
+}
+item {
+  name: "236935"
+  id: 2640
+  display_name: "Anas platyrhynchos domesticus"
+}
+item {
+  name: "7562"
+  id: 2641
+  display_name: "Troglodytes aedon"
+}
+item {
+  name: "339444"
+  id: 2642
+  display_name: "Buteo lineatus elegans"
+}
+item {
+  name: "42221"
+  id: 2643
+  display_name: "Odocoileus hemionus columbianus"
+}
+item {
+  name: "15764"
+  id: 2644
+  display_name: "Thamnophilus doliatus"
+}
+item {
+  name: "122261"
+  id: 2645
+  display_name: "Cucullia convexipennis"
+}
+item {
+  name: "122262"
+  id: 2646
+  display_name: "Brachystola magna"
+}
+item {
+  name: "7576"
+  id: 2647
+  display_name: "Thryomanes bewickii"
+}
+item {
+  name: "143015"
+  id: 2648
+  display_name: "Eubaphe mendica"
+}
+item {
+  name: "73592"
+  id: 2649
+  display_name: "Actinemys marmorata"
+}
+item {
+  name: "84549"
+  id: 2650
+  display_name: "Plathemis lydia"
+}
+item {
+  name: "23969"
+  id: 2651
+  display_name: "Hyla cinerea"
+}
+item {
+  name: "318882"
+  id: 2652
+  display_name: "Ancistrocerus gazella"
+}
+item {
+  name: "7072"
+  id: 2653
+  display_name: "Tadorna variegata"
+}
+item {
+  name: "48548"
+  id: 2654
+  display_name: "Vanessa cardui"
+}
+item {
+  name: "48549"
+  id: 2655
+  display_name: "Vanessa virginiensis"
+}
+item {
+  name: "122278"
+  id: 2656
+  display_name: "Pomacea canaliculata"
+}
+item {
+  name: "9457"
+  id: 2657
+  display_name: "Myioborus miniatus"
+}
+item {
+  name: "122280"
+  id: 2658
+  display_name: "Pyrgus albescens"
+}
+item {
+  name: "122281"
+  id: 2659
+  display_name: "Calycopis cecrops"
+}
+item {
+  name: "130474"
+  id: 2660
+  display_name: "Achlyodes pallida"
+}
+item {
+  name: "338503"
+  id: 2661
+  display_name: "Phalacrocorax varius varius"
+}
+item {
+  name: "9458"
+  id: 2662
+  display_name: "Myioborus pictus"
+}
+item {
+  name: "73629"
+  id: 2663
+  display_name: "Anolis nebulosus"
+}
+item {
+  name: "122291"
+  id: 2664
+  display_name: "Larus argentatus smithsonianus"
+}
+item {
+  name: "56756"
+  id: 2665
+  display_name: "Murgantia histrionica"
+}
+item {
+  name: "73148"
+  id: 2666
+  display_name: "Parkesia motacilla"
+}
+item {
+  name: "48575"
+  id: 2667
+  display_name: "Okenia rosacea"
+}
+item {
+  name: "56768"
+  id: 2668
+  display_name: "Sula granti"
+}
+item {
+  name: "48578"
+  id: 2669
+  display_name: "Anteos maerula"
+}
+item {
+  name: "64968"
+  id: 2670
+  display_name: "Anaxyrus americanus"
+}
+item {
+  name: "64970"
+  id: 2671
+  display_name: "Anaxyrus boreas"
+}
+item {
+  name: "115549"
+  id: 2672
+  display_name: "Crotalus lepidus lepidus"
+}
+item {
+  name: "64977"
+  id: 2673
+  display_name: "Anaxyrus fowleri"
+}
+item {
+  name: "19022"
+  id: 2674
+  display_name: "Ara macao"
+}
+item {
+  name: "24259"
+  id: 2675
+  display_name: "Pseudacris regilla"
+}
+item {
+  name: "64984"
+  id: 2676
+  display_name: "Anaxyrus punctatus"
+}
+item {
+  name: "64985"
+  id: 2677
+  display_name: "Anaxyrus quercicus"
+}
+item {
+  name: "73178"
+  id: 2678
+  display_name: "Peucaea ruficauda"
+}
+item {
+  name: "64987"
+  id: 2679
+  display_name: "Anaxyrus speciosus"
+}
+item {
+  name: "64989"
+  id: 2680
+  display_name: "Anaxyrus woodhousii"
+}
+item {
+  name: "339596"
+  id: 2681
+  display_name: "Calidris subruficollis"
+}
+item {
+  name: "56552"
+  id: 2682
+  display_name: "Carabus nemoralis"
+}
+item {
+  name: "84722"
+  id: 2683
+  display_name: "Ischnura verticalis"
+}
+item {
+  name: "122356"
+  id: 2684
+  display_name: "Eumorpha achemon"
+}
+item {
+  name: "318965"
+  id: 2685
+  display_name: "Chrysolina bankii"
+}
+item {
+  name: "228855"
+  id: 2686
+  display_name: "Protodeltote muscosula"
+}
+item {
+  name: "146940"
+  id: 2687
+  display_name: "Agriphila vulgivagella"
+}
+item {
+  name: "56832"
+  id: 2688
+  display_name: "Nymphalis antiopa"
+}
+item {
+  name: "61355"
+  id: 2689
+  display_name: "Vespula pensylvanica"
+}
+item {
+  name: "48645"
+  id: 2690
+  display_name: "Megathura crenulata"
+}
+item {
+  name: "73222"
+  id: 2691
+  display_name: "Phoenicopterus roseus"
+}
+item {
+  name: "363354"
+  id: 2692
+  display_name: "Lobatus gigas"
+}
+item {
+  name: "3802"
+  id: 2693
+  display_name: "Morus bassanus"
+}
+item {
+  name: "62722"
+  id: 2694
+  display_name: "Apalone spinifera spinifera"
+}
+item {
+  name: "48655"
+  id: 2695
+  display_name: "Aplysia californica"
+}
+item {
+  name: "54468"
+  id: 2696
+  display_name: "Aglais urticae"
+}
+item {
+  name: "48662"
+  id: 2697
+  display_name: "Danaus plexippus"
+}
+item {
+  name: "49071"
+  id: 2698
+  display_name: "Metridium senile"
+}
+item {
+  name: "228899"
+  id: 2699
+  display_name: "Psamatodes abydata"
+}
+item {
+  name: "133102"
+  id: 2700
+  display_name: "Oncometopia orbona"
+}
+item {
+  name: "39659"
+  id: 2701
+  display_name: "Chelonia mydas"
+}
+item {
+  name: "121437"
+  id: 2702
+  display_name: "Dolomedes triton"
+}
+item {
+  name: "94545"
+  id: 2703
+  display_name: "Argia fumipennis"
+}
+item {
+  name: "56887"
+  id: 2704
+  display_name: "Bombus pensylvanicus"
+}
+item {
+  name: "40509"
+  id: 2705
+  display_name: "Eptesicus fuscus"
+}
+item {
+  name: "58635"
+  id: 2706
+  display_name: "Lepomis megalotis"
+}
+item {
+  name: "100369"
+  id: 2707
+  display_name: "Erpetogomphus designatus"
+}
+item {
+  name: "58636"
+  id: 2708
+  display_name: "Lepomis cyanellus"
+}
+item {
+  name: "40522"
+  id: 2709
+  display_name: "Lasiurus borealis"
+}
+item {
+  name: "102006"
+  id: 2710
+  display_name: "Hagenius brevistylus"
+}
+item {
+  name: "50283"
+  id: 2711
+  display_name: "Marpesia petreus"
+}
+item {
+  name: "123829"
+  id: 2712
+  display_name: "Pelecanus occidentalis californicus"
+}
+item {
+  name: "62453"
+  id: 2713
+  display_name: "Anthidium manicatum"
+}
+item {
+  name: "56925"
+  id: 2714
+  display_name: "Graphocephala coccinea"
+}
+item {
+  name: "48738"
+  id: 2715
+  display_name: "Sphex pensylvanicus"
+}
+item {
+  name: "43151"
+  id: 2716
+  display_name: "Oryctolagus cuniculus"
+}
+item {
+  name: "19822"
+  id: 2717
+  display_name: "Glaucidium brasilianum"
+}
+item {
+  name: "48750"
+  id: 2718
+  display_name: "Lottia scabra"
+}
+item {
+  name: "335071"
+  id: 2719
+  display_name: "Elophila obliteralis"
+}
+item {
+  name: "81521"
+  id: 2720
+  display_name: "Vipera berus"
+}
+item {
+  name: "43697"
+  id: 2721
+  display_name: "Elephas maximus"
+}
+item {
+  name: "7079"
+  id: 2722
+  display_name: "Oxyura jamaicensis"
+}
+item {
+  name: "43042"
+  id: 2723
+  display_name: "Erinaceus europaeus"
+}
+item {
+  name: "40086"
+  id: 2724
+  display_name: "Gopherus agassizii"
+}
+item {
+  name: "81545"
+  id: 2725
+  display_name: "Lumbricus terrestris"
+}
+item {
+  name: "16010"
+  id: 2726
+  display_name: "Myiarchus cinerascens"
+}
+item {
+  name: "2669"
+  id: 2727
+  display_name: "Chloroceryle americana"
+}
+item {
+  name: "9535"
+  id: 2728
+  display_name: "Sturnella neglecta"
+}
+item {
+  name: "81554"
+  id: 2729
+  display_name: "Ictalurus punctatus"
+}
+item {
+  name: "339907"
+  id: 2730
+  display_name: "Ramphastos ambiguus"
+}
+item {
+  name: "39814"
+  id: 2731
+  display_name: "Terrapene carolina"
+}
+item {
+  name: "10254"
+  id: 2732
+  display_name: "Paroaria coronata"
+}
+item {
+  name: "40614"
+  id: 2733
+  display_name: "Antrozous pallidus"
+}
+item {
+  name: "502385"
+  id: 2734
+  display_name: "Probole amicaria"
+}
+item {
+  name: "24233"
+  id: 2735
+  display_name: "Acris gryllus"
+}
+item {
+  name: "81579"
+  id: 2736
+  display_name: "Steatoda triangulosa"
+}
+item {
+  name: "81580"
+  id: 2737
+  display_name: "Callosamia promethea"
+}
+item {
+  name: "146034"
+  id: 2738
+  display_name: "Coluber lateralis"
+}
+item {
+  name: "81582"
+  id: 2739
+  display_name: "Hyalophora cecropia"
+}
+item {
+  name: "81583"
+  id: 2740
+  display_name: "Anisota senatoria"
+}
+item {
+  name: "66002"
+  id: 2741
+  display_name: "Lithobates palustris"
+}
+item {
+  name: "81586"
+  id: 2742
+  display_name: "Citheronia regalis"
+}
+item {
+  name: "40629"
+  id: 2743
+  display_name: "Lasionycteris noctivagans"
+}
+item {
+  name: "81590"
+  id: 2744
+  display_name: "Eacles imperialis"
+}
+item {
+  name: "204472"
+  id: 2745
+  display_name: "Buteo buteo"
+}
+item {
+  name: "65212"
+  id: 2746
+  display_name: "Craugastor augusti"
+}
+item {
+  name: "48830"
+  id: 2747
+  display_name: "Patiria miniata"
+}
+item {
+  name: "48833"
+  id: 2748
+  display_name: "Pisaster giganteus"
+}
+item {
+  name: "16071"
+  id: 2749
+  display_name: "Myiodynastes luteiventris"
+}
+item {
+  name: "81610"
+  id: 2750
+  display_name: "Balanus glandula"
+}
+item {
+  name: "24268"
+  id: 2751
+  display_name: "Pseudacris crucifer"
+}
+item {
+  name: "16079"
+  id: 2752
+  display_name: "Contopus sordidulus"
+}
+item {
+  name: "204496"
+  id: 2753
+  display_name: "Corvus corone"
+}
+item {
+  name: "204498"
+  id: 2754
+  display_name: "Cyanoramphus novaezelandiae"
+}
+item {
+  name: "24277"
+  id: 2755
+  display_name: "Smilisca baudinii"
+}
+item {
+  name: "22631"
+  id: 2756
+  display_name: "Eleutherodactylus planirostris"
+}
+item {
+  name: "16100"
+  id: 2757
+  display_name: "Contopus virens"
+}
+item {
+  name: "42278"
+  id: 2758
+  display_name: "Aepyceros melampus"
+}
+item {
+  name: "16106"
+  id: 2759
+  display_name: "Contopus pertinax"
+}
+item {
+  name: "16110"
+  id: 2760
+  display_name: "Contopus cooperi"
+}
+item {
+  name: "42280"
+  id: 2761
+  display_name: "Connochaetes taurinus"
+}
+item {
+  name: "47455"
+  id: 2762
+  display_name: "Octopus rubescens"
+}
+item {
+  name: "204533"
+  id: 2763
+  display_name: "Larus argentatus"
+}
+item {
+  name: "81656"
+  id: 2764
+  display_name: "Nematocampa resistaria"
+}
+item {
+  name: "81657"
+  id: 2765
+  display_name: "Lacinipolia renigera"
+}
+item {
+  name: "204519"
+  id: 2766
+  display_name: "Halcyon smyrnensis"
+}
+item {
+  name: "62762"
+  id: 2767
+  display_name: "Cordulegaster dorsalis"
+}
+item {
+  name: "81663"
+  id: 2768
+  display_name: "Malacosoma disstria"
+}
+item {
+  name: "32512"
+  id: 2769
+  display_name: "Rena dulcis"
+}
+item {
+  name: "81665"
+  id: 2770
+  display_name: "Orgyia leucostigma"
+}
+item {
+  name: "130821"
+  id: 2771
+  display_name: "Haploa confusa"
+}
+item {
+  name: "81672"
+  id: 2772
+  display_name: "Clemensia albata"
+}
+item {
+  name: "204554"
+  id: 2773
+  display_name: "Onychognathus morio"
+}
+item {
+  name: "81677"
+  id: 2774
+  display_name: "Euchaetes egle"
+}
+item {
+  name: "81680"
+  id: 2775
+  display_name: "Scopula limboundata"
+}
+item {
+  name: "318497"
+  id: 2776
+  display_name: "Hemipenthes sinuosa"
+}
+item {
+  name: "179987"
+  id: 2777
+  display_name: "Ictidomys parvidens"
+}
+item {
+  name: "179988"
+  id: 2778
+  display_name: "Ictidomys tridecemlineatus"
+}
+item {
+  name: "81685"
+  id: 2779
+  display_name: "Evergestis pallidata"
+}
+item {
+  name: "81687"
+  id: 2780
+  display_name: "Noctua pronuba"
+}
+item {
+  name: "179992"
+  id: 2781
+  display_name: "Xerospermophilus spilosoma"
+}
+item {
+  name: "179994"
+  id: 2782
+  display_name: "Urocitellus armatus"
+}
+item {
+  name: "9519"
+  id: 2783
+  display_name: "Cyanocompsa parellina"
+}
+item {
+  name: "179998"
+  id: 2784
+  display_name: "Urocitellus columbianus"
+}
+item {
+  name: "114463"
+  id: 2785
+  display_name: "Trithemis annulata"
+}
+item {
+  name: "199169"
+  id: 2786
+  display_name: "Catocala maestosa"
+}
+item {
+  name: "143323"
+  id: 2787
+  display_name: "Tolype velleda"
+}
+item {
+  name: "120113"
+  id: 2788
+  display_name: "Anthrenus verbasci"
+}
+item {
+  name: "7601"
+  id: 2789
+  display_name: "Cistothorus palustris"
+}
+item {
+  name: "81706"
+  id: 2790
+  display_name: "Alaus oculatus"
+}
+item {
+  name: "220974"
+  id: 2791
+  display_name: "Harrisimemna trisignata"
+}
+item {
+  name: "20445"
+  id: 2792
+  display_name: "Tyto alba"
+}
+item {
+  name: "73523"
+  id: 2793
+  display_name: "Trogon caligatus"
+}
+item {
+  name: "49590"
+  id: 2794
+  display_name: "Micropterus dolomieu"
+}
+item {
+  name: "41729"
+  id: 2795
+  display_name: "Mirounga leonina"
+}
+item {
+  name: "48957"
+  id: 2796
+  display_name: "Arilus cristatus"
+}
+item {
+  name: "81727"
+  id: 2797
+  display_name: "Abaeis nicippe"
+}
+item {
+  name: "8000"
+  id: 2798
+  display_name: "Corvus monedula"
+}
+item {
+  name: "8001"
+  id: 2799
+  display_name: "Corvus ossifragus"
+}
+item {
+  name: "171843"
+  id: 2800
+  display_name: "Rabdotus dealbatus"
+}
+item {
+  name: "81734"
+  id: 2801
+  display_name: "Neophasia menapia"
+}
+item {
+  name: "258813"
+  id: 2802
+  display_name: "Clogmia albipunctata"
+}
+item {
+  name: "332243"
+  id: 2803
+  display_name: "Lepturobosca chrysocoma"
+}
+item {
+  name: "81744"
+  id: 2804
+  display_name: "Heliconius erato"
+}
+item {
+  name: "218424"
+  id: 2805
+  display_name: "Dicymolomia julianalis"
+}
+item {
+  name: "3813"
+  id: 2806
+  display_name: "Spheniscus demersus"
+}
+item {
+  name: "81749"
+  id: 2807
+  display_name: "Malacosoma americanum"
+}
+item {
+  name: "81752"
+  id: 2808
+  display_name: "Pyrausta tyralis"
+}
+item {
+  name: "48987"
+  id: 2809
+  display_name: "Hippodamia convergens"
+}
+item {
+  name: "8029"
+  id: 2810
+  display_name: "Corvus frugilegus"
+}
+item {
+  name: "8031"
+  id: 2811
+  display_name: "Corvus splendens"
+}
+item {
+  name: "147298"
+  id: 2812
+  display_name: "Lasiommata megera"
+}
+item {
+  name: "7087"
+  id: 2813
+  display_name: "Branta bernicla"
+}
+item {
+  name: "48550"
+  id: 2814
+  display_name: "Phoebis sennae"
+}
+item {
+  name: "4349"
+  id: 2815
+  display_name: "Larus hyperboreus"
+}
+item {
+  name: "84027"
+  id: 2816
+  display_name: "Trigonopeltastes delta"
+}
+item {
+  name: "194762"
+  id: 2817
+  display_name: "Vanessa itea"
+}
+item {
+  name: "311163"
+  id: 2818
+  display_name: "Pseudomops septentrionalis"
+}
+item {
+  name: "55957"
+  id: 2819
+  display_name: "Scudderia furcata"
+}
+item {
+  name: "39822"
+  id: 2820
+  display_name: "Pseudemys texana"
+}
+item {
+  name: "204685"
+  id: 2821
+  display_name: "Chlosyne ehrenbergii"
+}
+item {
+  name: "122767"
+  id: 2822
+  display_name: "Columba livia domestica"
+}
+item {
+  name: "55960"
+  id: 2823
+  display_name: "Sceloporus graciosus"
+}
+item {
+  name: "121823"
+  id: 2824
+  display_name: "Autographa californica"
+}
+item {
+  name: "8088"
+  id: 2825
+  display_name: "Garrulus glandarius"
+}
+item {
+  name: "65433"
+  id: 2826
+  display_name: "Ecnomiohyla miotympanum"
+}
+item {
+  name: "49051"
+  id: 2827
+  display_name: "Anthopleura sola"
+}
+item {
+  name: "125815"
+  id: 2828
+  display_name: "Coenonympha arcania"
+}
+item {
+  name: "55963"
+  id: 2829
+  display_name: "Malacosoma californicum"
+}
+item {
+  name: "120479"
+  id: 2830
+  display_name: "Anser anser domesticus"
+}
+item {
+  name: "133788"
+  id: 2831
+  display_name: "Xylocopa micans"
+}
+item {
+  name: "81559"
+  id: 2832
+  display_name: "Epargyreus clarus"
+}
+item {
+  name: "81839"
+  id: 2833
+  display_name: "Platycryptus undatus"
+}
+item {
+  name: "133791"
+  id: 2834
+  display_name: "Polistes exclamans"
+}
+item {
+  name: "84640"
+  id: 2835
+  display_name: "Polistes dominula"
+}
+item {
+  name: "73666"
+  id: 2836
+  display_name: "Aspidoscelis exsanguis"
+}
+item {
+  name: "73669"
+  id: 2837
+  display_name: "Aspidoscelis gularis"
+}
+item {
+  name: "16326"
+  id: 2838
+  display_name: "Mitrephanes phaeocercus"
+}
+item {
+  name: "49095"
+  id: 2839
+  display_name: "Pagurus samuelis"
+}
+item {
+  name: "73672"
+  id: 2840
+  display_name: "Aspidoscelis hyperythra"
+}
+item {
+  name: "59192"
+  id: 2841
+  display_name: "Polites sabuleti"
+}
+item {
+  name: "81561"
+  id: 2842
+  display_name: "Anaea andria"
+}
+item {
+  name: "81881"
+  id: 2843
+  display_name: "Amphipsalta zelandica"
+}
+item {
+  name: "73690"
+  id: 2844
+  display_name: "Aspidoscelis sexlineata"
+}
+item {
+  name: "73694"
+  id: 2845
+  display_name: "Aspidoscelis velox"
+}
+item {
+  name: "335840"
+  id: 2846
+  display_name: "Pyrausta inornatalis"
+}
+item {
+  name: "49126"
+  id: 2847
+  display_name: "Strongylocentrotus franciscanus"
+}
+item {
+  name: "204775"
+  id: 2848
+  display_name: "Kricogonia lyside"
+}
+item {
+  name: "475115"
+  id: 2849
+  display_name: "Ardenna creatopus"
+}
+item {
+  name: "475120"
+  id: 2850
+  display_name: "Ardenna gravis"
+}
+item {
+  name: "62803"
+  id: 2851
+  display_name: "Monadenia fidelis"
+}
+item {
+  name: "49150"
+  id: 2852
+  display_name: "Agraulis vanillae"
+}
+item {
+  name: "83929"
+  id: 2853
+  display_name: "Phanaeus vindex"
+}
+item {
+  name: "199839"
+  id: 2854
+  display_name: "Haemorhous cassinii"
+}

--- a/research/object_detection/data_decoders/tf_example_decoder.py
+++ b/research/object_detection/data_decoders/tf_example_decoder.py
@@ -19,9 +19,6 @@ protos for object detection.
 """
 import tensorflow as tf
 
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import math_ops
 from object_detection.core import data_decoder
 from object_detection.core import standard_fields as fields
 from object_detection.protos import input_reader_pb2
@@ -30,14 +27,12 @@ from object_detection.utils import label_map_util
 slim_example_decoder = tf.contrib.slim.tfexample_decoder
 
 
-# TODO(lzc): keep LookupTensor and BackupHandler in sync with
-# tf.contrib.slim.tfexample_decoder version.
-class LookupTensor(slim_example_decoder.Tensor):
-  """An ItemHandler that returns a parsed Tensor, the result of a lookup."""
+class _ClassTensorHandler(slim_example_decoder.Tensor):
+  """An ItemHandler to fetch class ids from class text."""
 
   def __init__(self,
                tensor_key,
-               table,
+               label_map_proto_file,
                shape_keys=None,
                shape=None,
                default_value=''):
@@ -47,7 +42,8 @@ class LookupTensor(slim_example_decoder.Tensor):
 
     Args:
       tensor_key: the name of the `TFExample` feature to read the tensor from.
-      table: A tf.lookup table.
+      label_map_proto_file: File path to a text format LabelMapProto message
+        mapping class text to id.
       shape_keys: Optional name or list of names of the TF-Example feature in
         which the tensor shape is stored. If a list, then each corresponds to
         one dimension of the shape.
@@ -59,16 +55,39 @@ class LookupTensor(slim_example_decoder.Tensor):
     Raises:
       ValueError: if both `shape_keys` and `shape` are specified.
     """
-    self._table = table
-    super(LookupTensor, self).__init__(tensor_key, shape_keys, shape,
-                                       default_value)
+    name_to_id = label_map_util.get_label_map_dict(
+        label_map_proto_file, use_display_name=False)
+    # We use a default_value of -1, but we expect all labels to be contained
+    # in the label map.
+    name_to_id_table = tf.contrib.lookup.HashTable(
+        initializer=tf.contrib.lookup.KeyValueTensorInitializer(
+            keys=tf.constant(list(name_to_id.keys())),
+            values=tf.constant(list(name_to_id.values()), dtype=tf.int64)),
+        default_value=-1)
+    display_name_to_id = label_map_util.get_label_map_dict(
+        label_map_proto_file, use_display_name=True)
+    # We use a default_value of -1, but we expect all labels to be contained
+    # in the label map.
+    display_name_to_id_table = tf.contrib.lookup.HashTable(
+        initializer=tf.contrib.lookup.KeyValueTensorInitializer(
+            keys=tf.constant(list(display_name_to_id.keys())),
+            values=tf.constant(
+                list(display_name_to_id.values()), dtype=tf.int64)),
+        default_value=-1)
+
+    self._name_to_id_table = name_to_id_table
+    self._display_name_to_id_table = display_name_to_id_table
+    super(_ClassTensorHandler, self).__init__(tensor_key, shape_keys, shape,
+                                              default_value)
 
   def tensors_to_item(self, keys_to_tensors):
-    unmapped_tensor = super(LookupTensor, self).tensors_to_item(keys_to_tensors)
-    return self._table.lookup(unmapped_tensor)
+    unmapped_tensor = super(_ClassTensorHandler,
+                            self).tensors_to_item(keys_to_tensors)
+    return tf.maximum(self._name_to_id_table.lookup(unmapped_tensor),
+                      self._display_name_to_id_table.lookup(unmapped_tensor))
 
 
-class BackupHandler(slim_example_decoder.ItemHandler):
+class _BackupHandler(slim_example_decoder.ItemHandler):
   """An ItemHandler that tries two ItemHandlers in order."""
 
   def __init__(self, handler, backup):
@@ -92,12 +111,12 @@ class BackupHandler(slim_example_decoder.ItemHandler):
           'Backup handler is of type %s instead of ItemHandler' % type(backup))
     self._handler = handler
     self._backup = backup
-    super(BackupHandler, self).__init__(handler.keys + backup.keys)
+    super(_BackupHandler, self).__init__(handler.keys + backup.keys)
 
   def tensors_to_item(self, keys_to_tensors):
     item = self._handler.tensors_to_item(keys_to_tensors)
-    return control_flow_ops.cond(
-        pred=math_ops.equal(math_ops.reduce_prod(array_ops.shape(item)), 0),
+    return tf.cond(
+        pred=tf.equal(tf.reduce_prod(tf.shape(item)), 0),
         true_fn=lambda: self._backup.tensors_to_item(keys_to_tensors),
         false_fn=lambda: item)
 
@@ -140,6 +159,9 @@ class TfExampleDecoder(data_decoder.DataDecoder):
         input_reader_pb2.DEFAULT, input_reader_pb2.NUMERICAL, or
         input_reader_pb2.PNG_MASKS.
     """
+    # TODO(rathodv): delete unused `use_display_name` argument once we change
+    # other decoders to handle label maps similarly.
+    del use_display_name
     self.keys_to_features = {
         'image/encoded':
             tf.FixedLenFeature((), tf.string, default_value=''),
@@ -267,27 +289,18 @@ class TfExampleDecoder(data_decoder.DataDecoder):
       else:
         raise ValueError('Did not recognize the `instance_mask_type` option.')
     if label_map_proto_file:
-      label_map = label_map_util.get_label_map_dict(label_map_proto_file,
-                                                    use_display_name)
-      # We use a default_value of -1, but we expect all labels to be contained
-      # in the label map.
-      table = tf.contrib.lookup.HashTable(
-          initializer=tf.contrib.lookup.KeyValueTensorInitializer(
-              keys=tf.constant(list(label_map.keys())),
-              values=tf.constant(list(label_map.values()), dtype=tf.int64)),
-          default_value=-1)
       # If the label_map_proto is provided, try to use it in conjunction with
       # the class text, and fall back to a materialized ID.
-      # TODO(lzc): note that here we are using BackupHandler defined in this
-      # file(which is branching slim_example_decoder.BackupHandler). Need to
-      # switch back to slim_example_decoder.BackupHandler once tf 1.5 becomes
-      # more popular.
-      label_handler = BackupHandler(
-          LookupTensor('image/object/class/text', table, default_value=''),
+      label_handler = _BackupHandler(
+          _ClassTensorHandler(
+              'image/object/class/text', label_map_proto_file,
+              default_value=''),
           slim_example_decoder.Tensor('image/object/class/label'))
-      image_label_handler = BackupHandler(
-          LookupTensor(
-              fields.TfExampleFields.image_class_text, table, default_value=''),
+      image_label_handler = _BackupHandler(
+          _ClassTensorHandler(
+              fields.TfExampleFields.image_class_text,
+              label_map_proto_file,
+              default_value=''),
           slim_example_decoder.Tensor(fields.TfExampleFields.image_class_label))
     else:
       label_handler = slim_example_decoder.Tensor('image/object/class/label')

--- a/research/object_detection/data_decoders/tf_example_decoder_test.py
+++ b/research/object_detection/data_decoders/tf_example_decoder_test.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Tests for object_detection.data_decoders.tf_example_decoder."""
 
 import os
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.core.example import example_pb2
-from tensorflow.core.example import feature_pb2
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
@@ -30,6 +27,7 @@ from tensorflow.python.ops import parsing_ops
 from object_detection.core import standard_fields as fields
 from object_detection.data_decoders import tf_example_decoder
 from object_detection.protos import input_reader_pb2
+from object_detection.utils import dataset_util
 
 slim_example_decoder = tf.contrib.slim.tfexample_decoder
 
@@ -56,25 +54,6 @@ class TfExampleDecoderTest(tf.test.TestCase):
         raise ValueError('Invalid encoding type.')
     return image_decoded
 
-  def _Int64Feature(self, value):
-    return tf.train.Feature(int64_list=tf.train.Int64List(value=value))
-
-  def _FloatFeature(self, value):
-    return tf.train.Feature(float_list=tf.train.FloatList(value=value))
-
-  def _BytesFeature(self, value):
-    if isinstance(value, list):
-      return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
-
-  def _Int64FeatureFromList(self, ndarray):
-    return feature_pb2.Feature(
-        int64_list=feature_pb2.Int64List(value=ndarray.flatten().tolist()))
-
-  def _BytesFeatureFromList(self, ndarray):
-    values = ndarray.flatten().tolist()
-    return feature_pb2.Feature(bytes_list=feature_pb2.BytesList(value=values))
-
   def testDecodeAdditionalChannels(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
@@ -88,14 +67,14 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded':
-                    self._BytesFeature(encoded_jpeg),
+                    dataset_util.bytes_feature(encoded_jpeg),
                 'image/additional_channels/encoded':
-                    self._BytesFeatureFromList(
-                        np.array([encoded_additional_channel] * 2)),
+                    dataset_util.bytes_list_feature(
+                        [encoded_additional_channel] * 2),
                 'image/format':
-                    self._BytesFeature('jpeg'),
+                    dataset_util.bytes_feature('jpeg'),
                 'image/source_id':
-                    self._BytesFeature('image_id'),
+                    dataset_util.bytes_feature('image_id'),
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder(
@@ -109,27 +88,27 @@ class TfExampleDecoderTest(tf.test.TestCase):
           tensor_dict[fields.InputDataFields.image_additional_channels])
 
   def testDecodeExampleWithBranchedBackupHandler(self):
-    example1 = example_pb2.Example(
-        features=feature_pb2.Features(
+    example1 = tf.train.Example(
+        features=tf.train.Features(
             feature={
                 'image/object/class/text':
-                    self._BytesFeatureFromList(
-                        np.array(['cat', 'dog', 'guinea pig'])),
+                    dataset_util.bytes_list_feature(
+                        ['cat', 'dog', 'guinea pig']),
                 'image/object/class/label':
-                    self._Int64FeatureFromList(np.array([42, 10, 900]))
+                    dataset_util.int64_list_feature([42, 10, 900])
             }))
-    example2 = example_pb2.Example(
-        features=feature_pb2.Features(
+    example2 = tf.train.Example(
+        features=tf.train.Features(
             feature={
                 'image/object/class/text':
-                    self._BytesFeatureFromList(
-                        np.array(['cat', 'dog', 'guinea pig'])),
+                    dataset_util.bytes_list_feature(
+                        ['cat', 'dog', 'guinea pig']),
             }))
-    example3 = example_pb2.Example(
-        features=feature_pb2.Features(
+    example3 = tf.train.Example(
+        features=tf.train.Features(
             feature={
                 'image/object/class/label':
-                    self._Int64FeatureFromList(np.array([42, 10, 901]))
+                    dataset_util.int64_list_feature([42, 10, 901])
             }))
     # 'dog' -> 0, 'guinea pig' -> 1, 'cat' -> 2
     table = lookup_ops.index_table_from_tensor(
@@ -162,10 +141,13 @@ class TfExampleDecoderTest(tf.test.TestCase):
 
   def testDecodeExampleWithBranchedLookup(self):
 
-    example = example_pb2.Example(features=feature_pb2.Features(feature={
-        'image/object/class/text': self._BytesFeatureFromList(
-            np.array(['cat', 'dog', 'guinea pig'])),
-    }))
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/object/class/text':
+                    dataset_util.bytes_list_feature(
+                        ['cat', 'dog', 'guinea pig']),
+            }))
     serialized_example = example.SerializeToString()
     # 'dog' -> 0, 'guinea pig' -> 1, 'cat' -> 2
     table = lookup_ops.index_table_from_tensor(
@@ -195,17 +177,20 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     decoded_jpeg = self._DecodeImage(encoded_jpeg)
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/source_id': self._BytesFeature('image_id'),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
+                'image/format': dataset_util.bytes_feature('jpeg'),
+                'image/source_id': dataset_util.bytes_feature('image_id'),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.image].
-                         get_shape().as_list()), [None, None, 3])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.image].get_shape().as_list()),
+        [None, None, 3])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
@@ -215,11 +200,13 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeImageKeyAndFilename(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/key/sha256': self._BytesFeature('abc'),
-        'image/filename': self._BytesFeature('filename')
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
+                'image/key/sha256': dataset_util.bytes_feature('abc'),
+                'image/filename': dataset_util.bytes_feature('filename')
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
@@ -234,17 +221,20 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_png = self._EncodeImage(image_tensor, encoding_type='png')
     decoded_png = self._DecodeImage(encoded_png, encoding_type='png')
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_png),
-        'image/format': self._BytesFeature('png'),
-        'image/source_id': self._BytesFeature('image_id')
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded': dataset_util.bytes_feature(encoded_png),
+                'image/format': dataset_util.bytes_feature('png'),
+                'image/source_id': dataset_util.bytes_feature('image_id')
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.image].
-                         get_shape().as_list()), [None, None, 3])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.image].get_shape().as_list()),
+        [None, None, 3])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
@@ -265,9 +255,12 @@ class TfExampleDecoderTest(tf.test.TestCase):
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
-                'image/encoded': self._BytesFeature(encoded_jpeg),
-                'image/format': self._BytesFeature('jpeg'),
-                'image/object/mask': self._BytesFeature(encoded_masks)
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/mask':
+                    dataset_util.bytes_list_feature(encoded_masks)
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder(
@@ -288,11 +281,16 @@ class TfExampleDecoderTest(tf.test.TestCase):
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
-                'image/encoded': self._BytesFeature(encoded_jpeg),
-                'image/format': self._BytesFeature('jpeg'),
-                'image/object/mask': self._BytesFeature(encoded_masks),
-                'image/height': self._Int64Feature([10]),
-                'image/width': self._Int64Feature([10]),
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/mask':
+                    dataset_util.bytes_list_feature(encoded_masks),
+                'image/height':
+                    dataset_util.int64_feature(10),
+                'image/width':
+                    dataset_util.int64_feature(10),
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder(
@@ -312,25 +310,33 @@ class TfExampleDecoderTest(tf.test.TestCase):
     bbox_xmins = [1.0, 5.0]
     bbox_ymaxs = [2.0, 6.0]
     bbox_xmaxs = [3.0, 7.0]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/bbox/ymin': self._FloatFeature(bbox_ymins),
-        'image/object/bbox/xmin': self._FloatFeature(bbox_xmins),
-        'image/object/bbox/ymax': self._FloatFeature(bbox_ymaxs),
-        'image/object/bbox/xmax': self._FloatFeature(bbox_xmaxs),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/bbox/ymin':
+                    dataset_util.float_list_feature(bbox_ymins),
+                'image/object/bbox/xmin':
+                    dataset_util.float_list_feature(bbox_xmins),
+                'image/object/bbox/ymax':
+                    dataset_util.float_list_feature(bbox_ymaxs),
+                'image/object/bbox/xmax':
+                    dataset_util.float_list_feature(bbox_xmaxs),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes].
-                         get_shape().as_list()), [None, 4])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes]
+                         .get_shape().as_list()), [None, 4])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    expected_boxes = np.vstack([bbox_ymins, bbox_xmins,
-                                bbox_ymaxs, bbox_xmaxs]).transpose()
+    expected_boxes = np.vstack([bbox_ymins, bbox_xmins, bbox_ymaxs,
+                                bbox_xmaxs]).transpose()
     self.assertAllEqual(expected_boxes,
                         tensor_dict[fields.InputDataFields.groundtruth_boxes])
     self.assertAllEqual(
@@ -346,30 +352,40 @@ class TfExampleDecoderTest(tf.test.TestCase):
     bbox_xmaxs = [3.0, 7.0]
     keypoint_ys = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
     keypoint_xs = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/bbox/ymin': self._FloatFeature(bbox_ymins),
-        'image/object/bbox/xmin': self._FloatFeature(bbox_xmins),
-        'image/object/bbox/ymax': self._FloatFeature(bbox_ymaxs),
-        'image/object/bbox/xmax': self._FloatFeature(bbox_xmaxs),
-        'image/object/keypoint/y': self._FloatFeature(keypoint_ys),
-        'image/object/keypoint/x': self._FloatFeature(keypoint_xs),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/bbox/ymin':
+                    dataset_util.float_list_feature(bbox_ymins),
+                'image/object/bbox/xmin':
+                    dataset_util.float_list_feature(bbox_xmins),
+                'image/object/bbox/ymax':
+                    dataset_util.float_list_feature(bbox_ymaxs),
+                'image/object/bbox/xmax':
+                    dataset_util.float_list_feature(bbox_xmaxs),
+                'image/object/keypoint/y':
+                    dataset_util.float_list_feature(keypoint_ys),
+                'image/object/keypoint/x':
+                    dataset_util.float_list_feature(keypoint_xs),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder(num_keypoints=3)
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes].
-                         get_shape().as_list()), [None, 4])
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.
-                                     groundtruth_keypoints].
-                         get_shape().as_list()), [2, 3, 2])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes]
+                         .get_shape().as_list()), [None, 4])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.groundtruth_keypoints].get_shape()
+         .as_list()), [2, 3, 2])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    expected_boxes = np.vstack([bbox_ymins, bbox_xmins,
-                                bbox_ymaxs, bbox_xmaxs]).transpose()
+    expected_boxes = np.vstack([bbox_ymins, bbox_xmins, bbox_ymaxs,
+                                bbox_xmaxs]).transpose()
     self.assertAllEqual(expected_boxes,
                         tensor_dict[fields.InputDataFields.groundtruth_boxes])
     self.assertAllEqual(
@@ -377,9 +393,9 @@ class TfExampleDecoderTest(tf.test.TestCase):
 
     expected_keypoints = (
         np.vstack([keypoint_ys, keypoint_xs]).transpose().reshape((2, 3, 2)))
-    self.assertAllEqual(expected_keypoints,
-                        tensor_dict[
-                            fields.InputDataFields.groundtruth_keypoints])
+    self.assertAllEqual(
+        expected_keypoints,
+        tensor_dict[fields.InputDataFields.groundtruth_keypoints])
 
   def testDecodeDefaultGroundtruthWeights(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
@@ -388,20 +404,28 @@ class TfExampleDecoderTest(tf.test.TestCase):
     bbox_xmins = [1.0, 5.0]
     bbox_ymaxs = [2.0, 6.0]
     bbox_xmaxs = [3.0, 7.0]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/bbox/ymin': self._FloatFeature(bbox_ymins),
-        'image/object/bbox/xmin': self._FloatFeature(bbox_xmins),
-        'image/object/bbox/ymax': self._FloatFeature(bbox_ymaxs),
-        'image/object/bbox/xmax': self._FloatFeature(bbox_xmaxs),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/bbox/ymin':
+                    dataset_util.float_list_feature(bbox_ymins),
+                'image/object/bbox/xmin':
+                    dataset_util.float_list_feature(bbox_xmins),
+                'image/object/bbox/ymax':
+                    dataset_util.float_list_feature(bbox_ymaxs),
+                'image/object/bbox/xmax':
+                    dataset_util.float_list_feature(bbox_xmaxs),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes].
-                         get_shape().as_list()), [None, 4])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_boxes]
+                         .get_shape().as_list()), [None, 4])
 
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
@@ -414,18 +438,22 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     bbox_classes = [0, 1]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/class/label': self._Int64Feature(bbox_classes),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/class/label':
+                    dataset_util.int64_list_feature(bbox_classes),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_classes].get_shape().as_list()),
-                        [2])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_classes]
+                         .get_shape().as_list()), [2])
 
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
@@ -437,11 +465,16 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     bbox_classes = [1, 2]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/class/label': self._Int64Feature(bbox_classes),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/class/label':
+                    dataset_util.int64_list_feature(bbox_classes),
+            })).SerializeToString()
     label_map_string = """
       item {
         id:1
@@ -460,9 +493,8 @@ class TfExampleDecoderTest(tf.test.TestCase):
         label_map_proto_file=label_map_path)
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_classes].get_shape().as_list()),
-                        [None])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_classes]
+                         .get_shape().as_list()), [None])
 
     init = tf.tables_initializer()
     with self.test_session() as sess:
@@ -480,11 +512,11 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded':
-                    self._BytesFeature(encoded_jpeg),
+                    dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    self._BytesFeature('jpeg'),
+                    dataset_util.bytes_feature('jpeg'),
                 'image/object/class/text':
-                    self._BytesFeature(bbox_classes_text),
+                    dataset_util.bytes_list_feature(bbox_classes_text),
             })).SerializeToString()
 
     label_map_string = """
@@ -522,11 +554,11 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded':
-                    self._BytesFeature(encoded_jpeg),
+                    dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    self._BytesFeature('jpeg'),
+                    dataset_util.bytes_feature('jpeg'),
                 'image/object/class/text':
-                    self._BytesFeature(bbox_classes_text),
+                    dataset_util.bytes_list_feature(bbox_classes_text),
             })).SerializeToString()
 
     label_map_string = """
@@ -561,17 +593,22 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     object_area = [100., 174.]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/area': self._FloatFeature(object_area),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/area':
+                    dataset_util.float_list_feature(object_area),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_area].
-                         get_shape().as_list()), [2])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_area]
+                         .get_shape().as_list()), [2])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
@@ -583,67 +620,81 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     object_is_crowd = [0, 1]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/is_crowd': self._Int64Feature(object_is_crowd),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/is_crowd':
+                    dataset_util.int64_list_feature(object_is_crowd),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_is_crowd].get_shape().as_list()),
-                        [2])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.groundtruth_is_crowd].get_shape()
+         .as_list()), [2])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    self.assertAllEqual([bool(item) for item in object_is_crowd],
-                        tensor_dict[
-                            fields.InputDataFields.groundtruth_is_crowd])
+    self.assertAllEqual(
+        [bool(item) for item in object_is_crowd],
+        tensor_dict[fields.InputDataFields.groundtruth_is_crowd])
 
   @test_util.enable_c_shapes
   def testDecodeObjectDifficult(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     object_difficult = [0, 1]
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/object/difficult': self._Int64Feature(object_difficult),
-    })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/difficult':
+                    dataset_util.int64_list_feature(object_difficult),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_difficult].get_shape().as_list()),
-                        [2])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.groundtruth_difficult].get_shape()
+         .as_list()), [2])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    self.assertAllEqual([bool(item) for item in object_difficult],
-                        tensor_dict[
-                            fields.InputDataFields.groundtruth_difficult])
+    self.assertAllEqual(
+        [bool(item) for item in object_difficult],
+        tensor_dict[fields.InputDataFields.groundtruth_difficult])
 
   @test_util.enable_c_shapes
   def testDecodeObjectGroupOf(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     object_group_of = [0, 1]
-    example = tf.train.Example(features=tf.train.Features(
-        feature={
-            'image/encoded': self._BytesFeature(encoded_jpeg),
-            'image/format': self._BytesFeature('jpeg'),
-            'image/object/group_of': self._Int64Feature(object_group_of),
-        })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/group_of':
+                    dataset_util.int64_list_feature(object_group_of),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_group_of].get_shape().as_list()),
-                        [2])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.groundtruth_group_of].get_shape()
+         .as_list()), [2])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
@@ -655,25 +706,27 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
     object_weights = [0.75, 1.0]
-    example = tf.train.Example(features=tf.train.Features(
-        feature={
-            'image/encoded': self._BytesFeature(encoded_jpeg),
-            'image/format': self._BytesFeature('jpeg'),
-            'image/object/weight': self._FloatFeature(object_weights),
-        })).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/object/weight':
+                    dataset_util.float_list_feature(object_weights),
+            })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((tensor_dict[
-        fields.InputDataFields.groundtruth_weights].get_shape().as_list()),
-                        [None])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_weights]
+                         .get_shape().as_list()), [None])
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    self.assertAllEqual(
-        object_weights,
-        tensor_dict[fields.InputDataFields.groundtruth_weights])
+    self.assertAllEqual(object_weights,
+                        tensor_dict[fields.InputDataFields.groundtruth_weights])
 
   @test_util.enable_c_shapes
   def testDecodeInstanceSegmentation(self):
@@ -682,15 +735,13 @@ class TfExampleDecoderTest(tf.test.TestCase):
     image_width = 3
 
     # Randomly generate image.
-    image_tensor = np.random.randint(256, size=(image_height,
-                                                image_width,
-                                                3)).astype(np.uint8)
+    image_tensor = np.random.randint(
+        256, size=(image_height, image_width, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
 
     # Randomly generate instance segmentation masks.
     instance_masks = (
-        np.random.randint(2, size=(num_instances,
-                                   image_height,
+        np.random.randint(2, size=(num_instances, image_height,
                                    image_width)).astype(np.float32))
     instance_masks_flattened = np.reshape(instance_masks, [-1])
 
@@ -698,25 +749,32 @@ class TfExampleDecoderTest(tf.test.TestCase):
     object_classes = np.random.randint(
         100, size=(num_instances)).astype(np.int64)
 
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/height': self._Int64Feature([image_height]),
-        'image/width': self._Int64Feature([image_width]),
-        'image/object/mask': self._FloatFeature(instance_masks_flattened),
-        'image/object/class/label': self._Int64Feature(
-            object_classes)})).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/height':
+                    dataset_util.int64_feature(image_height),
+                'image/width':
+                    dataset_util.int64_feature(image_width),
+                'image/object/mask':
+                    dataset_util.float_list_feature(instance_masks_flattened),
+                'image/object/class/label':
+                    dataset_util.int64_list_feature(object_classes)
+            })).SerializeToString()
     example_decoder = tf_example_decoder.TfExampleDecoder(
         load_instance_masks=True)
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
 
-    self.assertAllEqual((
-        tensor_dict[fields.InputDataFields.groundtruth_instance_masks].
-        get_shape().as_list()), [4, 5, 3])
+    self.assertAllEqual(
+        (tensor_dict[fields.InputDataFields.groundtruth_instance_masks]
+         .get_shape().as_list()), [4, 5, 3])
 
-    self.assertAllEqual((
-        tensor_dict[fields.InputDataFields.groundtruth_classes].
-        get_shape().as_list()), [4])
+    self.assertAllEqual((tensor_dict[fields.InputDataFields.groundtruth_classes]
+                         .get_shape().as_list()), [4])
 
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
@@ -724,24 +782,21 @@ class TfExampleDecoderTest(tf.test.TestCase):
     self.assertAllEqual(
         instance_masks.astype(np.float32),
         tensor_dict[fields.InputDataFields.groundtruth_instance_masks])
-    self.assertAllEqual(
-        object_classes,
-        tensor_dict[fields.InputDataFields.groundtruth_classes])
+    self.assertAllEqual(object_classes,
+                        tensor_dict[fields.InputDataFields.groundtruth_classes])
 
   def testInstancesNotAvailableByDefault(self):
     num_instances = 4
     image_height = 5
     image_width = 3
     # Randomly generate image.
-    image_tensor = np.random.randint(256, size=(image_height,
-                                                image_width,
-                                                3)).astype(np.uint8)
+    image_tensor = np.random.randint(
+        256, size=(image_height, image_width, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
 
     # Randomly generate instance segmentation masks.
     instance_masks = (
-        np.random.randint(2, size=(num_instances,
-                                   image_height,
+        np.random.randint(2, size=(num_instances, image_height,
                                    image_width)).astype(np.float32))
     instance_masks_flattened = np.reshape(instance_masks, [-1])
 
@@ -749,18 +804,26 @@ class TfExampleDecoderTest(tf.test.TestCase):
     object_classes = np.random.randint(
         100, size=(num_instances)).astype(np.int64)
 
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'image/encoded': self._BytesFeature(encoded_jpeg),
-        'image/format': self._BytesFeature('jpeg'),
-        'image/height': self._Int64Feature([image_height]),
-        'image/width': self._Int64Feature([image_width]),
-        'image/object/mask': self._FloatFeature(instance_masks_flattened),
-        'image/object/class/label': self._Int64Feature(
-            object_classes)})).SerializeToString()
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/height':
+                    dataset_util.int64_feature(image_height),
+                'image/width':
+                    dataset_util.int64_feature(image_width),
+                'image/object/mask':
+                    dataset_util.float_list_feature(instance_masks_flattened),
+                'image/object/class/label':
+                    dataset_util.int64_list_feature(object_classes)
+            })).SerializeToString()
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
-    self.assertTrue(fields.InputDataFields.groundtruth_instance_masks
-                    not in tensor_dict)
+    self.assertTrue(
+        fields.InputDataFields.groundtruth_instance_masks not in tensor_dict)
 
   def testDecodeImageLabels(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
@@ -768,9 +831,9 @@ class TfExampleDecoderTest(tf.test.TestCase):
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
-                'image/encoded': self._BytesFeature(encoded_jpeg),
-                'image/format': self._BytesFeature('jpeg'),
-                'image/class/label': self._Int64Feature([1, 2]),
+                'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
+                'image/format': dataset_util.bytes_feature('jpeg'),
+                'image/class/label': dataset_util.int64_list_feature([1, 2]),
             })).SerializeToString()
     example_decoder = tf_example_decoder.TfExampleDecoder()
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
@@ -784,9 +847,12 @@ class TfExampleDecoderTest(tf.test.TestCase):
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
-                'image/encoded': self._BytesFeature(encoded_jpeg),
-                'image/format': self._BytesFeature('jpeg'),
-                'image/class/text': self._BytesFeature(['dog', 'cat']),
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature('jpeg'),
+                'image/class/text':
+                    dataset_util.bytes_list_feature(['dog', 'cat']),
             })).SerializeToString()
     label_map_string = """
       item {

--- a/research/object_detection/dataset_tools/create_coco_tf_record.py
+++ b/research/object_detection/dataset_tools/create_coco_tf_record.py
@@ -177,8 +177,8 @@ def create_tf_example(image,
           dataset_util.float_list_feature(ymin),
       'image/object/bbox/ymax':
           dataset_util.float_list_feature(ymax),
-      'image/object/class/label':
-          dataset_util.int64_list_feature(category_ids),
+      'image/object/class/text':
+          dataset_util.bytes_list_feature(category_names),
       'image/object/is_crowd':
           dataset_util.int64_list_feature(is_crowd),
       'image/object/area':

--- a/research/object_detection/dataset_tools/create_coco_tf_record_test.py
+++ b/research/object_detection/dataset_tools/create_coco_tf_record_test.py
@@ -106,6 +106,9 @@ class CreateCocoTFRecordTest(tf.test.TestCase):
     self._assertProtoEqual(
         example.features.feature['image/object/bbox/ymax'].float_list.value,
         [0.75])
+    self._assertProtoEqual(
+        example.features.feature['image/object/class/text'].bytes_list.value,
+        ['cat'])
 
   def test_create_tf_example_with_instance_masks(self):
     image_file_name = 'tmp_image.jpg'
@@ -169,6 +172,9 @@ class CreateCocoTFRecordTest(tf.test.TestCase):
     self._assertProtoEqual(
         example.features.feature['image/object/bbox/ymax'].float_list.value,
         [1])
+    self._assertProtoEqual(
+        example.features.feature['image/object/class/text'].bytes_list.value,
+        ['dog'])
     encoded_mask_pngs = [
         io.BytesIO(encoded_masks) for encoded_masks in example.features.feature[
             'image/object/mask'].bytes_list.value

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -115,7 +115,7 @@ Model name                                                                      
 
 ## iNaturalist Species-trained models
 
-Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 | Outputs
+Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 (ms) | Outputs
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
 [faster_rcnn_resnet101_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_fgvc_2018_07_19.tar.gz) | 395  | 58              | Boxes
 [faster_rcnn_resnet50_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_fgvc_2018_07_19.tar.gz) | 366  | 55             | Boxes

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -115,7 +115,7 @@ Model name                                                                      
 
 ## iNaturalist Species-trained models
 
-Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 (ms) | Outputs
+Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 | Outputs
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
 [faster_rcnn_resnet101_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_fgvc_2018_07_19.tar.gz) | 395  | 58              | Boxes
 [faster_rcnn_resnet50_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_fgvc_2018_07_19.tar.gz) | 366  | 55             | Boxes

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -2,13 +2,12 @@
 
 We provide a collection of detection models pre-trained on the [COCO
 dataset](http://mscoco.org), the [Kitti dataset](http://www.cvlibs.net/datasets/kitti/),
-the [Open Images dataset](https://github.com/openimages/dataset) and the
-[AVA v2.1 dataset](https://research.google.com/ava/). These models can
-be useful for
-out-of-the-box inference if you are interested in categories already in COCO
-(e.g., humans, cars, etc) or in Open Images (e.g.,
-surfboard, jacuzzi, etc). They are also useful for initializing your models when
-training on novel datasets.
+the [Open Images dataset](https://github.com/openimages/dataset), the
+[AVA v2.1 dataset](https://research.google.com/ava/) and the
+[iNaturalist Species Detection Dataset](https://github.com/visipedia/inat_comp/blob/master/2017/README.md#bounding-boxes).
+These models can be useful for out-of-the-box inference if you are interested in
+categories already in those datasets. They are also useful for initializing your
+models when training on novel datasets.
 
 In the table below, we list each such pre-trained model including:
 

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -113,6 +113,13 @@ Model name                                                                      
 [faster_rcnn_inception_resnet_v2_atrous_oid](http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_resnet_v2_atrous_oid_2018_01_28.tar.gz) | 727 | 37              | Boxes
 [faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid](http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid_2018_01_28.tar.gz) | 347  |               | Boxes
 
+## iNaturalist Species-trained models
+
+Model name                                                                                                                                                        | Speed (ms) | Pascal mAP@0.5 (ms) | Outputs
+----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :-------------: | :-----:
+[faster_rcnn_resnet101_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_fgvc_2018_07_19.tar.gz) | 395  | 58              | Boxes
+[faster_rcnn_resnet50_fgvc](http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_fgvc_2018_07_19.tar.gz) | 366  | 55             | Boxes
+
 
 ## AVA v2.1 trained models
 

--- a/research/object_detection/g3doc/running_locally.md
+++ b/research/object_detection/g3doc/running_locally.md
@@ -37,12 +37,12 @@ A local training job can be run with the following command:
 PIPELINE_CONFIG_PATH={path to pipeline config file}
 MODEL_DIR={path to model directory}
 NUM_TRAIN_STEPS=50000
-NUM_EVAL_STEPS=2000
+SAMPLE_1_OF_N_EVAL_EXAMPLES=1
 python object_detection/model_main.py \
     --pipeline_config_path=${PIPELINE_CONFIG_PATH} \
     --model_dir=${MODEL_DIR} \
     --num_train_steps=${NUM_TRAIN_STEPS} \
-    --num_eval_steps=${NUM_EVAL_STEPS} \
+    --sample_1_of_n_eval_examples=$SAMPLE_1_OF_N_EVAL_EXAMPLES \
     --alsologtostderr
 ```
 

--- a/research/object_detection/g3doc/running_pets.md
+++ b/research/object_detection/g3doc/running_pets.md
@@ -216,7 +216,7 @@ To start training and evaluation, execute the following command from the
 ```bash
 # From tensorflow/models/research/
 gcloud ml-engine jobs submit training `whoami`_object_detection_pets_`date +%m_%d_%Y_%H_%M_%S` \
-    --runtime-version 1.9 \
+    --runtime-version 1.8 \
     --job-dir=gs://${YOUR_GCS_BUCKET}/model_dir \
     --packages dist/object_detection-0.1.tar.gz,slim/dist/slim-0.1.tar.gz,/tmp/pycocotools/pycocotools-2.0.tar.gz \
     --module-name object_detection.model_main \

--- a/research/object_detection/legacy/eval.py
+++ b/research/object_detection/legacy/eval.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 r"""Evaluation executable for detection models.
 
 This executable is used to evaluate DetectionModels. There are two ways of
@@ -54,29 +53,30 @@ from object_detection.legacy import evaluator
 from object_detection.utils import config_util
 from object_detection.utils import label_map_util
 
-
 tf.logging.set_verbosity(tf.logging.INFO)
 
 flags = tf.app.flags
 flags.DEFINE_boolean('eval_training_data', False,
                      'If training data should be evaluated for this job.')
-flags.DEFINE_string('checkpoint_dir', '',
-                    'Directory containing checkpoints to evaluate, typically '
-                    'set to `train_dir` used in the training job.')
-flags.DEFINE_string('eval_dir', '',
-                    'Directory to write eval summaries to.')
-flags.DEFINE_string('pipeline_config_path', '',
-                    'Path to a pipeline_pb2.TrainEvalPipelineConfig config '
-                    'file. If provided, other configs are ignored')
+flags.DEFINE_string(
+    'checkpoint_dir', '',
+    'Directory containing checkpoints to evaluate, typically '
+    'set to `train_dir` used in the training job.')
+flags.DEFINE_string('eval_dir', '', 'Directory to write eval summaries to.')
+flags.DEFINE_string(
+    'pipeline_config_path', '',
+    'Path to a pipeline_pb2.TrainEvalPipelineConfig config '
+    'file. If provided, other configs are ignored')
 flags.DEFINE_string('eval_config_path', '',
                     'Path to an eval_pb2.EvalConfig config file.')
 flags.DEFINE_string('input_config_path', '',
                     'Path to an input_reader_pb2.InputReader config file.')
 flags.DEFINE_string('model_config_path', '',
                     'Path to a model_pb2.DetectionModel config file.')
-flags.DEFINE_boolean('run_once', False, 'Option to only run a single pass of '
-                     'evaluation. Overrides the `max_evals` parameter in the '
-                     'provided config.')
+flags.DEFINE_boolean(
+    'run_once', False, 'Option to only run a single pass of '
+    'evaluation. Overrides the `max_evals` parameter in the '
+    'provided config.')
 FLAGS = flags.FLAGS
 
 
@@ -88,9 +88,10 @@ def main(unused_argv):
   if FLAGS.pipeline_config_path:
     configs = config_util.get_configs_from_pipeline_file(
         FLAGS.pipeline_config_path)
-    tf.gfile.Copy(FLAGS.pipeline_config_path,
-                  os.path.join(FLAGS.eval_dir, 'pipeline.config'),
-                  overwrite=True)
+    tf.gfile.Copy(
+        FLAGS.pipeline_config_path,
+        os.path.join(FLAGS.eval_dir, 'pipeline.config'),
+        overwrite=True)
   else:
     configs = config_util.get_configs_from_multiple_files(
         model_config_path=FLAGS.model_config_path,
@@ -99,9 +100,7 @@ def main(unused_argv):
     for name, config in [('model.config', FLAGS.model_config_path),
                          ('eval.config', FLAGS.eval_config_path),
                          ('input.config', FLAGS.input_config_path)]:
-      tf.gfile.Copy(config,
-                    os.path.join(FLAGS.eval_dir, name),
-                    overwrite=True)
+      tf.gfile.Copy(config, os.path.join(FLAGS.eval_dir, name), overwrite=True)
 
   model_config = configs['model']
   eval_config = configs['eval_config']
@@ -110,9 +109,7 @@ def main(unused_argv):
     input_config = configs['train_input_config']
 
   model_fn = functools.partial(
-      model_builder.build,
-      model_config=model_config,
-      is_training=False)
+      model_builder.build, model_config=model_config, is_training=False)
 
   def get_next(config):
     return dataset_builder.make_initializable_iterator(
@@ -120,10 +117,8 @@ def main(unused_argv):
 
   create_input_dict_fn = functools.partial(get_next, input_config)
 
-  label_map = label_map_util.load_labelmap(input_config.label_map_path)
-  max_num_classes = max([item.id for item in label_map.item])
-  categories = label_map_util.convert_label_map_to_categories(
-      label_map, max_num_classes)
+  categories = label_map_util.create_categories_from_labelmap(
+      input_config.label_map_path)
 
   if FLAGS.run_once:
     eval_config.max_evals = 1

--- a/research/object_detection/legacy/evaluator.py
+++ b/research/object_detection/legacy/evaluator.py
@@ -273,6 +273,7 @@ def evaluate(create_input_dict_fn, create_model_fn, eval_config, categories,
       master=eval_config.eval_master,
       save_graph=eval_config.save_graph,
       save_graph_dir=(eval_dir if eval_config.save_graph else ''),
-      losses_dict=losses_dict)
+      losses_dict=losses_dict,
+      eval_export_path=eval_config.export_path)
 
   return metrics

--- a/research/object_detection/matchers/argmax_matcher.py
+++ b/research/object_detection/matchers/argmax_matcher.py
@@ -99,17 +99,19 @@ class ArgMaxMatcher(matcher.Matcher):
       if self._unmatched_threshold == self._matched_threshold:
         raise ValueError('When negatives are in between matched and '
                          'unmatched thresholds, these cannot be of equal '
-                         'value. matched: %s, unmatched: %s',
-                         self._matched_threshold, self._unmatched_threshold)
+                         'value. matched: {}, unmatched: {}'.format(
+                             self._matched_threshold,
+                             self._unmatched_threshold))
     self._force_match_for_each_row = force_match_for_each_row
     self._negatives_lower_than_unmatched = negatives_lower_than_unmatched
 
-  def _match(self, similarity_matrix):
+  def _match(self, similarity_matrix, valid_rows):
     """Tries to match each column of the similarity matrix to a row.
 
     Args:
       similarity_matrix: tensor of shape [N, M] representing any similarity
         metric.
+      valid_rows: a boolean tensor of shape [N] indicating valid rows.
 
     Returns:
       Match object with corresponding matches for each of M columns.
@@ -167,8 +169,10 @@ class ArgMaxMatcher(matcher.Matcher):
             similarity_matrix)
         force_match_column_ids = tf.argmax(similarity_matrix, 1,
                                            output_type=tf.int32)
-        force_match_column_indicators = tf.one_hot(
-            force_match_column_ids, depth=similarity_matrix_shape[1])
+        force_match_column_indicators = (
+            tf.one_hot(
+                force_match_column_ids, depth=similarity_matrix_shape[1]) *
+            tf.cast(tf.expand_dims(valid_rows, axis=-1), dtype=tf.float32))
         force_match_row_ids = tf.argmax(force_match_column_indicators, 0,
                                         output_type=tf.int32)
         force_match_column_mask = tf.cast(

--- a/research/object_detection/matchers/bipartite_matcher.py
+++ b/research/object_detection/matchers/bipartite_matcher.py
@@ -35,7 +35,7 @@ class GreedyBipartiteMatcher(matcher.Matcher):
     super(GreedyBipartiteMatcher, self).__init__(
         use_matmul_gather=use_matmul_gather)
 
-  def _match(self, similarity_matrix, num_valid_rows=-1):
+  def _match(self, similarity_matrix, valid_rows):
     """Bipartite matches a collection rows and columns. A greedy bi-partite.
 
     TODO(rathodv): Add num_valid_columns options to match only that many columns
@@ -44,21 +44,27 @@ class GreedyBipartiteMatcher(matcher.Matcher):
     Args:
       similarity_matrix: Float tensor of shape [N, M] with pairwise similarity
         where higher values mean more similar.
-      num_valid_rows: A scalar or a 1-D tensor with one element describing the
-        number of valid rows of similarity_matrix to consider for the bipartite
-        matching. If set to be negative, then all rows from similarity_matrix
-        are used.
+      valid_rows: A boolean tensor of shape [N] indicating the rows that are
+        valid.
 
     Returns:
       match_results: int32 tensor of shape [M] with match_results[i]=-1
         meaning that column i is not matched and otherwise that it is matched to
         row match_results[i].
     """
+    valid_row_sim_matrix = tf.gather(similarity_matrix,
+                                     tf.squeeze(tf.where(valid_rows), axis=-1))
+    invalid_row_sim_matrix = tf.gather(
+        similarity_matrix,
+        tf.squeeze(tf.where(tf.logical_not(valid_rows)), axis=-1))
+    similarity_matrix = tf.concat(
+        [valid_row_sim_matrix, invalid_row_sim_matrix], axis=0)
     # Convert similarity matrix to distance matrix as tf.image.bipartite tries
     # to find minimum distance matches.
     distance_matrix = -1 * similarity_matrix
+    num_valid_rows = tf.reduce_sum(tf.to_float(valid_rows))
     _, match_results = image_ops.bipartite_match(
-        distance_matrix, num_valid_rows)
+        distance_matrix, num_valid_rows=num_valid_rows)
     match_results = tf.reshape(match_results, [-1])
     match_results = tf.cast(match_results, tf.int32)
     return match_results

--- a/research/object_detection/matchers/bipartite_matcher_test.py
+++ b/research/object_detection/matchers/bipartite_matcher_test.py
@@ -24,44 +24,54 @@ class GreedyBipartiteMatcherTest(tf.test.TestCase):
 
   def test_get_expected_matches_when_all_rows_are_valid(self):
     similarity_matrix = tf.constant([[0.50, 0.1, 0.8], [0.15, 0.2, 0.3]])
-    num_valid_rows = 2
+    valid_rows = tf.ones([2], dtype=tf.bool)
     expected_match_results = [-1, 1, 0]
 
     matcher = bipartite_matcher.GreedyBipartiteMatcher()
-    match = matcher.match(similarity_matrix, num_valid_rows=num_valid_rows)
+    match = matcher.match(similarity_matrix, valid_rows=valid_rows)
     with self.test_session() as sess:
       match_results_out = sess.run(match._match_results)
       self.assertAllEqual(match_results_out, expected_match_results)
 
-  def test_get_expected_matches_with_valid_rows_set_to_minus_one(self):
+  def test_get_expected_matches_with_all_rows_be_default(self):
     similarity_matrix = tf.constant([[0.50, 0.1, 0.8], [0.15, 0.2, 0.3]])
-    num_valid_rows = -1
     expected_match_results = [-1, 1, 0]
 
     matcher = bipartite_matcher.GreedyBipartiteMatcher()
-    match = matcher.match(similarity_matrix, num_valid_rows=num_valid_rows)
+    match = matcher.match(similarity_matrix)
     with self.test_session() as sess:
       match_results_out = sess.run(match._match_results)
       self.assertAllEqual(match_results_out, expected_match_results)
 
   def test_get_no_matches_with_zero_valid_rows(self):
     similarity_matrix = tf.constant([[0.50, 0.1, 0.8], [0.15, 0.2, 0.3]])
-    num_valid_rows = 0
+    valid_rows = tf.zeros([2], dtype=tf.bool)
     expected_match_results = [-1, -1, -1]
 
     matcher = bipartite_matcher.GreedyBipartiteMatcher()
-    match = matcher.match(similarity_matrix, num_valid_rows=num_valid_rows)
+    match = matcher.match(similarity_matrix, valid_rows)
     with self.test_session() as sess:
       match_results_out = sess.run(match._match_results)
       self.assertAllEqual(match_results_out, expected_match_results)
 
   def test_get_expected_matches_with_only_one_valid_row(self):
     similarity_matrix = tf.constant([[0.50, 0.1, 0.8], [0.15, 0.2, 0.3]])
-    num_valid_rows = 1
+    valid_rows = tf.constant([True, False], dtype=tf.bool)
     expected_match_results = [-1, -1, 0]
 
     matcher = bipartite_matcher.GreedyBipartiteMatcher()
-    match = matcher.match(similarity_matrix, num_valid_rows=num_valid_rows)
+    match = matcher.match(similarity_matrix, valid_rows)
+    with self.test_session() as sess:
+      match_results_out = sess.run(match._match_results)
+      self.assertAllEqual(match_results_out, expected_match_results)
+
+  def test_get_expected_matches_with_only_one_valid_row_at_bottom(self):
+    similarity_matrix = tf.constant([[0.15, 0.2, 0.3], [0.50, 0.1, 0.8]])
+    valid_rows = tf.constant([False, True], dtype=tf.bool)
+    expected_match_results = [-1, -1, 0]
+
+    matcher = bipartite_matcher.GreedyBipartiteMatcher()
+    match = matcher.match(similarity_matrix, valid_rows)
     with self.test_session() as sess:
       match_results_out = sess.run(match._match_results)
       self.assertAllEqual(match_results_out, expected_match_results)

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
@@ -103,7 +103,6 @@ from object_detection.core import box_list_ops
 from object_detection.core import box_predictor
 from object_detection.core import losses
 from object_detection.core import model
-from object_detection.core import post_processing
 from object_detection.core import standard_fields as fields
 from object_detection.core import target_assigner
 from object_detection.utils import ops
@@ -234,11 +233,11 @@ class FasterRCNNMetaArch(model.DetectionModel):
                first_stage_box_predictor_depth,
                first_stage_minibatch_size,
                first_stage_sampler,
-               first_stage_nms_score_threshold,
-               first_stage_nms_iou_threshold,
+               first_stage_non_max_suppression_fn,
                first_stage_max_proposals,
                first_stage_localization_loss_weight,
                first_stage_objectness_loss_weight,
+               crop_and_resize_fn,
                initial_crop_size,
                maxpool_kernel_size,
                maxpool_stride,
@@ -255,8 +254,9 @@ class FasterRCNNMetaArch(model.DetectionModel):
                hard_example_miner=None,
                parallel_iterations=16,
                add_summaries=True,
-               use_matmul_crop_and_resize=False,
-               clip_anchors_to_image=False):
+               clip_anchors_to_image=False,
+               use_static_shapes=False,
+               resize_masks=True):
     """FasterRCNNMetaArch Constructor.
 
     Args:
@@ -309,18 +309,22 @@ class FasterRCNNMetaArch(model.DetectionModel):
         to the loss function for any given image within the image batch and is
         only called "batch_size" due to terminology from the Faster R-CNN paper.
       first_stage_sampler: Sampler to use for first stage loss (RPN loss).
-      first_stage_nms_score_threshold: Score threshold for non max suppression
-        for the Region Proposal Network (RPN).  This value is expected to be in
-        [0, 1] as it is applied directly after a softmax transformation.  The
-        recommended value for Faster R-CNN is 0.
-      first_stage_nms_iou_threshold: The Intersection Over Union (IOU) threshold
-        for performing Non-Max Suppression (NMS) on the boxes predicted by the
-        Region Proposal Network (RPN).
+      first_stage_non_max_suppression_fn: batch_multiclass_non_max_suppression
+        callable that takes `boxes`, `scores` and optional `clip_window`(with
+        all other inputs already set) and returns a dictionary containing
+        tensors with keys: `detection_boxes`, `detection_scores`,
+        `detection_classes`, `num_detections`. This is used to perform non max
+        suppression  on the boxes predicted by the Region Proposal Network
+        (RPN).
+        See `post_processing.batch_multiclass_non_max_suppression` for the type
+        and shape of these tensors.
       first_stage_max_proposals: Maximum number of boxes to retain after
         performing Non-Max Suppression (NMS) on the boxes predicted by the
         Region Proposal Network (RPN).
       first_stage_localization_loss_weight: A float
       first_stage_objectness_loss_weight: A float
+      crop_and_resize_fn: A differentiable resampler to use for cropping RPN
+        proposal features.
       initial_crop_size: A single integer indicating the output size
         (width and height are set to be the same) of the initial bilinear
         interpolation based cropping during ROI pooling.
@@ -367,12 +371,13 @@ class FasterRCNNMetaArch(model.DetectionModel):
         in parallel for calls to tf.map_fn.
       add_summaries: boolean (default: True) controlling whether summary ops
         should be added to tensorflow graph.
-      use_matmul_crop_and_resize: Force the use of matrix multiplication based
-        crop and resize instead of standard tf.image.crop_and_resize while
-        computing second stage input feature maps.
       clip_anchors_to_image: Normally, anchors generated for a given image size
-      are pruned during training if they lie outside the image window. This
-      option clips the anchors to be within the image instead of pruning.
+        are pruned during training if they lie outside the image window. This
+        option clips the anchors to be within the image instead of pruning.
+      use_static_shapes: If True, uses implementation of ops with static shape
+        guarantees.
+      resize_masks: Indicates whether the masks presend in the groundtruth
+        should be resized in the model with `image_resizer_fn`
 
     Raises:
       ValueError: If `second_stage_batch_size` > `first_stage_max_proposals` at
@@ -384,9 +389,6 @@ class FasterRCNNMetaArch(model.DetectionModel):
     # in the future.
     super(FasterRCNNMetaArch, self).__init__(num_classes=num_classes)
 
-    if is_training and second_stage_batch_size > first_stage_max_proposals:
-      raise ValueError('second_stage_batch_size should be no greater than '
-                       'first_stage_max_proposals.')
     if not isinstance(first_stage_anchor_generator,
                       grid_anchor_generator.GridAnchorGenerator):
       raise ValueError('first_stage_anchor_generator must be of type '
@@ -394,6 +396,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
 
     self._is_training = is_training
     self._image_resizer_fn = image_resizer_fn
+    self._resize_masks = resize_masks
     self._feature_extractor = feature_extractor
     self._number_of_stages = number_of_stages
 
@@ -425,9 +428,9 @@ class FasterRCNNMetaArch(model.DetectionModel):
             min_depth=0,
             max_depth=0))
 
-    self._first_stage_nms_score_threshold = first_stage_nms_score_threshold
-    self._first_stage_nms_iou_threshold = first_stage_nms_iou_threshold
+    self._first_stage_nms_fn = first_stage_non_max_suppression_fn
     self._first_stage_max_proposals = first_stage_max_proposals
+    self._use_static_shapes = use_static_shapes
 
     self._first_stage_localization_loss = (
         losses.WeightedSmoothL1LocalizationLoss())
@@ -437,6 +440,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
     self._first_stage_obj_loss_weight = first_stage_objectness_loss_weight
 
     # Per-region cropping parameters
+    self._crop_and_resize_fn = crop_and_resize_fn
     self._initial_crop_size = initial_crop_size
     self._maxpool_kernel_size = maxpool_kernel_size
     self._maxpool_stride = maxpool_stride
@@ -458,7 +462,6 @@ class FasterRCNNMetaArch(model.DetectionModel):
     self._second_stage_cls_loss_weight = second_stage_classification_loss_weight
     self._second_stage_mask_loss_weight = (
         second_stage_mask_prediction_loss_weight)
-    self._use_matmul_crop_and_resize = use_matmul_crop_and_resize
     self._hard_example_miner = hard_example_miner
     self._parallel_iterations = parallel_iterations
 
@@ -956,8 +959,11 @@ class FasterRCNNMetaArch(model.DetectionModel):
       image_shape: A 1-D tensor representing the input image shape.
     """
     image_shape = tf.shape(preprocessed_inputs)
-    rpn_features_to_crop, _ = self._feature_extractor.extract_proposal_features(
-        preprocessed_inputs, scope=self.first_stage_feature_extractor_scope)
+
+    rpn_features_to_crop, self.endpoints = (
+        self._feature_extractor.extract_proposal_features(
+            preprocessed_inputs,
+            scope=self.first_stage_feature_extractor_scope))
 
     feature_map_shape = tf.shape(rpn_features_to_crop)
     anchors = box_list_ops.concatenate(
@@ -965,12 +971,15 @@ class FasterRCNNMetaArch(model.DetectionModel):
                                                       feature_map_shape[2])]))
     with slim.arg_scope(self._first_stage_box_predictor_arg_scope_fn()):
       kernel_size = self._first_stage_box_predictor_kernel_size
+      reuse = tf.get_variable_scope().reuse
       rpn_box_predictor_features = slim.conv2d(
           rpn_features_to_crop,
           self._first_stage_box_predictor_depth,
           kernel_size=[kernel_size, kernel_size],
           rate=self._first_stage_atrous_rate,
-          activation_fn=tf.nn.relu6)
+          activation_fn=tf.nn.relu6,
+          scope='Conv',
+          reuse=reuse)
     return (rpn_box_predictor_features, rpn_features_to_crop,
             anchors, image_shape)
 
@@ -1223,14 +1232,9 @@ class FasterRCNNMetaArch(model.DetectionModel):
         rpn_objectness_predictions_with_background_batch)[:, :, 1]
     clip_window = self._compute_clip_window(image_shapes)
     (proposal_boxes, proposal_scores, _, _, _,
-     num_proposals) = post_processing.batch_multiclass_non_max_suppression(
+     num_proposals) = self._first_stage_nms_fn(
          tf.expand_dims(proposal_boxes, axis=2),
-         tf.expand_dims(rpn_objectness_softmax_without_background,
-                        axis=2),
-         self._first_stage_nms_score_threshold,
-         self._first_stage_nms_iou_threshold,
-         self._first_stage_max_proposals,
-         self._first_stage_max_proposals,
+         tf.expand_dims(rpn_objectness_softmax_without_background, axis=2),
          clip_window=clip_window)
     if self._is_training:
       proposal_boxes = tf.stop_gradient(proposal_boxes)
@@ -1377,16 +1381,19 @@ class FasterRCNNMetaArch(model.DetectionModel):
 
     groundtruth_masks_list = self._groundtruth_lists.get(
         fields.BoxListFields.masks)
-    if groundtruth_masks_list is not None:
+    # TODO(rathodv): Remove mask resizing once the legacy pipeline is deleted.
+    if groundtruth_masks_list is not None and self._resize_masks:
       resized_masks_list = []
       for mask in groundtruth_masks_list:
+
         _, resized_mask, _ = self._image_resizer_fn(
             # Reuse the given `image_resizer_fn` to resize groundtruth masks.
             # `mask` tensor for an image is of the shape [num_masks,
             # image_height, image_width]. Below we create a dummy image of the
             # the shape [image_height, image_width, 1] to use with
             # `image_resizer_fn`.
-            image=tf.zeros(tf.stack([tf.shape(mask)[1], tf.shape(mask)[2], 1])),
+            image=tf.zeros(tf.stack([tf.shape(mask)[1],
+                                     tf.shape(mask)[2], 1])),
             masks=mask)
         resized_masks_list.append(resized_mask)
 
@@ -1443,11 +1450,16 @@ class FasterRCNNMetaArch(model.DetectionModel):
         tf.range(proposal_boxlist.num_boxes()) < num_valid_proposals,
         cls_weights > 0
     )
-    sampled_indices = self._second_stage_sampler.subsample(
+    selected_positions = self._second_stage_sampler.subsample(
         valid_indicator,
         self._second_stage_batch_size,
         positive_indicator)
-    return box_list_ops.boolean_mask(proposal_boxlist, sampled_indices)
+    return box_list_ops.boolean_mask(
+        proposal_boxlist,
+        selected_positions,
+        use_static_shapes=self._use_static_shapes,
+        indicator_sum=(self._second_stage_batch_size
+                       if self._use_static_shapes else None))
 
   def _compute_second_stage_input_feature_maps(self, features_to_crop,
                                                proposal_boxes_normalized):
@@ -1467,35 +1479,10 @@ class FasterRCNNMetaArch(model.DetectionModel):
     Returns:
       A float32 tensor with shape [K, new_height, new_width, depth].
     """
-    def get_box_inds(proposals):
-      proposals_shape = proposals.get_shape().as_list()
-      if any(dim is None for dim in proposals_shape):
-        proposals_shape = tf.shape(proposals)
-      ones_mat = tf.ones(proposals_shape[:2], dtype=tf.int32)
-      multiplier = tf.expand_dims(
-          tf.range(start=0, limit=proposals_shape[0]), 1)
-      return tf.reshape(ones_mat * multiplier, [-1])
-
-    if self._use_matmul_crop_and_resize:
-      def _single_image_crop_and_resize(inputs):
-        single_image_features_to_crop, proposal_boxes_normalized = inputs
-        return ops.matmul_crop_and_resize(
-            tf.expand_dims(single_image_features_to_crop, 0),
-            proposal_boxes_normalized,
-            [self._initial_crop_size, self._initial_crop_size])
-
-      cropped_regions = self._flatten_first_two_dimensions(
-          shape_utils.static_or_dynamic_map_fn(
-              _single_image_crop_and_resize,
-              elems=[features_to_crop, proposal_boxes_normalized],
-              dtype=tf.float32,
-              parallel_iterations=self._parallel_iterations))
-    else:
-      cropped_regions = tf.image.crop_and_resize(
-          features_to_crop,
-          self._flatten_first_two_dimensions(proposal_boxes_normalized),
-          get_box_inds(proposal_boxes_normalized),
-          (self._initial_crop_size, self._initial_crop_size))
+    cropped_regions = self._flatten_first_two_dimensions(
+        self._crop_and_resize_fn(
+            features_to_crop, proposal_boxes_normalized,
+            [self._initial_crop_size, self._initial_crop_size]))
     return slim.max_pool2d(
         cropped_regions,
         [self._maxpool_kernel_size, self._maxpool_kernel_size],
@@ -1738,11 +1725,17 @@ class FasterRCNNMetaArch(model.DetectionModel):
       sampled_reg_indices = tf.multiply(batch_sampled_indices,
                                         batch_reg_weights)
 
+      losses_mask = None
+      if self.groundtruth_has_field(fields.InputDataFields.is_annotated):
+        losses_mask = tf.stack(self.groundtruth_lists(
+            fields.InputDataFields.is_annotated))
       localization_losses = self._first_stage_localization_loss(
-          rpn_box_encodings, batch_reg_targets, weights=sampled_reg_indices)
+          rpn_box_encodings, batch_reg_targets, weights=sampled_reg_indices,
+          losses_mask=losses_mask)
       objectness_losses = self._first_stage_objectness_loss(
           rpn_objectness_predictions_with_background,
-          batch_one_hot_targets, weights=batch_sampled_indices)
+          batch_one_hot_targets, weights=batch_sampled_indices,
+          losses_mask=losses_mask)
       localization_loss = tf.reduce_mean(
           tf.reduce_sum(localization_losses, axis=1) / normalizer)
       objectness_loss = tf.reduce_mean(
@@ -1866,32 +1859,32 @@ class FasterRCNNMetaArch(model.DetectionModel):
       # for just one class to avoid over-counting for regression loss and
       # (optionally) mask loss.
       else:
-        # We only predict refined location encodings for the non background
-        # classes, but we now pad it to make it compatible with the class
-        # predictions
-        refined_box_encodings_with_background = tf.pad(
-            refined_box_encodings, [[0, 0], [1, 0], [0, 0]])
-        refined_box_encodings_masked_by_class_targets = tf.boolean_mask(
-            refined_box_encodings_with_background,
-            tf.greater(one_hot_flat_cls_targets_with_background, 0))
-        reshaped_refined_box_encodings = tf.reshape(
-            refined_box_encodings_masked_by_class_targets,
-            [batch_size, self.max_num_proposals, self._box_coder.code_size])
+        reshaped_refined_box_encodings = (
+            self._get_refined_encodings_for_postitive_class(
+                refined_box_encodings,
+                one_hot_flat_cls_targets_with_background, batch_size))
 
+      losses_mask = None
+      if self.groundtruth_has_field(fields.InputDataFields.is_annotated):
+        losses_mask = tf.stack(self.groundtruth_lists(
+            fields.InputDataFields.is_annotated))
       second_stage_loc_losses = self._second_stage_localization_loss(
           reshaped_refined_box_encodings,
-          batch_reg_targets, weights=batch_reg_weights) / normalizer
+          batch_reg_targets,
+          weights=batch_reg_weights,
+          losses_mask=losses_mask) / normalizer
       second_stage_cls_losses = ops.reduce_sum_trailing_dimensions(
           self._second_stage_classification_loss(
               class_predictions_with_background,
               batch_cls_targets_with_background,
-              weights=batch_cls_weights),
+              weights=batch_cls_weights,
+              losses_mask=losses_mask),
           ndims=2) / normalizer
 
       second_stage_loc_loss = tf.reduce_sum(
-          tf.boolean_mask(second_stage_loc_losses, paddings_indicator))
+          second_stage_loc_losses * tf.to_float(paddings_indicator))
       second_stage_cls_loss = tf.reduce_sum(
-          tf.boolean_mask(second_stage_cls_losses, paddings_indicator))
+          second_stage_cls_losses * tf.to_float(paddings_indicator))
 
       if self._hard_example_miner:
         (second_stage_loc_loss, second_stage_cls_loss
@@ -1954,10 +1947,9 @@ class FasterRCNNMetaArch(model.DetectionModel):
             box_list.BoxList(tf.reshape(proposal_boxes, [-1, 4])),
             image_shape[1], image_shape[2]).get()
 
-        flat_cropped_gt_mask = tf.image.crop_and_resize(
+        flat_cropped_gt_mask = self._crop_and_resize_fn(
             tf.expand_dims(flat_gt_masks, -1),
-            flat_normalized_proposals,
-            tf.range(flat_normalized_proposals.shape[0].value),
+            tf.expand_dims(flat_normalized_proposals, axis=1),
             [mask_height, mask_width])
 
         batch_cropped_gt_mask = tf.reshape(
@@ -1968,20 +1960,45 @@ class FasterRCNNMetaArch(model.DetectionModel):
             self._second_stage_mask_loss(
                 reshaped_prediction_masks,
                 batch_cropped_gt_mask,
-                weights=batch_mask_target_weights),
+                weights=batch_mask_target_weights,
+                losses_mask=losses_mask),
             ndims=2) / (
                 mask_height * mask_width * tf.maximum(
                     tf.reduce_sum(
                         batch_mask_target_weights, axis=1, keep_dims=True
                     ), tf.ones((batch_size, 1))))
         second_stage_mask_loss = tf.reduce_sum(
-            tf.boolean_mask(second_stage_mask_losses, paddings_indicator))
+            tf.where(paddings_indicator, second_stage_mask_losses,
+                     tf.zeros_like(second_stage_mask_losses)))
 
       if second_stage_mask_loss is not None:
         mask_loss = tf.multiply(self._second_stage_mask_loss_weight,
                                 second_stage_mask_loss, name='mask_loss')
         loss_dict[mask_loss.op.name] = mask_loss
     return loss_dict
+
+  def _get_refined_encodings_for_postitive_class(
+      self, refined_box_encodings, flat_cls_targets_with_background,
+      batch_size):
+    # We only predict refined location encodings for the non background
+    # classes, but we now pad it to make it compatible with the class
+    # predictions
+    refined_box_encodings_with_background = tf.pad(refined_box_encodings,
+                                                   [[0, 0], [1, 0], [0, 0]])
+    refined_box_encodings_masked_by_class_targets = (
+        box_list_ops.boolean_mask(
+            box_list.BoxList(
+                tf.reshape(refined_box_encodings_with_background,
+                           [-1, self._box_coder.code_size])),
+            tf.reshape(tf.greater(flat_cls_targets_with_background, 0), [-1]),
+            use_static_shapes=self._use_static_shapes,
+            indicator_sum=batch_size * self.max_num_proposals
+            if self._use_static_shapes else None).get())
+    return tf.reshape(
+        refined_box_encodings_masked_by_class_targets, [
+            batch_size, self.max_num_proposals,
+            self._box_coder.code_size
+        ])
 
   def _padded_batched_proposals_indicator(self,
                                           num_proposals,

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -14,8 +14,12 @@
 # ==============================================================================
 
 """Tests for object_detection.meta_architectures.faster_rcnn_meta_arch."""
+import functools
+from absl.testing import parameterized
+
 import numpy as np
 import tensorflow as tf
+
 from google.protobuf import text_format
 from object_detection.anchor_generators import grid_anchor_generator
 from object_detection.builders import box_predictor_builder
@@ -23,11 +27,14 @@ from object_detection.builders import hyperparams_builder
 from object_detection.builders import post_processing_builder
 from object_detection.core import balanced_positive_negative_sampler as sampler
 from object_detection.core import losses
+from object_detection.core import post_processing
 from object_detection.core import target_assigner
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.protos import box_predictor_pb2
 from object_detection.protos import hyperparams_pb2
 from object_detection.protos import post_processing_pb2
+from object_detection.utils import ops
+from object_detection.utils import test_case
 from object_detection.utils import test_utils
 
 slim = tf.contrib.slim
@@ -60,7 +67,7 @@ class FakeFasterRCNNFeatureExtractor(
                              num_outputs=3, kernel_size=1, scope='layer2')
 
 
-class FasterRCNNMetaArchTestBase(tf.test.TestCase):
+class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
   """Base class to test Faster R-CNN and R-FCN meta architectures."""
 
   def _build_arg_scope_with_hyperparams(self,
@@ -157,7 +164,8 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
                    masks_are_class_agnostic=False,
                    use_matmul_crop_and_resize=False,
                    clip_anchors_to_image=False,
-                   use_matmul_gather_in_matcher=False):
+                   use_matmul_gather_in_matcher=False,
+                   use_static_shapes=False):
 
     def image_resizer_fn(image, masks=None):
       """Fake image resizer function."""
@@ -220,11 +228,18 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
     first_stage_box_predictor_depth = 512
     first_stage_minibatch_size = 3
     first_stage_sampler = sampler.BalancedPositiveNegativeSampler(
-        positive_fraction=0.5, is_static=False)
+        positive_fraction=0.5, is_static=use_static_shapes)
 
     first_stage_nms_score_threshold = -1.0
     first_stage_nms_iou_threshold = 1.0
     first_stage_max_proposals = first_stage_max_proposals
+    first_stage_non_max_suppression_fn = functools.partial(
+        post_processing.batch_multiclass_non_max_suppression,
+        score_thresh=first_stage_nms_score_threshold,
+        iou_thresh=first_stage_nms_iou_threshold,
+        max_size_per_class=first_stage_max_proposals,
+        max_total_size=first_stage_max_proposals,
+        use_static_shapes=use_static_shapes)
 
     first_stage_localization_loss_weight = 1.0
     first_stage_objectness_loss_weight = 1.0
@@ -246,7 +261,7 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
     second_stage_non_max_suppression_fn, _ = post_processing_builder.build(
         post_processing_config)
     second_stage_sampler = sampler.BalancedPositiveNegativeSampler(
-        positive_fraction=1.0, is_static=False)
+        positive_fraction=1.0, is_static=use_static_shapes)
 
     second_stage_score_conversion_fn = tf.identity
     second_stage_localization_loss_weight = 1.0
@@ -268,6 +283,9 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
           loc_loss_weight=second_stage_localization_loss_weight,
           max_negatives_per_positive=None)
 
+    crop_and_resize_fn = (
+        ops.matmul_crop_and_resize
+        if use_matmul_crop_and_resize else ops.native_crop_and_resize)
     common_kwargs = {
         'is_training': is_training,
         'num_classes': num_classes,
@@ -284,8 +302,8 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
         'first_stage_box_predictor_depth': first_stage_box_predictor_depth,
         'first_stage_minibatch_size': first_stage_minibatch_size,
         'first_stage_sampler': first_stage_sampler,
-        'first_stage_nms_score_threshold': first_stage_nms_score_threshold,
-        'first_stage_nms_iou_threshold': first_stage_nms_iou_threshold,
+        'first_stage_non_max_suppression_fn':
+        first_stage_non_max_suppression_fn,
         'first_stage_max_proposals': first_stage_max_proposals,
         'first_stage_localization_loss_weight':
         first_stage_localization_loss_weight,
@@ -304,8 +322,10 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
         'second_stage_classification_loss':
         second_stage_classification_loss,
         'hard_example_miner': hard_example_miner,
-        'use_matmul_crop_and_resize': use_matmul_crop_and_resize,
-        'clip_anchors_to_image': clip_anchors_to_image
+        'crop_and_resize_fn': crop_and_resize_fn,
+        'clip_anchors_to_image': clip_anchors_to_image,
+        'use_static_shapes': use_static_shapes,
+        'resize_masks': True,
     }
 
     return self._get_model(
@@ -412,7 +432,7 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
         anchors = prediction_out['anchors']
         self.assertTrue(len(anchors.shape) == 2 and anchors.shape[1] == 4)
         num_anchors_out = anchors.shape[0]
-        self.assertTrue(num_anchors_out < num_anchors_strict_upper_bound)
+        self.assertLess(num_anchors_out, num_anchors_strict_upper_bound)
 
         self.assertTrue(np.all(np.greater_equal(anchors, 0)))
         self.assertTrue(np.all(np.less_equal(anchors[:, 0], height)))
@@ -484,94 +504,97 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
       for key in expected_shapes:
         self.assertAllEqual(tensor_dict_out[key].shape, expected_shapes[key])
 
-  def _test_predict_gives_correct_shapes_in_train_mode_both_stages(
-      self, use_matmul_crop_and_resize=False,
-      clip_anchors_to_image=False):
-    test_graph = tf.Graph()
-    with test_graph.as_default():
+  def test_predict_gives_correct_shapes_in_train_mode_both_stages(
+      self,
+      use_static_shapes=False):
+    batch_size = 2
+    image_size = 10
+    max_num_proposals = 7
+    initial_crop_size = 3
+    maxpool_stride = 1
+
+    def graph_fn(images, gt_boxes, gt_classes, gt_weights):
+      """Function to construct tf graph for the test."""
       model = self._build_model(
           is_training=True,
           number_of_stages=2,
           second_stage_batch_size=7,
           predict_masks=False,
-          use_matmul_crop_and_resize=use_matmul_crop_and_resize,
-          clip_anchors_to_image=clip_anchors_to_image)
+          use_matmul_crop_and_resize=use_static_shapes,
+          clip_anchors_to_image=use_static_shapes,
+          use_static_shapes=use_static_shapes)
 
-      batch_size = 2
-      image_size = 10
-      max_num_proposals = 7
-      initial_crop_size = 3
-      maxpool_stride = 1
-
-      image_shape = (batch_size, image_size, image_size, 3)
-      preprocessed_inputs = tf.zeros(image_shape, dtype=tf.float32)
-      groundtruth_boxes_list = [
-          tf.constant([[0, 0, .5, .5], [.5, .5, 1, 1]], dtype=tf.float32),
-          tf.constant([[0, .5, .5, 1], [.5, 0, 1, .5]], dtype=tf.float32)]
-      groundtruth_classes_list = [
-          tf.constant([[1, 0], [0, 1]], dtype=tf.float32),
-          tf.constant([[1, 0], [1, 0]], dtype=tf.float32)]
-      groundtruth_weights_list = [
-          tf.constant([1, 1], dtype=tf.float32),
-          tf.constant([1, 1], dtype=tf.float32)]
-      _, true_image_shapes = model.preprocess(tf.zeros(image_shape))
+      preprocessed_inputs, true_image_shapes = model.preprocess(images)
       model.provide_groundtruth(
-          groundtruth_boxes_list,
-          groundtruth_classes_list,
-          groundtruth_weights_list=groundtruth_weights_list)
-
+          groundtruth_boxes_list=tf.unstack(gt_boxes),
+          groundtruth_classes_list=tf.unstack(gt_classes),
+          groundtruth_weights_list=tf.unstack(gt_weights))
       result_tensor_dict = model.predict(preprocessed_inputs, true_image_shapes)
-      expected_shapes = {
-          'rpn_box_predictor_features':
-          (2, image_size, image_size, 512),
-          'rpn_features_to_crop': (2, image_size, image_size, 3),
-          'image_shape': (4,),
-          'refined_box_encodings': (2 * max_num_proposals, 2, 4),
-          'class_predictions_with_background': (2 * max_num_proposals, 2 + 1),
-          'num_proposals': (2,),
-          'proposal_boxes': (2, max_num_proposals, 4),
-          'proposal_boxes_normalized': (2, max_num_proposals, 4),
-          'box_classifier_features':
-          self._get_box_classifier_features_shape(image_size,
-                                                  batch_size,
-                                                  max_num_proposals,
-                                                  initial_crop_size,
-                                                  maxpool_stride,
-                                                  3)
-      }
+      return (result_tensor_dict['refined_box_encodings'],
+              result_tensor_dict['class_predictions_with_background'],
+              result_tensor_dict['proposal_boxes'],
+              result_tensor_dict['proposal_boxes_normalized'],
+              result_tensor_dict['anchors'],
+              result_tensor_dict['rpn_box_encodings'],
+              result_tensor_dict['rpn_objectness_predictions_with_background'],
+              result_tensor_dict['rpn_features_to_crop'],
+              result_tensor_dict['rpn_box_predictor_features'],
+             )
 
-      init_op = tf.global_variables_initializer()
-      with self.test_session(graph=test_graph) as sess:
-        sess.run(init_op)
-        tensor_dict_out = sess.run(result_tensor_dict)
-        self.assertEqual(set(tensor_dict_out.keys()),
-                         set(expected_shapes.keys()).union(set([
-                             'rpn_box_encodings',
-                             'rpn_objectness_predictions_with_background',
-                             'anchors'])))
-        for key in expected_shapes:
-          self.assertAllEqual(tensor_dict_out[key].shape, expected_shapes[key])
+    image_shape = (batch_size, image_size, image_size, 3)
+    images = np.zeros(image_shape, dtype=np.float32)
+    gt_boxes = np.stack([
+        np.array([[0, 0, .5, .5], [.5, .5, 1, 1]], dtype=np.float32),
+        np.array([[0, .5, .5, 1], [.5, 0, 1, .5]], dtype=np.float32)
+    ])
+    gt_classes = np.stack([
+        np.array([[1, 0], [0, 1]], dtype=np.float32),
+        np.array([[1, 0], [1, 0]], dtype=np.float32)
+    ])
+    gt_weights = np.stack([
+        np.array([1, 1], dtype=np.float32),
+        np.array([1, 1], dtype=np.float32)
+    ])
+    if use_static_shapes:
+      results = self.execute(graph_fn,
+                             [images, gt_boxes, gt_classes, gt_weights])
+    else:
+      results = self.execute_cpu(graph_fn,
+                                 [images, gt_boxes, gt_classes, gt_weights])
 
-        anchors_shape_out = tensor_dict_out['anchors'].shape
-        self.assertEqual(2, len(anchors_shape_out))
-        self.assertEqual(4, anchors_shape_out[1])
-        num_anchors_out = anchors_shape_out[0]
-        self.assertAllEqual(tensor_dict_out['rpn_box_encodings'].shape,
-                            (2, num_anchors_out, 4))
-        self.assertAllEqual(
-            tensor_dict_out['rpn_objectness_predictions_with_background'].shape,
-            (2, num_anchors_out, 2))
-
-  def test_predict_gives_correct_shapes_in_train_mode_both_stages(self):
-    self._test_predict_gives_correct_shapes_in_train_mode_both_stages()
-
-  def test_predict_gives_correct_shapes_in_train_mode_matmul_crop_resize(self):
-    self._test_predict_gives_correct_shapes_in_train_mode_both_stages(
-        use_matmul_crop_and_resize=True)
-
-  def test_predict_gives_correct_shapes_in_train_mode_clip_anchors(self):
-    self._test_predict_gives_correct_shapes_in_train_mode_both_stages(
-        clip_anchors_to_image=True)
+    expected_shapes = {
+        'rpn_box_predictor_features': (2, image_size, image_size, 512),
+        'rpn_features_to_crop': (2, image_size, image_size, 3),
+        'refined_box_encodings': (2 * max_num_proposals, 2, 4),
+        'class_predictions_with_background': (2 * max_num_proposals, 2 + 1),
+        'proposal_boxes': (2, max_num_proposals, 4),
+        'rpn_box_encodings': (2, image_size * image_size * 9, 4),
+        'proposal_boxes_normalized': (2, max_num_proposals, 4),
+        'box_classifier_features':
+            self._get_box_classifier_features_shape(
+                image_size, batch_size, max_num_proposals, initial_crop_size,
+                maxpool_stride, 3),
+        'rpn_objectness_predictions_with_background':
+        (2, image_size * image_size * 9, 2)
+    }
+    # TODO(rathodv): Possibly change utils/test_case.py to accept dictionaries
+    # and return dicionaries so don't have to rely on the order of tensors.
+    self.assertAllEqual(results[0].shape,
+                        expected_shapes['refined_box_encodings'])
+    self.assertAllEqual(results[1].shape,
+                        expected_shapes['class_predictions_with_background'])
+    self.assertAllEqual(results[2].shape, expected_shapes['proposal_boxes'])
+    self.assertAllEqual(results[3].shape,
+                        expected_shapes['proposal_boxes_normalized'])
+    anchors_shape = results[4].shape
+    self.assertAllEqual(results[5].shape,
+                        [batch_size, anchors_shape[0], 4])
+    self.assertAllEqual(results[6].shape,
+                        [batch_size, anchors_shape[0], 2])
+    self.assertAllEqual(results[7].shape,
+                        expected_shapes['rpn_features_to_crop'])
+    self.assertAllEqual(results[8].shape,
+                        expected_shapes['rpn_box_predictor_features'])
 
   def _test_postprocess_first_stage_only_inference_mode(
       self, pad_to_max_dimension=None):
@@ -848,10 +871,10 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
       loss_dict_out = sess.run(loss_dict)
       self.assertAllClose(loss_dict_out['Loss/RPNLoss/localization_loss'], 0)
       self.assertAllClose(loss_dict_out['Loss/RPNLoss/objectness_loss'], 0)
-      self.assertTrue('Loss/BoxClassifierLoss/localization_loss'
-                      not in loss_dict_out)
-      self.assertTrue('Loss/BoxClassifierLoss/classification_loss'
-                      not in loss_dict_out)
+      self.assertNotIn('Loss/BoxClassifierLoss/localization_loss',
+                       loss_dict_out)
+      self.assertNotIn('Loss/BoxClassifierLoss/classification_loss',
+                       loss_dict_out)
 
   # TODO(rathodv): Split test into two - with and without masks.
   def test_loss_full(self):
@@ -1157,22 +1180,58 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
           'Loss/BoxClassifierLoss/classification_loss'], 0)
       self.assertAllClose(loss_dict_out['Loss/BoxClassifierLoss/mask_loss'], 0)
 
-  def test_loss_full_zero_padded_proposals_nonzero_loss_with_two_images(self):
-    model = self._build_model(
-        is_training=True, number_of_stages=2, second_stage_batch_size=6)
+  def test_loss_full_zero_padded_proposals_nonzero_loss_with_two_images(
+      self, use_static_shapes=False, shared_boxes=False):
     batch_size = 2
-    anchors = tf.constant(
+    first_stage_max_proposals = 8
+    second_stage_batch_size = 6
+    num_classes = 2
+    def graph_fn(anchors, rpn_box_encodings,
+                 rpn_objectness_predictions_with_background, images,
+                 num_proposals, proposal_boxes, refined_box_encodings,
+                 class_predictions_with_background, groundtruth_boxes,
+                 groundtruth_classes):
+      """Function to construct tf graph for the test."""
+      model = self._build_model(
+          is_training=True, number_of_stages=2,
+          second_stage_batch_size=second_stage_batch_size,
+          first_stage_max_proposals=first_stage_max_proposals,
+          num_classes=num_classes,
+          use_matmul_crop_and_resize=use_static_shapes,
+          clip_anchors_to_image=use_static_shapes,
+          use_static_shapes=use_static_shapes)
+
+      prediction_dict = {
+          'rpn_box_encodings': rpn_box_encodings,
+          'rpn_objectness_predictions_with_background':
+          rpn_objectness_predictions_with_background,
+          'image_shape': tf.shape(images),
+          'anchors': anchors,
+          'refined_box_encodings': refined_box_encodings,
+          'class_predictions_with_background':
+          class_predictions_with_background,
+          'proposal_boxes': proposal_boxes,
+          'num_proposals': num_proposals
+      }
+      _, true_image_shapes = model.preprocess(images)
+      model.provide_groundtruth(tf.unstack(groundtruth_boxes),
+                                tf.unstack(groundtruth_classes))
+      loss_dict = model.loss(prediction_dict, true_image_shapes)
+      return (loss_dict['Loss/RPNLoss/localization_loss'],
+              loss_dict['Loss/RPNLoss/objectness_loss'],
+              loss_dict['Loss/BoxClassifierLoss/localization_loss'],
+              loss_dict['Loss/BoxClassifierLoss/classification_loss'])
+
+    anchors = np.array(
         [[0, 0, 16, 16],
          [0, 16, 16, 32],
          [16, 0, 32, 16],
-         [16, 16, 32, 32]], dtype=tf.float32)
-    rpn_box_encodings = tf.zeros(
-        [batch_size,
-         anchors.get_shape().as_list()[0],
-         BOX_CODE_SIZE], dtype=tf.float32)
+         [16, 16, 32, 32]], dtype=np.float32)
+    rpn_box_encodings = np.zeros(
+        [batch_size, anchors.shape[1], BOX_CODE_SIZE], dtype=np.float32)
     # use different numbers for the objectness category to break ties in
     # order of boxes returned by NMS
-    rpn_objectness_predictions_with_background = tf.constant(
+    rpn_objectness_predictions_with_background = np.array(
         [[[-10, 13],
           [10, -10],
           [10, -11],
@@ -1180,13 +1239,13 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
          [[-10, 13],
           [10, -10],
           [10, -11],
-          [10, -12]]], dtype=tf.float32)
-    image_shape = tf.constant([batch_size, 32, 32, 3], dtype=tf.int32)
+          [10, -12]]], dtype=np.float32)
+    images = np.zeros([batch_size, 32, 32, 3], dtype=np.float32)
 
     # box_classifier_batch_size is 6, but here we assume that the number of
     # actual proposals (not counting zero paddings) is fewer.
-    num_proposals = tf.constant([3, 2], dtype=tf.int32)
-    proposal_boxes = tf.constant(
+    num_proposals = np.array([3, 2], dtype=np.int32)
+    proposal_boxes = np.array(
         [[[0, 0, 16, 16],
           [0, 16, 16, 32],
           [16, 0, 32, 16],
@@ -1198,13 +1257,13 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
           [0, 0, 0, 0],  # begin paddings
           [0, 0, 0, 0],
           [0, 0, 0, 0],
-          [0, 0, 0, 0]]], dtype=tf.float32)
+          [0, 0, 0, 0]]], dtype=np.float32)
 
-    refined_box_encodings = tf.zeros(
-        (batch_size * model.max_num_proposals,
-         model.num_classes,
-         BOX_CODE_SIZE), dtype=tf.float32)
-    class_predictions_with_background = tf.constant(
+    refined_box_encodings = np.zeros(
+        (batch_size * second_stage_batch_size, 1
+         if shared_boxes else num_classes, BOX_CODE_SIZE),
+        dtype=np.float32)
+    class_predictions_with_background = np.array(
         [[-10, 10, -10],  # first image
          [10, -10, -10],
          [10, -10, -10],
@@ -1216,7 +1275,7 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
          [0, 0, 0],  # begin paddings
          [0, 0, 0],
          [0, 0, 0],
-         [0, 0, 0],], dtype=tf.float32)
+         [0, 0, 0],], dtype=np.float32)
 
     # The first groundtruth box is 4/5 of the anchor size in both directions
     # experiencing a loss of:
@@ -1225,38 +1284,29 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
     # The second groundtruth box is identical to the prediction and thus
     # experiences zero loss.
     # Total average loss is (abs(5 * log(1/2)) - .5) / 3.
-    groundtruth_boxes_list = [
-        tf.constant([[0.05, 0.05, 0.45, 0.45]], dtype=tf.float32),
-        tf.constant([[0.0, 0.0, 0.5, 0.5]], dtype=tf.float32)]
-    groundtruth_classes_list = [tf.constant([[1, 0]], dtype=tf.float32),
-                                tf.constant([[0, 1]], dtype=tf.float32)]
+    groundtruth_boxes = np.stack([
+        np.array([[0.05, 0.05, 0.45, 0.45]], dtype=np.float32),
+        np.array([[0.0, 0.0, 0.5, 0.5]], dtype=np.float32)])
+    groundtruth_classes = np.stack([np.array([[1, 0]], dtype=np.float32),
+                                    np.array([[0, 1]], dtype=np.float32)])
+
+    execute_fn = self.execute_cpu
+    if use_static_shapes:
+      execute_fn = self.execute
+
+    results = execute_fn(graph_fn, [
+        anchors, rpn_box_encodings, rpn_objectness_predictions_with_background,
+        images, num_proposals, proposal_boxes, refined_box_encodings,
+        class_predictions_with_background, groundtruth_boxes,
+        groundtruth_classes
+    ])
+
     exp_loc_loss = (-5 * np.log(.8) - 0.5) / 3.0
 
-    prediction_dict = {
-        'rpn_box_encodings': rpn_box_encodings,
-        'rpn_objectness_predictions_with_background':
-        rpn_objectness_predictions_with_background,
-        'image_shape': image_shape,
-        'anchors': anchors,
-        'refined_box_encodings': refined_box_encodings,
-        'class_predictions_with_background': class_predictions_with_background,
-        'proposal_boxes': proposal_boxes,
-        'num_proposals': num_proposals
-    }
-    _, true_image_shapes = model.preprocess(tf.zeros(image_shape))
-    model.provide_groundtruth(groundtruth_boxes_list,
-                              groundtruth_classes_list)
-    loss_dict = model.loss(prediction_dict, true_image_shapes)
-
-    with self.test_session() as sess:
-      loss_dict_out = sess.run(loss_dict)
-      self.assertAllClose(loss_dict_out['Loss/RPNLoss/localization_loss'],
-                          exp_loc_loss)
-      self.assertAllClose(loss_dict_out['Loss/RPNLoss/objectness_loss'], 0)
-      self.assertAllClose(loss_dict_out[
-          'Loss/BoxClassifierLoss/localization_loss'], exp_loc_loss)
-      self.assertAllClose(loss_dict_out[
-          'Loss/BoxClassifierLoss/classification_loss'], 0)
+    self.assertAllClose(results[0], exp_loc_loss, rtol=1e-4, atol=1e-4)
+    self.assertAllClose(results[1], 0.0)
+    self.assertAllClose(results[2], exp_loc_loss, rtol=1e-4, atol=1e-4)
+    self.assertAllClose(results[3], 0.0)
 
   def test_loss_with_hard_mining(self):
     model = self._build_model(is_training=True,
@@ -1346,10 +1396,14 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
       self.assertAllClose(loss_dict_out[
           'Loss/BoxClassifierLoss/classification_loss'], 0)
 
-  def test_loss_full_with_shared_boxes(self):
-    model = self._build_model(
-        is_training=True, number_of_stages=2, second_stage_batch_size=6)
+  def test_loss_with_hard_mining_and_losses_mask(self):
+    model = self._build_model(is_training=True,
+                              number_of_stages=2,
+                              second_stage_batch_size=None,
+                              first_stage_max_proposals=6,
+                              hard_mining=True)
     batch_size = 2
+    number_of_proposals = 3
     anchors = tf.constant(
         [[0, 0, 16, 16],
          [0, 16, 16, 32],
@@ -1361,63 +1415,77 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
          BOX_CODE_SIZE], dtype=tf.float32)
     # use different numbers for the objectness category to break ties in
     # order of boxes returned by NMS
-    rpn_objectness_predictions_with_background = tf.constant([
-        [[-10, 13],
-         [10, -10],
-         [10, -11],
-         [-10, 12]],
-        [[10, -10],
-         [-10, 13],
-         [-10, 12],
-         [10, -11]]], dtype=tf.float32)
+    rpn_objectness_predictions_with_background = tf.constant(
+        [[[-10, 13],
+          [-10, 12],
+          [10, -11],
+          [10, -12]],
+         [[-10, 13],
+          [-10, 12],
+          [10, -11],
+          [10, -12]]], dtype=tf.float32)
     image_shape = tf.constant([batch_size, 32, 32, 3], dtype=tf.int32)
 
-    num_proposals = tf.constant([6, 6], dtype=tf.int32)
+    # box_classifier_batch_size is 6, but here we assume that the number of
+    # actual proposals (not counting zero paddings) is fewer (3).
+    num_proposals = tf.constant([number_of_proposals, number_of_proposals],
+                                dtype=tf.int32)
     proposal_boxes = tf.constant(
-        2 * [[[0, 0, 16, 16],
-              [0, 16, 16, 32],
-              [16, 0, 32, 16],
-              [16, 16, 32, 32],
-              [0, 0, 16, 16],
-              [0, 16, 16, 32]]], dtype=tf.float32)
+        [[[0, 0, 16, 16],  # first image
+          [0, 16, 16, 32],
+          [16, 0, 32, 16],
+          [0, 0, 0, 0],  # begin paddings
+          [0, 0, 0, 0],
+          [0, 0, 0, 0]],
+         [[0, 0, 16, 16],  # second image
+          [0, 16, 16, 32],
+          [16, 0, 32, 16],
+          [0, 0, 0, 0],  # begin paddings
+          [0, 0, 0, 0],
+          [0, 0, 0, 0]]], dtype=tf.float32)
+
     refined_box_encodings = tf.zeros(
         (batch_size * model.max_num_proposals,
-         1,  # one box shared among all the classes
+         model.num_classes,
          BOX_CODE_SIZE), dtype=tf.float32)
     class_predictions_with_background = tf.constant(
         [[-10, 10, -10],  # first image
-         [10, -10, -10],
-         [10, -10, -10],
          [-10, -10, 10],
-         [-10, 10, -10],
          [10, -10, -10],
-         [10, -10, -10],  # second image
-         [-10, 10, -10],
-         [-10, 10, -10],
+         [0, 0, 0],  # begin paddings
+         [0, 0, 0],
+         [0, 0, 0],
+         [-10, 10, -10],  # second image
+         [-10, -10, 10],
          [10, -10, -10],
-         [10, -10, -10],
-         [-10, 10, -10]], dtype=tf.float32)
+         [0, 0, 0],  # begin paddings
+         [0, 0, 0],
+         [0, 0, 0]], dtype=tf.float32)
 
-    mask_predictions_logits = 20 * tf.ones((batch_size *
-                                            model.max_num_proposals,
-                                            model.num_classes,
-                                            14, 14),
-                                           dtype=tf.float32)
-
+    # The first groundtruth box is 4/5 of the anchor size in both directions
+    # experiencing a loss of:
+    # 2 * SmoothL1(5 * log(4/5)) / (num_proposals * batch_size)
+    #   = 2 * (abs(5 * log(1/2)) - .5) / 3
+    # The second groundtruth box is 46/50 of the anchor size in both directions
+    # experiencing a loss of:
+    # 2 * SmoothL1(5 * log(42/50)) / (num_proposals * batch_size)
+    #   = 2 * (.5(5 * log(.92))^2 - .5) / 3.
+    # Since the first groundtruth box experiences greater loss, and we have
+    # set num_hard_examples=1 in the HardMiner, the final localization loss
+    # corresponds to that of the first groundtruth box.
     groundtruth_boxes_list = [
-        tf.constant([[0, 0, .5, .5], [.5, .5, 1, 1]], dtype=tf.float32),
-        tf.constant([[0, .5, .5, 1], [.5, 0, 1, .5]], dtype=tf.float32)]
-    groundtruth_classes_list = [tf.constant([[1, 0], [0, 1]], dtype=tf.float32),
-                                tf.constant([[1, 0], [1, 0]], dtype=tf.float32)]
+        tf.constant([[0.05, 0.05, 0.45, 0.45],
+                     [0.02, 0.52, 0.48, 0.98]], dtype=tf.float32),
+        tf.constant([[0.05, 0.05, 0.45, 0.45],
+                     [0.02, 0.52, 0.48, 0.98]], dtype=tf.float32)]
+    groundtruth_classes_list = [
+        tf.constant([[1, 0], [0, 1]], dtype=tf.float32),
+        tf.constant([[1, 0], [0, 1]], dtype=tf.float32)]
+    is_annotated_list = [tf.constant(True, dtype=tf.bool),
+                         tf.constant(False, dtype=tf.bool)]
+    exp_loc_loss = (2 * (-5 * np.log(.8) - 0.5) /
+                    (number_of_proposals * batch_size))
 
-    # Set all elements of groundtruth mask to 1.0. In this case all proposal
-    # crops of the groundtruth masks should return a mask that covers the entire
-    # proposal. Thus, if mask_predictions_logits element values are all greater
-    # than 20, the loss should be zero.
-    groundtruth_masks_list = [tf.convert_to_tensor(np.ones((2, 32, 32)),
-                                                   dtype=tf.float32),
-                              tf.convert_to_tensor(np.ones((2, 32, 32)),
-                                                   dtype=tf.float32)]
     prediction_dict = {
         'rpn_box_encodings': rpn_box_encodings,
         'rpn_objectness_predictions_with_background':
@@ -1427,24 +1495,20 @@ class FasterRCNNMetaArchTestBase(tf.test.TestCase):
         'refined_box_encodings': refined_box_encodings,
         'class_predictions_with_background': class_predictions_with_background,
         'proposal_boxes': proposal_boxes,
-        'num_proposals': num_proposals,
-        'mask_predictions': mask_predictions_logits
+        'num_proposals': num_proposals
     }
     _, true_image_shapes = model.preprocess(tf.zeros(image_shape))
     model.provide_groundtruth(groundtruth_boxes_list,
                               groundtruth_classes_list,
-                              groundtruth_masks_list)
+                              is_annotated_list=is_annotated_list)
     loss_dict = model.loss(prediction_dict, true_image_shapes)
 
     with self.test_session() as sess:
       loss_dict_out = sess.run(loss_dict)
-      self.assertAllClose(loss_dict_out['Loss/RPNLoss/localization_loss'], 0)
-      self.assertAllClose(loss_dict_out['Loss/RPNLoss/objectness_loss'], 0)
       self.assertAllClose(loss_dict_out[
-          'Loss/BoxClassifierLoss/localization_loss'], 0)
+          'Loss/BoxClassifierLoss/localization_loss'], exp_loc_loss)
       self.assertAllClose(loss_dict_out[
           'Loss/BoxClassifierLoss/classification_loss'], 0)
-      self.assertAllClose(loss_dict_out['Loss/BoxClassifierLoss/mask_loss'], 0)
 
   def test_restore_map_for_classification_ckpt(self):
     # Define mock tensorflow classification graph and save variables.

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -504,6 +504,13 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
       for key in expected_shapes:
         self.assertAllEqual(tensor_dict_out[key].shape, expected_shapes[key])
 
+  # BEGIN GOOGLE-INTERNAL
+  # TODO(bhattad): Remove conditional after CMLE moves to TF 1.11
+  @parameterized.parameters(
+      {'use_static_shapes': False},
+      {'use_static_shapes': True}
+  )
+  # END GOOGLE-INTERNAL
   def test_predict_gives_correct_shapes_in_train_mode_both_stages(
       self,
       use_static_shapes=False):
@@ -1180,6 +1187,16 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
           'Loss/BoxClassifierLoss/classification_loss'], 0)
       self.assertAllClose(loss_dict_out['Loss/BoxClassifierLoss/mask_loss'], 0)
 
+  # BEGIN GOOGLE-INTERNAL
+  # TODO(bhattad): Remove conditional after CMLE moves to TF 1.11
+  @parameterized.parameters(
+      {'use_static_shapes': False, 'shared_boxes': False},
+      {'use_static_shapes': False, 'shared_boxes': True},
+
+      {'use_static_shapes': True, 'shared_boxes': False},
+      {'use_static_shapes': True, 'shared_boxes': True},
+  )
+  # END GOOGLE-INTERNAL
   def test_loss_full_zero_padded_proposals_nonzero_loss_with_two_images(
       self, use_static_shapes=False, shared_boxes=False):
     batch_size = 2

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -14,105 +14,26 @@
 # ==============================================================================
 
 """Tests for object_detection.meta_architectures.ssd_meta_arch."""
-import functools
+
 from absl.testing import parameterized
 
 import numpy as np
 import tensorflow as tf
 
-from object_detection.core import anchor_generator
-from object_detection.core import balanced_positive_negative_sampler as sampler
-from object_detection.core import box_list
-from object_detection.core import losses
-from object_detection.core import post_processing
-from object_detection.core import region_similarity_calculator as sim_calc
-from object_detection.core import target_assigner
 from object_detection.meta_architectures import ssd_meta_arch
-from object_detection.utils import ops
-from object_detection.utils import test_case
+from object_detection.meta_architectures import ssd_meta_arch_test_lib
 from object_detection.utils import test_utils
 
 slim = tf.contrib.slim
 keras = tf.keras.layers
 
 
-class FakeSSDFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
-
-  def __init__(self):
-    super(FakeSSDFeatureExtractor, self).__init__(
-        is_training=True,
-        depth_multiplier=0,
-        min_depth=0,
-        pad_to_multiple=1,
-        conv_hyperparams_fn=None)
-
-  def preprocess(self, resized_inputs):
-    return tf.identity(resized_inputs)
-
-  def extract_features(self, preprocessed_inputs):
-    with tf.variable_scope('mock_model'):
-      features = slim.conv2d(inputs=preprocessed_inputs, num_outputs=32,
-                             kernel_size=1, scope='layer1')
-      return [features]
-
-
-class FakeSSDKerasFeatureExtractor(ssd_meta_arch.SSDKerasFeatureExtractor):
-
-  def __init__(self):
-    with tf.name_scope('mock_model'):
-      super(FakeSSDKerasFeatureExtractor, self).__init__(
-          is_training=True,
-          depth_multiplier=0,
-          min_depth=0,
-          pad_to_multiple=1,
-          conv_hyperparams_config=None,
-          freeze_batchnorm=False,
-          inplace_batchnorm_update=False,
-      )
-
-      self._conv = keras.Conv2D(filters=32, kernel_size=1, name='layer1')
-
-  def preprocess(self, resized_inputs):
-    return tf.identity(resized_inputs)
-
-  def _extract_features(self, preprocessed_inputs, **kwargs):
-    with tf.name_scope('mock_model'):
-      return [self._conv(preprocessed_inputs)]
-
-
-class MockAnchorGenerator2x2(anchor_generator.AnchorGenerator):
-  """Sets up a simple 2x2 anchor grid on the unit square."""
-
-  def name_scope(self):
-    return 'MockAnchorGenerator'
-
-  def num_anchors_per_location(self):
-    return [1]
-
-  def _generate(self, feature_map_shape_list, im_height, im_width):
-    return [box_list.BoxList(
-        tf.constant([[0, 0, .5, .5],
-                     [0, .5, .5, 1],
-                     [.5, 0, 1, .5],
-                     [1., 1., 1.5, 1.5]  # Anchor that is outside clip_window.
-                    ], tf.float32))]
-
-  def num_anchors(self):
-    return 4
-
-
-def _get_value_for_matching_key(dictionary, suffix):
-  for key in dictionary.keys():
-    if key.endswith(suffix):
-      return dictionary[key]
-  raise ValueError('key not found {}'.format(suffix))
-
-
 @parameterized.parameters(
     {'use_keras': False},
     {'use_keras': True},
 )
-class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
+class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
+                      parameterized.TestCase):
 
   def _create_model(self,
                     apply_hard_mining=True,
@@ -123,96 +44,25 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
                     use_expected_classification_loss_under_sampling=False,
                     minimum_negative_sampling=1,
                     desired_negative_sampling_ratio=3,
-                    use_keras=False):
-    is_training = False
-    num_classes = 1
-    mock_anchor_generator = MockAnchorGenerator2x2()
-    if use_keras:
-      mock_box_predictor = test_utils.MockKerasBoxPredictor(
-          is_training, num_classes)
-    else:
-      mock_box_predictor = test_utils.MockBoxPredictor(
-          is_training, num_classes)
-    mock_box_coder = test_utils.MockBoxCoder()
-    if use_keras:
-      fake_feature_extractor = FakeSSDKerasFeatureExtractor()
-    else:
-      fake_feature_extractor = FakeSSDFeatureExtractor()
-    mock_matcher = test_utils.MockMatcher()
-    region_similarity_calculator = sim_calc.IouSimilarity()
-    encode_background_as_zeros = False
-    def image_resizer_fn(image):
-      return [tf.identity(image), tf.shape(image)]
-
-    classification_loss = losses.WeightedSigmoidClassificationLoss()
-    localization_loss = losses.WeightedSmoothL1LocalizationLoss()
-    non_max_suppression_fn = functools.partial(
-        post_processing.batch_multiclass_non_max_suppression,
-        score_thresh=-20.0,
-        iou_thresh=1.0,
-        max_size_per_class=5,
-        max_total_size=5)
-    classification_loss_weight = 1.0
-    localization_loss_weight = 1.0
-    negative_class_weight = 1.0
-    normalize_loss_by_num_matches = False
-
-    hard_example_miner = None
-    if apply_hard_mining:
-      # This hard example miner is expected to be a no-op.
-      hard_example_miner = losses.HardExampleMiner(
-          num_hard_examples=None,
-          iou_threshold=1.0)
-
-    random_example_sampler = None
-    if random_example_sampling:
-      random_example_sampler = sampler.BalancedPositiveNegativeSampler(
-          positive_fraction=0.5)
-
-    target_assigner_instance = target_assigner.TargetAssigner(
-        region_similarity_calculator,
-        mock_matcher,
-        mock_box_coder,
-        negative_class_weight=negative_class_weight,
-        weight_regression_loss_by_score=weight_regression_loss_by_score)
-
-    expected_classification_loss_under_sampling = None
-    if use_expected_classification_loss_under_sampling:
-      expected_classification_loss_under_sampling = functools.partial(
-          ops.expected_classification_loss_under_sampling,
-          minimum_negative_sampling=minimum_negative_sampling,
-          desired_negative_sampling_ratio=desired_negative_sampling_ratio)
-
-    code_size = 4
-    model = ssd_meta_arch.SSDMetaArch(
-        is_training,
-        mock_anchor_generator,
-        mock_box_predictor,
-        mock_box_coder,
-        fake_feature_extractor,
-        mock_matcher,
-        region_similarity_calculator,
-        encode_background_as_zeros,
-        negative_class_weight,
-        image_resizer_fn,
-        non_max_suppression_fn,
-        tf.identity,
-        classification_loss,
-        localization_loss,
-        classification_loss_weight,
-        localization_loss_weight,
-        normalize_loss_by_num_matches,
-        hard_example_miner,
-        target_assigner_instance=target_assigner_instance,
-        add_summaries=False,
+                    use_keras=False,
+                    predict_mask=False,
+                    use_static_shapes=False,
+                    nms_max_size_per_class=5):
+    return super(SsdMetaArchTest, self)._create_model(
+        model_fn=ssd_meta_arch.SSDMetaArch,
+        apply_hard_mining=apply_hard_mining,
         normalize_loc_loss_by_codesize=normalize_loc_loss_by_codesize,
-        freeze_batchnorm=False,
-        inplace_batchnorm_update=False,
         add_background_class=add_background_class,
-        random_example_sampler=random_example_sampler,
-        expected_classification_loss_under_sampling=
-        expected_classification_loss_under_sampling)
-    return model, num_classes, mock_anchor_generator.num_anchors(), code_size
+        random_example_sampling=random_example_sampling,
+        weight_regression_loss_by_score=weight_regression_loss_by_score,
+        use_expected_classification_loss_under_sampling=
+        use_expected_classification_loss_under_sampling,
+        minimum_negative_sampling=minimum_negative_sampling,
+        desired_negative_sampling_ratio=desired_negative_sampling_ratio,
+        use_keras=use_keras,
+        predict_mask=predict_mask,
+        use_static_shapes=use_static_shapes,
+        nms_max_size_per_class=nms_max_size_per_class)
 
   def test_preprocess_preserves_shapes_with_dynamic_input_image(
       self, use_keras):
@@ -360,6 +210,7 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       self.assertAllClose(detections_out['num_detections'],
                           expected_num_detections)
 
+
   def test_loss_results_are_correct(self, use_keras):
 
     with tf.Graph().as_default():
@@ -374,9 +225,10 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       prediction_dict = model.predict(preprocessed_tensor,
                                       true_image_shapes=None)
       loss_dict = model.loss(prediction_dict, true_image_shapes=None)
-      return (
-          _get_value_for_matching_key(loss_dict, 'Loss/localization_loss'),
-          _get_value_for_matching_key(loss_dict, 'Loss/classification_loss'))
+      return (self._get_value_for_matching_key(loss_dict,
+                                               'Loss/localization_loss'),
+              self._get_value_for_matching_key(loss_dict,
+                                               'Loss/classification_loss'))
 
     batch_size = 2
     preprocessed_input = np.random.rand(batch_size, 2, 2, 3).astype(np.float32)
@@ -413,7 +265,8 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       prediction_dict = model.predict(preprocessed_tensor,
                                       true_image_shapes=None)
       loss_dict = model.loss(prediction_dict, true_image_shapes=None)
-      return (_get_value_for_matching_key(loss_dict, 'Loss/localization_loss'),)
+      return (self._get_value_for_matching_key(loss_dict,
+                                               'Loss/localization_loss'),)
 
     batch_size = 2
     preprocessed_input = np.random.rand(batch_size, 2, 2, 3).astype(np.float32)
@@ -443,9 +296,10 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       prediction_dict = model.predict(preprocessed_tensor,
                                       true_image_shapes=None)
       loss_dict = model.loss(prediction_dict, true_image_shapes=None)
-      return (
-          _get_value_for_matching_key(loss_dict, 'Loss/localization_loss'),
-          _get_value_for_matching_key(loss_dict, 'Loss/classification_loss'))
+      return (self._get_value_for_matching_key(loss_dict,
+                                               'Loss/localization_loss'),
+              self._get_value_for_matching_key(loss_dict,
+                                               'Loss/classification_loss'))
 
     batch_size = 2
     preprocessed_input = np.random.rand(batch_size, 2, 2, 3).astype(np.float32)
@@ -591,6 +445,55 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
     self.assertAllClose(localization_loss, expected_localization_loss)
     self.assertAllClose(classification_loss, expected_classification_loss)
 
+  def test_loss_results_are_correct_with_losses_mask(self, use_keras):
+
+    with tf.Graph().as_default():
+      _, num_classes, num_anchors, _ = self._create_model(use_keras=use_keras)
+    def graph_fn(preprocessed_tensor, groundtruth_boxes1, groundtruth_boxes2,
+                 groundtruth_boxes3, groundtruth_classes1, groundtruth_classes2,
+                 groundtruth_classes3):
+      groundtruth_boxes_list = [groundtruth_boxes1, groundtruth_boxes2,
+                                groundtruth_boxes3]
+      groundtruth_classes_list = [groundtruth_classes1, groundtruth_classes2,
+                                  groundtruth_classes3]
+      is_annotated_list = [tf.constant(True), tf.constant(True),
+                           tf.constant(False)]
+      model, _, _, _ = self._create_model(apply_hard_mining=False)
+      model.provide_groundtruth(groundtruth_boxes_list,
+                                groundtruth_classes_list,
+                                is_annotated_list=is_annotated_list)
+      prediction_dict = model.predict(preprocessed_tensor,
+                                      true_image_shapes=None)
+      loss_dict = model.loss(prediction_dict, true_image_shapes=None)
+      return (self._get_value_for_matching_key(loss_dict,
+                                               'Loss/localization_loss'),
+              self._get_value_for_matching_key(loss_dict,
+                                               'Loss/classification_loss'))
+
+    batch_size = 3
+    preprocessed_input = np.random.rand(batch_size, 2, 2, 3).astype(np.float32)
+    groundtruth_boxes1 = np.array([[0, 0, .5, .5]], dtype=np.float32)
+    groundtruth_boxes2 = np.array([[0, 0, .5, .5]], dtype=np.float32)
+    groundtruth_boxes3 = np.array([[0, 0, .5, .5]], dtype=np.float32)
+    groundtruth_classes1 = np.array([[1]], dtype=np.float32)
+    groundtruth_classes2 = np.array([[1]], dtype=np.float32)
+    groundtruth_classes3 = np.array([[1]], dtype=np.float32)
+    expected_localization_loss = 0.0
+    # Note that we are subtracting 1 from batch_size, since the final image is
+    # not annotated.
+    expected_classification_loss = ((batch_size - 1) * num_anchors
+                                    * (num_classes+1) * np.log(2.0))
+    (localization_loss,
+     classification_loss) = self.execute(graph_fn, [preprocessed_input,
+                                                    groundtruth_boxes1,
+                                                    groundtruth_boxes2,
+                                                    groundtruth_boxes3,
+                                                    groundtruth_classes1,
+                                                    groundtruth_classes2,
+                                                    groundtruth_classes3])
+    self.assertAllClose(localization_loss, expected_localization_loss)
+    self.assertAllClose(classification_loss, expected_classification_loss)
+
   def test_restore_map_for_detection_ckpt(self, use_keras):
     model, _, _, _ = self._create_model(use_keras=use_keras)
     model.predict(tf.constant(np.array([[[[0, 0], [1, 1]], [[1, 0], [0, 1]]]],
@@ -678,10 +581,8 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       use_keras):
 
     with tf.Graph().as_default():
-      _, num_classes, num_anchors, _ = self._create_model(
-          random_example_sampling=True,
-          use_keras=use_keras)
-    print num_classes, num_anchors
+      _, num_classes, _, _ = self._create_model(
+          random_example_sampling=True, use_keras=use_keras)
 
     def graph_fn(preprocessed_tensor, groundtruth_boxes1, groundtruth_boxes2,
                  groundtruth_classes1, groundtruth_classes2):
@@ -694,9 +595,10 @@ class SsdMetaArchTest(test_case.TestCase, parameterized.TestCase):
       prediction_dict = model.predict(
           preprocessed_tensor, true_image_shapes=None)
       loss_dict = model.loss(prediction_dict, true_image_shapes=None)
-      return (_get_value_for_matching_key(loss_dict, 'Loss/localization_loss'),
-              _get_value_for_matching_key(loss_dict,
-                                          'Loss/classification_loss'))
+      return (self._get_value_for_matching_key(loss_dict,
+                                               'Loss/localization_loss'),
+              self._get_value_for_matching_key(loss_dict,
+                                               'Loss/classification_loss'))
 
     batch_size = 2
     preprocessed_input = np.random.rand(batch_size, 2, 2, 3).astype(np.float32)

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -210,6 +210,60 @@ class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
       self.assertAllClose(detections_out['num_detections'],
                           expected_num_detections)
 
+  # BEGIN GOOGLE-INTERNAL
+  # TODO(b/112621326): Remove conditional after CMLE moves to TF 1.11
+  def test_postprocess_results_are_correct_static(self, use_keras):
+    with tf.Graph().as_default():
+      _, _, _, _ = self._create_model(use_keras=use_keras)
+    def graph_fn(input_image):
+      model, _, _, _ = self._create_model(use_static_shapes=True,
+                                          nms_max_size_per_class=4)
+      preprocessed_inputs, true_image_shapes = model.preprocess(input_image)
+      prediction_dict = model.predict(preprocessed_inputs,
+                                      true_image_shapes)
+      detections = model.postprocess(prediction_dict, true_image_shapes)
+      return (detections['detection_boxes'], detections['detection_scores'],
+              detections['detection_classes'], detections['num_detections'])
+
+    batch_size = 2
+    image_size = 2
+    channels = 3
+    input_image = np.random.rand(batch_size, image_size, image_size,
+                                 channels).astype(np.float32)
+    expected_boxes = [
+        [
+            [0, 0, .5, .5],
+            [0, .5, .5, 1],
+            [.5, 0, 1, .5],
+            [0, 0, 0, 0]
+        ],  # padding
+        [
+            [0, 0, .5, .5],
+            [0, .5, .5, 1],
+            [.5, 0, 1, .5],
+            [0, 0, 0, 0]
+        ]
+    ]  # padding
+    expected_scores = [[0, 0, 0, 0], [0, 0, 0, 0]]
+    expected_classes = [[0, 0, 0, 0], [0, 0, 0, 0]]
+    expected_num_detections = np.array([3, 3])
+
+    (detection_boxes, detection_scores, detection_classes,
+     num_detections) = self.execute(graph_fn, [input_image])
+    for image_idx in range(batch_size):
+      self.assertTrue(test_utils.first_rows_close_as_set(
+          detection_boxes[image_idx][
+              0:expected_num_detections[image_idx]].tolist(),
+          expected_boxes[image_idx][0:expected_num_detections[image_idx]]))
+      self.assertAllClose(
+          detection_scores[image_idx][0:expected_num_detections[image_idx]],
+          expected_scores[image_idx][0:expected_num_detections[image_idx]])
+      self.assertAllClose(
+          detection_classes[image_idx][0:expected_num_detections[image_idx]],
+          expected_classes[image_idx][0:expected_num_detections[image_idx]])
+    self.assertAllClose(num_detections,
+                        expected_num_detections)
+  # END GOOGLE-INTERNAL
 
   def test_loss_results_are_correct(self, use_keras):
 

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test_lib.py
@@ -1,0 +1,224 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helper functions for SSD models meta architecture tests."""
+
+import functools
+import tensorflow as tf
+
+from object_detection.core import anchor_generator
+from object_detection.core import balanced_positive_negative_sampler as sampler
+from object_detection.core import box_list
+from object_detection.core import losses
+from object_detection.core import post_processing
+from object_detection.core import region_similarity_calculator as sim_calc
+from object_detection.core import target_assigner
+from object_detection.meta_architectures import ssd_meta_arch
+from object_detection.utils import ops
+from object_detection.utils import test_case
+from object_detection.utils import test_utils
+
+slim = tf.contrib.slim
+keras = tf.keras.layers
+
+
+class FakeSSDFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
+  """Fake ssd feature extracture for ssd meta arch tests."""
+
+  def __init__(self):
+    super(FakeSSDFeatureExtractor, self).__init__(
+        is_training=True,
+        depth_multiplier=0,
+        min_depth=0,
+        pad_to_multiple=1,
+        conv_hyperparams_fn=None)
+
+  def preprocess(self, resized_inputs):
+    return tf.identity(resized_inputs)
+
+  def extract_features(self, preprocessed_inputs):
+    with tf.variable_scope('mock_model'):
+      features = slim.conv2d(
+          inputs=preprocessed_inputs,
+          num_outputs=32,
+          kernel_size=1,
+          scope='layer1')
+      return [features]
+
+
+class FakeSSDKerasFeatureExtractor(ssd_meta_arch.SSDKerasFeatureExtractor):
+  """Fake keras based ssd feature extracture for ssd meta arch tests."""
+
+  def __init__(self):
+    with tf.name_scope('mock_model'):
+      super(FakeSSDKerasFeatureExtractor, self).__init__(
+          is_training=True,
+          depth_multiplier=0,
+          min_depth=0,
+          pad_to_multiple=1,
+          conv_hyperparams_config=None,
+          freeze_batchnorm=False,
+          inplace_batchnorm_update=False,
+      )
+
+      self._conv = keras.Conv2D(filters=32, kernel_size=1, name='layer1')
+
+  def preprocess(self, resized_inputs):
+    return tf.identity(resized_inputs)
+
+  def _extract_features(self, preprocessed_inputs, **kwargs):
+    with tf.name_scope('mock_model'):
+      return [self._conv(preprocessed_inputs)]
+
+
+class MockAnchorGenerator2x2(anchor_generator.AnchorGenerator):
+  """A simple 2x2 anchor grid on the unit square used for test only."""
+
+  def name_scope(self):
+    return 'MockAnchorGenerator'
+
+  def num_anchors_per_location(self):
+    return [1]
+
+  def _generate(self, feature_map_shape_list, im_height, im_width):
+    return [
+        box_list.BoxList(
+            tf.constant(
+                [
+                    [0, 0, .5, .5],
+                    [0, .5, .5, 1],
+                    [.5, 0, 1, .5],
+                    [1., 1., 1.5, 1.5]  # Anchor that is outside clip_window.
+                ],
+                tf.float32))
+    ]
+
+  def num_anchors(self):
+    return 4
+
+
+class SSDMetaArchTestBase(test_case.TestCase):
+  """Base class to test SSD based meta architectures."""
+
+  def _create_model(self,
+                    model_fn=ssd_meta_arch.SSDMetaArch,
+                    apply_hard_mining=True,
+                    normalize_loc_loss_by_codesize=False,
+                    add_background_class=True,
+                    random_example_sampling=False,
+                    weight_regression_loss_by_score=False,
+                    use_expected_classification_loss_under_sampling=False,
+                    minimum_negative_sampling=1,
+                    desired_negative_sampling_ratio=3,
+                    use_keras=False,
+                    predict_mask=False,
+                    use_static_shapes=False,
+                    nms_max_size_per_class=5):
+    is_training = False
+    num_classes = 1
+    mock_anchor_generator = MockAnchorGenerator2x2()
+    if use_keras:
+      mock_box_predictor = test_utils.MockKerasBoxPredictor(
+          is_training, num_classes, predict_mask=predict_mask)
+    else:
+      mock_box_predictor = test_utils.MockBoxPredictor(
+          is_training, num_classes, predict_mask=predict_mask)
+    mock_box_coder = test_utils.MockBoxCoder()
+    if use_keras:
+      fake_feature_extractor = FakeSSDKerasFeatureExtractor()
+    else:
+      fake_feature_extractor = FakeSSDFeatureExtractor()
+    mock_matcher = test_utils.MockMatcher()
+    region_similarity_calculator = sim_calc.IouSimilarity()
+    encode_background_as_zeros = False
+
+    def image_resizer_fn(image):
+      return [tf.identity(image), tf.shape(image)]
+
+    classification_loss = losses.WeightedSigmoidClassificationLoss()
+    localization_loss = losses.WeightedSmoothL1LocalizationLoss()
+    non_max_suppression_fn = functools.partial(
+        post_processing.batch_multiclass_non_max_suppression,
+        score_thresh=-20.0,
+        iou_thresh=1.0,
+        max_size_per_class=nms_max_size_per_class,
+        max_total_size=nms_max_size_per_class,
+        use_static_shapes=use_static_shapes)
+    classification_loss_weight = 1.0
+    localization_loss_weight = 1.0
+    negative_class_weight = 1.0
+    normalize_loss_by_num_matches = False
+
+    hard_example_miner = None
+    if apply_hard_mining:
+      # This hard example miner is expected to be a no-op.
+      hard_example_miner = losses.HardExampleMiner(
+          num_hard_examples=None, iou_threshold=1.0)
+
+    random_example_sampler = None
+    if random_example_sampling:
+      random_example_sampler = sampler.BalancedPositiveNegativeSampler(
+          positive_fraction=0.5)
+
+    target_assigner_instance = target_assigner.TargetAssigner(
+        region_similarity_calculator,
+        mock_matcher,
+        mock_box_coder,
+        negative_class_weight=negative_class_weight,
+        weight_regression_loss_by_score=weight_regression_loss_by_score)
+
+    expected_classification_loss_under_sampling = None
+    if use_expected_classification_loss_under_sampling:
+      expected_classification_loss_under_sampling = functools.partial(
+          ops.expected_classification_loss_under_sampling,
+          minimum_negative_sampling=minimum_negative_sampling,
+          desired_negative_sampling_ratio=desired_negative_sampling_ratio)
+
+    code_size = 4
+    model = model_fn(
+        is_training=is_training,
+        anchor_generator=mock_anchor_generator,
+        box_predictor=mock_box_predictor,
+        box_coder=mock_box_coder,
+        feature_extractor=fake_feature_extractor,
+        encode_background_as_zeros=encode_background_as_zeros,
+        image_resizer_fn=image_resizer_fn,
+        non_max_suppression_fn=non_max_suppression_fn,
+        score_conversion_fn=tf.identity,
+        classification_loss=classification_loss,
+        localization_loss=localization_loss,
+        classification_loss_weight=classification_loss_weight,
+        localization_loss_weight=localization_loss_weight,
+        normalize_loss_by_num_matches=normalize_loss_by_num_matches,
+        hard_example_miner=hard_example_miner,
+        target_assigner_instance=target_assigner_instance,
+        add_summaries=False,
+        normalize_loc_loss_by_codesize=normalize_loc_loss_by_codesize,
+        freeze_batchnorm=False,
+        inplace_batchnorm_update=False,
+        add_background_class=add_background_class,
+        random_example_sampler=random_example_sampler,
+        expected_classification_loss_under_sampling=
+        expected_classification_loss_under_sampling)
+    return model, num_classes, mock_anchor_generator.num_anchors(), code_size
+
+  def _get_value_for_matching_key(self, dictionary, suffix):
+    for key in dictionary.keys():
+      if key.endswith(suffix):
+        return dictionary[key]
+    raise ValueError('key not found {}'.format(suffix))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/metrics/coco_evaluation_test.py
+++ b/research/object_detection/metrics/coco_evaluation_test.py
@@ -24,14 +24,25 @@ from object_detection.core import standard_fields
 from object_detection.metrics import coco_evaluation
 
 
+def _get_categories_list():
+  return [{
+      'id': 1,
+      'name': 'person'
+  }, {
+      'id': 2,
+      'name': 'dog'
+  }, {
+      'id': 3,
+      'name': 'cat'
+  }]
+
+
 class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetections(self):
     """Tests that mAP is calculated correctly on GT and Detections."""
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     coco_evaluator.add_single_ground_truth_image_info(
         image_id='image1',
         groundtruth_dict={
@@ -88,17 +99,8 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetectionsSkipCrowd(self):
     """Tests computing mAP with is_crowd GT boxes skipped."""
-    category_list = [{
-        'id': 0,
-        'name': 'person'
-    }, {
-        'id': 1,
-        'name': 'cat'
-    }, {
-        'id': 2,
-        'name': 'dog'
-    }]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     coco_evaluator.add_single_ground_truth_image_info(
         image_id='image1',
         groundtruth_dict={
@@ -124,17 +126,8 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetectionsEmptyCrowd(self):
     """Tests computing mAP with empty is_crowd array passed in."""
-    category_list = [{
-        'id': 0,
-        'name': 'person'
-    }, {
-        'id': 1,
-        'name': 'cat'
-    }, {
-        'id': 2,
-        'name': 'dog'
-    }]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     coco_evaluator.add_single_ground_truth_image_info(
         image_id='image1',
         groundtruth_dict={
@@ -160,11 +153,9 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testRejectionOnDuplicateGroundtruth(self):
     """Tests that groundtruth cannot be added more than once for an image."""
-    categories = [{'id': 1, 'name': 'cat'},
-                  {'id': 2, 'name': 'dog'},
-                  {'id': 3, 'name': 'elephant'}]
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     #  Add groundtruth
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(categories)
     image_key1 = 'img1'
     groundtruth_boxes1 = np.array([[0, 0, 1, 1], [0, 0, 2, 2], [0, 0, 3, 3]],
                                   dtype=float)
@@ -189,11 +180,9 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testRejectionOnDuplicateDetections(self):
     """Tests that detections cannot be added more than once for an image."""
-    categories = [{'id': 1, 'name': 'cat'},
-                  {'id': 2, 'name': 'dog'},
-                  {'id': 3, 'name': 'elephant'}]
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     #  Add groundtruth
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(categories)
     coco_evaluator.add_single_ground_truth_image_info(
         image_id='image1',
         groundtruth_dict={
@@ -227,10 +216,8 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 
   def testExceptionRaisedWithMissingGroundtruth(self):
     """Tests that exception is raised for detection with missing groundtruth."""
-    categories = [{'id': 1, 'name': 'cat'},
-                  {'id': 2, 'name': 'dog'},
-                  {'id': 3, 'name': 'elephant'}]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(categories)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     with self.assertRaises(ValueError):
       coco_evaluator.add_single_detected_image_info(
           image_id='image1',
@@ -247,10 +234,8 @@ class CocoDetectionEvaluationTest(tf.test.TestCase):
 class CocoEvaluationPyFuncTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetections(self):
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     image_id = tf.placeholder(tf.string, shape=())
     groundtruth_boxes = tf.placeholder(tf.float32, shape=(None, 4))
     groundtruth_classes = tf.placeholder(tf.float32, shape=(None))
@@ -310,31 +295,22 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP@.75IOU'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (small)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@10'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (small)'], 1.0)
     self.assertFalse(coco_evaluator._groundtruth_list)
     self.assertFalse(coco_evaluator._detection_boxes_list)
     self.assertFalse(coco_evaluator._image_ids)
 
   def testGetOneMAPWithMatchingGroundtruthAndDetectionsPadded(self):
-    category_list = [{
-        'id': 0,
-        'name': 'person'
-    }, {
-        'id': 1,
-        'name': 'cat'
-    }, {
-        'id': 2,
-        'name': 'dog'
-    }]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     image_id = tf.placeholder(tf.string, shape=())
     groundtruth_boxes = tf.placeholder(tf.float32, shape=(None, 4))
     groundtruth_classes = tf.placeholder(tf.float32, shape=(None))
@@ -415,24 +391,22 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP@.75IOU'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (small)'], 1.0)
-    self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 0.75)
+    self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 0.83333331)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@10'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (small)'], 1.0)
     self.assertFalse(coco_evaluator._groundtruth_list)
     self.assertFalse(coco_evaluator._detection_boxes_list)
     self.assertFalse(coco_evaluator._image_ids)
 
   def testGetOneMAPWithMatchingGroundtruthAndDetectionsBatched(self):
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     batch_size = 3
     image_id = tf.placeholder(tf.string, shape=(batch_size))
     groundtruth_boxes = tf.placeholder(tf.float32, shape=(batch_size, None, 4))
@@ -479,24 +453,22 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP@.75IOU'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (small)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@10'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (small)'], 1.0)
     self.assertFalse(coco_evaluator._groundtruth_list)
     self.assertFalse(coco_evaluator._detection_boxes_list)
     self.assertFalse(coco_evaluator._image_ids)
 
   def testGetOneMAPWithMatchingGroundtruthAndDetectionsPaddedBatches(self):
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoDetectionEvaluator(
+        _get_categories_list())
     batch_size = 3
     image_id = tf.placeholder(tf.string, shape=(batch_size))
     groundtruth_boxes = tf.placeholder(tf.float32, shape=(batch_size, None, 4))
@@ -525,27 +497,40 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
     _, update_op = eval_metric_ops['DetectionBoxes_Precision/mAP']
 
     with self.test_session() as sess:
-      sess.run(update_op,
-               feed_dict={
-                   image_id: ['image1', 'image2', 'image3'],
-                   groundtruth_boxes: np.array([[[100., 100., 200., 200.],
-                                                 [-1, -1, -1, -1]],
-                                                [[50., 50., 100., 100.],
-                                                 [-1, -1, -1, -1]],
-                                                [[25., 25., 50., 50.],
-                                                 [10., 10., 15., 15.]]]),
-                   groundtruth_classes: np.array([[1, -1], [3, -1], [2, 2]]),
-                   num_gt_boxes_per_image: np.array([1, 1, 2]),
-                   detection_boxes: np.array([[[100., 100., 200., 200.],
-                                               [0., 0., 0., 0.]],
-                                              [[50., 50., 100., 100.],
-                                               [0., 0., 0., 0.]],
-                                              [[25., 25., 50., 50.],
-                                               [10., 10., 15., 15.]]]),
-                   detection_scores: np.array([[.8, 0.], [.7, 0.], [.95, .9]]),
-                   detection_classes: np.array([[1, -1], [3, -1], [2, 2]]),
-                   num_det_boxes_per_image: np.array([1, 1, 2]),
-               })
+      sess.run(
+          update_op,
+          feed_dict={
+              image_id: ['image1', 'image2', 'image3'],
+              groundtruth_boxes:
+                  np.array([[[100., 100., 200., 200.], [-1, -1, -1, -1]],
+                            [[50., 50., 100., 100.], [-1, -1, -1, -1]],
+                            [[25., 25., 50., 50.], [10., 10., 15., 15.]]]),
+              groundtruth_classes:
+                  np.array([[1, -1], [3, -1], [2, 2]]),
+              num_gt_boxes_per_image:
+                  np.array([1, 1, 2]),
+              detection_boxes:
+                  np.array([[[100., 100., 200., 200.],
+                             [0., 0., 0., 0.],
+                             [0., 0., 0., 0.]],
+                            [[50., 50., 100., 100.],
+                             [0., 0., 0., 0.],
+                             [0., 0., 0., 0.]],
+                            [[25., 25., 50., 50.],
+                             [10., 10., 15., 15.],
+                             [10., 10., 15., 15.]]]),
+              detection_scores:
+                  np.array([[.8, 0., 0.], [.7, 0., 0.], [.95, .9, 0.9]]),
+              detection_classes:
+                  np.array([[1, -1, -1], [3, -1, -1], [2, 2, 2]]),
+              num_det_boxes_per_image:
+                  np.array([1, 1, 3]),
+          })
+
+    # Check the number of bounding boxes added.
+    self.assertEqual(len(coco_evaluator._groundtruth_list), 4)
+    self.assertEqual(len(coco_evaluator._detection_boxes_list), 5)
+
     metrics = {}
     for key, (value_op, _) in eval_metric_ops.iteritems():
       metrics[key] = value_op
@@ -555,14 +540,14 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP@.75IOU'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Precision/mAP (small)'], 1.0)
-    self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 0.75)
+    self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@1'], 0.83333331)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@10'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (large)'], 1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (medium)'],
-                           -1.0)
+                           1.0)
     self.assertAlmostEqual(metrics['DetectionBoxes_Recall/AR@100 (small)'], 1.0)
     self.assertFalse(coco_evaluator._groundtruth_list)
     self.assertFalse(coco_evaluator._detection_boxes_list)
@@ -572,10 +557,7 @@ class CocoEvaluationPyFuncTest(tf.test.TestCase):
 class CocoMaskEvaluationTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetections(self):
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoMaskEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoMaskEvaluator(_get_categories_list())
     coco_evaluator.add_single_ground_truth_image_info(
         image_id='image1',
         groundtruth_dict={
@@ -657,10 +639,7 @@ class CocoMaskEvaluationTest(tf.test.TestCase):
 class CocoMaskEvaluationPyFuncTest(tf.test.TestCase):
 
   def testGetOneMAPWithMatchingGroundtruthAndDetections(self):
-    category_list = [{'id': 0, 'name': 'person'},
-                     {'id': 1, 'name': 'cat'},
-                     {'id': 2, 'name': 'dog'}]
-    coco_evaluator = coco_evaluation.CocoMaskEvaluator(category_list)
+    coco_evaluator = coco_evaluation.CocoMaskEvaluator(_get_categories_list())
     image_id = tf.placeholder(tf.string, shape=())
     groundtruth_boxes = tf.placeholder(tf.float32, shape=(None, 4))
     groundtruth_classes = tf.placeholder(tf.float32, shape=(None))
@@ -755,6 +734,7 @@ class CocoMaskEvaluationPyFuncTest(tf.test.TestCase):
     self.assertFalse(coco_evaluator._image_ids_with_detections)
     self.assertFalse(coco_evaluator._image_id_to_mask_shape_map)
     self.assertFalse(coco_evaluator._detection_masks_list)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/metrics/offline_eval_map_corloc.py
+++ b/research/object_detection/metrics/offline_eval_map_corloc.py
@@ -91,10 +91,8 @@ def read_data_and_evaluate(input_config, eval_config):
   if input_config.WhichOneof('input_reader') == 'tf_record_input_reader':
     input_paths = input_config.tf_record_input_reader.input_path
 
-    label_map = label_map_util.load_labelmap(input_config.label_map_path)
-    max_num_classes = max([item.id for item in label_map.item])
-    categories = label_map_util.convert_label_map_to_categories(
-        label_map, max_num_classes)
+    categories = label_map_util.create_categories_from_labelmap(
+        input_config.label_map_path)
 
     object_detection_evaluators = evaluator.get_evaluators(
         eval_config, categories)

--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -571,6 +571,10 @@ def create_estimator_and_inputs(run_config,
         use_tpu=use_tpu,
         config=run_config,
         # TODO(lzc): Remove conditional after CMLE moves to TF 1.9
+        # BEGIN GOOGLE-INTERNAL
+        export_to_tpu=export_to_tpu,
+        eval_on_tpu=False,  # Eval runs on CPU, so disable eval on TPU
+        # END GOOGLE-INTERNAL
         params=params if params else {})
   else:
     estimator = tf.estimator.Estimator(model_fn=model_fn, config=run_config)

--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -242,6 +242,7 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
       gt_weights_list = None
       if fields.InputDataFields.groundtruth_weights in labels:
         gt_weights_list = labels[fields.InputDataFields.groundtruth_weights]
+      gt_is_crowd_list = None
       if fields.InputDataFields.groundtruth_is_crowd in labels:
         gt_is_crowd_list = labels[fields.InputDataFields.groundtruth_is_crowd]
       detection_model.provide_groundtruth(

--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import copy
 import functools
 import os
 
@@ -43,9 +44,12 @@ MODEL_BUILD_UTIL_MAP = {
         config_util.create_pipeline_proto_from_configs,
     'merge_external_params_with_configs':
         config_util.merge_external_params_with_configs,
-    'create_train_input_fn': inputs.create_train_input_fn,
-    'create_eval_input_fn': inputs.create_eval_input_fn,
-    'create_predict_input_fn': inputs.create_predict_input_fn,
+    'create_train_input_fn':
+        inputs.create_train_input_fn,
+    'create_eval_input_fn':
+        inputs.create_eval_input_fn,
+    'create_predict_input_fn':
+        inputs.create_predict_input_fn,
 }
 
 
@@ -126,8 +130,9 @@ def unstack_batch(tensor_dict, unpad_groundtruth_tensors=True):
     ValueError: If unpad_tensors is True and `tensor_dict` does not contain
       `num_groundtruth_boxes` tensor.
   """
-  unbatched_tensor_dict = {key: tf.unstack(tensor)
-                           for key, tensor in tensor_dict.items()}
+  unbatched_tensor_dict = {
+      key: tf.unstack(tensor) for key, tensor in tensor_dict.items()
+  }
   if unpad_groundtruth_tensors:
     if (fields.InputDataFields.num_groundtruth_boxes not in
         unbatched_tensor_dict):
@@ -206,8 +211,8 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
     # Make sure to set the Keras learning phase. True during training,
     # False for inference.
     tf.keras.backend.set_learning_phase(is_training)
-    detection_model = detection_model_fn(is_training=is_training,
-                                         add_summaries=(not use_tpu))
+    detection_model = detection_model_fn(
+        is_training=is_training, add_summaries=(not use_tpu))
     scaffold_fn = None
 
     if mode == tf.estimator.ModeKeys.TRAIN:
@@ -270,13 +275,16 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
                 train_config.load_all_detection_checkpoint_vars))
         available_var_map = (
             variables_helper.get_variables_available_in_checkpoint(
-                asg_map, train_config.fine_tune_checkpoint,
+                asg_map,
+                train_config.fine_tune_checkpoint,
                 include_global_step=False))
         if use_tpu:
+
           def tpu_scaffold():
             tf.train.init_from_checkpoint(train_config.fine_tune_checkpoint,
                                           available_var_map)
             return tf.train.Scaffold()
+
           scaffold_fn = tpu_scaffold
         else:
           tf.train.init_from_checkpoint(train_config.fine_tune_checkpoint,
@@ -290,8 +298,8 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
         regularization_losses = tf.get_collection(
             tf.GraphKeys.REGULARIZATION_LOSSES)
         if regularization_losses:
-          regularization_loss = tf.add_n(regularization_losses,
-                                         name='regularization_loss')
+          regularization_loss = tf.add_n(
+              regularization_losses, name='regularization_loss')
           losses.append(regularization_loss)
           losses_dict['Loss/regularization_loss'] = regularization_loss
       total_loss = tf.add_n(losses, name='total_loss')
@@ -353,14 +361,14 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
     eval_metric_ops = None
     scaffold = None
     if mode == tf.estimator.ModeKeys.EVAL:
-      class_agnostic = (fields.DetectionResultFields.detection_classes
-                        not in detections)
-      groundtruth = _prepare_groundtruth_for_eval(
-          detection_model, class_agnostic)
+      class_agnostic = (
+          fields.DetectionResultFields.detection_classes not in detections)
+      groundtruth = _prepare_groundtruth_for_eval(detection_model,
+                                                  class_agnostic)
       use_original_images = fields.InputDataFields.original_image in features
       eval_images = (
-          features[fields.InputDataFields.original_image] if use_original_images
-          else features[fields.InputDataFields.image])
+          features[fields.InputDataFields.original_image]
+          if use_original_images else features[fields.InputDataFields.image])
       eval_dict = eval_util.result_dict_for_single_example(
           eval_images[0:1],
           features[inputs.HASH_KEY][0],
@@ -374,28 +382,26 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False):
       else:
         category_index = label_map_util.create_category_index_from_labelmap(
             eval_input_config.label_map_path)
-      img_summary = None
+      vis_metric_ops = None
       if not use_tpu and use_original_images:
-        detection_and_groundtruth = (
-            vis_utils.draw_side_by_side_evaluation_image(
-                eval_dict, category_index, max_boxes_to_draw=eval_config.max_num_boxes_to_visualize,
-                min_score_thresh=eval_config.min_score_threshold,
-                use_normalized_coordinates=False))
-        img_summary = tf.summary.image('Detections_Left_Groundtruth_Right',
-                                       detection_and_groundtruth)
+        eval_metric_op_vis = vis_utils.VisualizeSingleFrameDetections(
+            category_index,
+            max_examples_to_draw=eval_config.num_visualizations,
+            max_boxes_to_draw=eval_config.max_num_boxes_to_visualize,
+            min_score_thresh=eval_config.min_score_threshold,
+            use_normalized_coordinates=False)
+        vis_metric_ops = eval_metric_op_vis.get_estimator_eval_metric_ops(
+            eval_dict)
 
       # Eval metrics on a single example.
       eval_metric_ops = eval_util.get_eval_metric_ops_for_evaluators(
-          eval_config,
-          category_index.values(),
-          eval_dict)
+          eval_config, category_index.values(), eval_dict)
       for loss_key, loss_tensor in iter(losses_dict.items()):
         eval_metric_ops[loss_key] = tf.metrics.mean(loss_tensor)
       for var in optimizer_summary_vars:
         eval_metric_ops[var.op.name] = (var, tf.no_op())
-      if img_summary is not None:
-        eval_metric_ops['Detections_Left_Groundtruth_Right'] = (
-            img_summary, tf.no_op())
+      if vis_metric_ops is not None:
+        eval_metric_ops.update(vis_metric_ops)
       eval_metric_ops = {str(k): v for k, v in eval_metric_ops.items()}
 
       if eval_config.use_moving_averages:
@@ -435,12 +441,14 @@ def create_estimator_and_inputs(run_config,
                                 hparams,
                                 pipeline_config_path,
                                 train_steps=None,
-                                eval_steps=None,
+                                sample_1_of_n_eval_examples=1,
+                                sample_1_of_n_eval_on_train_examples=1,
                                 model_fn_creator=create_model_fn,
                                 use_tpu_estimator=False,
                                 use_tpu=False,
                                 num_shards=1,
                                 params=None,
+                                override_eval_num_epochs=True,
                                 **kwargs):
   """Creates `Estimator`, input functions, and steps.
 
@@ -450,8 +458,11 @@ def create_estimator_and_inputs(run_config,
     pipeline_config_path: A path to a pipeline config file.
     train_steps: Number of training steps. If None, the number of training steps
       is set from the `TrainConfig` proto.
-    eval_steps: Number of evaluation steps per evaluation cycle. If None, the
-      number of evaluation steps is set from the `EvalConfig` proto.
+    sample_1_of_n_eval_examples: Integer representing how often an eval example
+      should be sampled. If 1, will sample all examples.
+    sample_1_of_n_eval_on_train_examples: Similar to
+      `sample_1_of_n_eval_examples`, except controls the sampling of training
+      data for evaluation.
     model_fn_creator: A function that creates a `model_fn` for `Estimator`.
       Follows the signature:
 
@@ -470,6 +481,8 @@ def create_estimator_and_inputs(run_config,
       is True.
     params: Parameter dictionary passed from the estimator. Only used if
       `use_tpu_estimator` is True.
+    override_eval_num_epochs: Whether to overwrite the number of epochs to
+      1 for eval_input.
     **kwargs: Additional keyword arguments for configuration override.
 
   Returns:
@@ -480,8 +493,6 @@ def create_estimator_and_inputs(run_config,
     'eval_on_train_input_fn': An evaluation-on-train input function.
     'predict_input_fn': A prediction input function.
     'train_steps': Number of training steps. Either directly from input or from
-      configuration.
-    'eval_steps': Number of evaluation steps. Either directly from input or from
       configuration.
   """
   get_configs_from_pipeline_file = MODEL_BUILD_UTIL_MAP[
@@ -495,26 +506,38 @@ def create_estimator_and_inputs(run_config,
   create_predict_input_fn = MODEL_BUILD_UTIL_MAP['create_predict_input_fn']
 
   configs = get_configs_from_pipeline_file(pipeline_config_path)
+  kwargs.update({
+      'train_steps': train_steps,
+      'sample_1_of_n_eval_examples': sample_1_of_n_eval_examples,
+      'retain_original_images_in_eval': False if use_tpu else True,
+  })
   configs = merge_external_params_with_configs(
-      configs,
-      hparams,
-      train_steps=train_steps,
-      eval_steps=eval_steps,
-      retain_original_images_in_eval=False if use_tpu else True,
-      **kwargs)
+      configs, hparams, kwargs_dict=kwargs)
   model_config = configs['model']
   train_config = configs['train_config']
   train_input_config = configs['train_input_config']
   eval_config = configs['eval_config']
   eval_input_config = configs['eval_input_config']
+  eval_on_train_input_config = copy.deepcopy(train_input_config)
+  eval_on_train_input_config.sample_1_of_n_examples = (
+      sample_1_of_n_eval_on_train_examples)
+  if override_eval_num_epochs and eval_input_config.num_epochs != 1:
+    tf.logging.warning('Expected number of evaluation epochs is 1, but '
+                       'instead encountered `eval_input_config.num_epochs` = '
+                       '{}. Overwriting `num_epochs` to 1.'.format(
+                           eval_input_config.num_epochs))
+    eval_input_config.num_epochs = 1
+  if override_eval_num_epochs and eval_on_train_input_config.num_epochs != 1:
+    tf.logging.warning('Expected number of evaluation epochs is 1, but '
+                       'instead encountered `eval_on_train_input_config'
+                       '.num_epochs` = '
+                       '{}. Overwriting `num_epochs` to 1.'.format(
+                           eval_on_train_input_config.num_epochs))
+    eval_on_train_input_config.num_epochs = 1
 
   # update train_steps from config but only when non-zero value is provided
   if train_steps is None and train_config.num_steps != 0:
     train_steps = train_config.num_steps
-
-  # update eval_steps from config but only when non-zero value is provided
-  if eval_steps is None and eval_config.num_examples != 0:
-    eval_steps = eval_config.num_examples
 
   detection_model_fn = functools.partial(
       model_builder.build, model_config=model_config)
@@ -530,12 +553,14 @@ def create_estimator_and_inputs(run_config,
       model_config=model_config)
   eval_on_train_input_fn = create_eval_input_fn(
       eval_config=eval_config,
-      eval_input_config=train_input_config,
+      eval_input_config=eval_on_train_input_config,
       model_config=model_config)
   predict_input_fn = create_predict_input_fn(
       model_config=model_config, predict_input_config=eval_input_config)
 
-  tf.logging.info('create_estimator_and_inputs: use_tpu %s', use_tpu)
+  export_to_tpu = hparams.get('export_to_tpu', False)
+  tf.logging.info('create_estimator_and_inputs: use_tpu %s, export_to_tpu %s',
+                  use_tpu, export_to_tpu)
   model_fn = model_fn_creator(detection_model_fn, configs, hparams, use_tpu)
   if use_tpu_estimator:
     estimator = tf.contrib.tpu.TPUEstimator(
@@ -552,8 +577,7 @@ def create_estimator_and_inputs(run_config,
 
   # Write the as-run pipeline config to disk.
   if run_config.is_chief:
-    pipeline_config_final = create_pipeline_proto_from_configs(
-        configs)
+    pipeline_config_final = create_pipeline_proto_from_configs(configs)
     config_util.save_pipeline_config(pipeline_config_final, estimator.model_dir)
 
   return dict(
@@ -562,8 +586,7 @@ def create_estimator_and_inputs(run_config,
       eval_input_fn=eval_input_fn,
       eval_on_train_input_fn=eval_on_train_input_fn,
       predict_input_fn=predict_input_fn,
-      train_steps=train_steps,
-      eval_steps=eval_steps)
+      train_steps=train_steps)
 
 
 def create_train_and_eval_specs(train_input_fn,
@@ -571,9 +594,7 @@ def create_train_and_eval_specs(train_input_fn,
                                 eval_on_train_input_fn,
                                 predict_input_fn,
                                 train_steps,
-                                eval_steps,
                                 eval_on_train_data=False,
-                                eval_on_train_steps=None,
                                 final_exporter_name='Servo',
                                 eval_spec_name='eval'):
   """Creates a `TrainSpec` and `EvalSpec`s.
@@ -585,11 +606,8 @@ def create_train_and_eval_specs(train_input_fn,
       evaluation on train data.
     predict_input_fn: Function that produces features for inference.
     train_steps: Number of training steps.
-    eval_steps: Number of eval steps.
     eval_on_train_data: Whether to evaluate model on training data. Default is
       False.
-    eval_on_train_steps: Number of eval steps for training data. If not given,
-      uses eval_steps.
     final_exporter_name: String name given to `FinalExporter`.
     eval_spec_name: String name given to main `EvalSpec`.
 
@@ -609,32 +627,30 @@ def create_train_and_eval_specs(train_input_fn,
       tf.estimator.EvalSpec(
           name=eval_spec_name,
           input_fn=eval_input_fn,
-          steps=eval_steps,
+          steps=None,
           exporters=exporter)
   ]
 
   if eval_on_train_data:
     eval_specs.append(
         tf.estimator.EvalSpec(
-            name='eval_on_train', input_fn=eval_on_train_input_fn,
-            steps=eval_on_train_steps or eval_steps))
+            name='eval_on_train', input_fn=eval_on_train_input_fn, steps=None))
 
   return train_spec, eval_specs
 
 
-def continuous_eval(estimator, model_dir, input_fn, eval_steps, train_steps,
-                    name):
+def continuous_eval(estimator, model_dir, input_fn, train_steps, name):
   """Perform continuous evaluation on checkpoints written to a model directory.
 
   Args:
     estimator: Estimator object to use for evaluation.
     model_dir: Model directory to read checkpoints for continuous evaluation.
     input_fn: Input function to use for evaluation.
-    eval_steps: Number of steps to run during each evaluation.
     train_steps: Number of training steps. This is used to infer the last
       checkpoint and stop evaluation loop.
     name: Namescope for eval summary.
   """
+
   def terminate_eval():
     tf.logging.info('Terminating eval after 180 seconds of no checkpoints')
     return True
@@ -646,10 +662,7 @@ def continuous_eval(estimator, model_dir, input_fn, eval_steps, train_steps,
     tf.logging.info('Starting Evaluation.')
     try:
       eval_results = estimator.evaluate(
-          input_fn=input_fn,
-          steps=eval_steps,
-          checkpoint_path=ckpt,
-          name=name)
+          input_fn=input_fn, steps=None, checkpoint_path=ckpt, name=name)
       tf.logging.info('Eval results: %s' % eval_results)
 
       # Terminate eval job when final checkpoint is reached
@@ -716,7 +729,6 @@ def populate_experiment(run_config,
   eval_input_fn = train_and_eval_dict['eval_input_fn']
   predict_input_fn = train_and_eval_dict['predict_input_fn']
   train_steps = train_and_eval_dict['train_steps']
-  eval_steps = train_and_eval_dict['eval_steps']
 
   export_strategies = [
       tf.contrib.learn.utils.saved_model_export_utils.make_export_strategy(
@@ -728,6 +740,7 @@ def populate_experiment(run_config,
       train_input_fn=train_input_fn,
       eval_input_fn=eval_input_fn,
       train_steps=train_steps,
-      eval_steps=eval_steps,
+      eval_steps=None,
       export_strategies=export_strategies,
-      eval_delay_secs=120,)
+      eval_delay_secs=120,
+  )

--- a/research/object_detection/model_lib_test.py
+++ b/research/object_detection/model_lib_test.py
@@ -240,7 +240,7 @@ class ModelLibTest(tf.test.TestCase):
     self.assertIsInstance(estimator, tf.estimator.Estimator)
     self.assertEqual(20, train_steps)
     self.assertIn('train_input_fn', train_and_eval_dict)
-    self.assertIn('eval_input_fn', train_and_eval_dict)
+    self.assertIn('eval_input_fns', train_and_eval_dict)
     self.assertIn('eval_on_train_input_fn', train_and_eval_dict)
 
   def test_create_estimator_with_default_train_eval_steps(self):
@@ -292,25 +292,25 @@ class ModelLibTest(tf.test.TestCase):
         pipeline_config_path,
         train_steps=train_steps)
     train_input_fn = train_and_eval_dict['train_input_fn']
-    eval_input_fn = train_and_eval_dict['eval_input_fn']
+    eval_input_fns = train_and_eval_dict['eval_input_fns']
     eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
     predict_input_fn = train_and_eval_dict['predict_input_fn']
     train_steps = train_and_eval_dict['train_steps']
 
     train_spec, eval_specs = model_lib.create_train_and_eval_specs(
         train_input_fn,
-        eval_input_fn,
+        eval_input_fns,
         eval_on_train_input_fn,
         predict_input_fn,
         train_steps,
         eval_on_train_data=True,
         final_exporter_name='exporter',
-        eval_spec_name='holdout')
+        eval_spec_names=['holdout'])
     self.assertEqual(train_steps, train_spec.max_steps)
     self.assertEqual(2, len(eval_specs))
     self.assertEqual(None, eval_specs[0].steps)
     self.assertEqual('holdout', eval_specs[0].name)
-    self.assertEqual('exporter', eval_specs[0].exporters[0].name)
+    self.assertEqual('exporter_holdout', eval_specs[0].exporters[0].name)
     self.assertEqual(None, eval_specs[1].steps)
     self.assertEqual('eval_on_train', eval_specs[1].name)
 

--- a/research/object_detection/model_lib_test.py
+++ b/research/object_detection/model_lib_test.py
@@ -64,11 +64,13 @@ def _get_configs_for_model(model_name):
   data_path = _get_data_path()
   label_map_path = _get_labelmap_path()
   configs = config_util.get_configs_from_pipeline_file(filename)
+  override_dict = {
+      'train_input_path': data_path,
+      'eval_input_path': data_path,
+      'label_map_path': label_map_path
+  }
   configs = config_util.merge_external_params_with_configs(
-      configs,
-      train_input_path=data_path,
-      eval_input_path=data_path,
-      label_map_path=label_map_path)
+      configs, kwargs_dict=override_dict)
   return configs
 
 
@@ -145,6 +147,9 @@ class ModelLibTest(tf.test.TestCase):
         self.assertEqual(batch_size, detection_scores.shape.as_list()[0])
         self.assertEqual(tf.float32, detection_scores.dtype)
         self.assertEqual(tf.float32, num_detections.dtype)
+        if mode == 'eval':
+          self.assertIn('Detections_Left_Groundtruth_Right/0',
+                        estimator_spec.eval_metric_ops)
       if model_mode == tf.estimator.ModeKeys.TRAIN:
         self.assertIsNotNone(estimator_spec.train_op)
       return estimator_spec
@@ -225,19 +230,15 @@ class ModelLibTest(tf.test.TestCase):
         hparams_overrides='load_pretrained=false')
     pipeline_config_path = get_pipeline_config_path(MODEL_NAME_FOR_TEST)
     train_steps = 20
-    eval_steps = 10
     train_and_eval_dict = model_lib.create_estimator_and_inputs(
         run_config,
         hparams,
         pipeline_config_path,
-        train_steps=train_steps,
-        eval_steps=eval_steps)
+        train_steps=train_steps)
     estimator = train_and_eval_dict['estimator']
     train_steps = train_and_eval_dict['train_steps']
-    eval_steps = train_and_eval_dict['eval_steps']
     self.assertIsInstance(estimator, tf.estimator.Estimator)
     self.assertEqual(20, train_steps)
-    self.assertEqual(10, eval_steps)
     self.assertIn('train_input_fn', train_and_eval_dict)
     self.assertIn('eval_input_fn', train_and_eval_dict)
     self.assertIn('eval_on_train_input_fn', train_and_eval_dict)
@@ -250,16 +251,13 @@ class ModelLibTest(tf.test.TestCase):
     pipeline_config_path = get_pipeline_config_path(MODEL_NAME_FOR_TEST)
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
     config_train_steps = configs['train_config'].num_steps
-    config_eval_steps = configs['eval_config'].num_examples
     train_and_eval_dict = model_lib.create_estimator_and_inputs(
         run_config, hparams, pipeline_config_path)
     estimator = train_and_eval_dict['estimator']
     train_steps = train_and_eval_dict['train_steps']
-    eval_steps = train_and_eval_dict['eval_steps']
 
     self.assertIsInstance(estimator, tf.estimator.Estimator)
     self.assertEqual(config_train_steps, train_steps)
-    self.assertEqual(config_eval_steps, eval_steps)
 
   def test_create_tpu_estimator_and_inputs(self):
     """Tests that number of train/eval defaults to config values."""
@@ -269,21 +267,17 @@ class ModelLibTest(tf.test.TestCase):
         hparams_overrides='load_pretrained=false')
     pipeline_config_path = get_pipeline_config_path(MODEL_NAME_FOR_TEST)
     train_steps = 20
-    eval_steps = 10
     train_and_eval_dict = model_lib.create_estimator_and_inputs(
         run_config,
         hparams,
         pipeline_config_path,
         train_steps=train_steps,
-        eval_steps=eval_steps,
         use_tpu_estimator=True)
     estimator = train_and_eval_dict['estimator']
     train_steps = train_and_eval_dict['train_steps']
-    eval_steps = train_and_eval_dict['eval_steps']
 
     self.assertIsInstance(estimator, tpu_estimator.TPUEstimator)
     self.assertEqual(20, train_steps)
-    self.assertEqual(10, eval_steps)
 
   def test_create_train_and_eval_specs(self):
     """Tests that `TrainSpec` and `EvalSpec` is created correctly."""
@@ -292,20 +286,16 @@ class ModelLibTest(tf.test.TestCase):
         hparams_overrides='load_pretrained=false')
     pipeline_config_path = get_pipeline_config_path(MODEL_NAME_FOR_TEST)
     train_steps = 20
-    eval_steps = 10
-    eval_on_train_steps = 15
     train_and_eval_dict = model_lib.create_estimator_and_inputs(
         run_config,
         hparams,
         pipeline_config_path,
-        train_steps=train_steps,
-        eval_steps=eval_steps)
+        train_steps=train_steps)
     train_input_fn = train_and_eval_dict['train_input_fn']
     eval_input_fn = train_and_eval_dict['eval_input_fn']
     eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
     predict_input_fn = train_and_eval_dict['predict_input_fn']
     train_steps = train_and_eval_dict['train_steps']
-    eval_steps = train_and_eval_dict['eval_steps']
 
     train_spec, eval_specs = model_lib.create_train_and_eval_specs(
         train_input_fn,
@@ -313,17 +303,15 @@ class ModelLibTest(tf.test.TestCase):
         eval_on_train_input_fn,
         predict_input_fn,
         train_steps,
-        eval_steps,
         eval_on_train_data=True,
-        eval_on_train_steps=eval_on_train_steps,
         final_exporter_name='exporter',
         eval_spec_name='holdout')
     self.assertEqual(train_steps, train_spec.max_steps)
     self.assertEqual(2, len(eval_specs))
-    self.assertEqual(eval_steps, eval_specs[0].steps)
+    self.assertEqual(None, eval_specs[0].steps)
     self.assertEqual('holdout', eval_specs[0].name)
     self.assertEqual('exporter', eval_specs[0].exporters[0].name)
-    self.assertEqual(eval_on_train_steps, eval_specs[1].steps)
+    self.assertEqual(None, eval_specs[1].steps)
     self.assertEqual('eval_on_train', eval_specs[1].name)
 
   def test_experiment(self):
@@ -339,7 +327,7 @@ class ModelLibTest(tf.test.TestCase):
         train_steps=10,
         eval_steps=20)
     self.assertEqual(10, experiment.train_steps)
-    self.assertEqual(20, experiment.eval_steps)
+    self.assertEqual(None, experiment.eval_steps)
 
 
 class UnbatchTensorsTest(tf.test.TestCase):

--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -31,7 +31,16 @@ flags.DEFINE_string(
 flags.DEFINE_string('pipeline_config_path', None, 'Path to pipeline config '
                     'file.')
 flags.DEFINE_integer('num_train_steps', None, 'Number of train steps.')
-flags.DEFINE_integer('num_eval_steps', None, 'Number of train steps.')
+flags.DEFINE_boolean('eval_training_data', False,
+                     'If training data should be evaluated for this job. Note '
+                     'that one call only use this in eval-only mode, and '
+                     '`checkpoint_dir` must be supplied.')
+flags.DEFINE_integer('sample_1_of_n_eval_examples', 1, 'Will sample one of '
+                     'every n eval input examples, where n is provided.')
+flags.DEFINE_integer('sample_1_of_n_eval_on_train_examples', 5, 'Will sample '
+                     'one of every n train input examples for evaluation, '
+                     'where n is provided. This is only used if '
+                     '`eval_training_data` is True.')
 flags.DEFINE_string(
     'hparams_overrides', None, 'Hyperparameter overrides, '
     'represented as a string containing comma-separated '
@@ -44,8 +53,6 @@ flags.DEFINE_boolean(
     'run_once', False, 'If running in eval-only mode, whether to run just '
     'one round of eval vs running continuously (default).'
 )
-flags.DEFINE_boolean('eval_training_data', False,
-                     'If training data should be evaluated for this job.')
 FLAGS = flags.FLAGS
 
 
@@ -59,14 +66,15 @@ def main(unused_argv):
       hparams=model_hparams.create_hparams(FLAGS.hparams_overrides),
       pipeline_config_path=FLAGS.pipeline_config_path,
       train_steps=FLAGS.num_train_steps,
-      eval_steps=FLAGS.num_eval_steps)
+      sample_1_of_n_eval_examples=FLAGS.sample_1_of_n_eval_examples,
+      sample_1_of_n_eval_on_train_examples=(
+          FLAGS.sample_1_of_n_eval_on_train_examples))
   estimator = train_and_eval_dict['estimator']
   train_input_fn = train_and_eval_dict['train_input_fn']
   eval_input_fn = train_and_eval_dict['eval_input_fn']
   eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
   predict_input_fn = train_and_eval_dict['predict_input_fn']
   train_steps = train_and_eval_dict['train_steps']
-  eval_steps = train_and_eval_dict['eval_steps']
 
   if FLAGS.checkpoint_dir:
     if FLAGS.eval_training_data:
@@ -77,12 +85,12 @@ def main(unused_argv):
       input_fn = eval_input_fn
     if FLAGS.run_once:
       estimator.evaluate(input_fn,
-                         eval_steps,
+                         num_eval_steps=None,
                          checkpoint_path=tf.train.latest_checkpoint(
                              FLAGS.checkpoint_dir))
     else:
       model_lib.continuous_eval(estimator, FLAGS.model_dir, input_fn,
-                                eval_steps, train_steps, name)
+                                train_steps, name)
   else:
     train_spec, eval_specs = model_lib.create_train_and_eval_specs(
         train_input_fn,
@@ -90,7 +98,6 @@ def main(unused_argv):
         eval_on_train_input_fn,
         predict_input_fn,
         train_steps,
-        eval_steps,
         eval_on_train_data=False)
 
     # Currently only a single Eval Spec is allowed.

--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -71,7 +71,7 @@ def main(unused_argv):
           FLAGS.sample_1_of_n_eval_on_train_examples))
   estimator = train_and_eval_dict['estimator']
   train_input_fn = train_and_eval_dict['train_input_fn']
-  eval_input_fn = train_and_eval_dict['eval_input_fn']
+  eval_input_fns = train_and_eval_dict['eval_input_fns']
   eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
   predict_input_fn = train_and_eval_dict['predict_input_fn']
   train_steps = train_and_eval_dict['train_steps']
@@ -82,19 +82,20 @@ def main(unused_argv):
       input_fn = eval_on_train_input_fn
     else:
       name = 'validation_data'
-      input_fn = eval_input_fn
+      # The first eval input will be evaluated.
+      input_fn = eval_input_fns[0]
     if FLAGS.run_once:
       estimator.evaluate(input_fn,
                          num_eval_steps=None,
                          checkpoint_path=tf.train.latest_checkpoint(
                              FLAGS.checkpoint_dir))
     else:
-      model_lib.continuous_eval(estimator, FLAGS.model_dir, input_fn,
+      model_lib.continuous_eval(estimator, FLAGS.checkpoint_dir, input_fn,
                                 train_steps, name)
   else:
     train_spec, eval_specs = model_lib.create_train_and_eval_specs(
         train_input_fn,
-        eval_input_fn,
+        eval_input_fns,
         eval_on_train_input_fn,
         predict_input_fn,
         train_steps,

--- a/research/object_detection/model_tpu_main.py
+++ b/research/object_detection/model_tpu_main.py
@@ -117,7 +117,7 @@ def main(unused_argv):
       **kwargs)
   estimator = train_and_eval_dict['estimator']
   train_input_fn = train_and_eval_dict['train_input_fn']
-  eval_input_fn = train_and_eval_dict['eval_input_fn']
+  eval_input_fns = train_and_eval_dict['eval_input_fns']
   eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
   train_steps = train_and_eval_dict['train_steps']
 
@@ -131,7 +131,8 @@ def main(unused_argv):
       input_fn = eval_on_train_input_fn
     else:
       name = 'validation_data'
-      input_fn = eval_input_fn
+      # Currently only a single eval input is allowed.
+      input_fn = eval_input_fns[0]
     model_lib.continuous_eval(estimator, FLAGS.model_dir, input_fn, train_steps,
                               name)
 

--- a/research/object_detection/model_tpu_main.py
+++ b/research/object_detection/model_tpu_main.py
@@ -62,15 +62,20 @@ flags.DEFINE_integer('train_batch_size', None, 'Batch size for training. If '
 flags.DEFINE_string(
     'hparams_overrides', None, 'Comma-separated list of '
     'hyperparameters to override defaults.')
+flags.DEFINE_integer('num_train_steps', None, 'Number of train steps.')
 flags.DEFINE_boolean('eval_training_data', False,
                      'If training data should be evaluated for this job.')
+flags.DEFINE_integer('sample_1_of_n_eval_examples', 1, 'Will sample one of '
+                     'every n eval input examples, where n is provided.')
+flags.DEFINE_integer('sample_1_of_n_eval_on_train_examples', 5, 'Will sample '
+                     'one of every n train input examples for evaluation, '
+                     'where n is provided. This is only used if '
+                     '`eval_training_data` is True.')
 flags.DEFINE_string(
     'model_dir', None, 'Path to output model directory '
     'where event and checkpoint files will be written.')
 flags.DEFINE_string('pipeline_config_path', None, 'Path to pipeline config '
                     'file.')
-flags.DEFINE_integer('num_train_steps', None, 'Number of train steps.')
-flags.DEFINE_integer('num_eval_steps', None, 'Number of train steps.')
 
 FLAGS = tf.flags.FLAGS
 
@@ -103,7 +108,9 @@ def main(unused_argv):
       hparams=model_hparams.create_hparams(FLAGS.hparams_overrides),
       pipeline_config_path=FLAGS.pipeline_config_path,
       train_steps=FLAGS.num_train_steps,
-      eval_steps=FLAGS.num_eval_steps,
+      sample_1_of_n_eval_examples=FLAGS.sample_1_of_n_eval_examples,
+      sample_1_of_n_eval_on_train_examples=(
+          FLAGS.sample_1_of_n_eval_on_train_examples),
       use_tpu_estimator=True,
       use_tpu=FLAGS.use_tpu,
       num_shards=FLAGS.num_shards,
@@ -113,7 +120,6 @@ def main(unused_argv):
   eval_input_fn = train_and_eval_dict['eval_input_fn']
   eval_on_train_input_fn = train_and_eval_dict['eval_on_train_input_fn']
   train_steps = train_and_eval_dict['train_steps']
-  eval_steps = train_and_eval_dict['eval_steps']
 
   if FLAGS.mode == 'train':
     estimator.train(input_fn=train_input_fn, max_steps=train_steps)
@@ -126,8 +132,8 @@ def main(unused_argv):
     else:
       name = 'validation_data'
       input_fn = eval_input_fn
-    model_lib.continuous_eval(estimator, FLAGS.model_dir, input_fn, eval_steps,
-                              train_steps, name)
+    model_lib.continuous_eval(estimator, FLAGS.model_dir, input_fn, train_steps,
+                              name)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/feature_map_generators.py
+++ b/research/object_detection/models/feature_map_generators.py
@@ -24,6 +24,7 @@ Feature map generators build on the base feature extractors and produce a list
 of final feature maps.
 """
 import collections
+import functools
 import tensorflow as tf
 from object_detection.utils import ops
 slim = tf.contrib.slim
@@ -43,6 +44,220 @@ def get_depth_fn(depth_multiplier, min_depth):
     new_depth = int(depth * depth_multiplier)
     return max(new_depth, min_depth)
   return multiply_depth
+
+
+class KerasMultiResolutionFeatureMaps(tf.keras.Model):
+  """Generates multi resolution feature maps from input image features.
+
+  A Keras model that generates multi-scale feature maps for detection as in the
+  SSD papers by Liu et al: https://arxiv.org/pdf/1512.02325v2.pdf, See Sec 2.1.
+
+  More specifically, when called on inputs it performs the following two tasks:
+  1) If a layer name is provided in the configuration, returns that layer as a
+     feature map.
+  2) If a layer name is left as an empty string, constructs a new feature map
+     based on the spatial shape and depth configuration. Note that the current
+     implementation only supports generating new layers using convolution of
+     stride 2 resulting in a spatial resolution reduction by a factor of 2.
+     By default convolution kernel size is set to 3, and it can be customized
+     by caller.
+
+  An example of the configuration for Inception V3:
+  {
+    'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', ''],
+    'layer_depth': [-1, -1, -1, 512, 256, 128]
+  }
+
+  When this feature generator object is called on input image_features:
+    Args:
+      image_features: A dictionary of handles to activation tensors from the
+        base feature extractor.
+
+    Returns:
+      feature_maps: an OrderedDict mapping keys (feature map names) to
+        tensors where each tensor has shape [batch, height_i, width_i, depth_i].
+  """
+
+  def __init__(self,
+               feature_map_layout,
+               depth_multiplier,
+               min_depth,
+               insert_1x1_conv,
+               is_training,
+               conv_hyperparams,
+               freeze_batchnorm,
+               name=None):
+    """Constructor.
+
+    Args:
+      feature_map_layout: Dictionary of specifications for the feature map
+        layouts in the following format (Inception V2/V3 respectively):
+        {
+          'from_layer': ['Mixed_3c', 'Mixed_4c', 'Mixed_5c', '', '', ''],
+          'layer_depth': [-1, -1, -1, 512, 256, 128]
+        }
+        or
+        {
+          'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', ''],
+          'layer_depth': [-1, -1, -1, 512, 256, 128]
+        }
+        If 'from_layer' is specified, the specified feature map is directly used
+        as a box predictor layer, and the layer_depth is directly infered from
+        the feature map (instead of using the provided 'layer_depth' parameter).
+        In this case, our convention is to set 'layer_depth' to -1 for clarity.
+        Otherwise, if 'from_layer' is an empty string, then the box predictor
+        layer will be built from the previous layer using convolution
+        operations. Note that the current implementation only supports
+        generating new layers using convolutions of stride 2 (resulting in a
+        spatial resolution reduction by a factor of 2), and will be extended to
+        a more flexible design. Convolution kernel size is set to 3 by default,
+        and can be customized by 'conv_kernel_size' parameter (similarily,
+        'conv_kernel_size' should be set to -1 if 'from_layer' is specified).
+        The created convolution operation will be a normal 2D convolution by
+        default, and a depthwise convolution followed by 1x1 convolution if
+        'use_depthwise' is set to True.
+      depth_multiplier: Depth multiplier for convolutional layers.
+      min_depth: Minimum depth for convolutional layers.
+      insert_1x1_conv: A boolean indicating whether an additional 1x1
+        convolution should be inserted before shrinking the feature map.
+      is_training: Indicates whether the feature generator is in training mode.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops.
+      freeze_batchnorm: Bool. Whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      name: A string name scope to assign to the model. If 'None', Keras
+        will auto-generate one from the class name.
+    """
+    super(KerasMultiResolutionFeatureMaps, self).__init__(name=name)
+
+    self.feature_map_layout = feature_map_layout
+    self.convolutions = []
+
+    depth_fn = get_depth_fn(depth_multiplier, min_depth)
+
+    base_from_layer = ''
+    use_explicit_padding = False
+    if 'use_explicit_padding' in feature_map_layout:
+      use_explicit_padding = feature_map_layout['use_explicit_padding']
+    use_depthwise = False
+    if 'use_depthwise' in feature_map_layout:
+      use_depthwise = feature_map_layout['use_depthwise']
+    for index, from_layer in enumerate(feature_map_layout['from_layer']):
+      net = tf.keras.Sequential(name='output_%d' % index)
+      self.convolutions.append(net)
+      layer_depth = feature_map_layout['layer_depth'][index]
+      conv_kernel_size = 3
+      if 'conv_kernel_size' in feature_map_layout:
+        conv_kernel_size = feature_map_layout['conv_kernel_size'][index]
+      if from_layer:
+        base_from_layer = from_layer
+      else:
+        if insert_1x1_conv:
+          layer_name = '{}_1_Conv2d_{}_1x1_{}'.format(
+              base_from_layer, index, depth_fn(layer_depth / 2))
+          net.add(tf.keras.layers.Conv2D(depth_fn(layer_depth / 2),
+                                         [1, 1],
+                                         padding='SAME',
+                                         strides=1,
+                                         name=layer_name + '_conv',
+                                         **conv_hyperparams.params()))
+          net.add(
+              conv_hyperparams.build_batch_norm(
+                  training=(is_training and not freeze_batchnorm),
+                  name=layer_name + '_batchnorm'))
+          net.add(
+              conv_hyperparams.build_activation_layer(
+                  name=layer_name))
+
+        layer_name = '{}_2_Conv2d_{}_{}x{}_s2_{}'.format(
+            base_from_layer, index, conv_kernel_size, conv_kernel_size,
+            depth_fn(layer_depth))
+        stride = 2
+        padding = 'SAME'
+        if use_explicit_padding:
+          padding = 'VALID'
+          # We define this function here while capturing the value of
+          # conv_kernel_size, to avoid holding a reference to the loop variable
+          # conv_kernel_size inside of a lambda function
+          def fixed_padding(features, kernel_size=conv_kernel_size):
+            ops.fixed_padding(features, kernel_size)
+          net.add(tf.keras.layers.Lambda(fixed_padding))
+        # TODO(rathodv): Add some utilities to simplify the creation of
+        # Depthwise & non-depthwise convolutions w/ normalization & activations
+        if use_depthwise:
+          net.add(tf.keras.layers.DepthwiseConv2D(
+              [conv_kernel_size, conv_kernel_size],
+              depth_multiplier=1,
+              padding=padding,
+              strides=stride,
+              name=layer_name + '_depthwise_conv',
+              **conv_hyperparams.params()))
+          net.add(
+              conv_hyperparams.build_batch_norm(
+                  training=(is_training and not freeze_batchnorm),
+                  name=layer_name + '_depthwise_batchnorm'))
+          net.add(
+              conv_hyperparams.build_activation_layer(
+                  name=layer_name + '_depthwise'))
+
+          net.add(tf.keras.layers.Conv2D(depth_fn(layer_depth), [1, 1],
+                                         padding='SAME',
+                                         strides=1,
+                                         name=layer_name + '_conv',
+                                         **conv_hyperparams.params()))
+          net.add(
+              conv_hyperparams.build_batch_norm(
+                  training=(is_training and not freeze_batchnorm),
+                  name=layer_name + '_batchnorm'))
+          net.add(
+              conv_hyperparams.build_activation_layer(
+                  name=layer_name))
+
+        else:
+          net.add(tf.keras.layers.Conv2D(depth_fn(layer_depth),
+                                         [conv_kernel_size, conv_kernel_size],
+                                         padding=padding,
+                                         strides=stride,
+                                         name=layer_name + '_conv',
+                                         **conv_hyperparams.params()))
+          net.add(
+              conv_hyperparams.build_batch_norm(
+                  training=(is_training and not freeze_batchnorm),
+                  name=layer_name + '_batchnorm'))
+          net.add(
+              conv_hyperparams.build_activation_layer(
+                  name=layer_name))
+
+  def call(self, image_features):
+    """Generate the multi-resolution feature maps.
+
+    Executed when calling the `.__call__` method on input.
+
+    Args:
+      image_features: A dictionary of handles to activation tensors from the
+        base feature extractor.
+
+    Returns:
+      feature_maps: an OrderedDict mapping keys (feature map names) to
+        tensors where each tensor has shape [batch, height_i, width_i, depth_i].
+    """
+    feature_maps = []
+    feature_map_keys = []
+
+    for index, from_layer in enumerate(self.feature_map_layout['from_layer']):
+      if from_layer:
+        feature_map = image_features[from_layer]
+        feature_map_keys.append(from_layer)
+      else:
+        feature_map = feature_maps[-1]
+        feature_map = self.convolutions[index](feature_map)
+        layer_name = self.convolutions[index].layers[-1].name
+        feature_map_keys.append(layer_name)
+      feature_maps.append(feature_map)
+    return collections.OrderedDict(
+        [(x, y) for (x, y) in zip(feature_map_keys, feature_maps)])
 
 
 def multi_resolution_feature_maps(feature_map_layout, depth_multiplier,
@@ -77,7 +292,7 @@ def multi_resolution_feature_maps(feature_map_layout, depth_multiplier,
       }
       or
       {
-        'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', '', ''],
+        'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', ''],
         'layer_depth': [-1, -1, -1, 512, 256, 128]
       }
       If 'from_layer' is specified, the specified feature map is directly used
@@ -179,7 +394,10 @@ def multi_resolution_feature_maps(feature_map_layout, depth_multiplier,
       [(x, y) for (x, y) in zip(feature_map_keys, feature_maps)])
 
 
-def fpn_top_down_feature_maps(image_features, depth, scope=None):
+def fpn_top_down_feature_maps(image_features,
+                              depth,
+                              use_depthwise=False,
+                              scope=None):
   """Generates `top-down` feature maps for Feature Pyramid Networks.
 
   See https://arxiv.org/abs/1612.03144 for details.
@@ -189,6 +407,7 @@ def fpn_top_down_feature_maps(image_features, depth, scope=None):
       Spatial resolutions of succesive tensors must reduce exactly by a factor
       of 2.
     depth: depth of output feature maps.
+    use_depthwise: use depthwise separable conv instead of regular conv.
     scope: A scope name to wrap this op under.
 
   Returns:
@@ -200,7 +419,7 @@ def fpn_top_down_feature_maps(image_features, depth, scope=None):
     output_feature_maps_list = []
     output_feature_map_keys = []
     with slim.arg_scope(
-        [slim.conv2d], padding='SAME', stride=1):
+        [slim.conv2d, slim.separable_conv2d], padding='SAME', stride=1):
       top_down = slim.conv2d(
           image_features[-1][1],
           depth, [1, 1], activation_fn=None, normalizer_fn=None,
@@ -216,7 +435,11 @@ def fpn_top_down_feature_maps(image_features, depth, scope=None):
             activation_fn=None, normalizer_fn=None,
             scope='projection_%d' % (level + 1))
         top_down += residual
-        output_feature_maps_list.append(slim.conv2d(
+        if use_depthwise:
+          conv_op = functools.partial(slim.separable_conv2d, depth_multiplier=1)
+        else:
+          conv_op = slim.conv2d
+        output_feature_maps_list.append(conv_op(
             top_down,
             depth, [3, 3],
             scope='smoothing_%d' % (level + 1)))
@@ -226,7 +449,7 @@ def fpn_top_down_feature_maps(image_features, depth, scope=None):
 
 
 def pooling_pyramid_feature_maps(base_feature_map_depth, num_layers,
-                                 image_features):
+                                 image_features, replace_pool_with_conv=False):
   """Generates pooling pyramid feature maps.
 
   The pooling pyramid feature maps is motivated by
@@ -250,6 +473,8 @@ def pooling_pyramid_feature_maps(base_feature_map_depth, num_layers,
       from the base feature.
     image_features: A dictionary of handles to activation tensors from the
       feature extractor.
+    replace_pool_with_conv: Whether or not to replace pooling operations with
+      convolutions in the PPN. Default is False.
 
   Returns:
     feature_maps: an OrderedDict mapping keys (feature map names) to
@@ -279,12 +504,22 @@ def pooling_pyramid_feature_maps(base_feature_map_depth, num_layers,
   feature_map_keys.append(feature_map_key)
   feature_maps.append(image_features)
   feature_map = image_features
-  with slim.arg_scope([slim.max_pool2d], padding='SAME', stride=2):
-    for i in range(num_layers - 1):
-      feature_map_key = 'MaxPool2d_%d_2x2' % i
-      feature_map = slim.max_pool2d(
-          feature_map, [2, 2], padding='SAME', scope=feature_map_key)
-      feature_map_keys.append(feature_map_key)
-      feature_maps.append(feature_map)
+  if replace_pool_with_conv:
+    with slim.arg_scope([slim.conv2d], padding='SAME', stride=2):
+      for i in range(num_layers - 1):
+        feature_map_key = 'Conv2d_{}_3x3_s2_{}'.format(i,
+                                                       base_feature_map_depth)
+        feature_map = slim.conv2d(
+            feature_map, base_feature_map_depth, [3, 3], scope=feature_map_key)
+        feature_map_keys.append(feature_map_key)
+        feature_maps.append(feature_map)
+  else:
+    with slim.arg_scope([slim.max_pool2d], padding='SAME', stride=2):
+      for i in range(num_layers - 1):
+        feature_map_key = 'MaxPool2d_%d_2x2' % i
+        feature_map = slim.max_pool2d(
+            feature_map, [2, 2], padding='SAME', scope=feature_map_key)
+        feature_map_keys.append(feature_map_key)
+        feature_maps.append(feature_map)
   return collections.OrderedDict(
       [(x, y) for (x, y) in zip(feature_map_keys, feature_maps)])

--- a/research/object_detection/models/feature_map_generators_test.py
+++ b/research/object_detection/models/feature_map_generators_test.py
@@ -15,9 +15,15 @@
 
 """Tests for feature map generators."""
 
+from absl.testing import parameterized
+
 import tensorflow as tf
 
+from google.protobuf import text_format
+
+from object_detection.builders import hyperparams_builder
 from object_detection.models import feature_map_generators
+from object_detection.protos import hyperparams_pb2
 
 INCEPTION_V2_LAYOUT = {
     'from_layer': ['Mixed_3c', 'Mixed_4c', 'Mixed_5c', '', '', ''],
@@ -40,21 +46,60 @@ EMBEDDED_SSD_MOBILENET_V1_LAYOUT = {
 }
 
 
-# TODO(rathodv): add tests with different anchor strides.
+@parameterized.parameters(
+    {'use_keras': False},
+    {'use_keras': True},
+)
 class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
 
-  def test_get_expected_feature_map_shapes_with_inception_v2(self):
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+      regularizer {
+        l2_regularizer {
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+        }
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def _build_feature_map_generator(self, feature_map_layout, use_keras):
+    if use_keras:
+      return feature_map_generators.KerasMultiResolutionFeatureMaps(
+          feature_map_layout=feature_map_layout,
+          depth_multiplier=1,
+          min_depth=32,
+          insert_1x1_conv=True,
+          freeze_batchnorm=False,
+          is_training=True,
+          conv_hyperparams=self._build_conv_hyperparams(),
+          name='FeatureMaps'
+      )
+    else:
+      def feature_map_generator(image_features):
+        return feature_map_generators.multi_resolution_feature_maps(
+            feature_map_layout=feature_map_layout,
+            depth_multiplier=1,
+            min_depth=32,
+            insert_1x1_conv=True,
+            image_features=image_features)
+      return feature_map_generator
+
+  def test_get_expected_feature_map_shapes_with_inception_v2(self, use_keras):
     image_features = {
         'Mixed_3c': tf.random_uniform([4, 28, 28, 256], dtype=tf.float32),
         'Mixed_4c': tf.random_uniform([4, 14, 14, 576], dtype=tf.float32),
         'Mixed_5c': tf.random_uniform([4, 7, 7, 1024], dtype=tf.float32)
     }
-    feature_maps = feature_map_generators.multi_resolution_feature_maps(
+    feature_map_generator = self._build_feature_map_generator(
         feature_map_layout=INCEPTION_V2_LAYOUT,
-        depth_multiplier=1,
-        min_depth=32,
-        insert_1x1_conv=True,
-        image_features=image_features)
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
 
     expected_feature_map_shapes = {
         'Mixed_3c': (4, 28, 28, 256),
@@ -70,21 +115,22 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
       out_feature_maps = sess.run(feature_maps)
       out_feature_map_shapes = dict(
           (key, value.shape) for key, value in out_feature_maps.items())
-      self.assertDictEqual(out_feature_map_shapes, expected_feature_map_shapes)
+      self.assertDictEqual(expected_feature_map_shapes, out_feature_map_shapes)
 
-  def test_get_expected_feature_map_shapes_with_inception_v3(self):
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+  def test_get_expected_feature_map_shapes_with_inception_v3(self, use_keras):
     image_features = {
         'Mixed_5d': tf.random_uniform([4, 35, 35, 256], dtype=tf.float32),
         'Mixed_6e': tf.random_uniform([4, 17, 17, 576], dtype=tf.float32),
         'Mixed_7c': tf.random_uniform([4, 8, 8, 1024], dtype=tf.float32)
     }
 
-    feature_maps = feature_map_generators.multi_resolution_feature_maps(
+    feature_map_generator = self._build_feature_map_generator(
         feature_map_layout=INCEPTION_V3_LAYOUT,
-        depth_multiplier=1,
-        min_depth=32,
-        insert_1x1_conv=True,
-        image_features=image_features)
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
 
     expected_feature_map_shapes = {
         'Mixed_5d': (4, 35, 35, 256),
@@ -100,10 +146,10 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
       out_feature_maps = sess.run(feature_maps)
       out_feature_map_shapes = dict(
           (key, value.shape) for key, value in out_feature_maps.items())
-      self.assertDictEqual(out_feature_map_shapes, expected_feature_map_shapes)
+      self.assertDictEqual(expected_feature_map_shapes, out_feature_map_shapes)
 
   def test_get_expected_feature_map_shapes_with_embedded_ssd_mobilenet_v1(
-      self):
+      self, use_keras):
     image_features = {
         'Conv2d_11_pointwise': tf.random_uniform([4, 16, 16, 512],
                                                  dtype=tf.float32),
@@ -111,12 +157,11 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
                                                  dtype=tf.float32),
     }
 
-    feature_maps = feature_map_generators.multi_resolution_feature_maps(
+    feature_map_generator = self._build_feature_map_generator(
         feature_map_layout=EMBEDDED_SSD_MOBILENET_V1_LAYOUT,
-        depth_multiplier=1,
-        min_depth=32,
-        insert_1x1_conv=True,
-        image_features=image_features)
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
 
     expected_feature_map_shapes = {
         'Conv2d_11_pointwise': (4, 16, 16, 512),
@@ -131,7 +176,62 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
       out_feature_maps = sess.run(feature_maps)
       out_feature_map_shapes = dict(
           (key, value.shape) for key, value in out_feature_maps.items())
-      self.assertDictEqual(out_feature_map_shapes, expected_feature_map_shapes)
+      self.assertDictEqual(expected_feature_map_shapes, out_feature_map_shapes)
+
+  def test_get_expected_variable_names_with_inception_v2(self, use_keras):
+    image_features = {
+        'Mixed_3c': tf.random_uniform([4, 28, 28, 256], dtype=tf.float32),
+        'Mixed_4c': tf.random_uniform([4, 14, 14, 576], dtype=tf.float32),
+        'Mixed_5c': tf.random_uniform([4, 7, 7, 1024], dtype=tf.float32)
+    }
+    feature_map_generator = self._build_feature_map_generator(
+        feature_map_layout=INCEPTION_V2_LAYOUT,
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
+
+    expected_slim_variables = set([
+        'Mixed_5c_1_Conv2d_3_1x1_256/weights',
+        'Mixed_5c_1_Conv2d_3_1x1_256/biases',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512/weights',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512/biases',
+        'Mixed_5c_1_Conv2d_4_1x1_128/weights',
+        'Mixed_5c_1_Conv2d_4_1x1_128/biases',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256/weights',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256/biases',
+        'Mixed_5c_1_Conv2d_5_1x1_128/weights',
+        'Mixed_5c_1_Conv2d_5_1x1_128/biases',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256/weights',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256/biases',
+    ])
+
+    expected_keras_variables = set([
+        'FeatureMaps/output_3/Mixed_5c_1_Conv2d_3_1x1_256_conv/kernel',
+        'FeatureMaps/output_3/Mixed_5c_1_Conv2d_3_1x1_256_conv/bias',
+        'FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_conv/kernel',
+        'FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_conv/bias',
+        'FeatureMaps/output_4/Mixed_5c_1_Conv2d_4_1x1_128_conv/kernel',
+        'FeatureMaps/output_4/Mixed_5c_1_Conv2d_4_1x1_128_conv/bias',
+        'FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_conv/kernel',
+        'FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_conv/bias',
+        'FeatureMaps/output_5/Mixed_5c_1_Conv2d_5_1x1_128_conv/kernel',
+        'FeatureMaps/output_5/Mixed_5c_1_Conv2d_5_1x1_128_conv/bias',
+        'FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_conv/kernel',
+        'FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_conv/bias',
+    ])
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      sess.run(feature_maps)
+      actual_variable_set = set(
+          [var.op.name for var in tf.trainable_variables()])
+      if use_keras:
+        self.assertSetEqual(expected_keras_variables, actual_variable_set)
+      else:
+        self.assertSetEqual(expected_slim_variables, actual_variable_set)
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
 
 
 class FPNFeatureMapGeneratorTest(tf.test.TestCase):
@@ -161,6 +261,31 @@ class FPNFeatureMapGeneratorTest(tf.test.TestCase):
                                 for key, value in out_feature_maps.items()}
       self.assertDictEqual(out_feature_map_shapes, expected_feature_map_shapes)
 
+  def test_get_expected_feature_map_shapes_with_depthwise(self):
+    image_features = [
+        ('block2', tf.random_uniform([4, 8, 8, 256], dtype=tf.float32)),
+        ('block3', tf.random_uniform([4, 4, 4, 256], dtype=tf.float32)),
+        ('block4', tf.random_uniform([4, 2, 2, 256], dtype=tf.float32)),
+        ('block5', tf.random_uniform([4, 1, 1, 256], dtype=tf.float32))
+    ]
+    feature_maps = feature_map_generators.fpn_top_down_feature_maps(
+        image_features=image_features, depth=128, use_depthwise=True)
+
+    expected_feature_map_shapes = {
+        'top_down_block2': (4, 8, 8, 128),
+        'top_down_block3': (4, 4, 4, 128),
+        'top_down_block4': (4, 2, 2, 128),
+        'top_down_block5': (4, 1, 1, 128)
+    }
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      out_feature_maps = sess.run(feature_maps)
+      out_feature_map_shapes = {key: value.shape
+                                for key, value in out_feature_maps.items()}
+      self.assertDictEqual(out_feature_map_shapes, expected_feature_map_shapes)
+
 
 class GetDepthFunctionTest(tf.test.TestCase):
 
@@ -173,6 +298,95 @@ class GetDepthFunctionTest(tf.test.TestCase):
     depth_fn = feature_map_generators.get_depth_fn(depth_multiplier=0.5,
                                                    min_depth=16)
     self.assertEqual(depth_fn(64), 32)
+
+
+@parameterized.parameters(
+    {'replace_pool_with_conv': False},
+    {'replace_pool_with_conv': True},
+)
+class PoolingPyramidFeatureMapGeneratorTest(tf.test.TestCase):
+
+  def test_get_expected_feature_map_shapes(self, replace_pool_with_conv):
+    image_features = {
+        'image_features': tf.random_uniform([4, 19, 19, 1024])
+    }
+    feature_maps = feature_map_generators.pooling_pyramid_feature_maps(
+        base_feature_map_depth=1024,
+        num_layers=6,
+        image_features=image_features,
+        replace_pool_with_conv=replace_pool_with_conv)
+
+    expected_pool_feature_map_shapes = {
+        'Base_Conv2d_1x1_1024': (4, 19, 19, 1024),
+        'MaxPool2d_0_2x2': (4, 10, 10, 1024),
+        'MaxPool2d_1_2x2': (4, 5, 5, 1024),
+        'MaxPool2d_2_2x2': (4, 3, 3, 1024),
+        'MaxPool2d_3_2x2': (4, 2, 2, 1024),
+        'MaxPool2d_4_2x2': (4, 1, 1, 1024),
+    }
+
+    expected_conv_feature_map_shapes = {
+        'Base_Conv2d_1x1_1024': (4, 19, 19, 1024),
+        'Conv2d_0_3x3_s2_1024': (4, 10, 10, 1024),
+        'Conv2d_1_3x3_s2_1024': (4, 5, 5, 1024),
+        'Conv2d_2_3x3_s2_1024': (4, 3, 3, 1024),
+        'Conv2d_3_3x3_s2_1024': (4, 2, 2, 1024),
+        'Conv2d_4_3x3_s2_1024': (4, 1, 1, 1024),
+    }
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      out_feature_maps = sess.run(feature_maps)
+      out_feature_map_shapes = {key: value.shape
+                                for key, value in out_feature_maps.items()}
+      if replace_pool_with_conv:
+        self.assertDictEqual(expected_conv_feature_map_shapes,
+                             out_feature_map_shapes)
+      else:
+        self.assertDictEqual(expected_pool_feature_map_shapes,
+                             out_feature_map_shapes)
+
+  def test_get_expected_variable_names(self, replace_pool_with_conv):
+    image_features = {
+        'image_features': tf.random_uniform([4, 19, 19, 1024])
+    }
+    feature_maps = feature_map_generators.pooling_pyramid_feature_maps(
+        base_feature_map_depth=1024,
+        num_layers=6,
+        image_features=image_features,
+        replace_pool_with_conv=replace_pool_with_conv)
+
+    expected_pool_variables = set([
+        'Base_Conv2d_1x1_1024/weights',
+        'Base_Conv2d_1x1_1024/biases',
+    ])
+
+    expected_conv_variables = set([
+        'Base_Conv2d_1x1_1024/weights',
+        'Base_Conv2d_1x1_1024/biases',
+        'Conv2d_0_3x3_s2_1024/weights',
+        'Conv2d_0_3x3_s2_1024/biases',
+        'Conv2d_1_3x3_s2_1024/weights',
+        'Conv2d_1_3x3_s2_1024/biases',
+        'Conv2d_2_3x3_s2_1024/weights',
+        'Conv2d_2_3x3_s2_1024/biases',
+        'Conv2d_3_3x3_s2_1024/weights',
+        'Conv2d_3_3x3_s2_1024/biases',
+        'Conv2d_4_3x3_s2_1024/weights',
+        'Conv2d_4_3x3_s2_1024/biases',
+    ])
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      sess.run(feature_maps)
+      actual_variable_set = set(
+          [var.op.name for var in tf.trainable_variables()])
+      if replace_pool_with_conv:
+        self.assertSetEqual(expected_conv_variables, actual_variable_set)
+      else:
+        self.assertSetEqual(expected_pool_variables, actual_variable_set)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/feature_map_generators_test.py
+++ b/research/object_detection/models/feature_map_generators_test.py
@@ -118,6 +118,38 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
       self.assertDictEqual(expected_feature_map_shapes, out_feature_map_shapes)
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_get_expected_feature_map_shapes_with_inception_v2_use_depthwise(
+      self, use_keras):
+    image_features = {
+        'Mixed_3c': tf.random_uniform([4, 28, 28, 256], dtype=tf.float32),
+        'Mixed_4c': tf.random_uniform([4, 14, 14, 576], dtype=tf.float32),
+        'Mixed_5c': tf.random_uniform([4, 7, 7, 1024], dtype=tf.float32)
+    }
+    layout_copy = INCEPTION_V2_LAYOUT.copy()
+    layout_copy['use_depthwise'] = True
+    feature_map_generator = self._build_feature_map_generator(
+        feature_map_layout=layout_copy,
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
+
+    expected_feature_map_shapes = {
+        'Mixed_3c': (4, 28, 28, 256),
+        'Mixed_4c': (4, 14, 14, 576),
+        'Mixed_5c': (4, 7, 7, 1024),
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512': (4, 4, 4, 512),
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256': (4, 2, 2, 256),
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256': (4, 1, 1, 256)}
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      out_feature_maps = sess.run(feature_maps)
+      out_feature_map_shapes = dict(
+          (key, value.shape) for key, value in out_feature_maps.items())
+      self.assertDictEqual(expected_feature_map_shapes, out_feature_map_shapes)
+  # END GOOGLE-INTERNAL
 
   def test_get_expected_feature_map_shapes_with_inception_v3(self, use_keras):
     image_features = {
@@ -232,6 +264,82 @@ class MultiResolutionFeatureMapGeneratorTest(tf.test.TestCase):
         self.assertSetEqual(expected_slim_variables, actual_variable_set)
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_get_expected_variable_names_with_inception_v2_use_depthwise(
+      self,
+      use_keras):
+    image_features = {
+        'Mixed_3c': tf.random_uniform([4, 28, 28, 256], dtype=tf.float32),
+        'Mixed_4c': tf.random_uniform([4, 14, 14, 576], dtype=tf.float32),
+        'Mixed_5c': tf.random_uniform([4, 7, 7, 1024], dtype=tf.float32)
+    }
+    layout_copy = INCEPTION_V2_LAYOUT.copy()
+    layout_copy['use_depthwise'] = True
+    feature_map_generator = self._build_feature_map_generator(
+        feature_map_layout=layout_copy,
+        use_keras=use_keras
+    )
+    feature_maps = feature_map_generator(image_features)
+
+    expected_slim_variables = set([
+        'Mixed_5c_1_Conv2d_3_1x1_256/weights',
+        'Mixed_5c_1_Conv2d_3_1x1_256/biases',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512_depthwise/depthwise_weights',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512_depthwise/biases',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512/weights',
+        'Mixed_5c_2_Conv2d_3_3x3_s2_512/biases',
+        'Mixed_5c_1_Conv2d_4_1x1_128/weights',
+        'Mixed_5c_1_Conv2d_4_1x1_128/biases',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256_depthwise/depthwise_weights',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256_depthwise/biases',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256/weights',
+        'Mixed_5c_2_Conv2d_4_3x3_s2_256/biases',
+        'Mixed_5c_1_Conv2d_5_1x1_128/weights',
+        'Mixed_5c_1_Conv2d_5_1x1_128/biases',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256_depthwise/depthwise_weights',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256_depthwise/biases',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256/weights',
+        'Mixed_5c_2_Conv2d_5_3x3_s2_256/biases',
+    ])
+
+    expected_keras_variables = set([
+        'FeatureMaps/output_3/Mixed_5c_1_Conv2d_3_1x1_256_conv/kernel',
+        'FeatureMaps/output_3/Mixed_5c_1_Conv2d_3_1x1_256_conv/bias',
+        ('FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_depthwise_conv/'
+         'depthwise_kernel'),
+        ('FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_depthwise_conv/'
+         'bias'),
+        'FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_conv/kernel',
+        'FeatureMaps/output_3/Mixed_5c_2_Conv2d_3_3x3_s2_512_conv/bias',
+        'FeatureMaps/output_4/Mixed_5c_1_Conv2d_4_1x1_128_conv/kernel',
+        'FeatureMaps/output_4/Mixed_5c_1_Conv2d_4_1x1_128_conv/bias',
+        ('FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_depthwise_conv/'
+         'depthwise_kernel'),
+        ('FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_depthwise_conv/'
+         'bias'),
+        'FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_conv/kernel',
+        'FeatureMaps/output_4/Mixed_5c_2_Conv2d_4_3x3_s2_256_conv/bias',
+        'FeatureMaps/output_5/Mixed_5c_1_Conv2d_5_1x1_128_conv/kernel',
+        'FeatureMaps/output_5/Mixed_5c_1_Conv2d_5_1x1_128_conv/bias',
+        ('FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_depthwise_conv/'
+         'depthwise_kernel'),
+        ('FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_depthwise_conv/'
+         'bias'),
+        'FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_conv/kernel',
+        'FeatureMaps/output_5/Mixed_5c_2_Conv2d_5_3x3_s2_256_conv/bias',
+    ])
+
+    init_op = tf.global_variables_initializer()
+    with self.test_session() as sess:
+      sess.run(init_op)
+      sess.run(feature_maps)
+      actual_variable_set = set(
+          [var.op.name for var in tf.trainable_variables()])
+      if use_keras:
+        self.assertSetEqual(expected_keras_variables, actual_variable_set)
+      else:
+        self.assertSetEqual(expected_slim_variables, actual_variable_set)
+  # END GOOGLE-INTERNAL
 
 
 class FPNFeatureMapGeneratorTest(tf.test.TestCase):

--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
@@ -1,0 +1,206 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ssd_mobilenet_v2_fpn_feature_extractor."""
+import numpy as np
+import tensorflow as tf
+
+from object_detection.models import ssd_feature_extractor_test
+from object_detection.models import ssd_mobilenet_v2_fpn_feature_extractor
+
+slim = tf.contrib.slim
+
+
+class SsdMobilenetV2FpnFeatureExtractorTest(
+    ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
+
+  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
+                                is_training=True, use_explicit_padding=False):
+    """Constructs a new feature extractor.
+
+    Args:
+      depth_multiplier: float depth multiplier for feature extractor
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      is_training: whether the network is in training mode.
+      use_explicit_padding: Use 'VALID' padding for convolutions, but prepad
+        inputs so that the output dimensions are the same as if 'SAME' padding
+        were used.
+    Returns:
+      an ssd_meta_arch.SSDFeatureExtractor object.
+    """
+    min_depth = 32
+    return (ssd_mobilenet_v2_fpn_feature_extractor.
+            SSDMobileNetV2FpnFeatureExtractor(
+                is_training,
+                depth_multiplier,
+                min_depth,
+                pad_to_multiple,
+                self.conv_hyperparams_fn,
+                use_explicit_padding=use_explicit_padding))
+
+  def test_extract_features_returns_correct_shapes_256(self):
+    image_height = 256
+    image_width = 256
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 32, 32, 256), (2, 16, 16, 256),
+                                  (2, 8, 8, 256), (2, 4, 4, 256),
+                                  (2, 2, 2, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False)
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=True)
+
+  def test_extract_features_returns_correct_shapes_384(self):
+    image_height = 320
+    image_width = 320
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 40, 40, 256), (2, 20, 20, 256),
+                                  (2, 10, 10, 256), (2, 5, 5, 256),
+                                  (2, 3, 3, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False)
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=True)
+
+  def test_extract_features_with_dynamic_image_shape(self):
+    image_height = 256
+    image_width = 256
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 32, 32, 256), (2, 16, 16, 256),
+                                  (2, 8, 8, 256), (2, 4, 4, 256),
+                                  (2, 2, 2, 256)]
+    self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False)
+    self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=True)
+
+  def test_extract_features_returns_correct_shapes_with_pad_to_multiple(self):
+    image_height = 299
+    image_width = 299
+    depth_multiplier = 1.0
+    pad_to_multiple = 32
+    expected_feature_map_shape = [(2, 40, 40, 256), (2, 20, 20, 256),
+                                  (2, 10, 10, 256), (2, 5, 5, 256),
+                                  (2, 3, 3, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False)
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=True)
+
+  def test_extract_features_returns_correct_shapes_enforcing_min_depth(self):
+    image_height = 256
+    image_width = 256
+    depth_multiplier = 0.5**12
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 32, 32, 32), (2, 16, 16, 32),
+                                  (2, 8, 8, 32), (2, 4, 4, 32),
+                                  (2, 2, 2, 32)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False)
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=True)
+
+  def test_extract_features_raises_error_with_invalid_image_size(self):
+    image_height = 32
+    image_width = 32
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    self.check_extract_features_raises_error_with_invalid_image_size(
+        image_height, image_width, depth_multiplier, pad_to_multiple)
+
+  def test_preprocess_returns_correct_value_range(self):
+    image_height = 256
+    image_width = 256
+    depth_multiplier = 1
+    pad_to_multiple = 1
+    test_image = np.random.rand(2, image_height, image_width, 3)
+    feature_extractor = self._create_feature_extractor(depth_multiplier,
+                                                       pad_to_multiple)
+    preprocessed_image = feature_extractor.preprocess(test_image)
+    self.assertTrue(np.all(np.less_equal(np.abs(preprocessed_image), 1.0)))
+
+  def test_variables_only_created_in_scope(self):
+    depth_multiplier = 1
+    pad_to_multiple = 1
+    scope_name = 'MobilenetV2'
+    self.check_feature_extractor_variables_under_scope(
+        depth_multiplier, pad_to_multiple, scope_name)
+
+  def test_fused_batchnorm(self):
+    image_height = 256
+    image_width = 256
+    depth_multiplier = 1
+    pad_to_multiple = 1
+    image_placeholder = tf.placeholder(tf.float32,
+                                       [1, image_height, image_width, 3])
+    feature_extractor = self._create_feature_extractor(depth_multiplier,
+                                                       pad_to_multiple)
+    preprocessed_image = feature_extractor.preprocess(image_placeholder)
+    _ = feature_extractor.extract_features(preprocessed_image)
+    self.assertTrue(
+        any(op.type == 'FusedBatchNorm'
+            for op in tf.get_default_graph().get_operations()))
+
+  def test_get_expected_feature_map_variable_names(self):
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+
+    expected_feature_maps_variables = set([
+        # Mobilenet V2 feature maps
+        'MobilenetV2/expanded_conv_4/depthwise/depthwise_weights',
+        'MobilenetV2/expanded_conv_7/depthwise/depthwise_weights',
+        'MobilenetV2/expanded_conv_14/depthwise/depthwise_weights',
+        'MobilenetV2/Conv_1/weights',
+        # FPN layers
+        'MobilenetV2/fpn/bottom_up_Conv2d_20/weights',
+        'MobilenetV2/fpn/bottom_up_Conv2d_21/weights',
+        'MobilenetV2/fpn/smoothing_1/weights',
+        'MobilenetV2/fpn/smoothing_2/weights',
+        'MobilenetV2/fpn/projection_1/weights',
+        'MobilenetV2/fpn/projection_2/weights',
+        'MobilenetV2/fpn/projection_3/weights',
+    ])
+
+    g = tf.Graph()
+    with g.as_default():
+      preprocessed_inputs = tf.placeholder(tf.float32, (4, None, None, 3))
+      feature_extractor = self._create_feature_extractor(
+          depth_multiplier, pad_to_multiple)
+      feature_extractor.extract_features(preprocessed_inputs)
+      actual_variable_set = set([
+          var.op.name for var in g.get_collection(tf.GraphKeys.GLOBAL_VARIABLES)
+      ])
+      variable_intersection = expected_feature_maps_variables.intersection(
+          actual_variable_set)
+      self.assertSetEqual(expected_feature_maps_variables,
+                          variable_intersection)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor.py
+++ b/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor.py
@@ -43,6 +43,7 @@ class _SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                fpn_scope_name,
                fpn_min_level=3,
                fpn_max_level=7,
+               additional_layer_depth=256,
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
@@ -72,6 +73,7 @@ class _SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         maps in the backbone network, additional feature maps are created by
         applying stride 2 convolutions until we get the desired number of fpn
         levels.
+      additional_layer_depth: additional feature map layer channel depth.
       reuse_weights: Whether to reuse variables. Default is None.
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False. UNUSED currently.
@@ -104,6 +106,7 @@ class _SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
     self._fpn_scope_name = fpn_scope_name
     self._fpn_min_level = fpn_min_level
     self._fpn_max_level = fpn_max_level
+    self._additional_layer_depth = additional_layer_depth
 
   def preprocess(self, resized_inputs):
     """SSD preprocessing.
@@ -177,7 +180,7 @@ class _SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
             feature_block_list.append('block{}'.format(level - 1))
           fpn_features = feature_map_generators.fpn_top_down_feature_maps(
               [(key, image_features[key]) for key in feature_block_list],
-              depth=256)
+              depth=self._additional_layer_depth)
           feature_maps = []
           for level in range(self._fpn_min_level, base_fpn_max_level + 1):
             feature_maps.append(
@@ -188,7 +191,7 @@ class _SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
           for i in range(base_fpn_max_level, self._fpn_max_level):
             last_feature_map = slim.conv2d(
                 last_feature_map,
-                num_outputs=256,
+                num_outputs=self._additional_layer_depth,
                 kernel_size=[3, 3],
                 stride=2,
                 padding='SAME',
@@ -208,6 +211,7 @@ class SSDResnet50V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
                conv_hyperparams_fn,
                fpn_min_level=3,
                fpn_max_level=7,
+               additional_layer_depth=256,
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
@@ -226,6 +230,7 @@ class SSDResnet50V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         base feature extractor.
       fpn_min_level: the minimum level in feature pyramid networks.
       fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
       reuse_weights: Whether to reuse variables. Default is None.
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False. UNUSED currently.
@@ -245,6 +250,7 @@ class SSDResnet50V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         'fpn',
         fpn_min_level,
         fpn_max_level,
+        additional_layer_depth,
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
@@ -263,6 +269,7 @@ class SSDResnet101V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
                conv_hyperparams_fn,
                fpn_min_level=3,
                fpn_max_level=7,
+               additional_layer_depth=256,
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
@@ -281,6 +288,7 @@ class SSDResnet101V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         base feature extractor.
       fpn_min_level: the minimum level in feature pyramid networks.
       fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
       reuse_weights: Whether to reuse variables. Default is None.
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False. UNUSED currently.
@@ -300,6 +308,7 @@ class SSDResnet101V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         'fpn',
         fpn_min_level,
         fpn_max_level,
+        additional_layer_depth,
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
@@ -318,6 +327,7 @@ class SSDResnet152V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
                conv_hyperparams_fn,
                fpn_min_level=3,
                fpn_max_level=7,
+               additional_layer_depth=256,
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
@@ -336,6 +346,7 @@ class SSDResnet152V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         base feature extractor.
       fpn_min_level: the minimum level in feature pyramid networks.
       fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
       reuse_weights: Whether to reuse variables. Default is None.
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False. UNUSED currently.
@@ -355,6 +366,7 @@ class SSDResnet152V1FpnFeatureExtractor(_SSDResnetV1FpnFeatureExtractor):
         'fpn',
         fpn_min_level,
         fpn_max_level,
+        additional_layer_depth,
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,

--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -36,7 +36,6 @@
       },
       "outputs": [],
       "source": [
-        "from distutils.version import StrictVersion\n",
         "import numpy as np\n",
         "import os\n",
         "import six.moves.urllib as urllib\n",
@@ -45,6 +44,7 @@
         "import tensorflow as tf\n",
         "import zipfile\n",
         "\n",
+        "from distutils.version import StrictVersion\n",
         "from collections import defaultdict\n",
         "from io import StringIO\n",
         "from matplotlib import pyplot as plt\n",
@@ -166,9 +166,7 @@
         "PATH_TO_FROZEN_GRAPH = MODEL_NAME + '/frozen_inference_graph.pb'\n",
         "\n",
         "# List of the strings that is used to add correct label for each box.\n",
-        "PATH_TO_LABELS = os.path.join('data', 'mscoco_label_map.pbtxt')\n",
-        "\n",
-        "NUM_CLASSES = 90"
+        "PATH_TO_LABELS = os.path.join('data', 'mscoco_label_map.pbtxt')"
       ]
     },
     {
@@ -265,9 +263,7 @@
       },
       "outputs": [],
       "source": [
-        "label_map = label_map_util.load_labelmap(PATH_TO_LABELS)\n",
-        "categories = label_map_util.convert_label_map_to_categories(label_map, max_num_classes=NUM_CLASSES, use_display_name=True)\n",
-        "category_index = label_map_util.create_category_index(categories)"
+        "category_index = label_map_util.create_category_index_from_labelmap(PATH_TO_LABELS, use_display_name=True)"
       ]
     },
     {

--- a/research/object_detection/predictors/convolutional_box_predictor.py
+++ b/research/object_detection/predictors/convolutional_box_predictor.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 """Convolutional Box Predictors with and without weight sharing."""
+import functools
 import tensorflow as tf
 from object_detection.core import box_predictor
 from object_detection.utils import static_shape
@@ -163,7 +164,7 @@ class ConvolutionalBoxPredictor(box_predictor.BoxPredictor):
               else:
                 head_obj = self._other_heads[head_name]
               prediction = head_obj.predict(
-                  features=image_feature,
+                  features=net,
                   num_predictions_per_location=num_predictions_per_location)
               predictions[head_name].append(prediction)
     return predictions
@@ -203,7 +204,8 @@ class WeightSharedConvolutionalBoxPredictor(box_predictor.BoxPredictor):
                num_layers_before_predictor,
                kernel_size=3,
                apply_batch_norm=False,
-               share_prediction_tower=False):
+               share_prediction_tower=False,
+               use_depthwise=False):
     """Constructor.
 
     Args:
@@ -226,6 +228,8 @@ class WeightSharedConvolutionalBoxPredictor(box_predictor.BoxPredictor):
         this predictor.
       share_prediction_tower: Whether to share the multi-layer tower between box
         prediction and class prediction heads.
+      use_depthwise: Whether to use depthwise separable conv2d instead of
+       regular conv2d.
     """
     super(WeightSharedConvolutionalBoxPredictor, self).__init__(is_training,
                                                                 num_classes)
@@ -238,6 +242,7 @@ class WeightSharedConvolutionalBoxPredictor(box_predictor.BoxPredictor):
     self._kernel_size = kernel_size
     self._apply_batch_norm = apply_batch_norm
     self._share_prediction_tower = share_prediction_tower
+    self._use_depthwise = use_depthwise
 
   @property
   def num_classes(self):
@@ -270,7 +275,11 @@ class WeightSharedConvolutionalBoxPredictor(box_predictor.BoxPredictor):
                           inserted_layer_counter):
     net = image_feature
     for i in range(self._num_layers_before_predictor):
-      net = slim.conv2d(
+      if self._use_depthwise:
+        conv_op = functools.partial(slim.separable_conv2d, depth_multiplier=1)
+      else:
+        conv_op = slim.conv2d
+      net = conv_op(
           net,
           self._depth, [self._kernel_size, self._kernel_size],
           stride=1,

--- a/research/object_detection/predictors/convolutional_keras_box_predictor.py
+++ b/research/object_detection/predictors/convolutional_keras_box_predictor.py
@@ -1,0 +1,188 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Convolutional Box Predictors with and without weight sharing."""
+import collections
+
+import tensorflow as tf
+
+from object_detection.core import box_predictor
+from object_detection.utils import static_shape
+
+keras = tf.keras.layers
+
+BOX_ENCODINGS = box_predictor.BOX_ENCODINGS
+CLASS_PREDICTIONS_WITH_BACKGROUND = (
+    box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND)
+MASK_PREDICTIONS = box_predictor.MASK_PREDICTIONS
+
+
+class _NoopVariableScope(object):
+  """A dummy class that does not push any scope."""
+
+  def __enter__(self):
+    return None
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    return False
+
+
+class ConvolutionalBoxPredictor(box_predictor.KerasBoxPredictor):
+  """Convolutional Keras Box Predictor.
+
+  Optionally add an intermediate 1x1 convolutional layer after features and
+  predict in parallel branches box_encodings and
+  class_predictions_with_background.
+
+  Currently this box predictor assumes that predictions are "shared" across
+  classes --- that is each anchor makes box predictions which do not depend
+  on class.
+  """
+
+  def __init__(self,
+               is_training,
+               num_classes,
+               box_prediction_heads,
+               class_prediction_heads,
+               other_heads,
+               conv_hyperparams,
+               num_layers_before_predictor,
+               min_depth,
+               max_depth,
+               freeze_batchnorm,
+               inplace_batchnorm_update,
+               name=None):
+    """Constructor.
+
+    Args:
+      is_training: Indicates whether the BoxPredictor is in training mode.
+      num_classes: number of classes.  Note that num_classes *does not*
+        include the background category, so if groundtruth labels take values
+        in {0, 1, .., K-1}, num_classes=K (and not K+1, even though the
+        assigned classification targets can range from {0,... K}).
+      box_prediction_heads: A list of heads that predict the boxes.
+      class_prediction_heads: A list of heads that predict the classes.
+      other_heads: A dictionary mapping head names to lists of convolutional
+        heads.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops.
+      num_layers_before_predictor: Number of the additional conv layers before
+        the predictor.
+      min_depth: Minimum feature depth prior to predicting box encodings
+        and class predictions.
+      max_depth: Maximum feature depth prior to predicting box encodings
+        and class predictions. If max_depth is set to 0, no additional
+        feature map will be inserted before location and class predictions.
+      freeze_batchnorm: Whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      inplace_batchnorm_update: Whether to update batch norm moving average
+        values inplace. When this is false train op must add a control
+        dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+        batch norm statistics.
+      name: A string name scope to assign to the model. If `None`, Keras
+        will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if min_depth > max_depth.
+    """
+    super(ConvolutionalBoxPredictor, self).__init__(
+        is_training, num_classes, freeze_batchnorm=freeze_batchnorm,
+        inplace_batchnorm_update=inplace_batchnorm_update,
+        name=name)
+    if min_depth > max_depth:
+      raise ValueError('min_depth should be less than or equal to max_depth')
+    if len(box_prediction_heads) != len(class_prediction_heads):
+      raise ValueError('All lists of heads must be the same length.')
+    for other_head_list in other_heads.values():
+      if len(box_prediction_heads) != len(other_head_list):
+        raise ValueError('All lists of heads must be the same length.')
+
+    self._prediction_heads = {
+        BOX_ENCODINGS: box_prediction_heads,
+        CLASS_PREDICTIONS_WITH_BACKGROUND: class_prediction_heads,
+    }
+
+    if other_heads:
+      self._prediction_heads.update(other_heads)
+
+    self._conv_hyperparams = conv_hyperparams
+    self._min_depth = min_depth
+    self._max_depth = max_depth
+    self._num_layers_before_predictor = num_layers_before_predictor
+
+    self._shared_nets = []
+
+  def build(self, input_shapes):
+    """Creates the variables of the layer."""
+    if len(input_shapes) != len(self._prediction_heads[BOX_ENCODINGS]):
+      raise ValueError('This box predictor was constructed with %d heads,'
+                       'but there are %d inputs.' %
+                       (len(self._prediction_heads[BOX_ENCODINGS]),
+                        len(input_shapes)))
+    for stack_index, input_shape in enumerate(input_shapes):
+      net = tf.keras.Sequential(name='PreHeadConvolutions_%d' % stack_index)
+      self._shared_nets.append(net)
+
+      # Add additional conv layers before the class predictor.
+      features_depth = static_shape.get_depth(input_shape)
+      depth = max(min(features_depth, self._max_depth), self._min_depth)
+      tf.logging.info(
+          'depth of additional conv before box predictor: {}'.format(depth))
+      if depth > 0 and self._num_layers_before_predictor > 0:
+        for i in range(self._num_layers_before_predictor):
+          net.add(keras.Conv2D(depth, [1, 1],
+                               name='Conv2d_%d_1x1_%d' % (i, depth),
+                               padding='SAME',
+                               **self._conv_hyperparams.params()))
+          net.add(self._conv_hyperparams.build_batch_norm(
+              training=(self._is_training and not self._freeze_batchnorm),
+              name='Conv2d_%d_1x1_%d_norm' % (i, depth)))
+          net.add(self._conv_hyperparams.build_activation_layer(
+              name='Conv2d_%d_1x1_%d_activation' % (i, depth),
+          ))
+    self.built = True
+
+  def _predict(self, image_features):
+    """Computes encoded object locations and corresponding confidences.
+
+    Args:
+      image_features: A list of float tensors of shape [batch_size, height_i,
+        width_i, channels_i] containing features for a batch of images.
+
+    Returns:
+      box_encodings: A list of float tensors of shape
+        [batch_size, num_anchors_i, q, code_size] representing the location of
+        the objects, where q is 1 or the number of classes. Each entry in the
+        list corresponds to a feature map in the input `image_features` list.
+      class_predictions_with_background: A list of float tensors of shape
+        [batch_size, num_anchors_i, num_classes + 1] representing the class
+        predictions for the proposals. Each entry in the list corresponds to a
+        feature map in the input `image_features` list.
+    """
+    predictions = collections.defaultdict(list)
+
+    for (index, image_feature) in enumerate(image_features):
+
+      # Apply shared conv layers before the head predictors.
+      net = self._shared_nets[index](image_feature)
+
+      for head_name in self._prediction_heads:
+        head_obj = self._prediction_heads[head_name][index]
+        prediction = head_obj(net)
+        predictions[head_name].append(prediction)
+
+    return predictions

--- a/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
+++ b/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
@@ -1,0 +1,195 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for object_detection.predictors.convolutional_keras_box_predictor."""
+import numpy as np
+import tensorflow as tf
+
+from google.protobuf import text_format
+from object_detection.builders import box_predictor_builder
+from object_detection.builders import hyperparams_builder
+from object_detection.predictors import convolutional_keras_box_predictor as box_predictor
+from object_detection.protos import hyperparams_pb2
+from object_detection.utils import test_case
+
+
+class ConvolutionalKerasBoxPredictorTest(test_case.TestCase):
+
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+      activation: RELU_6
+      regularizer {
+        l2_regularizer {
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+        }
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def test_get_boxes_for_five_aspect_ratios_per_location(self):
+    def graph_fn(image_features):
+      conv_box_predictor = (
+          box_predictor_builder.build_convolutional_keras_box_predictor(
+              is_training=False,
+              num_classes=0,
+              conv_hyperparams=self._build_conv_hyperparams(),
+              freeze_batchnorm=False,
+              inplace_batchnorm_update=False,
+              num_predictions_per_location_list=[5],
+              min_depth=0,
+              max_depth=32,
+              num_layers_before_predictor=1,
+              use_dropout=True,
+              dropout_keep_prob=0.8,
+              kernel_size=1,
+              box_code_size=4
+          ))
+      box_predictions = conv_box_predictor([image_features])
+      box_encodings = tf.concat(
+          box_predictions[box_predictor.BOX_ENCODINGS], axis=1)
+      objectness_predictions = tf.concat(
+          box_predictions[box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND],
+          axis=1)
+      return (box_encodings, objectness_predictions)
+    image_features = np.random.rand(4, 8, 8, 64).astype(np.float32)
+    (box_encodings, objectness_predictions) = self.execute(graph_fn,
+                                                           [image_features])
+    self.assertAllEqual(box_encodings.shape, [4, 320, 1, 4])
+    self.assertAllEqual(objectness_predictions.shape, [4, 320, 1])
+
+  def test_get_boxes_for_one_aspect_ratio_per_location(self):
+    def graph_fn(image_features):
+      conv_box_predictor = (
+          box_predictor_builder.build_convolutional_keras_box_predictor(
+              is_training=False,
+              num_classes=0,
+              conv_hyperparams=self._build_conv_hyperparams(),
+              freeze_batchnorm=False,
+              inplace_batchnorm_update=False,
+              num_predictions_per_location_list=[1],
+              min_depth=0,
+              max_depth=32,
+              num_layers_before_predictor=1,
+              use_dropout=True,
+              dropout_keep_prob=0.8,
+              kernel_size=1,
+              box_code_size=4
+          ))
+      box_predictions = conv_box_predictor([image_features])
+      box_encodings = tf.concat(
+          box_predictions[box_predictor.BOX_ENCODINGS], axis=1)
+      objectness_predictions = tf.concat(box_predictions[
+          box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND], axis=1)
+      return (box_encodings, objectness_predictions)
+    image_features = np.random.rand(4, 8, 8, 64).astype(np.float32)
+    (box_encodings, objectness_predictions) = self.execute(graph_fn,
+                                                           [image_features])
+    self.assertAllEqual(box_encodings.shape, [4, 64, 1, 4])
+    self.assertAllEqual(objectness_predictions.shape, [4, 64, 1])
+
+  def test_get_multi_class_predictions_for_five_aspect_ratios_per_location(
+      self):
+    num_classes_without_background = 6
+    image_features = np.random.rand(4, 8, 8, 64).astype(np.float32)
+    def graph_fn(image_features):
+      conv_box_predictor = (
+          box_predictor_builder.build_convolutional_keras_box_predictor(
+              is_training=False,
+              num_classes=num_classes_without_background,
+              conv_hyperparams=self._build_conv_hyperparams(),
+              freeze_batchnorm=False,
+              inplace_batchnorm_update=False,
+              num_predictions_per_location_list=[5],
+              min_depth=0,
+              max_depth=32,
+              num_layers_before_predictor=1,
+              use_dropout=True,
+              dropout_keep_prob=0.8,
+              kernel_size=1,
+              box_code_size=4
+          ))
+      box_predictions = conv_box_predictor([image_features])
+      box_encodings = tf.concat(
+          box_predictions[box_predictor.BOX_ENCODINGS], axis=1)
+      class_predictions_with_background = tf.concat(
+          box_predictions[box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND],
+          axis=1)
+      return (box_encodings, class_predictions_with_background)
+    (box_encodings,
+     class_predictions_with_background) = self.execute(graph_fn,
+                                                       [image_features])
+    self.assertAllEqual(box_encodings.shape, [4, 320, 1, 4])
+    self.assertAllEqual(class_predictions_with_background.shape,
+                        [4, 320, num_classes_without_background+1])
+
+  def test_get_predictions_with_feature_maps_of_dynamic_shape(
+      self):
+    image_features = tf.placeholder(dtype=tf.float32, shape=[4, None, None, 64])
+    conv_box_predictor = (
+        box_predictor_builder.build_convolutional_keras_box_predictor(
+            is_training=False,
+            num_classes=0,
+            conv_hyperparams=self._build_conv_hyperparams(),
+            freeze_batchnorm=False,
+            inplace_batchnorm_update=False,
+            num_predictions_per_location_list=[5],
+            min_depth=0,
+            max_depth=32,
+            num_layers_before_predictor=1,
+            use_dropout=True,
+            dropout_keep_prob=0.8,
+            kernel_size=1,
+            box_code_size=4
+        ))
+    box_predictions = conv_box_predictor([image_features])
+    box_encodings = tf.concat(
+        box_predictions[box_predictor.BOX_ENCODINGS], axis=1)
+    objectness_predictions = tf.concat(
+        box_predictions[box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND],
+        axis=1)
+    init_op = tf.global_variables_initializer()
+
+    resolution = 32
+    expected_num_anchors = resolution*resolution*5
+    with self.test_session() as sess:
+      sess.run(init_op)
+      (box_encodings_shape,
+       objectness_predictions_shape) = sess.run(
+           [tf.shape(box_encodings), tf.shape(objectness_predictions)],
+           feed_dict={image_features:
+                      np.random.rand(4, resolution, resolution, 64)})
+      actual_variable_set = set(
+          [var.op.name for var in tf.trainable_variables()])
+      self.assertAllEqual(box_encodings_shape, [4, expected_num_anchors, 1, 4])
+      self.assertAllEqual(objectness_predictions_shape,
+                          [4, expected_num_anchors, 1])
+    expected_variable_set = set([
+        'BoxPredictor/PreHeadConvolutions_0/Conv2d_0_1x1_32/bias',
+        'BoxPredictor/PreHeadConvolutions_0/Conv2d_0_1x1_32/kernel',
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor/bias',
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor/kernel',
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor/bias',
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor/kernel'])
+    self.assertEqual(expected_variable_set, actual_variable_set)
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
+++ b/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
@@ -190,6 +190,69 @@ class ConvolutionalKerasBoxPredictorTest(test_case.TestCase):
     self.assertEqual(expected_variable_set, actual_variable_set)
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_use_depthwise_convolution(self):
+    image_features = tf.placeholder(dtype=tf.float32, shape=[4, None, None, 64])
+    conv_box_predictor = (
+        box_predictor_builder.build_convolutional_keras_box_predictor(
+            is_training=False,
+            num_classes=0,
+            conv_hyperparams=self._build_conv_hyperparams(),
+            freeze_batchnorm=False,
+            inplace_batchnorm_update=False,
+            num_predictions_per_location_list=[5],
+            min_depth=0,
+            max_depth=32,
+            num_layers_before_predictor=1,
+            use_dropout=True,
+            dropout_keep_prob=0.8,
+            kernel_size=1,
+            box_code_size=4,
+            use_depthwise=True
+        ))
+    box_predictions = conv_box_predictor([image_features])
+    box_encodings = tf.concat(
+        box_predictions[box_predictor.BOX_ENCODINGS], axis=1)
+    objectness_predictions = tf.concat(
+        box_predictions[box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND],
+        axis=1)
+    init_op = tf.global_variables_initializer()
+
+    resolution = 32
+    expected_num_anchors = resolution*resolution*5
+    with self.test_session() as sess:
+      sess.run(init_op)
+      (box_encodings_shape,
+       objectness_predictions_shape) = sess.run(
+           [tf.shape(box_encodings), tf.shape(objectness_predictions)],
+           feed_dict={image_features:
+                      np.random.rand(4, resolution, resolution, 64)})
+      actual_variable_set = set(
+          [var.op.name for var in tf.trainable_variables()])
+    self.assertAllEqual(box_encodings_shape, [4, expected_num_anchors, 1, 4])
+    self.assertAllEqual(objectness_predictions_shape,
+                        [4, expected_num_anchors, 1])
+    expected_variable_set = set([
+        'BoxPredictor/PreHeadConvolutions_0/Conv2d_0_1x1_32/bias',
+        'BoxPredictor/PreHeadConvolutions_0/Conv2d_0_1x1_32/kernel',
+
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor_depthwise/'
+        'bias',
+
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor_depthwise/'
+        'depthwise_kernel',
+
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor/bias',
+        'BoxPredictor/ConvolutionalBoxHead_0/BoxEncodingPredictor/kernel',
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor_depthwise/bias',
+
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor_depthwise/'
+        'depthwise_kernel',
+
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor/bias',
+        'BoxPredictor/ConvolutionalClassHead_0/ClassPredictor/kernel'])
+    self.assertEqual(expected_variable_set, actual_variable_set)
+  # END GOOGLE-INTERNAL
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/predictors/heads/box_head.py
+++ b/research/object_detection/predictors/heads/box_head.py
@@ -19,6 +19,7 @@ Contains Box prediction head classes for different meta architectures.
 All the box prediction heads have a predict function that receives the
 `features` as the first argument and returns `box_encodings`.
 """
+import functools
 import tensorflow as tf
 
 from object_detection.predictors.heads import head
@@ -196,18 +197,19 @@ class WeightSharedConvolutionalBoxHead(head.Head):
   def __init__(self,
                box_code_size,
                kernel_size=3,
-               class_prediction_bias_init=0.0):
+               use_depthwise=False):
     """Constructor.
 
     Args:
       box_code_size: Size of encoding for each box.
       kernel_size: Size of final convolution kernel.
-      class_prediction_bias_init: constant value to initialize bias of the last
-        conv2d layer before class prediction.
+      use_depthwise: Whether to use depthwise convolutions for prediction
+        steps. Default is False.
     """
     super(WeightSharedConvolutionalBoxHead, self).__init__()
     self._box_code_size = box_code_size
     self._kernel_size = kernel_size
+    self._use_depthwise = use_depthwise
 
   def predict(self, features, num_predictions_per_location):
     """Predicts boxes.
@@ -224,7 +226,11 @@ class WeightSharedConvolutionalBoxHead(head.Head):
         the objects.
     """
     box_encodings_net = features
-    box_encodings = slim.conv2d(
+    if self._use_depthwise:
+      conv_op = functools.partial(slim.separable_conv2d, depth_multiplier=1)
+    else:
+      conv_op = slim.conv2d
+    box_encodings = conv_op(
         box_encodings_net,
         num_predictions_per_location * self._box_code_size,
         [self._kernel_size, self._kernel_size],

--- a/research/object_detection/predictors/heads/class_head.py
+++ b/research/object_detection/predictors/heads/class_head.py
@@ -213,7 +213,8 @@ class WeightSharedConvolutionalClassHead(head.Head):
                class_prediction_bias_init=0.0,
                use_dropout=False,
                dropout_keep_prob=0.8,
-               use_depthwise=False):
+               use_depthwise=False,
+               score_converter_fn=tf.identity):
     """Constructor.
 
     Args:
@@ -228,6 +229,8 @@ class WeightSharedConvolutionalClassHead(head.Head):
       dropout_keep_prob: Probability of keeping activiations.
       use_depthwise: Whether to use depthwise convolutions for prediction
         steps. Default is False.
+      score_converter_fn: Callable elementwise nonlinearity (that takes tensors
+        as inputs and returns tensors).
     """
     super(WeightSharedConvolutionalClassHead, self).__init__()
     self._num_classes = num_classes
@@ -236,6 +239,7 @@ class WeightSharedConvolutionalClassHead(head.Head):
     self._use_dropout = use_dropout
     self._dropout_keep_prob = dropout_keep_prob
     self._use_depthwise = use_depthwise
+    self._score_converter_fn = score_converter_fn
 
   def predict(self, features, num_predictions_per_location):
     """Predicts boxes.
@@ -273,6 +277,8 @@ class WeightSharedConvolutionalClassHead(head.Head):
     batch_size = features.get_shape().as_list()[0]
     if batch_size is None:
       batch_size = tf.shape(features)[0]
+    class_predictions_with_background = self._score_converter_fn(
+        class_predictions_with_background)
     class_predictions_with_background = tf.reshape(
         class_predictions_with_background, [batch_size, -1, num_class_slots])
     return class_predictions_with_background

--- a/research/object_detection/predictors/heads/head.py
+++ b/research/object_detection/predictors/heads/head.py
@@ -36,6 +36,8 @@ Mask RCNN box predictor.
 """
 from abc import abstractmethod
 
+import tensorflow as tf
+
 
 class Head(object):
   """Mask RCNN head base class."""
@@ -52,6 +54,26 @@ class Head(object):
       features: A float tensor of features.
       num_predictions_per_location: Int containing number of predictions per
         location.
+
+    Returns:
+      A tf.float32 tensor.
+    """
+    pass
+
+
+class KerasHead(tf.keras.Model):
+  """Keras head base class."""
+
+  def call(self, features):
+    """The Keras model call will delegate to the `_predict` method."""
+    return self._predict(features)
+
+  @abstractmethod
+  def _predict(self, features):
+    """Returns the head's predictions.
+
+    Args:
+      features: A float tensor of features.
 
     Returns:
       A tf.float32 tensor.

--- a/research/object_detection/predictors/heads/keras_box_head.py
+++ b/research/object_detection/predictors/heads/keras_box_head.py
@@ -1,0 +1,124 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Box Head.
+
+Contains Box prediction head classes for different meta architectures.
+All the box prediction heads have a _predict function that receives the
+`features` as the first argument and returns `box_encodings`.
+"""
+import tensorflow as tf
+
+from object_detection.predictors.heads import head
+
+
+class ConvolutionalBoxHead(head.KerasHead):
+  """Convolutional box prediction head."""
+
+  def __init__(self,
+               is_training,
+               box_code_size,
+               kernel_size,
+               num_predictions_per_location,
+               conv_hyperparams,
+               freeze_batchnorm,
+               use_depthwise=True,
+               name=None):
+    """Constructor.
+
+    Args:
+      is_training: Indicates whether the BoxPredictor is in training mode.
+      box_code_size: Size of encoding for each box.
+      kernel_size: Size of final convolution kernel.  If the
+        spatial resolution of the feature map is smaller than the kernel size,
+        then the kernel size is automatically set to be
+        min(feature_width, feature_height).
+      num_predictions_per_location: Number of box predictions to be made per
+        spatial location. Int specifying number of boxes per location.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops.
+      freeze_batchnorm: Bool. Whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      use_depthwise: Whether to use depthwise convolutions for prediction
+        steps. Default is False.
+      name: A string name scope to assign to the model. If `None`, Keras
+        will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if min_depth > max_depth.
+    """
+    super(ConvolutionalBoxHead, self).__init__(name=name)
+    self._is_training = is_training
+    self._box_code_size = box_code_size
+    self._kernel_size = kernel_size
+    self._num_predictions_per_location = num_predictions_per_location
+    self._use_depthwise = use_depthwise
+
+    self._box_encoder_layers = []
+
+    if self._use_depthwise:
+      self._box_encoder_layers.append(
+          tf.keras.layers.DepthwiseConv2D(
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              depth_multiplier=1,
+              strides=1,
+              dilation_rate=1,
+              name='BoxEncodingPredictor_depthwise',
+              **conv_hyperparams.params()))
+      self._box_encoder_layers.append(
+          conv_hyperparams.build_batch_norm(
+              training=(is_training and not freeze_batchnorm),
+              name='BoxEncodingPredictor_depthwise_batchnorm'))
+      self._box_encoder_layers.append(
+          conv_hyperparams.build_activation_layer(
+              name='BoxEncodingPredictor_depthwise_activation'))
+      self._box_encoder_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * self._box_code_size, [1, 1],
+              name='BoxEncodingPredictor',
+              **conv_hyperparams.params(activation=None)))
+    else:
+      self._box_encoder_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * self._box_code_size,
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              name='BoxEncodingPredictor',
+              **conv_hyperparams.params(activation=None)))
+
+  def _predict(self, features):
+    """Predicts boxes.
+
+    Args:
+      features: A float tensor of shape [batch_size, height, width, channels]
+        containing image features.
+
+    Returns:
+      box_encodings: A float tensor of shape
+        [batch_size, num_anchors, q, code_size] representing the location of
+        the objects, where q is 1 or the number of classes.
+    """
+    box_encodings = features
+    for layer in self._box_encoder_layers:
+      box_encodings = layer(box_encodings)
+    batch_size = features.get_shape().as_list()[0]
+    if batch_size is None:
+      batch_size = tf.shape(features)[0]
+    box_encodings = tf.reshape(box_encodings,
+                               [batch_size, -1, 1, self._box_code_size])
+    return box_encodings

--- a/research/object_detection/predictors/heads/keras_box_head_test.py
+++ b/research/object_detection/predictors/heads/keras_box_head_test.py
@@ -1,0 +1,62 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for object_detection.predictors.heads.box_head."""
+import tensorflow as tf
+
+from google.protobuf import text_format
+from object_detection.builders import hyperparams_builder
+from object_detection.predictors.heads import keras_box_head
+from object_detection.protos import hyperparams_pb2
+from object_detection.utils import test_case
+
+
+class ConvolutionalKerasBoxHeadTest(test_case.TestCase):
+
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+    activation: NONE
+      regularizer {
+        l2_regularizer {
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+        }
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def test_prediction_size_depthwise_false(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    box_prediction_head = keras_box_head.ConvolutionalBoxHead(
+        is_training=True,
+        box_code_size=4,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=False)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    box_encodings = box_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 1, 4], box_encodings.get_shape().as_list())
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/predictors/heads/keras_box_head_test.py
+++ b/research/object_detection/predictors/heads/keras_box_head_test.py
@@ -57,6 +57,22 @@ class ConvolutionalKerasBoxHeadTest(test_case.TestCase):
     self.assertAllEqual([64, 323, 1, 4], box_encodings.get_shape().as_list())
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_prediction_size_depthwise_true(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    box_prediction_head = keras_box_head.ConvolutionalBoxHead(
+        is_training=True,
+        box_code_size=4,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=True)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    box_encodings = box_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 1, 4], box_encodings.get_shape().as_list())
+  # END GOOGLE-INTERNAL
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/predictors/heads/keras_class_head.py
+++ b/research/object_detection/predictors/heads/keras_class_head.py
@@ -1,0 +1,148 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Class Head.
+
+Contains Class prediction head classes for different meta architectures.
+All the class prediction heads have a predict function that receives the
+`features` as the first argument and returns class predictions with background.
+"""
+import tensorflow as tf
+
+from object_detection.predictors.heads import head
+
+
+class ConvolutionalClassHead(head.KerasHead):
+  """Convolutional class prediction head."""
+
+  def __init__(self,
+               is_training,
+               num_classes,
+               use_dropout,
+               dropout_keep_prob,
+               kernel_size,
+               num_predictions_per_location,
+               conv_hyperparams,
+               freeze_batchnorm,
+               class_prediction_bias_init=0.0,
+               use_depthwise=False,
+               name=None):
+    """Constructor.
+
+    Args:
+      is_training: Indicates whether the BoxPredictor is in training mode.
+      num_classes: Number of classes.
+      use_dropout: Option to use dropout or not.  Note that a single dropout
+        op is applied here prior to both box and class predictions, which stands
+        in contrast to the ConvolutionalBoxPredictor below.
+      dropout_keep_prob: Keep probability for dropout.
+        This is only used if use_dropout is True.
+      kernel_size: Size of final convolution kernel.  If the
+        spatial resolution of the feature map is smaller than the kernel size,
+        then the kernel size is automatically set to be
+        min(feature_width, feature_height).
+      num_predictions_per_location: Number of box predictions to be made per
+        spatial location. Int specifying number of boxes per location.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops.
+      freeze_batchnorm: Bool. Whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      class_prediction_bias_init: constant value to initialize bias of the last
+        conv2d layer before class prediction.
+      use_depthwise: Whether to use depthwise convolutions for prediction
+        steps. Default is False.
+      name: A string name scope to assign to the model. If `None`, Keras
+        will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if min_depth > max_depth.
+    """
+    super(ConvolutionalClassHead, self).__init__(name=name)
+    self._is_training = is_training
+    self._num_classes = num_classes
+    self._use_dropout = use_dropout
+    self._dropout_keep_prob = dropout_keep_prob
+    self._kernel_size = kernel_size
+    self._class_prediction_bias_init = class_prediction_bias_init
+    self._use_depthwise = use_depthwise
+    self._num_class_slots = self._num_classes + 1
+
+    self._class_predictor_layers = []
+
+    if self._use_dropout:
+      self._class_predictor_layers.append(
+          # The Dropout layer's `training` parameter for the call method must
+          # be set implicitly by the Keras set_learning_phase. The object
+          # detection training code takes care of this.
+          tf.keras.layers.Dropout(rate=1.0 - self._dropout_keep_prob))
+    if self._use_depthwise:
+      self._class_predictor_layers.append(
+          tf.keras.layers.DepthwiseConv2D(
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              depth_multiplier=1,
+              strides=1,
+              dilation_rate=1,
+              name='ClassPredictor_depthwise',
+              **conv_hyperparams.params()))
+      self._class_predictor_layers.append(
+          conv_hyperparams.build_batch_norm(
+              training=(is_training and not freeze_batchnorm),
+              name='ClassPredictor_depthwise_batchnorm'))
+      self._class_predictor_layers.append(
+          conv_hyperparams.build_activation_layer(
+              name='ClassPredictor_depthwise_activation'))
+      self._class_predictor_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * self._num_class_slots, [1, 1],
+              name='ClassPredictor',
+              **conv_hyperparams.params(activation=None)))
+    else:
+      self._class_predictor_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * self._num_class_slots,
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              name='ClassPredictor',
+              bias_initializer=tf.constant_initializer(
+                  self._class_prediction_bias_init),
+              **conv_hyperparams.params(activation=None)))
+
+  def _predict(self, features):
+    """Predicts boxes.
+
+    Args:
+      features: A float tensor of shape [batch_size, height, width, channels]
+        containing image features.
+
+    Returns:
+      class_predictions_with_background: A float tensor of shape
+        [batch_size, num_anchors, num_classes + 1] representing the class
+        predictions for the proposals.
+    """
+    # Add a slot for the background class.
+    class_predictions_with_background = features
+    for layer in self._class_predictor_layers:
+      class_predictions_with_background = layer(
+          class_predictions_with_background)
+    batch_size = features.get_shape().as_list()[0]
+    if batch_size is None:
+      batch_size = tf.shape(features)[0]
+    class_predictions_with_background = tf.reshape(
+        class_predictions_with_background,
+        [batch_size, -1, self._num_class_slots])
+    return class_predictions_with_background

--- a/research/object_detection/predictors/heads/keras_class_head_test.py
+++ b/research/object_detection/predictors/heads/keras_class_head_test.py
@@ -1,0 +1,65 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for object_detection.predictors.heads.class_head."""
+import tensorflow as tf
+
+from google.protobuf import text_format
+from object_detection.builders import hyperparams_builder
+from object_detection.predictors.heads import keras_class_head
+from object_detection.protos import hyperparams_pb2
+from object_detection.utils import test_case
+
+
+class ConvolutionalKerasClassPredictorTest(test_case.TestCase):
+
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+    activation: NONE
+      regularizer {
+        l2_regularizer {
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+        }
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def test_prediction_size_depthwise_false(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    class_prediction_head = keras_class_head.ConvolutionalClassHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=False)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    class_predictions = class_prediction_head(image_feature,)
+    self.assertAllEqual([64, 323, 21],
+                        class_predictions.get_shape().as_list())
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/predictors/heads/keras_class_head_test.py
+++ b/research/object_detection/predictors/heads/keras_class_head_test.py
@@ -60,6 +60,25 @@ class ConvolutionalKerasClassPredictorTest(test_case.TestCase):
                         class_predictions.get_shape().as_list())
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_prediction_size_depthwise_true(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    class_prediction_head = keras_class_head.ConvolutionalClassHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=True)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    class_predictions = class_prediction_head(image_feature,)
+    self.assertAllEqual([64, 323, 21],
+                        class_predictions.get_shape().as_list())
+  # END GOOGLE-INTERNAL
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/predictors/heads/keras_mask_head.py
+++ b/research/object_detection/predictors/heads/keras_mask_head.py
@@ -1,0 +1,158 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Keras Mask Heads.
+
+Contains Mask prediction head classes for different meta architectures.
+All the mask prediction heads have a predict function that receives the
+`features` as the first argument and returns `mask_predictions`.
+"""
+import tensorflow as tf
+
+from object_detection.predictors.heads import head
+
+
+class ConvolutionalMaskHead(head.KerasHead):
+  """Convolutional class prediction head."""
+
+  def __init__(self,
+               is_training,
+               num_classes,
+               use_dropout,
+               dropout_keep_prob,
+               kernel_size,
+               num_predictions_per_location,
+               conv_hyperparams,
+               freeze_batchnorm,
+               use_depthwise=False,
+               mask_height=7,
+               mask_width=7,
+               masks_are_class_agnostic=False,
+               name=None):
+    """Constructor.
+
+    Args:
+      is_training: Indicates whether the BoxPredictor is in training mode.
+      num_classes: Number of classes.
+      use_dropout: Option to use dropout or not.  Note that a single dropout
+        op is applied here prior to both box and class predictions, which stands
+        in contrast to the ConvolutionalBoxPredictor below.
+      dropout_keep_prob: Keep probability for dropout.
+        This is only used if use_dropout is True.
+      kernel_size: Size of final convolution kernel.  If the
+        spatial resolution of the feature map is smaller than the kernel size,
+        then the kernel size is automatically set to be
+        min(feature_width, feature_height).
+      num_predictions_per_location: Number of box predictions to be made per
+        spatial location. Int specifying number of boxes per location.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops.
+      freeze_batchnorm: Bool. Whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      use_depthwise: Whether to use depthwise convolutions for prediction
+        steps. Default is False.
+      mask_height: Desired output mask height. The default value is 7.
+      mask_width: Desired output mask width. The default value is 7.
+      masks_are_class_agnostic: Boolean determining if the mask-head is
+        class-agnostic or not.
+      name: A string name scope to assign to the model. If `None`, Keras
+        will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if min_depth > max_depth.
+    """
+    super(ConvolutionalMaskHead, self).__init__(name=name)
+    self._is_training = is_training
+    self._num_classes = num_classes
+    self._use_dropout = use_dropout
+    self._dropout_keep_prob = dropout_keep_prob
+    self._kernel_size = kernel_size
+    self._num_predictions_per_location = num_predictions_per_location
+    self._use_depthwise = use_depthwise
+    self._mask_height = mask_height
+    self._mask_width = mask_width
+    self._masks_are_class_agnostic = masks_are_class_agnostic
+
+    self._mask_predictor_layers = []
+
+    # Add a slot for the background class.
+    if self._masks_are_class_agnostic:
+      self._num_masks = 1
+    else:
+      self._num_masks = self._num_classes
+
+    num_mask_channels = self._num_masks * self._mask_height * self._mask_width
+
+    if self._use_dropout:
+      self._mask_predictor_layers.append(
+          # The Dropout layer's `training` parameter for the call method must
+          # be set implicitly by the Keras set_learning_phase. The object
+          # detection training code takes care of this.
+          tf.keras.layers.Dropout(rate=1.0 - self._dropout_keep_prob))
+    if self._use_depthwise:
+      self._mask_predictor_layers.append(
+          tf.keras.layers.DepthwiseConv2D(
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              depth_multiplier=1,
+              strides=1,
+              dilation_rate=1,
+              name='MaskPredictor_depthwise',
+              **conv_hyperparams.params()))
+      self._mask_predictor_layers.append(
+          conv_hyperparams.build_batch_norm(
+              training=(is_training and not freeze_batchnorm),
+              name='MaskPredictor_depthwise_batchnorm'))
+      self._mask_predictor_layers.append(
+          conv_hyperparams.build_activation_layer(
+              name='MaskPredictor_depthwise_activation'))
+      self._mask_predictor_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * num_mask_channels, [1, 1],
+              name='MaskPredictor',
+              **conv_hyperparams.params(activation=None)))
+    else:
+      self._mask_predictor_layers.append(
+          tf.keras.layers.Conv2D(
+              num_predictions_per_location * num_mask_channels,
+              [self._kernel_size, self._kernel_size],
+              padding='SAME',
+              name='MaskPredictor',
+              **conv_hyperparams.params(activation=None)))
+
+  def _predict(self, features):
+    """Predicts boxes.
+
+    Args:
+      features: A float tensor of shape [batch_size, height, width, channels]
+        containing image features.
+
+    Returns:
+      mask_predictions: A float tensors of shape
+        [batch_size, num_anchors, num_masks, mask_height, mask_width]
+        representing the mask predictions for the proposals.
+    """
+    mask_predictions = features
+    for layer in self._mask_predictor_layers:
+      mask_predictions = layer(mask_predictions)
+    batch_size = features.get_shape().as_list()[0]
+    if batch_size is None:
+      batch_size = tf.shape(features)[0]
+    mask_predictions = tf.reshape(
+        mask_predictions,
+        [batch_size, -1, self._num_masks, self._mask_height, self._mask_width])
+    return mask_predictions

--- a/research/object_detection/predictors/heads/keras_mask_head_test.py
+++ b/research/object_detection/predictors/heads/keras_mask_head_test.py
@@ -1,0 +1,90 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for object_detection.predictors.heads.mask_head."""
+import tensorflow as tf
+
+from google.protobuf import text_format
+from object_detection.builders import hyperparams_builder
+from object_detection.predictors.heads import keras_mask_head
+from object_detection.protos import hyperparams_pb2
+from object_detection.utils import test_case
+
+
+class ConvolutionalMaskPredictorTest(test_case.TestCase):
+
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+    activation: NONE
+      regularizer {
+        l2_regularizer {
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+        }
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def test_prediction_size_use_depthwise_false(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    mask_prediction_head = keras_mask_head.ConvolutionalMaskHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=False,
+        mask_height=7,
+        mask_width=7)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    mask_predictions = mask_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 20, 7, 7],
+                        mask_predictions.get_shape().as_list())
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+  def test_class_agnostic_prediction_size_use_depthwise_false(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    mask_prediction_head = keras_mask_head.ConvolutionalMaskHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=False,
+        mask_height=7,
+        mask_width=7,
+        masks_are_class_agnostic=True)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    mask_predictions = mask_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 1, 7, 7],
+                        mask_predictions.get_shape().as_list())
+
+  # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/predictors/heads/keras_mask_head_test.py
+++ b/research/object_detection/predictors/heads/keras_mask_head_test.py
@@ -62,6 +62,27 @@ class ConvolutionalMaskPredictorTest(test_case.TestCase):
                         mask_predictions.get_shape().as_list())
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_prediction_size_use_depthwise_true(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    mask_prediction_head = keras_mask_head.ConvolutionalMaskHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=True,
+        mask_height=7,
+        mask_width=7)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    mask_predictions = mask_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 20, 7, 7],
+                        mask_predictions.get_shape().as_list())
+  # END GOOGLE-INTERNAL
 
   def test_class_agnostic_prediction_size_use_depthwise_false(self):
     conv_hyperparams = self._build_conv_hyperparams()
@@ -85,6 +106,28 @@ class ConvolutionalMaskPredictorTest(test_case.TestCase):
                         mask_predictions.get_shape().as_list())
 
   # TODO(kaftan): Remove conditional after CMLE moves to TF 1.10
+  # BEGIN GOOGLE-INTERNAL
+  def test_class_agnostic_prediction_size_use_depthwise_true(self):
+    conv_hyperparams = self._build_conv_hyperparams()
+    mask_prediction_head = keras_mask_head.ConvolutionalMaskHead(
+        is_training=True,
+        num_classes=20,
+        use_dropout=True,
+        dropout_keep_prob=0.5,
+        kernel_size=3,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=False,
+        num_predictions_per_location=1,
+        use_depthwise=True,
+        mask_height=7,
+        mask_width=7,
+        masks_are_class_agnostic=True)
+    image_feature = tf.random_uniform(
+        [64, 17, 19, 1024], minval=-10.0, maxval=10.0, dtype=tf.float32)
+    mask_predictions = mask_prediction_head(image_feature)
+    self.assertAllEqual([64, 323, 1, 7, 7],
+                        mask_predictions.get_shape().as_list())
+  # END GOOGLE-INTERNAL
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/predictors/heads/mask_head.py
+++ b/research/object_detection/predictors/heads/mask_head.py
@@ -148,6 +148,7 @@ class MaskRCNNMaskHead(head.Head):
           upsampled_features,
           num_outputs=num_masks,
           activation_fn=None,
+          normalizer_fn=None,
           kernel_size=[3, 3])
       return tf.expand_dims(
           tf.transpose(mask_predictions, perm=[0, 3, 1, 2]),

--- a/research/object_detection/protos/box_predictor.proto
+++ b/research/object_detection/protos/box_predictor.proto
@@ -75,7 +75,7 @@ message ConvolutionalBoxPredictor {
 }
 
 // Configuration proto for weight shared convolutional box predictor.
-// Next id: 16
+// Next id: 18
 message WeightSharedConvolutionalBoxPredictor {
   // Hyperparameters for convolution ops used in the box predictor.
   optional Hyperparams conv_hyperparams = 1;
@@ -115,6 +115,25 @@ message WeightSharedConvolutionalBoxPredictor {
 
   // Configs for a mask prediction head.
   optional MaskHead mask_head = 15;
+
+  // Enum to specify how to convert the detection scores at inference time.
+  enum ScoreConverter {
+    // Input scores equals output scores.
+    IDENTITY = 0;
+
+    // Applies a sigmoid on input scores.
+    SIGMOID = 1;
+  }
+
+  // Callable elementwise score converter at inference time.
+  optional ScoreConverter score_converter = 16 [default = IDENTITY];
+
+  // If specified, apply clipping to box encodings.
+  message BoxEncodingsClipRange {
+    optional float min = 1;
+    optional float max = 2;
+  }
+  optional BoxEncodingsClipRange box_encodings_clip_range = 17;
 }
 
 // TODO(alirezafathi): Refactor the proto file to be able to configure mask rcnn

--- a/research/object_detection/protos/box_predictor.proto
+++ b/research/object_detection/protos/box_predictor.proto
@@ -15,7 +15,21 @@ message BoxPredictor {
   }
 }
 
+// Configuration proto for MaskHead in predictors.
+// Next id: 4
+message MaskHead {
+  // The height and the width of the predicted mask. Only used when
+  // predict_instance_masks is true.
+  optional int32 mask_height = 1 [default = 15];
+  optional int32 mask_width = 2 [default = 15];
+
+  // Whether to predict class agnostic masks. Only used when
+  // predict_instance_masks is true.
+  optional bool masks_are_class_agnostic = 3 [default = true];
+}
+
 // Configuration proto for Convolutional box predictor.
+// Next id: 13
 message ConvolutionalBoxPredictor {
   // Hyperparameters for convolution ops used in the box predictor.
   optional Hyperparams conv_hyperparams = 1;
@@ -55,9 +69,13 @@ message ConvolutionalBoxPredictor {
 
   // Whether to use depthwise separable convolution for box predictor layers.
   optional bool use_depthwise = 11 [default = false];
+
+  // Configs for a mask prediction head.
+  optional MaskHead mask_head = 12;
 }
 
 // Configuration proto for weight shared convolutional box predictor.
+// Next id: 16
 message WeightSharedConvolutionalBoxPredictor {
   // Hyperparameters for convolution ops used in the box predictor.
   optional Hyperparams conv_hyperparams = 1;
@@ -85,12 +103,18 @@ message WeightSharedConvolutionalBoxPredictor {
   // Whether to use dropout for class prediction.
   optional bool use_dropout = 11 [default = false];
 
-  // Keep probability for dropout
+  // Keep probability for dropout.
   optional float dropout_keep_probability = 12 [default = 0.8];
 
   // Whether to share the multi-layer tower between box prediction and class
   // prediction heads.
   optional bool share_prediction_tower = 13 [default = false];
+
+  // Whether to use depthwise separable convolution for box predictor layers.
+  optional bool use_depthwise = 14 [default = false];
+
+  // Configs for a mask prediction head.
+  optional MaskHead mask_head = 15;
 }
 
 // TODO(alirezafathi): Refactor the proto file to be able to configure mask rcnn

--- a/research/object_detection/protos/eval.proto
+++ b/research/object_detection/protos/eval.proto
@@ -8,13 +8,13 @@ message EvalConfig {
   optional uint32 num_visualizations = 1 [default=10];
 
   // Number of examples to process of evaluation.
-  optional uint32 num_examples = 2 [default=5000];
+  optional uint32 num_examples = 2 [default=5000, deprecated=true];
 
   // How often to run evaluation.
   optional uint32 eval_interval_secs = 3 [default=300];
 
   // Maximum number of times to run evaluation. If set to 0, will run forever.
-  optional uint32 max_evals = 4 [default=0];
+  optional uint32 max_evals = 4 [default=0, deprecated=true];
 
   // Whether the TensorFlow graph used for evaluation should be saved to disk.
   optional bool save_graph = 5 [default=false];

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -157,6 +157,13 @@ message FasterRcnn {
   // Whether to use the balanced positive negative sampler implementation with
   // static shape guarantees.
   optional bool use_static_balanced_label_sampler = 34 [default = false];
+
+  // If True, uses implementation of ops with static shape guarantees.
+  optional bool use_static_shapes = 35 [default = false];
+
+  // Whether the masks present in groundtruth should be resized in the model to
+  // match the image size.
+  optional bool resize_masks = 36 [default = true];
 }
 
 

--- a/research/object_detection/protos/input_reader.proto
+++ b/research/object_detection/protos/input_reader.proto
@@ -22,7 +22,12 @@ enum InstanceMaskType {
   PNG_MASKS = 2;        // Encoded PNG masks.
 }
 
+// Next id: 24
 message InputReader {
+  // Name of input reader. Typically used to describe the dataset that is read
+  // by this input reader.
+  optional string name = 23 [default=""];
+
   // Path to StringIntLabelMap pbtxt file specifying the mapping from string
   // labels to integer ids.
   optional string label_map_path = 1 [default=""];
@@ -40,6 +45,12 @@ message InputReader {
   // The number of times a data source is read. If set to zero, the data source
   // will be reused indefinitely.
   optional uint32 num_epochs = 5 [default=0];
+
+  // Integer representing how often an example should be sampled. To feed
+  // only 1/3 of your data into your model, set `sample_1_of_n_examples` to 3.
+  // This is particularly useful for evaluation, where you might not prefer to
+  // evaluate all of your samples.
+  optional uint32 sample_1_of_n_examples = 22 [default=1];
 
   // Number of file shards to read in parallel.
   optional uint32 num_readers = 6 [default=64];
@@ -61,7 +72,6 @@ message InputReader {
   // Minimum number of records to keep in reader queue. A large value is needed
   // to generate a good random shuffle.
   optional uint32 min_after_dequeue = 4 [default=1000, deprecated=true];
-
 
   // Number of records to read from each reader at once.
   optional uint32 read_block_length = 15 [default=32];

--- a/research/object_detection/protos/pipeline.proto
+++ b/research/object_detection/protos/pipeline.proto
@@ -10,12 +10,13 @@ import "object_detection/protos/train.proto";
 
 // Convenience message for configuring a training and eval pipeline. Allows all
 // of the pipeline parameters to be configured from one file.
+// Next id: 7
 message TrainEvalPipelineConfig {
   optional DetectionModel model = 1;
   optional TrainConfig train_config = 2;
   optional InputReader train_input_reader = 3;
   optional EvalConfig eval_config = 4;
-  optional InputReader eval_input_reader = 5;
+  repeated InputReader eval_input_reader = 5;
   optional GraphRewriter graph_rewriter = 6;
   extensions 1000 to max;
 }

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -17,6 +17,9 @@ message BatchNonMaxSuppression {
 
   // Maximum number of detections to retain across all classes.
   optional int32 max_total_detections = 5 [default = 100];
+
+  // Whether to use the implementation of NMS that guarantees static shapes.
+  optional bool use_static_shapes = 6 [default = false];
 }
 
 // Configuration proto for post-processing predicted boxes and

--- a/research/object_detection/protos/ssd.proto
+++ b/research/object_detection/protos/ssd.proto
@@ -163,5 +163,8 @@ message FeaturePyramidNetworks {
 
   // maximum level in feature pyramid
   optional int32 max_level = 2 [default = 7];
+
+  // channel depth for additional coarse feature layers.
+  optional int32 additional_layer_depth = 3 [default = 256];
 }
 

--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -6,7 +6,7 @@ import "object_detection/protos/optimizer.proto";
 import "object_detection/protos/preprocessor.proto";
 
 // Message for configuring DetectionModel training jobs (train.py).
-// Next id: 26
+// Next id: 27
 message TrainConfig {
   // Effective batch size to use for training.
   // For TPU (or sync SGD jobs), the batch size per core (or GPU) is going to be
@@ -112,4 +112,7 @@ message TrainConfig {
   // dictionary, so that they can be displayed in Tensorboard. Note that this
   // will lead to a larger memory footprint.
   optional bool retain_original_images = 23 [default=false];
+
+  // Whether to use bfloat16 for training.
+  optional bool use_bfloat16 = 26 [default=false];
 }

--- a/research/object_detection/samples/configs/faster_rcnn_resnet101_fgvc.config
+++ b/research/object_detection/samples/configs/faster_rcnn_resnet101_fgvc.config
@@ -1,0 +1,135 @@
+# Faster R-CNN with Resnet-101 (v1)
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  faster_rcnn {
+    num_classes: 2854
+    image_resizer {
+      keep_aspect_ratio_resizer {
+        min_dimension: 600
+        max_dimension: 1024
+      }
+    }
+    feature_extractor {
+      type: 'faster_rcnn_resnet101'
+      first_stage_features_stride: 16
+    }
+    first_stage_anchor_generator {
+      grid_anchor_generator {
+        scales: [0.25, 0.5, 1.0, 2.0]
+        aspect_ratios: [0.5, 1.0, 2.0]
+        height_stride: 16
+        width_stride: 16
+      }
+    }
+    first_stage_box_predictor_conv_hyperparams {
+      op: CONV
+      regularizer {
+        l2_regularizer {
+          weight: 0.0
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+          stddev: 0.01
+        }
+      }
+    }
+    first_stage_nms_score_threshold: 0.0
+    first_stage_nms_iou_threshold: 0.7
+    first_stage_max_proposals: 32
+    first_stage_localization_loss_weight: 2.0
+    first_stage_objectness_loss_weight: 1.0
+    initial_crop_size: 14
+    maxpool_kernel_size: 2
+    maxpool_stride: 2
+    second_stage_batch_size: 32
+    second_stage_box_predictor {
+      mask_rcnn_box_predictor {
+        use_dropout: false
+        dropout_keep_probability: 1.0
+        fc_hyperparams {
+          op: FC
+          regularizer {
+            l2_regularizer {
+              weight: 0.0
+            }
+          }
+          initializer {
+            variance_scaling_initializer {
+              factor: 1.0
+              uniform: true
+              mode: FAN_AVG
+            }
+          }
+        }
+      }
+    }
+    second_stage_post_processing {
+      batch_non_max_suppression {
+        score_threshold: 0.0
+        iou_threshold: 0.6
+        max_detections_per_class: 5
+        max_total_detections: 5
+      }
+      score_converter: SOFTMAX
+    }
+    second_stage_localization_loss_weight: 2.0
+    second_stage_classification_loss_weight: 1.0
+  }
+}
+
+train_config: {
+  batch_size: 1
+  num_steps: 4000000
+  optimizer {
+    momentum_optimizer: {
+      learning_rate: {
+        manual_step_learning_rate {
+          initial_learning_rate: 0.0003
+          schedule {
+            step: 3000000
+            learning_rate: .00003
+          }
+          schedule {
+            step: 3500000
+            learning_rate: .000003
+          }
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  gradient_clipping_by_norm: 10.0
+  fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+}
+
+train_input_reader: {
+  label_map_path: "PATH_TO_BE_CONFIGURED/fgvc_2854_classes_label_map.pbtxt"
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/animal_2854_train.record"
+  }
+}
+
+eval_config: {
+  metrics_set: "pascal_voc_detection_metrics"
+  use_moving_averages: false
+  num_examples: 48736
+}
+
+eval_input_reader: {
+  label_map_path: "PATH_TO_BE_CONFIGURED/fgvc_2854_classes_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/animal_2854_val.record"
+  }
+}

--- a/research/object_detection/samples/configs/faster_rcnn_resnet50_fgvc.config
+++ b/research/object_detection/samples/configs/faster_rcnn_resnet50_fgvc.config
@@ -1,0 +1,135 @@
+# Faster R-CNN with Resnet-50 (v1)
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  faster_rcnn {
+    num_classes: 2854
+    image_resizer {
+      keep_aspect_ratio_resizer {
+        min_dimension: 600
+        max_dimension: 1024
+      }
+    }
+    feature_extractor {
+      type: 'faster_rcnn_resnet50'
+      first_stage_features_stride: 16
+    }
+    first_stage_anchor_generator {
+      grid_anchor_generator {
+        scales: [0.25, 0.5, 1.0, 2.0]
+        aspect_ratios: [0.5, 1.0, 2.0]
+        height_stride: 16
+        width_stride: 16
+      }
+    }
+    first_stage_box_predictor_conv_hyperparams {
+      op: CONV
+      regularizer {
+        l2_regularizer {
+          weight: 0.0
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+          stddev: 0.01
+        }
+      }
+    }
+    first_stage_nms_score_threshold: 0.0
+    first_stage_nms_iou_threshold: 0.7
+    first_stage_max_proposals: 32
+    first_stage_localization_loss_weight: 2.0
+    first_stage_objectness_loss_weight: 1.0
+    initial_crop_size: 14
+    maxpool_kernel_size: 2
+    maxpool_stride: 2
+    second_stage_batch_size: 32
+    second_stage_box_predictor {
+      mask_rcnn_box_predictor {
+        use_dropout: false
+        dropout_keep_probability: 1.0
+        fc_hyperparams {
+          op: FC
+          regularizer {
+            l2_regularizer {
+              weight: 0.0
+            }
+          }
+          initializer {
+            variance_scaling_initializer {
+              factor: 1.0
+              uniform: true
+              mode: FAN_AVG
+            }
+          }
+        }
+      }
+    }
+    second_stage_post_processing {
+      batch_non_max_suppression {
+        score_threshold: 0.0
+        iou_threshold: 0.6
+        max_detections_per_class: 5
+        max_total_detections: 5
+      }
+      score_converter: SOFTMAX
+    }
+    second_stage_localization_loss_weight: 2.0
+    second_stage_classification_loss_weight: 1.0
+  }
+}
+
+train_config: {
+  batch_size: 1
+  num_steps: 4000000
+  optimizer {
+    momentum_optimizer: {
+      learning_rate: {
+        manual_step_learning_rate {
+          initial_learning_rate: 0.0003
+          schedule {
+            step: 3000000
+            learning_rate: .00003
+          }
+          schedule {
+            step: 3500000
+            learning_rate: .000003
+          }
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  gradient_clipping_by_norm: 10.0
+  fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+}
+
+train_input_reader: {
+  label_map_path: "PATH_TO_BE_CONFIGURED/fgvc_2854_classes_label_map.pbtxt"
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/animal_2854_train.record"
+  }
+}
+
+eval_config: {
+  metrics_set: "pascal_voc_detection_metrics"
+  use_moving_averages: false
+  num_examples: 10
+}
+
+eval_input_reader: {
+  label_map_path: "PATH_TO_BE_CONFIGURED/fgvc_2854_classes_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/animal_2854_val.record"
+  }
+}

--- a/research/object_detection/utils/config_util.py
+++ b/research/object_detection/utils/config_util.py
@@ -544,6 +544,8 @@ def _maybe_update_config_with_key_value(configs, key, value):
     _update_use_moving_averages(configs, value)
   elif field_name == "retain_original_images_in_eval":
     _update_retain_original_images(configs["eval_config"], value)
+  elif field_name == "use_bfloat16":
+    _update_use_bfloat16(configs, value)
   else:
     return False
   return True
@@ -919,3 +921,16 @@ def _update_retain_original_images(eval_config, retain_original_images):
       in eval mode.
   """
   eval_config.retain_original_images = retain_original_images
+
+
+def _update_use_bfloat16(configs, use_bfloat16):
+  """Updates `configs` to reflect the new setup on whether to use bfloat16.
+
+  The configs dictionary is updated in place, and hence not returned.
+
+  Args:
+    configs: Dictionary of configuration objects. See outputs from
+      get_configs_from_pipeline_file() or get_configs_from_multiple_files().
+    use_bfloat16: A bool, indicating whether to use bfloat16 for training.
+  """
+  configs["train_config"].use_bfloat16 = use_bfloat16

--- a/research/object_detection/utils/config_util.py
+++ b/research/object_detection/utils/config_util.py
@@ -103,15 +103,20 @@ def create_configs_from_pipeline_proto(pipeline_config):
 
   Returns:
     Dictionary of configuration objects. Keys are `model`, `train_config`,
-      `train_input_config`, `eval_config`, `eval_input_config`. Value are the
-      corresponding config objects.
+      `train_input_config`, `eval_config`, `eval_input_configs`. Value are
+      the corresponding config objects or list of config objects (only for
+      eval_input_configs).
   """
   configs = {}
   configs["model"] = pipeline_config.model
   configs["train_config"] = pipeline_config.train_config
   configs["train_input_config"] = pipeline_config.train_input_reader
   configs["eval_config"] = pipeline_config.eval_config
-  configs["eval_input_config"] = pipeline_config.eval_input_reader
+  configs["eval_input_configs"] = pipeline_config.eval_input_reader
+  # Keeps eval_input_config only for backwards compatibility. All clients should
+  # read eval_input_configs instead.
+  if configs["eval_input_configs"]:
+    configs["eval_input_config"] = configs["eval_input_configs"][0]
   if pipeline_config.HasField("graph_rewriter"):
     configs["graph_rewriter_config"] = pipeline_config.graph_rewriter
 
@@ -150,7 +155,7 @@ def create_pipeline_proto_from_configs(configs):
   pipeline_config.train_config.CopyFrom(configs["train_config"])
   pipeline_config.train_input_reader.CopyFrom(configs["train_input_config"])
   pipeline_config.eval_config.CopyFrom(configs["eval_config"])
-  pipeline_config.eval_input_reader.CopyFrom(configs["eval_input_config"])
+  pipeline_config.eval_input_reader.extend(configs["eval_input_configs"])
   if "graph_rewriter_config" in configs:
     pipeline_config.graph_rewriter.CopyFrom(configs["graph_rewriter_config"])
   return pipeline_config
@@ -224,7 +229,7 @@ def get_configs_from_multiple_files(model_config_path="",
     eval_input_config = input_reader_pb2.InputReader()
     with tf.gfile.GFile(eval_input_config_path, "r") as f:
       text_format.Merge(f.read(), eval_input_config)
-      configs["eval_input_config"] = eval_input_config
+      configs["eval_input_configs"] = [eval_input_config]
 
   if graph_rewriter_config_path:
     configs["graph_rewriter_config"] = get_graph_rewriter_config_from_file(
@@ -284,14 +289,136 @@ def _is_generic_key(key):
       "graph_rewriter_config",
       "model",
       "train_input_config",
-      "train_input_config",
-      "train_config"]:
+      "train_config",
+      "eval_config"]:
     if key.startswith(prefix + "."):
       return True
   return False
 
 
-def merge_external_params_with_configs(configs, hparams=None, **kwargs):
+def _check_and_convert_legacy_input_config_key(key):
+  """Checks key and converts legacy input config update to specific update.
+
+  Args:
+    key: string indicates the target of update operation.
+
+  Returns:
+    is_valid_input_config_key: A boolean indicating whether the input key is to
+      update input config(s).
+    key_name: 'eval_input_configs' or 'train_input_config' string if
+      is_valid_input_config_key is true. None if is_valid_input_config_key is
+      false.
+    input_name: always returns None since legacy input config key never
+      specifies the target input config. Keeping this output only to match the
+      output form defined for input config update.
+    field_name: the field name in input config. `key` itself if
+      is_valid_input_config_key is false.
+  """
+  key_name = None
+  input_name = None
+  field_name = key
+  is_valid_input_config_key = True
+  if field_name == "train_shuffle":
+    key_name = "train_input_config"
+    field_name = "shuffle"
+  elif field_name == "eval_shuffle":
+    key_name = "eval_input_configs"
+    field_name = "shuffle"
+  elif field_name == "sample_1_of_n_eval_examples":
+    key_name = "eval_input_configs"
+    field_name = "sample_1_of_n_examples"
+  elif field_name == "train_input_path":
+    key_name = "train_input_config"
+    field_name = "input_path"
+  elif field_name == "eval_input_path":
+    key_name = "eval_input_configs"
+    field_name = "input_path"
+  elif field_name == "train_input_path":
+    key_name = "train_input_config"
+    field_name = "input_path"
+  elif field_name == "eval_input_path":
+    key_name = "eval_input_configs"
+    field_name = "input_path"
+  elif field_name == "append_train_input_path":
+    key_name = "train_input_config"
+    field_name = "input_path"
+  elif field_name == "append_eval_input_path":
+    key_name = "eval_input_configs"
+    field_name = "input_path"
+  else:
+    is_valid_input_config_key = False
+
+  return is_valid_input_config_key, key_name, input_name, field_name
+
+
+def check_and_parse_input_config_key(configs, key):
+  """Checks key and returns specific fields if key is valid input config update.
+
+  Args:
+    configs: Dictionary of configuration objects. See outputs from
+      get_configs_from_pipeline_file() or get_configs_from_multiple_files().
+    key: string indicates the target of update operation.
+
+  Returns:
+    is_valid_input_config_key: A boolean indicate whether the input key is to
+      update input config(s).
+    key_name: 'eval_input_configs' or 'train_input_config' string if
+      is_valid_input_config_key is true. None if is_valid_input_config_key is
+      false.
+    input_name: the name of the input config to be updated. None if
+      is_valid_input_config_key is false.
+    field_name: the field name in input config. `key` itself if
+      is_valid_input_config_key is false.
+
+  Raises:
+    ValueError: when the input key format doesn't match any known formats.
+    ValueError: if key_name doesn't match 'eval_input_configs' or
+      'train_input_config'.
+    ValueError: if input_name doesn't match any name in train or eval input
+      configs.
+    ValueError: if field_name doesn't match any supported fields.
+  """
+  key_name = None
+  input_name = None
+  field_name = None
+  fields = key.split(":")
+  if len(fields) == 1:
+    field_name = key
+    return _check_and_convert_legacy_input_config_key(key)
+  elif len(fields) == 3:
+    key_name = fields[0]
+    input_name = fields[1]
+    field_name = fields[2]
+  else:
+    raise ValueError("Invalid key format when overriding configs.")
+
+  # Checks if key_name is valid for specific update.
+  if key_name not in ["eval_input_configs", "train_input_config"]:
+    raise ValueError("Invalid key_name when overriding input config.")
+
+  # Checks if input_name is valid for specific update. For train input config it
+  # should match configs[key_name].name, for eval input configs it should match
+  # the name field of one of the eval_input_configs.
+  if isinstance(configs[key_name], input_reader_pb2.InputReader):
+    is_valid_input_name = configs[key_name].name == input_name
+  else:
+    is_valid_input_name = input_name in [
+        eval_input_config.name for eval_input_config in configs[key_name]
+    ]
+  if not is_valid_input_name:
+    raise ValueError("Invalid input_name when overriding input config.")
+
+  # Checks if field_name is valid for specific update.
+  if field_name not in [
+      "input_path", "label_map_path", "shuffle", "mask_type",
+      "sample_1_of_n_eval_examples"
+  ]:
+    raise ValueError("Invalid field_name when overriding input config.")
+
+  return True, key_name, input_name, field_name
+
+
+def merge_external_params_with_configs(configs, hparams=None, kwargs_dict=None):
   """Updates `configs` dictionary based on supplied parameters.
 
   This utility is for modifying specific fields in the object detection configs.
@@ -304,6 +431,31 @@ def merge_external_params_with_configs(configs, hparams=None, **kwargs):
   1. Strategy-based overrides, which update multiple relevant configuration
   options. For example, updating `learning_rate` will update both the warmup and
   final learning rates.
+  In this case key can be one of the following formats:
+      1. legacy update: single string that indicates the attribute to be
+        updated. E.g. 'lable_map_path', 'eval_input_path', 'shuffle'.
+        Note that when updating fields (e.g. eval_input_path, eval_shuffle) in
+        eval_input_configs, the override will only be applied when
+        eval_input_configs has exactly 1 element.
+      2. specific update: colon separated string that indicates which field in
+        which input_config to update. It should have 3 fields:
+        - key_name: Name of the input config we should update, either
+          'train_input_config' or 'eval_input_configs'
+        - input_name: a 'name' that can be used to identify elements, especially
+          when configs[key_name] is a repeated field.
+        - field_name: name of the field that you want to override.
+        For example, given configs dict as below:
+          configs = {
+            'model': {...}
+            'train_config': {...}
+            'train_input_config': {...}
+            'eval_config': {...}
+            'eval_input_configs': [{ name:"eval_coco", ...},
+                                   { name:"eval_voc", ... }]
+          }
+        Assume we want to update the input_path of the eval_input_config
+        whose name is 'eval_coco'. The `key` would then be:
+        'eval_input_configs:eval_coco:input_path'
   2. Generic key/value, which update a specific parameter based on namespaced
   configuration keys. For example,
   `model.ssd.loss.hard_example_miner.max_negatives_per_positive` will update the
@@ -314,60 +466,165 @@ def merge_external_params_with_configs(configs, hparams=None, **kwargs):
     configs: Dictionary of configuration objects. See outputs from
       get_configs_from_pipeline_file() or get_configs_from_multiple_files().
     hparams: A `HParams`.
-    **kwargs: Extra keyword arguments that are treated the same way as
+    kwargs_dict: Extra keyword arguments that are treated the same way as
       attribute/value pairs in `hparams`. Note that hyperparameters with the
       same names will override keyword arguments.
 
   Returns:
     `configs` dictionary.
+
+  Raises:
+    ValueError: when the key string doesn't match any of its allowed formats.
   """
 
+  if kwargs_dict is None:
+    kwargs_dict = {}
   if hparams:
-    kwargs.update(hparams.values())
-  for key, value in kwargs.items():
+    kwargs_dict.update(hparams.values())
+  for key, value in kwargs_dict.items():
     tf.logging.info("Maybe overwriting %s: %s", key, value)
     # pylint: disable=g-explicit-bool-comparison
     if value == "" or value is None:
       continue
     # pylint: enable=g-explicit-bool-comparison
-    if key == "learning_rate":
-      _update_initial_learning_rate(configs, value)
-    elif key == "batch_size":
-      _update_batch_size(configs, value)
-    elif key == "momentum_optimizer_value":
-      _update_momentum_optimizer_value(configs, value)
-    elif key == "classification_localization_weight_ratio":
-      # Localization weight is fixed to 1.0.
-      _update_classification_localization_weight_ratio(configs, value)
-    elif key == "focal_loss_gamma":
-      _update_focal_loss_gamma(configs, value)
-    elif key == "focal_loss_alpha":
-      _update_focal_loss_alpha(configs, value)
-    elif key == "train_steps":
-      _update_train_steps(configs, value)
-    elif key == "eval_steps":
-      _update_eval_steps(configs, value)
-    elif key == "train_input_path":
-      _update_input_path(configs["train_input_config"], value)
-    elif key == "eval_input_path":
-      _update_input_path(configs["eval_input_config"], value)
-    elif key == "label_map_path":
-      _update_label_map_path(configs, value)
-    elif key == "mask_type":
-      _update_mask_type(configs, value)
-    elif key == "eval_with_moving_averages":
-      _update_use_moving_averages(configs, value)
-    elif key == "train_shuffle":
-      _update_shuffle(configs["train_input_config"], value)
-    elif key == "eval_shuffle":
-      _update_shuffle(configs["eval_input_config"], value)
-    elif key == "retain_original_images_in_eval":
-      _update_retain_original_images(configs["eval_config"], value)
+    elif _maybe_update_config_with_key_value(configs, key, value):
+      continue
     elif _is_generic_key(key):
       _update_generic(configs, key, value)
     else:
       tf.logging.info("Ignoring config override key: %s", key)
   return configs
+
+
+def _maybe_update_config_with_key_value(configs, key, value):
+  """Checks key type and updates `configs` with the key value pair accordingly.
+
+  Args:
+    configs: Dictionary of configuration objects. See outputs from
+      get_configs_from_pipeline_file() or get_configs_from_multiple_files().
+    key: String indicates the field(s) to be updated.
+    value: Value used to override existing field value.
+
+  Returns:
+    A boolean value that indicates whether the override succeeds.
+
+  Raises:
+    ValueError: when the key string doesn't match any of the formats above.
+  """
+  is_valid_input_config_key, key_name, input_name, field_name = (
+      check_and_parse_input_config_key(configs, key))
+  if is_valid_input_config_key:
+    update_input_reader_config(
+        configs,
+        key_name=key_name,
+        input_name=input_name,
+        field_name=field_name,
+        value=value)
+  elif field_name == "learning_rate":
+    _update_initial_learning_rate(configs, value)
+  elif field_name == "batch_size":
+    _update_batch_size(configs, value)
+  elif field_name == "momentum_optimizer_value":
+    _update_momentum_optimizer_value(configs, value)
+  elif field_name == "classification_localization_weight_ratio":
+    # Localization weight is fixed to 1.0.
+    _update_classification_localization_weight_ratio(configs, value)
+  elif field_name == "focal_loss_gamma":
+    _update_focal_loss_gamma(configs, value)
+  elif field_name == "focal_loss_alpha":
+    _update_focal_loss_alpha(configs, value)
+  elif field_name == "train_steps":
+    _update_train_steps(configs, value)
+  elif field_name == "label_map_path":
+    _update_label_map_path(configs, value)
+  elif field_name == "mask_type":
+    _update_mask_type(configs, value)
+  elif field_name == "eval_with_moving_averages":
+    _update_use_moving_averages(configs, value)
+  elif field_name == "retain_original_images_in_eval":
+    _update_retain_original_images(configs["eval_config"], value)
+  else:
+    return False
+  return True
+
+
+def _update_tf_record_input_path(input_config, input_path):
+  """Updates input configuration to reflect a new input path.
+
+  The input_config object is updated in place, and hence not returned.
+
+  Args:
+    input_config: A input_reader_pb2.InputReader.
+    input_path: A path to data or list of paths.
+
+  Raises:
+    TypeError: if input reader type is not `tf_record_input_reader`.
+  """
+  input_reader_type = input_config.WhichOneof("input_reader")
+  if input_reader_type == "tf_record_input_reader":
+    input_config.tf_record_input_reader.ClearField("input_path")
+    if isinstance(input_path, list):
+      input_config.tf_record_input_reader.input_path.extend(input_path)
+    else:
+      input_config.tf_record_input_reader.input_path.append(input_path)
+  else:
+    raise TypeError("Input reader type must be `tf_record_input_reader`.")
+
+
+def update_input_reader_config(configs,
+                               key_name=None,
+                               input_name=None,
+                               field_name=None,
+                               value=None,
+                               path_updater=_update_tf_record_input_path):
+  """Updates specified input reader config field.
+
+  Args:
+    configs: Dictionary of configuration objects. See outputs from
+      get_configs_from_pipeline_file() or get_configs_from_multiple_files().
+    key_name: Name of the input config we should update, either
+      'train_input_config' or 'eval_input_configs'
+    input_name: String name used to identify input config to update with. Should
+      be either None or value of the 'name' field in one of the input reader
+      configs.
+    field_name: Field name in input_reader_pb2.InputReader.
+    value: Value used to override existing field value.
+    path_updater: helper function used to update the input path. Only used when
+      field_name is "input_path".
+
+  Raises:
+    ValueError: when input field_name is None.
+    ValueError: when input_name is None and number of eval_input_readers does
+      not equal to 1.
+  """
+  if isinstance(configs[key_name], input_reader_pb2.InputReader):
+    # Updates singular input_config object.
+    target_input_config = configs[key_name]
+    if field_name == "input_path":
+      path_updater(input_config=target_input_config, input_path=value)
+    else:
+      setattr(target_input_config, field_name, value)
+  elif input_name is None and len(configs[key_name]) == 1:
+    # Updates first (and the only) object of input_config list.
+    target_input_config = configs[key_name][0]
+    if field_name == "input_path":
+      path_updater(input_config=target_input_config, input_path=value)
+    else:
+      setattr(target_input_config, field_name, value)
+  elif input_name is not None and len(configs[key_name]):
+    # Updates input_config whose name matches input_name.
+    update_count = 0
+    for input_config in configs[key_name]:
+      if input_config.name == input_name:
+        setattr(input_config, field_name, value)
+        update_count = update_count + 1
+    if not update_count:
+      raise ValueError(
+          "Input name {} not found when overriding.".format(input_name))
+    elif update_count > 1:
+      raise ValueError("Duplicate input name found when overriding.")
+  else:
+    raise ValueError("Unknown input config overriding.")
 
 
 def _update_initial_learning_rate(configs, learning_rate):
@@ -596,29 +853,6 @@ def _update_eval_steps(configs, eval_steps):
   configs["eval_config"].num_examples = int(eval_steps)
 
 
-def _update_input_path(input_config, input_path):
-  """Updates input configuration to reflect a new input path.
-
-  The input_config object is updated in place, and hence not returned.
-
-  Args:
-    input_config: A input_reader_pb2.InputReader.
-    input_path: A path to data or list of paths.
-
-  Raises:
-    TypeError: if input reader type is not `tf_record_input_reader`.
-  """
-  input_reader_type = input_config.WhichOneof("input_reader")
-  if input_reader_type == "tf_record_input_reader":
-    input_config.tf_record_input_reader.ClearField("input_path")
-    if isinstance(input_path, list):
-      input_config.tf_record_input_reader.input_path.extend(input_path)
-    else:
-      input_config.tf_record_input_reader.input_path.append(input_path)
-  else:
-    raise TypeError("Input reader type must be `tf_record_input_reader`.")
-
-
 def _update_label_map_path(configs, label_map_path):
   """Updates the label map path for both train and eval input readers.
 
@@ -630,7 +864,8 @@ def _update_label_map_path(configs, label_map_path):
     label_map_path: New path to `StringIntLabelMap` pbtxt file.
   """
   configs["train_input_config"].label_map_path = label_map_path
-  configs["eval_input_config"].label_map_path = label_map_path
+  for eval_input_config in configs["eval_input_configs"]:
+    eval_input_config.label_map_path = label_map_path
 
 
 def _update_mask_type(configs, mask_type):
@@ -645,7 +880,8 @@ def _update_mask_type(configs, mask_type):
       input_reader_pb2.InstanceMaskType
   """
   configs["train_input_config"].mask_type = mask_type
-  configs["eval_input_config"].mask_type = mask_type
+  for eval_input_config in configs["eval_input_configs"]:
+    eval_input_config.mask_type = mask_type
 
 
 def _update_use_moving_averages(configs, use_moving_averages):
@@ -660,18 +896,6 @@ def _update_use_moving_averages(configs, use_moving_averages):
       should be loaded during evaluation.
   """
   configs["eval_config"].use_moving_averages = use_moving_averages
-
-
-def _update_shuffle(input_config, shuffle):
-  """Updates input configuration to reflect a new shuffle configuration.
-
-  The input_config object is updated in place, and hence not returned.
-
-  Args:
-    input_config: A input_reader_pb2.InputReader.
-    shuffle: Whether or not to shuffle the input data before reading.
-  """
-  input_config.shuffle = shuffle
 
 
 def _update_retain_original_images(eval_config, retain_original_images):

--- a/research/object_detection/utils/config_util_test.py
+++ b/research/object_detection/utils/config_util_test.py
@@ -83,7 +83,7 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config.train_config.batch_size = 32
     pipeline_config.train_input_reader.label_map_path = "path/to/label_map"
     pipeline_config.eval_config.num_examples = 20
-    pipeline_config.eval_input_reader.queue_capacity = 100
+    pipeline_config.eval_input_reader.add().queue_capacity = 100
 
     _write_config(pipeline_config, pipeline_config_path)
 
@@ -96,7 +96,7 @@ class ConfigUtilTest(tf.test.TestCase):
     self.assertProtoEquals(pipeline_config.eval_config,
                            configs["eval_config"])
     self.assertProtoEquals(pipeline_config.eval_input_reader,
-                           configs["eval_input_config"])
+                           configs["eval_input_configs"])
 
   def test_create_configs_from_pipeline_proto(self):
     """Tests creating configs dictionary from pipeline proto."""
@@ -106,7 +106,7 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config.train_config.batch_size = 32
     pipeline_config.train_input_reader.label_map_path = "path/to/label_map"
     pipeline_config.eval_config.num_examples = 20
-    pipeline_config.eval_input_reader.queue_capacity = 100
+    pipeline_config.eval_input_reader.add().queue_capacity = 100
 
     configs = config_util.create_configs_from_pipeline_proto(pipeline_config)
     self.assertProtoEquals(pipeline_config.model, configs["model"])
@@ -116,7 +116,7 @@ class ConfigUtilTest(tf.test.TestCase):
                            configs["train_input_config"])
     self.assertProtoEquals(pipeline_config.eval_config, configs["eval_config"])
     self.assertProtoEquals(pipeline_config.eval_input_reader,
-                           configs["eval_input_config"])
+                           configs["eval_input_configs"])
 
   def test_create_pipeline_proto_from_configs(self):
     """Tests that proto can be reconstructed from configs dictionary."""
@@ -127,7 +127,7 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config.train_config.batch_size = 32
     pipeline_config.train_input_reader.label_map_path = "path/to/label_map"
     pipeline_config.eval_config.num_examples = 20
-    pipeline_config.eval_input_reader.queue_capacity = 100
+    pipeline_config.eval_input_reader.add().queue_capacity = 100
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
@@ -142,7 +142,7 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config.train_config.batch_size = 32
     pipeline_config.train_input_reader.label_map_path = "path/to/label_map"
     pipeline_config.eval_config.num_examples = 20
-    pipeline_config.eval_input_reader.queue_capacity = 100
+    pipeline_config.eval_input_reader.add().queue_capacity = 100
 
     config_util.save_pipeline_config(pipeline_config, self.get_temp_dir())
     configs = config_util.get_configs_from_pipeline_file(
@@ -197,8 +197,7 @@ class ConfigUtilTest(tf.test.TestCase):
     self.assertProtoEquals(train_input_config,
                            configs["train_input_config"])
     self.assertProtoEquals(eval_config, configs["eval_config"])
-    self.assertProtoEquals(eval_input_config,
-                           configs["eval_input_config"])
+    self.assertProtoEquals(eval_input_config, configs["eval_input_configs"][0])
 
   def _assertOptimizerWithNewLearningRate(self, optimizer_name):
     """Asserts successful updating of all learning rate schemes."""
@@ -281,6 +280,41 @@ class ConfigUtilTest(tf.test.TestCase):
   def testAdamOptimizerWithNewLearningRate(self):
     """Tests new learning rates for Adam Optimizer."""
     self._assertOptimizerWithNewLearningRate("adam_optimizer")
+
+  def testGenericConfigOverride(self):
+    """Tests generic config overrides for all top-level configs."""
+    # Set one parameter for each of the top-level pipeline configs:
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    pipeline_config.model.ssd.num_classes = 1
+    pipeline_config.train_config.batch_size = 1
+    pipeline_config.eval_config.num_visualizations = 1
+    pipeline_config.train_input_reader.label_map_path = "/some/path"
+    pipeline_config.eval_input_reader.add().label_map_path = "/some/path"
+    pipeline_config.graph_rewriter.quantization.weight_bits = 1
+
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    _write_config(pipeline_config, pipeline_config_path)
+
+    # Override each of the parameters:
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    hparams = tf.contrib.training.HParams(
+        **{
+            "model.ssd.num_classes": 2,
+            "train_config.batch_size": 2,
+            "train_input_config.label_map_path": "/some/other/path",
+            "eval_config.num_visualizations": 2,
+            "graph_rewriter_config.quantization.weight_bits": 2
+        })
+    configs = config_util.merge_external_params_with_configs(configs, hparams)
+
+    # Ensure that the parameters have the overridden values:
+    self.assertEqual(2, configs["model"].ssd.num_classes)
+    self.assertEqual(2, configs["train_config"].batch_size)
+    self.assertEqual("/some/other/path",
+                     configs["train_input_config"].label_map_path)
+    self.assertEqual(2, configs["eval_config"].num_visualizations)
+    self.assertEqual(2,
+                     configs["graph_rewriter_config"].quantization.weight_bits)
 
   def testNewBatchSize(self):
     """Tests that batch size is updated appropriately."""
@@ -406,25 +440,19 @@ class ConfigUtilTest(tf.test.TestCase):
   def testMergingKeywordArguments(self):
     """Tests that keyword arguments get merged as do hyperparameters."""
     original_num_train_steps = 100
-    original_num_eval_steps = 5
     desired_num_train_steps = 10
-    desired_num_eval_steps = 1
     pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
 
     pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
     pipeline_config.train_config.num_steps = original_num_train_steps
-    pipeline_config.eval_config.num_examples = original_num_eval_steps
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"train_steps": desired_num_train_steps}
     configs = config_util.merge_external_params_with_configs(
-        configs,
-        train_steps=desired_num_train_steps,
-        eval_steps=desired_num_eval_steps)
+        configs, kwargs_dict=override_dict)
     train_steps = configs["train_config"].num_steps
-    eval_steps = configs["eval_config"].num_examples
     self.assertEqual(desired_num_train_steps, train_steps)
-    self.assertEqual(desired_num_eval_steps, eval_steps)
 
   def testGetNumberOfClasses(self):
     """Tests that number of classes can be retrieved."""
@@ -449,8 +477,9 @@ class ConfigUtilTest(tf.test.TestCase):
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"train_input_path": new_train_path}
     configs = config_util.merge_external_params_with_configs(
-        configs, train_input_path=new_train_path)
+        configs, kwargs_dict=override_dict)
     reader_config = configs["train_input_config"].tf_record_input_reader
     final_path = reader_config.input_path
     self.assertEqual([new_train_path], final_path)
@@ -467,8 +496,9 @@ class ConfigUtilTest(tf.test.TestCase):
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"train_input_path": new_train_path}
     configs = config_util.merge_external_params_with_configs(
-        configs, train_input_path=new_train_path)
+        configs, kwargs_dict=override_dict)
     reader_config = configs["train_input_config"].tf_record_input_reader
     final_path = reader_config.input_path
     self.assertEqual(new_train_path, final_path)
@@ -482,17 +512,18 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
     train_input_reader = pipeline_config.train_input_reader
     train_input_reader.label_map_path = original_label_map_path
-    eval_input_reader = pipeline_config.eval_input_reader
+    eval_input_reader = pipeline_config.eval_input_reader.add()
     eval_input_reader.label_map_path = original_label_map_path
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"label_map_path": new_label_map_path}
     configs = config_util.merge_external_params_with_configs(
-        configs, label_map_path=new_label_map_path)
+        configs, kwargs_dict=override_dict)
     self.assertEqual(new_label_map_path,
                      configs["train_input_config"].label_map_path)
-    self.assertEqual(new_label_map_path,
-                     configs["eval_input_config"].label_map_path)
+    for eval_input_config in configs["eval_input_configs"]:
+      self.assertEqual(new_label_map_path, eval_input_config.label_map_path)
 
   def testDontOverwriteEmptyLabelMapPath(self):
     """Tests that label map path will not by overwritten with empty string."""
@@ -503,17 +534,18 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
     train_input_reader = pipeline_config.train_input_reader
     train_input_reader.label_map_path = original_label_map_path
-    eval_input_reader = pipeline_config.eval_input_reader
+    eval_input_reader = pipeline_config.eval_input_reader.add()
     eval_input_reader.label_map_path = original_label_map_path
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"label_map_path": new_label_map_path}
     configs = config_util.merge_external_params_with_configs(
-        configs, label_map_path=new_label_map_path)
+        configs, kwargs_dict=override_dict)
     self.assertEqual(original_label_map_path,
                      configs["train_input_config"].label_map_path)
     self.assertEqual(original_label_map_path,
-                     configs["eval_input_config"].label_map_path)
+                     configs["eval_input_configs"][0].label_map_path)
 
   def testNewMaskType(self):
     """Tests that mask type can be overwritten in input readers."""
@@ -524,15 +556,16 @@ class ConfigUtilTest(tf.test.TestCase):
     pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
     train_input_reader = pipeline_config.train_input_reader
     train_input_reader.mask_type = original_mask_type
-    eval_input_reader = pipeline_config.eval_input_reader
+    eval_input_reader = pipeline_config.eval_input_reader.add()
     eval_input_reader.mask_type = original_mask_type
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"mask_type": new_mask_type}
     configs = config_util.merge_external_params_with_configs(
-        configs, mask_type=new_mask_type)
+        configs, kwargs_dict=override_dict)
     self.assertEqual(new_mask_type, configs["train_input_config"].mask_type)
-    self.assertEqual(new_mask_type, configs["eval_input_config"].mask_type)
+    self.assertEqual(new_mask_type, configs["eval_input_configs"][0].mask_type)
 
   def testUseMovingAverageForEval(self):
     use_moving_averages_orig = False
@@ -543,8 +576,9 @@ class ConfigUtilTest(tf.test.TestCase):
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"eval_with_moving_averages": True}
     configs = config_util.merge_external_params_with_configs(
-        configs, eval_with_moving_averages=True)
+        configs, kwargs_dict=override_dict)
     self.assertEqual(True, configs["eval_config"].use_moving_averages)
 
   def  testGetImageResizerConfig(self):
@@ -585,14 +619,14 @@ class ConfigUtilTest(tf.test.TestCase):
 
     pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
     pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
-    pipeline_config.eval_input_reader.shuffle = original_shuffle
+    pipeline_config.eval_input_reader.add().shuffle = original_shuffle
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"eval_shuffle": desired_shuffle}
     configs = config_util.merge_external_params_with_configs(
-        configs, eval_shuffle=desired_shuffle)
-    eval_shuffle = configs["eval_input_config"].shuffle
-    self.assertEqual(desired_shuffle, eval_shuffle)
+        configs, kwargs_dict=override_dict)
+    self.assertEqual(desired_shuffle, configs["eval_input_configs"][0].shuffle)
 
   def testTrainShuffle(self):
     """Tests that `train_shuffle` keyword arguments are applied correctly."""
@@ -605,8 +639,9 @@ class ConfigUtilTest(tf.test.TestCase):
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"train_shuffle": desired_shuffle}
     configs = config_util.merge_external_params_with_configs(
-        configs, train_shuffle=desired_shuffle)
+        configs, kwargs_dict=override_dict)
     train_shuffle = configs["train_input_config"].shuffle
     self.assertEqual(desired_shuffle, train_shuffle)
 
@@ -622,10 +657,189 @@ class ConfigUtilTest(tf.test.TestCase):
     _write_config(pipeline_config, pipeline_config_path)
 
     configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {
+        "retain_original_images_in_eval": desired_retain_original_images
+    }
     configs = config_util.merge_external_params_with_configs(
-        configs, retain_original_images_in_eval=desired_retain_original_images)
+        configs, kwargs_dict=override_dict)
     retain_original_images = configs["eval_config"].retain_original_images
     self.assertEqual(desired_retain_original_images, retain_original_images)
+
+  def testOverwriteEvalSampling(self):
+    original_num_eval_examples = 1
+    new_num_eval_examples = 10
+
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    pipeline_config.eval_input_reader.add().sample_1_of_n_examples = (
+        original_num_eval_examples)
+    _write_config(pipeline_config, pipeline_config_path)
+
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"sample_1_of_n_eval_examples": new_num_eval_examples}
+    configs = config_util.merge_external_params_with_configs(
+        configs, kwargs_dict=override_dict)
+    self.assertEqual(new_num_eval_examples,
+                     configs["eval_input_configs"][0].sample_1_of_n_examples)
+
+  def testUpdateMaskTypeForAllInputConfigs(self):
+    original_mask_type = input_reader_pb2.NUMERICAL_MASKS
+    new_mask_type = input_reader_pb2.PNG_MASKS
+
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    train_config = pipeline_config.train_input_reader
+    train_config.mask_type = original_mask_type
+    eval_1 = pipeline_config.eval_input_reader.add()
+    eval_1.mask_type = original_mask_type
+    eval_1.name = "eval_1"
+    eval_2 = pipeline_config.eval_input_reader.add()
+    eval_2.mask_type = original_mask_type
+    eval_2.name = "eval_2"
+    _write_config(pipeline_config, pipeline_config_path)
+
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"mask_type": new_mask_type}
+    configs = config_util.merge_external_params_with_configs(
+        configs, kwargs_dict=override_dict)
+
+    self.assertEqual(configs["train_input_config"].mask_type, new_mask_type)
+    for eval_input_config in configs["eval_input_configs"]:
+      self.assertEqual(eval_input_config.mask_type, new_mask_type)
+
+  def testErrorOverwritingMultipleInputConfig(self):
+    original_shuffle = False
+    new_shuffle = True
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    eval_1 = pipeline_config.eval_input_reader.add()
+    eval_1.shuffle = original_shuffle
+    eval_1.name = "eval_1"
+    eval_2 = pipeline_config.eval_input_reader.add()
+    eval_2.shuffle = original_shuffle
+    eval_2.name = "eval_2"
+    _write_config(pipeline_config, pipeline_config_path)
+
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+    override_dict = {"eval_shuffle": new_shuffle}
+    with self.assertRaises(ValueError):
+      configs = config_util.merge_external_params_with_configs(
+          configs, kwargs_dict=override_dict)
+
+  def testCheckAndParseInputConfigKey(self):
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    pipeline_config.eval_input_reader.add().name = "eval_1"
+    pipeline_config.eval_input_reader.add().name = "eval_2"
+    _write_config(pipeline_config, pipeline_config_path)
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+
+    specific_shuffle_update_key = "eval_input_configs:eval_2:shuffle"
+    is_valid_input_config_key, key_name, input_name, field_name = (
+        config_util.check_and_parse_input_config_key(
+            configs, specific_shuffle_update_key))
+    self.assertTrue(is_valid_input_config_key)
+    self.assertEqual(key_name, "eval_input_configs")
+    self.assertEqual(input_name, "eval_2")
+    self.assertEqual(field_name, "shuffle")
+
+    legacy_shuffle_update_key = "eval_shuffle"
+    is_valid_input_config_key, key_name, input_name, field_name = (
+        config_util.check_and_parse_input_config_key(configs,
+                                                     legacy_shuffle_update_key))
+    self.assertTrue(is_valid_input_config_key)
+    self.assertEqual(key_name, "eval_input_configs")
+    self.assertEqual(input_name, None)
+    self.assertEqual(field_name, "shuffle")
+
+    non_input_config_update_key = "label_map_path"
+    is_valid_input_config_key, key_name, input_name, field_name = (
+        config_util.check_and_parse_input_config_key(
+            configs, non_input_config_update_key))
+    self.assertFalse(is_valid_input_config_key)
+    self.assertEqual(key_name, None)
+    self.assertEqual(input_name, None)
+    self.assertEqual(field_name, "label_map_path")
+
+    with self.assertRaisesRegexp(ValueError,
+                                 "Invalid key format when overriding configs."):
+      config_util.check_and_parse_input_config_key(
+          configs, "train_input_config:shuffle")
+
+    with self.assertRaisesRegexp(
+        ValueError, "Invalid key_name when overriding input config."):
+      config_util.check_and_parse_input_config_key(
+          configs, "invalid_key_name:train_name:shuffle")
+
+    with self.assertRaisesRegexp(
+        ValueError, "Invalid input_name when overriding input config."):
+      config_util.check_and_parse_input_config_key(
+          configs, "eval_input_configs:unknown_eval_name:shuffle")
+
+    with self.assertRaisesRegexp(
+        ValueError, "Invalid field_name when overriding input config."):
+      config_util.check_and_parse_input_config_key(
+          configs, "eval_input_configs:eval_2:unknown_field_name")
+
+  def testUpdateInputReaderConfigSuccess(self):
+    original_shuffle = False
+    new_shuffle = True
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    pipeline_config.train_input_reader.shuffle = original_shuffle
+    _write_config(pipeline_config, pipeline_config_path)
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+
+    config_util.update_input_reader_config(
+        configs,
+        key_name="train_input_config",
+        input_name=None,
+        field_name="shuffle",
+        value=new_shuffle)
+    self.assertEqual(configs["train_input_config"].shuffle, new_shuffle)
+
+    config_util.update_input_reader_config(
+        configs,
+        key_name="train_input_config",
+        input_name=None,
+        field_name="shuffle",
+        value=new_shuffle)
+    self.assertEqual(configs["train_input_config"].shuffle, new_shuffle)
+
+  def testUpdateInputReaderConfigErrors(self):
+    pipeline_config_path = os.path.join(self.get_temp_dir(), "pipeline.config")
+    pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+    pipeline_config.eval_input_reader.add().name = "same_eval_name"
+    pipeline_config.eval_input_reader.add().name = "same_eval_name"
+    _write_config(pipeline_config, pipeline_config_path)
+    configs = config_util.get_configs_from_pipeline_file(pipeline_config_path)
+
+    with self.assertRaisesRegexp(ValueError,
+                                 "Duplicate input name found when overriding."):
+      config_util.update_input_reader_config(
+          configs,
+          key_name="eval_input_configs",
+          input_name="same_eval_name",
+          field_name="shuffle",
+          value=False)
+
+    with self.assertRaisesRegexp(
+        ValueError, "Input name name_not_exist not found when overriding."):
+      config_util.update_input_reader_config(
+          configs,
+          key_name="eval_input_configs",
+          input_name="name_not_exist",
+          field_name="shuffle",
+          value=False)
+
+    with self.assertRaisesRegexp(ValueError,
+                                 "Unknown input config overriding."):
+      config_util.update_input_reader_config(
+          configs,
+          key_name="eval_input_configs",
+          input_name=None,
+          field_name="shuffle",
+          value=False)
 
 
 if __name__ == "__main__":

--- a/research/object_detection/utils/label_map_util.py
+++ b/research/object_detection/utils/label_map_util.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Label map utility functions."""
 
 import logging
@@ -73,10 +72,10 @@ def get_max_label_map_index(label_map):
 def convert_label_map_to_categories(label_map,
                                     max_num_classes,
                                     use_display_name=True):
-  """Loads label map proto and returns categories list compatible with eval.
+  """Given label map proto returns categories list compatible with eval.
 
-  This function loads a label map and returns a list of dicts, each of which
-  has the following keys:
+  This function converts label map proto and returns a list of dicts, each of
+  which  has the following keys:
     'id': (required) an integer id uniquely identifying this category.
     'name': (required) string representing category name
       e.g., 'cat', 'dog', 'pizza'.
@@ -89,9 +88,10 @@ def convert_label_map_to_categories(label_map,
     label_map: a StringIntLabelMapProto or None.  If None, a default categories
       list is created with max_num_classes categories.
     max_num_classes: maximum number of (consecutive) label indices to include.
-    use_display_name: (boolean) choose whether to load 'display_name' field
-      as category name.  If False or if the display_name field does not exist,
-      uses 'name' field as category names instead.
+    use_display_name: (boolean) choose whether to load 'display_name' field as
+      category name.  If False or if the display_name field does not exist, uses
+      'name' field as category names instead.
+
   Returns:
     categories: a list of dictionaries representing all possible categories.
   """
@@ -107,8 +107,9 @@ def convert_label_map_to_categories(label_map,
     return categories
   for item in label_map.item:
     if not 0 < item.id <= max_num_classes:
-      logging.info('Ignore item %d since it falls outside of requested '
-                   'label range.', item.id)
+      logging.info(
+          'Ignore item %d since it falls outside of requested '
+          'label range.', item.id)
       continue
     if use_display_name and item.HasField('display_name'):
       name = item.display_name
@@ -188,20 +189,44 @@ def get_label_map_dict(label_map_path,
   return label_map_dict
 
 
-def create_category_index_from_labelmap(label_map_path):
+def create_categories_from_labelmap(label_map_path, use_display_name=True):
+  """Reads a label map and returns categories list compatible with eval.
+
+  This function converts label map proto and returns a list of dicts, each of
+  which  has the following keys:
+    'id': an integer id uniquely identifying this category.
+    'name': string representing category name e.g., 'cat', 'dog'.
+
+  Args:
+    label_map_path: Path to `StringIntLabelMap` proto text file.
+    use_display_name: (boolean) choose whether to load 'display_name' field
+      as category name.  If False or if the display_name field does not exist,
+      uses 'name' field as category names instead.
+
+  Returns:
+    categories: a list of dictionaries representing all possible categories.
+  """
+  label_map = load_labelmap(label_map_path)
+  max_num_classes = max(item.id for item in label_map.item)
+  return convert_label_map_to_categories(label_map, max_num_classes,
+                                         use_display_name)
+
+
+def create_category_index_from_labelmap(label_map_path, use_display_name=True):
   """Reads a label map and returns a category index.
 
   Args:
     label_map_path: Path to `StringIntLabelMap` proto text file.
+    use_display_name: (boolean) choose whether to load 'display_name' field
+      as category name.  If False or if the display_name field does not exist,
+      uses 'name' field as category names instead.
 
   Returns:
     A category index, which is a dictionary that maps integer ids to dicts
     containing categories, e.g.
     {1: {'id': 1, 'name': 'dog'}, 2: {'id': 2, 'name': 'cat'}, ...}
   """
-  label_map = load_labelmap(label_map_path)
-  max_num_classes = max(item.id for item in label_map.item)
-  categories = convert_label_map_to_categories(label_map, max_num_classes)
+  categories = create_categories_from_labelmap(label_map_path, use_display_name)
   return create_category_index(categories)
 
 

--- a/research/object_detection/utils/label_map_util_test.py
+++ b/research/object_detection/utils/label_map_util_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Tests for object_detection.utils.label_map_util."""
 
 import os
@@ -189,7 +188,7 @@ class LabelMapUtilTest(tf.test.TestCase):
     }]
     self.assertListEqual(expected_categories_list, categories)
 
-  def test_convert_label_map_to_coco_categories(self):
+  def test_convert_label_map_to_categories(self):
     label_map_proto = self._generate_label_map(num_classes=4)
     categories = label_map_util.convert_label_map_to_categories(
         label_map_proto, max_num_classes=3)
@@ -205,7 +204,7 @@ class LabelMapUtilTest(tf.test.TestCase):
     }]
     self.assertListEqual(expected_categories_list, categories)
 
-  def test_convert_label_map_to_coco_categories_with_few_classes(self):
+  def test_convert_label_map_to_categories_with_few_classes(self):
     label_map_proto = self._generate_label_map(num_classes=4)
     cat_no_offset = label_map_util.convert_label_map_to_categories(
         label_map_proto, max_num_classes=2)
@@ -238,6 +237,30 @@ class LabelMapUtilTest(tf.test.TestCase):
         }
     }, category_index)
 
+  def test_create_categories_from_labelmap(self):
+    label_map_string = """
+      item {
+        id:1
+        name:'dog'
+      }
+      item {
+        id:2
+        name:'cat'
+      }
+    """
+    label_map_path = os.path.join(self.get_temp_dir(), 'label_map.pbtxt')
+    with tf.gfile.Open(label_map_path, 'wb') as f:
+      f.write(label_map_string)
+
+    categories = label_map_util.create_categories_from_labelmap(label_map_path)
+    self.assertListEqual([{
+        'name': u'dog',
+        'id': 1
+    }, {
+        'name': u'cat',
+        'id': 2
+    }], categories)
+
   def test_create_category_index_from_labelmap(self):
     label_map_string = """
       item {
@@ -265,6 +288,46 @@ class LabelMapUtilTest(tf.test.TestCase):
             'id': 2
         }
     }, category_index)
+
+  def test_create_category_index_from_labelmap_display(self):
+    label_map_string = """
+      item {
+        id:2
+        name:'cat'
+        display_name:'meow'
+      }
+      item {
+        id:1
+        name:'dog'
+        display_name:'woof'
+      }
+    """
+    label_map_path = os.path.join(self.get_temp_dir(), 'label_map.pbtxt')
+    with tf.gfile.Open(label_map_path, 'wb') as f:
+      f.write(label_map_string)
+
+    self.assertDictEqual({
+        1: {
+            'name': u'dog',
+            'id': 1
+        },
+        2: {
+            'name': u'cat',
+            'id': 2
+        }
+    }, label_map_util.create_category_index_from_labelmap(
+        label_map_path, False))
+
+    self.assertDictEqual({
+        1: {
+            'name': u'woof',
+            'id': 1
+        },
+        2: {
+            'name': u'meow',
+            'id': 2
+        }
+    }, label_map_util.create_category_index_from_labelmap(label_map_path))
 
 
 if __name__ == '__main__':

--- a/research/object_detection/utils/ops.py
+++ b/research/object_detection/utils/ops.py
@@ -697,8 +697,11 @@ def position_sensitive_crop_regions(image,
   image_crops = []
   for (split, box) in zip(image_splits, position_sensitive_boxes):
     if split.shape.is_fully_defined() and box.shape.is_fully_defined():
-      crop = matmul_crop_and_resize(
-          tf.expand_dims(split, 0), box, bin_crop_size)
+      crop = tf.squeeze(
+          matmul_crop_and_resize(
+              tf.expand_dims(split, axis=0), tf.expand_dims(box, axis=0),
+              bin_crop_size),
+          axis=0)
     else:
       crop = tf.image.crop_and_resize(
           tf.expand_dims(split, 0), box,
@@ -785,14 +788,19 @@ def reframe_box_masks_to_image_masks(box_masks, boxes, image_height,
   return tf.squeeze(image_masks, axis=3)
 
 
-def merge_boxes_with_multiple_labels(boxes, classes, num_classes):
+def merge_boxes_with_multiple_labels(boxes,
+                                     classes,
+                                     num_classes,
+                                     quantization_bins=10000):
   """Merges boxes with same coordinates and returns K-hot encoded classes.
 
   Args:
-    boxes: A tf.float32 tensor with shape [N, 4] holding N boxes.
+    boxes: A tf.float32 tensor with shape [N, 4] holding N boxes. Only
+      normalized coordinates are allowed.
     classes: A tf.int32 tensor with shape [N] holding class indices.
       The class index starts at 0.
     num_classes: total number of classes to use for K-hot encoding.
+    quantization_bins: the number of bins used to quantize the box coordinate.
 
   Returns:
     merged_boxes: A tf.float32 tensor with shape [N', 4] holding boxes,
@@ -802,33 +810,47 @@ def merge_boxes_with_multiple_labels(boxes, classes, num_classes):
     merged_box_indices: A tf.int32 tensor with shape [N'] holding original
       indices of the boxes.
   """
-  def merge_numpy_boxes(boxes, classes, num_classes):
-    """Python function to merge numpy boxes."""
-    if boxes.size < 1:
-      return (np.zeros([0, 4], dtype=np.float32),
-              np.zeros([0, num_classes], dtype=np.int32),
-              np.zeros([0], dtype=np.int32))
-    box_to_class_indices = {}
-    for box_index in range(boxes.shape[0]):
-      box = tuple(boxes[box_index, :].tolist())
-      class_index = classes[box_index]
-      if box not in box_to_class_indices:
-        box_to_class_indices[box] = [box_index, np.zeros([num_classes])]
-      box_to_class_indices[box][1][class_index] = 1
-    merged_boxes = np.vstack(box_to_class_indices.keys()).astype(np.float32)
-    class_encodings = [item[1] for item in box_to_class_indices.values()]
-    class_encodings = np.vstack(class_encodings).astype(np.int32)
-    merged_box_indices = [item[0] for item in box_to_class_indices.values()]
-    merged_box_indices = np.array(merged_box_indices).astype(np.int32)
-    return merged_boxes, class_encodings, merged_box_indices
+  boxes_shape = tf.shape(boxes)
+  classes_shape = tf.shape(classes)
+  shape_aligned_assert = shape_utils.assert_shape_equal_along_first_dimension(
+      boxes_shape, classes_shape)
+  box_dimension_assert = tf.assert_equal(boxes_shape[1], 4)
+  box_normalized_assert = shape_utils.assert_box_normalized(boxes)
 
-  merged_boxes, class_encodings, merged_box_indices = tf.py_func(
-      merge_numpy_boxes, [boxes, classes, num_classes],
-      [tf.float32, tf.int32, tf.int32])
-  merged_boxes = tf.reshape(merged_boxes, [-1, 4])
-  class_encodings = tf.reshape(class_encodings, [-1, num_classes])
-  merged_box_indices = tf.reshape(merged_box_indices, [-1])
-  return merged_boxes, class_encodings, merged_box_indices
+  with tf.control_dependencies(
+      [shape_aligned_assert, box_dimension_assert, box_normalized_assert]):
+    quantized_boxes = tf.to_int64(boxes * (quantization_bins - 1))
+    ymin, xmin, ymax, xmax = tf.unstack(quantized_boxes, axis=1)
+    hashcodes = (
+        ymin +
+        xmin * quantization_bins +
+        ymax * quantization_bins * quantization_bins +
+        xmax * quantization_bins * quantization_bins * quantization_bins)
+    unique_hashcodes, unique_indices = tf.unique(hashcodes)
+    num_boxes = tf.shape(boxes)[0]
+    num_unique_boxes = tf.shape(unique_hashcodes)[0]
+    merged_box_indices = tf.unsorted_segment_min(
+        tf.range(num_boxes), unique_indices, num_unique_boxes)
+    merged_boxes = tf.gather(boxes, merged_box_indices)
+
+    def merge_box_mapper(i):
+      box_mask = tf.equal(
+          unique_indices, i * tf.ones(num_boxes, dtype=tf.int32))
+      box_mask = tf.reshape(box_mask, [-1])
+      box_labels = tf.boolean_mask(classes, box_mask)
+      return tf.sparse_to_dense(
+          box_labels, [num_classes], 1, validate_indices=False)
+
+    class_encodings = tf.map_fn(
+        merge_box_mapper,
+        tf.range(num_unique_boxes),
+        back_prop=False,
+        dtype=tf.int32)
+
+    merged_boxes = tf.reshape(merged_boxes, [-1, 4])
+    class_encodings = tf.reshape(class_encodings, [-1, num_classes])
+    merged_box_indices = tf.reshape(merged_box_indices, [-1])
+    return merged_boxes, class_encodings, merged_box_indices
 
 
 def nearest_neighbor_upsampling(input_tensor, scale):
@@ -895,7 +917,8 @@ def matmul_crop_and_resize(image, boxes, crop_size, scope=None):
   Returns a tensor with crops from the input image at positions defined at
   the bounding box locations in boxes. The cropped boxes are all resized
   (with bilinear interpolation) to a fixed size = `[crop_height, crop_width]`.
-  The result is a 4-D tensor `[num_boxes, crop_height, crop_width, depth]`.
+  The result is a 5-D tensor `[batch, num_boxes, crop_height, crop_width,
+  depth]`.
 
   Running time complexity:
     O((# channels) * (# boxes) * (crop_size)^2 * M), where M is the number
@@ -918,10 +941,9 @@ def matmul_crop_and_resize(image, boxes, crop_size, scope=None):
       A 4-D tensor of shape `[batch, image_height, image_width, depth]`.
       Both `image_height` and `image_width` need to be positive.
     boxes: A `Tensor` of type `float32`.
-      A 2-D tensor of shape `[num_boxes, 4]`. The `i`-th row of the tensor
-      specifies the coordinates of a box in the `box_ind[i]` image and is
-      specified in normalized coordinates `[y1, x1, y2, x2]`. A normalized
-      coordinate value of `y` is mapped to the image coordinate at
+      A 3-D tensor of shape `[batch, num_boxes, 4]`. The boxes are specified in
+      normalized coordinates and are of the form `[y1, x1, y2, x2]`. A
+      normalized coordinate value of `y` is mapped to the image coordinate at
       `y * (image_height - 1)`, so as the `[0, 1]` interval of normalized image
       height is mapped to `[0, image_height - 1] in image height coordinates.
       We do allow y1 > y2, in which case the sampled crop is an up-down flipped
@@ -935,14 +957,14 @@ def matmul_crop_and_resize(image, boxes, crop_size, scope=None):
     scope: A name for the operation (optional).
 
   Returns:
-    A 4-D tensor of shape `[num_boxes, crop_height, crop_width, depth]`
+    A 5-D tensor of shape `[batch, num_boxes, crop_height, crop_width, depth]`
 
   Raises:
     ValueError: if image tensor does not have shape
-      `[1, image_height, image_width, depth]` and all dimensions statically
+      `[batch, image_height, image_width, depth]` and all dimensions statically
       defined.
-    ValueError: if boxes tensor does not have shape `[num_boxes, 4]` where
-      num_boxes > 0.
+    ValueError: if boxes tensor does not have shape `[batch, num_boxes, 4]`
+      where num_boxes > 0.
     ValueError: if crop_size is not a list of two positive integers
   """
   img_shape = image.shape.as_list()
@@ -953,13 +975,11 @@ def matmul_crop_and_resize(image, boxes, crop_size, scope=None):
   dimensions = img_shape + crop_size + boxes_shape
   if not all([isinstance(dim, int) for dim in dimensions]):
     raise ValueError('all input shapes must be statically defined')
-  if len(crop_size) != 2:
-    raise ValueError('`crop_size` must be a list of length 2')
-  if len(boxes_shape) != 2 or boxes_shape[1] != 4:
-    raise ValueError('`boxes` should have shape `[num_boxes, 4]`')
-  if len(img_shape) != 4 and img_shape[0] != 1:
+  if len(boxes_shape) != 3 or boxes_shape[2] != 4:
+    raise ValueError('`boxes` should have shape `[batch, num_boxes, 4]`')
+  if len(img_shape) != 4:
     raise ValueError('image should have shape '
-                     '`[1, image_height, image_width, depth]`')
+                     '`[batch, image_height, image_width, depth]`')
   num_crops = boxes_shape[0]
   if not num_crops > 0:
     raise ValueError('number of boxes must be > 0')
@@ -968,43 +988,65 @@ def matmul_crop_and_resize(image, boxes, crop_size, scope=None):
 
   def _lin_space_weights(num, img_size):
     if num > 1:
-      alpha = (img_size - 1) / float(num - 1)
-      indices = np.reshape(np.arange(num), (1, num))
-      start_weights = alpha * (num - 1 - indices)
-      stop_weights = alpha * indices
+      start_weights = tf.linspace(img_size - 1.0, 0.0, num)
+      stop_weights = img_size - 1 - start_weights
     else:
-      start_weights = num * [.5 * (img_size - 1)]
-      stop_weights = num * [.5 * (img_size - 1)]
-    return (tf.constant(start_weights, dtype=tf.float32),
-            tf.constant(stop_weights, dtype=tf.float32))
+      start_weights = tf.constant(num * [.5 * (img_size - 1)], dtype=tf.float32)
+      stop_weights = tf.constant(num * [.5 * (img_size - 1)], dtype=tf.float32)
+    return (start_weights, stop_weights)
 
   with tf.name_scope(scope, 'MatMulCropAndResize'):
     y1_weights, y2_weights = _lin_space_weights(crop_size[0], img_height)
     x1_weights, x2_weights = _lin_space_weights(crop_size[1], img_width)
-    [y1, x1, y2, x2] = tf.split(value=boxes, num_or_size_splits=4, axis=1)
+    [y1, x1, y2, x2] = tf.unstack(boxes, axis=2)
 
     # Pixel centers of input image and grid points along height and width
     image_idx_h = tf.constant(
-        np.reshape(np.arange(img_height), (1, 1, img_height)), dtype=tf.float32)
+        np.reshape(np.arange(img_height), (1, 1, 1, img_height)),
+        dtype=tf.float32)
     image_idx_w = tf.constant(
-        np.reshape(np.arange(img_width), (1, 1, img_width)), dtype=tf.float32)
-    grid_pos_h = tf.expand_dims(y1 * y1_weights + y2 * y2_weights, 2)
-    grid_pos_w = tf.expand_dims(x1 * x1_weights + x2 * x2_weights, 2)
+        np.reshape(np.arange(img_width), (1, 1, 1, img_width)),
+        dtype=tf.float32)
+    grid_pos_h = tf.expand_dims(
+        tf.einsum('ab,c->abc', y1, y1_weights) + tf.einsum(
+            'ab,c->abc', y2, y2_weights),
+        axis=3)
+    grid_pos_w = tf.expand_dims(
+        tf.einsum('ab,c->abc', x1, x1_weights) + tf.einsum(
+            'ab,c->abc', x2, x2_weights),
+        axis=3)
 
     # Create kernel matrices of pairwise kernel evaluations between pixel
     # centers of image and grid points.
     kernel_h = tf.nn.relu(1 - tf.abs(image_idx_h - grid_pos_h))
     kernel_w = tf.nn.relu(1 - tf.abs(image_idx_w - grid_pos_w))
 
-    # TODO(jonathanhuang): investigate whether all channels can be processed
-    # without the explicit unstack --- possibly with a permute and map_fn call.
-    result_channels = []
-    for channel in tf.unstack(image, axis=3):
-      result_channels.append(
-          tf.matmul(
-              tf.matmul(kernel_h, tf.tile(channel, [num_crops, 1, 1])),
-              kernel_w, transpose_b=True))
-    return tf.stack(result_channels, axis=3)
+    # Compute matrix multiplication between the spatial dimensions of the image
+    # and height-wise kernel using einsum.
+    intermediate_image = tf.einsum('abci,aiop->abcop', kernel_h, image)
+    # Compute matrix multiplication between the spatial dimensions of the
+    # intermediate_image and width-wise kernel using einsum.
+    return tf.einsum('abno,abcop->abcnp', kernel_w, intermediate_image)
+
+
+def native_crop_and_resize(image, boxes, crop_size, scope=None):
+  """Same as `matmul_crop_and_resize` but uses tf.image.crop_and_resize."""
+  def get_box_inds(proposals):
+    proposals_shape = proposals.get_shape().as_list()
+    if any(dim is None for dim in proposals_shape):
+      proposals_shape = tf.shape(proposals)
+    ones_mat = tf.ones(proposals_shape[:2], dtype=tf.int32)
+    multiplier = tf.expand_dims(
+        tf.range(start=0, limit=proposals_shape[0]), 1)
+    return tf.reshape(ones_mat * multiplier, [-1])
+
+  with tf.name_scope(scope, 'CropAndResize'):
+    cropped_regions = tf.image.crop_and_resize(
+        image, tf.reshape(boxes, [-1] + boxes.shape.as_list()[2:]),
+        get_box_inds(boxes), crop_size)
+    final_shape = tf.concat([tf.shape(boxes)[:2],
+                             tf.shape(cropped_regions)[1:]], axis=0)
+    return tf.reshape(cropped_regions, final_shape)
 
 
 def expected_classification_loss_under_sampling(batch_cls_targets, cls_losses,

--- a/research/object_detection/utils/ops.py
+++ b/research/object_detection/utils/ops.py
@@ -160,6 +160,9 @@ def pad_to_multiple(tensor, multiple):
   Returns:
     padded_tensor: the tensor zero padded to the specified multiple.
   """
+  if multiple == 1:
+    return tensor
+
   tensor_shape = tensor.get_shape()
   batch_size = static_shape.get_batch_size(tensor_shape)
   tensor_height = static_shape.get_height(tensor_shape)

--- a/research/object_detection/utils/ops_test.py
+++ b/research/object_detection/utils/ops_test.py
@@ -1147,23 +1147,26 @@ class MergeBoxesWithMultipleLabelsTest(tf.test.TestCase):
          [0.25, 0.25, 0.75, 0.75]],
         dtype=tf.float32)
     class_indices = tf.constant([0, 4, 2], dtype=tf.int32)
+    class_confidences = tf.constant([0.8, 0.2, 0.1], dtype=tf.float32)
     num_classes = 5
-    merged_boxes, merged_classes, merged_box_indices = (
-        ops.merge_boxes_with_multiple_labels(boxes, class_indices, num_classes))
+    merged_boxes, merged_classes, merged_confidences, merged_box_indices = (
+        ops.merge_boxes_with_multiple_labels(
+            boxes, class_indices, class_confidences, num_classes))
     expected_merged_boxes = np.array(
         [[0.25, 0.25, 0.75, 0.75], [0.0, 0.0, 0.5, 0.75]], dtype=np.float32)
     expected_merged_classes = np.array(
         [[1, 0, 1, 0, 0], [0, 0, 0, 0, 1]], dtype=np.int32)
+    expected_merged_confidences = np.array(
+        [[0.8, 0, 0.1, 0, 0], [0, 0, 0, 0, 0.2]], dtype=np.float32)
     expected_merged_box_indices = np.array([0, 1], dtype=np.int32)
     with self.test_session() as sess:
-      np_merged_boxes, np_merged_classes, np_merged_box_indices = sess.run(
-          [merged_boxes, merged_classes, merged_box_indices])
-      if np_merged_classes[0, 0] != 1:
-        expected_merged_boxes = expected_merged_boxes[::-1, :]
-        expected_merged_classes = expected_merged_classes[::-1, :]
-        expected_merged_box_indices = expected_merged_box_indices[::-1, :]
+      (np_merged_boxes, np_merged_classes, np_merged_confidences,
+       np_merged_box_indices) = sess.run(
+           [merged_boxes, merged_classes, merged_confidences,
+            merged_box_indices])
       self.assertAllClose(np_merged_boxes, expected_merged_boxes)
       self.assertAllClose(np_merged_classes, expected_merged_classes)
+      self.assertAllClose(np_merged_confidences, expected_merged_confidences)
       self.assertAllClose(np_merged_box_indices, expected_merged_box_indices)
 
   def testMergeBoxesWithMultipleLabelsCornerCase(self):
@@ -1172,34 +1175,48 @@ class MergeBoxesWithMultipleLabelsTest(tf.test.TestCase):
          [1, 1, 1, 1], [1, 0, 1, 1], [0, 1, 1, 1], [0, 0, 1, 1]],
         dtype=tf.float32)
     class_indices = tf.constant([0, 1, 2, 3, 2, 1, 0, 3], dtype=tf.int32)
+    class_confidences = tf.constant([0.1, 0.9, 0.2, 0.8, 0.3, 0.7, 0.4, 0.6],
+                                    dtype=tf.float32)
     num_classes = 4
-    merged_boxes, merged_classes, merged_box_indices = (
-        ops.merge_boxes_with_multiple_labels(boxes, class_indices, num_classes))
+    merged_boxes, merged_classes, merged_confidences, merged_box_indices = (
+        ops.merge_boxes_with_multiple_labels(
+            boxes, class_indices, class_confidences, num_classes))
     expected_merged_boxes = np.array(
         [[0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1]],
         dtype=np.float32)
     expected_merged_classes = np.array(
         [[1, 0, 0, 1], [1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]],
         dtype=np.int32)
+    expected_merged_confidences = np.array(
+        [[0.1, 0, 0, 0.6], [0.4, 0.9, 0, 0],
+         [0, 0.7, 0.2, 0], [0, 0, 0.3, 0.8]], dtype=np.float32)
     expected_merged_box_indices = np.array([0, 1, 2, 3], dtype=np.int32)
     with self.test_session() as sess:
-      np_merged_boxes, np_merged_classes, np_merged_box_indices = sess.run(
-          [merged_boxes, merged_classes, merged_box_indices])
+      (np_merged_boxes, np_merged_classes, np_merged_confidences,
+       np_merged_box_indices) = sess.run(
+           [merged_boxes, merged_classes, merged_confidences,
+            merged_box_indices])
       self.assertAllClose(np_merged_boxes, expected_merged_boxes)
       self.assertAllClose(np_merged_classes, expected_merged_classes)
+      self.assertAllClose(np_merged_confidences, expected_merged_confidences)
       self.assertAllClose(np_merged_box_indices, expected_merged_box_indices)
 
   def testMergeBoxesWithEmptyInputs(self):
     boxes = tf.zeros([0, 4], dtype=tf.float32)
     class_indices = tf.constant([], dtype=tf.int32)
+    class_confidences = tf.constant([], dtype=tf.float32)
     num_classes = 5
-    merged_boxes, merged_classes, merged_box_indices = (
-        ops.merge_boxes_with_multiple_labels(boxes, class_indices, num_classes))
+    merged_boxes, merged_classes, merged_confidences, merged_box_indices = (
+        ops.merge_boxes_with_multiple_labels(
+            boxes, class_indices, class_confidences, num_classes))
     with self.test_session() as sess:
-      np_merged_boxes, np_merged_classes, np_merged_box_indices = sess.run(
-          [merged_boxes, merged_classes, merged_box_indices])
+      (np_merged_boxes, np_merged_classes, np_merged_confidences,
+       np_merged_box_indices) = sess.run(
+           [merged_boxes, merged_classes, merged_confidences,
+            merged_box_indices])
       self.assertAllEqual(np_merged_boxes.shape, [0, 4])
       self.assertAllEqual(np_merged_classes.shape, [0, 5])
+      self.assertAllEqual(np_merged_confidences.shape, [0, 5])
       self.assertAllEqual(np_merged_box_indices.shape, [0])
 
 

--- a/research/object_detection/utils/ops_test.py
+++ b/research/object_detection/utils/ops_test.py
@@ -1166,9 +1166,32 @@ class MergeBoxesWithMultipleLabelsTest(tf.test.TestCase):
       self.assertAllClose(np_merged_classes, expected_merged_classes)
       self.assertAllClose(np_merged_box_indices, expected_merged_box_indices)
 
+  def testMergeBoxesWithMultipleLabelsCornerCase(self):
+    boxes = tf.constant(
+        [[0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1],
+         [1, 1, 1, 1], [1, 0, 1, 1], [0, 1, 1, 1], [0, 0, 1, 1]],
+        dtype=tf.float32)
+    class_indices = tf.constant([0, 1, 2, 3, 2, 1, 0, 3], dtype=tf.int32)
+    num_classes = 4
+    merged_boxes, merged_classes, merged_box_indices = (
+        ops.merge_boxes_with_multiple_labels(boxes, class_indices, num_classes))
+    expected_merged_boxes = np.array(
+        [[0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1]],
+        dtype=np.float32)
+    expected_merged_classes = np.array(
+        [[1, 0, 0, 1], [1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]],
+        dtype=np.int32)
+    expected_merged_box_indices = np.array([0, 1, 2, 3], dtype=np.int32)
+    with self.test_session() as sess:
+      np_merged_boxes, np_merged_classes, np_merged_box_indices = sess.run(
+          [merged_boxes, merged_classes, merged_box_indices])
+      self.assertAllClose(np_merged_boxes, expected_merged_boxes)
+      self.assertAllClose(np_merged_classes, expected_merged_classes)
+      self.assertAllClose(np_merged_box_indices, expected_merged_box_indices)
+
   def testMergeBoxesWithEmptyInputs(self):
-    boxes = tf.constant([[]])
-    class_indices = tf.constant([])
+    boxes = tf.zeros([0, 4], dtype=tf.float32)
+    class_indices = tf.constant([], dtype=tf.int32)
     num_classes = 5
     merged_boxes, merged_classes, merged_box_indices = (
         ops.merge_boxes_with_multiple_labels(boxes, class_indices, num_classes))
@@ -1268,8 +1291,8 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
       return ops.matmul_crop_and_resize(image, boxes, crop_size=[1, 1])
 
     image = np.array([[[[1], [2]], [[3], [4]]]], dtype=np.float32)
-    boxes = np.array([[0, 0, 1, 1]], dtype=np.float32)
-    expected_output = [[[[2.5]]]]
+    boxes = np.array([[[0, 0, 1, 1]]], dtype=np.float32)
+    expected_output = [[[[[2.5]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1279,8 +1302,8 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
       return ops.matmul_crop_and_resize(image, boxes, crop_size=[1, 1])
 
     image = np.array([[[[1], [2]], [[3], [4]]]], dtype=np.float32)
-    boxes = np.array([[1, 1, 0, 0]], dtype=np.float32)
-    expected_output = [[[[2.5]]]]
+    boxes = np.array([[[1, 1, 0, 0]]], dtype=np.float32)
+    expected_output = [[[[[2.5]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1290,10 +1313,10 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
       return ops.matmul_crop_and_resize(image, boxes, crop_size=[3, 3])
 
     image = np.array([[[[1], [2]], [[3], [4]]]], dtype=np.float32)
-    boxes = np.array([[0, 0, 1, 1]], dtype=np.float32)
-    expected_output = [[[[1.0], [1.5], [2.0]],
-                        [[2.0], [2.5], [3.0]],
-                        [[3.0], [3.5], [4.0]]]]
+    boxes = np.array([[[0, 0, 1, 1]]], dtype=np.float32)
+    expected_output = [[[[[1.0], [1.5], [2.0]],
+                         [[2.0], [2.5], [3.0]],
+                         [[3.0], [3.5], [4.0]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1303,10 +1326,10 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
       return ops.matmul_crop_and_resize(image, boxes, crop_size=[3, 3])
 
     image = np.array([[[[1], [2]], [[3], [4]]]], dtype=np.float32)
-    boxes = np.array([[1, 1, 0, 0]], dtype=np.float32)
-    expected_output = [[[[4.0], [3.5], [3.0]],
-                        [[3.0], [2.5], [2.0]],
-                        [[2.0], [1.5], [1.0]]]]
+    boxes = np.array([[[1, 1, 0, 0]]], dtype=np.float32)
+    expected_output = [[[[[4.0], [3.5], [3.0]],
+                         [[3.0], [2.5], [2.0]],
+                         [[2.0], [1.5], [1.0]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1318,14 +1341,14 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
     image = np.array([[[[1], [2], [3]],
                        [[4], [5], [6]],
                        [[7], [8], [9]]]], dtype=np.float32)
-    boxes = np.array([[0, 0, 1, 1],
-                      [0, 0, .5, .5]], dtype=np.float32)
-    expected_output = [[[[1], [3]], [[7], [9]]],
-                       [[[1], [2]], [[4], [5]]]]
+    boxes = np.array([[[0, 0, 1, 1],
+                       [0, 0, .5, .5]]], dtype=np.float32)
+    expected_output = [[[[[1], [3]], [[7], [9]]],
+                        [[[1], [2]], [[4], [5]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
-  def testMatMulCropAndResize3x3To2x2MultiChannel(self):
+  def testMatMulCropAndResize3x3To2x2_2Channels(self):
 
     def graph_fn(image, boxes):
       return ops.matmul_crop_and_resize(image, boxes, crop_size=[2, 2])
@@ -1333,10 +1356,32 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
     image = np.array([[[[1, 0], [2, 1], [3, 2]],
                        [[4, 3], [5, 4], [6, 5]],
                        [[7, 6], [8, 7], [9, 8]]]], dtype=np.float32)
-    boxes = np.array([[0, 0, 1, 1],
-                      [0, 0, .5, .5]], dtype=np.float32)
-    expected_output = [[[[1, 0], [3, 2]], [[7, 6], [9, 8]]],
-                       [[[1, 0], [2, 1]], [[4, 3], [5, 4]]]]
+    boxes = np.array([[[0, 0, 1, 1],
+                       [0, 0, .5, .5]]], dtype=np.float32)
+    expected_output = [[[[[1, 0], [3, 2]], [[7, 6], [9, 8]]],
+                        [[[1, 0], [2, 1]], [[4, 3], [5, 4]]]]]
+    crop_output = self.execute(graph_fn, [image, boxes])
+    self.assertAllClose(crop_output, expected_output)
+
+  def testBatchMatMulCropAndResize3x3To2x2_2Channels(self):
+
+    def graph_fn(image, boxes):
+      return ops.matmul_crop_and_resize(image, boxes, crop_size=[2, 2])
+
+    image = np.array([[[[1, 0], [2, 1], [3, 2]],
+                       [[4, 3], [5, 4], [6, 5]],
+                       [[7, 6], [8, 7], [9, 8]]],
+                      [[[1, 0], [2, 1], [3, 2]],
+                       [[4, 3], [5, 4], [6, 5]],
+                       [[7, 6], [8, 7], [9, 8]]]], dtype=np.float32)
+    boxes = np.array([[[0, 0, 1, 1],
+                       [0, 0, .5, .5]],
+                      [[1, 1, 0, 0],
+                       [.5, .5, 0, 0]]], dtype=np.float32)
+    expected_output = [[[[[1, 0], [3, 2]], [[7, 6], [9, 8]]],
+                        [[[1, 0], [2, 1]], [[4, 3], [5, 4]]]],
+                       [[[[9, 8], [7, 6]], [[3, 2], [1, 0]]],
+                        [[[5, 4], [4, 3]], [[2, 1], [1, 0]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1348,10 +1393,10 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
     image = np.array([[[[1], [2], [3]],
                        [[4], [5], [6]],
                        [[7], [8], [9]]]], dtype=np.float32)
-    boxes = np.array([[1, 1, 0, 0],
-                      [.5, .5, 0, 0]], dtype=np.float32)
-    expected_output = [[[[9], [7]], [[3], [1]]],
-                       [[[5], [4]], [[2], [1]]]]
+    boxes = np.array([[[1, 1, 0, 0],
+                       [.5, .5, 0, 0]]], dtype=np.float32)
+    expected_output = [[[[[9], [7]], [[3], [1]]],
+                        [[[5], [4]], [[2], [1]]]]]
     crop_output = self.execute(graph_fn, [image, boxes])
     self.assertAllClose(crop_output, expected_output)
 
@@ -1361,6 +1406,31 @@ class OpsTestMatMulCropAndResize(test_case.TestCase):
     crop_size = [4, 4]
     with self.assertRaises(ValueError):
       _ = ops.matmul_crop_and_resize(image, boxes, crop_size)
+
+
+class OpsTestCropAndResize(test_case.TestCase):
+
+  def testBatchCropAndResize3x3To2x2_2Channels(self):
+
+    def graph_fn(image, boxes):
+      return ops.native_crop_and_resize(image, boxes, crop_size=[2, 2])
+
+    image = np.array([[[[1, 0], [2, 1], [3, 2]],
+                       [[4, 3], [5, 4], [6, 5]],
+                       [[7, 6], [8, 7], [9, 8]]],
+                      [[[1, 0], [2, 1], [3, 2]],
+                       [[4, 3], [5, 4], [6, 5]],
+                       [[7, 6], [8, 7], [9, 8]]]], dtype=np.float32)
+    boxes = np.array([[[0, 0, 1, 1],
+                       [0, 0, .5, .5]],
+                      [[1, 1, 0, 0],
+                       [.5, .5, 0, 0]]], dtype=np.float32)
+    expected_output = [[[[[1, 0], [3, 2]], [[7, 6], [9, 8]]],
+                        [[[1, 0], [2, 1]], [[4, 3], [5, 4]]]],
+                       [[[[9, 8], [7, 6]], [[3, 2], [1, 0]]],
+                        [[[5, 4], [4, 3]], [[2, 1], [1, 0]]]]]
+    crop_output = self.execute_cpu(graph_fn, [image, boxes])
+    self.assertAllClose(crop_output, expected_output)
 
 
 class OpsTestExpectedClassificationLoss(test_case.TestCase):

--- a/research/object_detection/utils/shape_utils.py
+++ b/research/object_detection/utils/shape_utils.py
@@ -342,3 +342,26 @@ def assert_shape_equal_along_first_dimension(shape_a, shape_b):
     else: return tf.no_op()
   else:
     return tf.assert_equal(shape_a[0], shape_b[0])
+
+
+def assert_box_normalized(boxes, maximum_normalized_coordinate=1.1):
+  """Asserts the input box tensor is normalized.
+
+  Args:
+    boxes: a tensor of shape [N, 4] where N is the number of boxes.
+    maximum_normalized_coordinate: Maximum coordinate value to be considered
+      as normalized, default to 1.1.
+
+  Returns:
+    a tf.Assert op which fails when the input box tensor is not normalized.
+
+  Raises:
+    ValueError: When the input box tensor is not normalized.
+  """
+  box_minimum = tf.reduce_min(boxes)
+  box_maximum = tf.reduce_max(boxes)
+  return tf.Assert(
+      tf.logical_and(
+          tf.less_equal(box_maximum, maximum_normalized_coordinate),
+          tf.greater_equal(box_minimum, 0)),
+      [boxes])

--- a/research/object_detection/utils/test_case.py
+++ b/research/object_detection/utils/test_case.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """A convenience wrapper around tf.test.TestCase to enable TPU tests."""
 
+import os
 import tensorflow as tf
 from tensorflow.contrib import tpu
 
@@ -21,6 +22,8 @@ flags = tf.app.flags
 
 flags.DEFINE_bool('tpu_test', False, 'Whether to configure test for TPU.')
 FLAGS = flags.FLAGS
+
+
 
 
 class TestCase(tf.test.TestCase):

--- a/research/object_detection/utils/test_case.py
+++ b/research/object_detection/utils/test_case.py
@@ -24,6 +24,34 @@ flags.DEFINE_bool('tpu_test', False, 'Whether to configure test for TPU.')
 FLAGS = flags.FLAGS
 
 
+# BEGIN GOOGLE-INTERNAL
+def hlo_memory_profile(function):
+  """Decorator to set environment variables that produce XLA HLO memory profile.
+
+  Args:
+    function: A function to run with XLA HLO profiling on.
+
+  Returns:
+    A decorated function that dumps the XLA HLO memory profile in test output
+    directory.
+
+  Usage:
+    @test_case.hlo_memory_profile
+    def test_run_my_tf_tpu_op(self):
+      ...
+
+    After running the test, access the memory profile proto from output files
+    and generate visualization using XLA memory visualizer.
+  """
+  def wrapper_func(*args, **kwargs):
+    outputs_dir = os.environ['TEST_UNDECLARED_OUTPUTS_DIR']
+    path_to_function = os.path.join(outputs_dir, 'hlo_memory_profile',
+                                    function.__name__)
+    os.environ['TF_XLA_FLAGS'] = (
+        '--xla_dump_optimized_hlo_proto_to=' + path_to_function)
+    return function(*args, **kwargs)
+  return wrapper_func
+# END GOOGLE-INTERNAL
 
 
 class TestCase(tf.test.TestCase):

--- a/research/object_detection/utils/test_utils.py
+++ b/research/object_detection/utils/test_utils.py
@@ -24,6 +24,9 @@ from object_detection.core import box_predictor
 from object_detection.core import matcher
 from object_detection.utils import shape_utils
 
+# Default size (both width and height) used for testing mask predictions.
+DEFAULT_MASK_SIZE = 5
+
 
 class MockBoxCoder(box_coder.BoxCoder):
   """Simple `difference` BoxCoder."""
@@ -42,8 +45,9 @@ class MockBoxCoder(box_coder.BoxCoder):
 class MockBoxPredictor(box_predictor.BoxPredictor):
   """Simple box predictor that ignores inputs and outputs all zeros."""
 
-  def __init__(self, is_training, num_classes):
+  def __init__(self, is_training, num_classes, predict_mask=False):
     super(MockBoxPredictor, self).__init__(is_training, num_classes)
+    self._predict_mask = predict_mask
 
   def _predict(self, image_features, num_predictions_per_location):
     image_feature = image_features[0]
@@ -57,17 +61,29 @@ class MockBoxPredictor(box_predictor.BoxPredictor):
         (batch_size, num_anchors, 1, code_size), dtype=tf.float32)
     class_predictions_with_background = zero + tf.zeros(
         (batch_size, num_anchors, self.num_classes + 1), dtype=tf.float32)
-    return {box_predictor.BOX_ENCODINGS: box_encodings,
-            box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND:
-            class_predictions_with_background}
+    masks = zero + tf.zeros(
+        (batch_size, num_anchors, self.num_classes, DEFAULT_MASK_SIZE,
+         DEFAULT_MASK_SIZE),
+        dtype=tf.float32)
+    predictions_dict = {
+        box_predictor.BOX_ENCODINGS:
+            box_encodings,
+        box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND:
+            class_predictions_with_background
+    }
+    if self._predict_mask:
+      predictions_dict[box_predictor.MASK_PREDICTIONS] = masks
+
+    return predictions_dict
 
 
 class MockKerasBoxPredictor(box_predictor.KerasBoxPredictor):
   """Simple box predictor that ignores inputs and outputs all zeros."""
 
-  def __init__(self, is_training, num_classes):
+  def __init__(self, is_training, num_classes, predict_mask=False):
     super(MockKerasBoxPredictor, self).__init__(
         is_training, num_classes, False, False)
+    self._predict_mask = predict_mask
 
   def _predict(self, image_features, **kwargs):
     image_feature = image_features[0]
@@ -81,9 +97,19 @@ class MockKerasBoxPredictor(box_predictor.KerasBoxPredictor):
         (batch_size, num_anchors, 1, code_size), dtype=tf.float32)
     class_predictions_with_background = zero + tf.zeros(
         (batch_size, num_anchors, self.num_classes + 1), dtype=tf.float32)
-    return {box_predictor.BOX_ENCODINGS: box_encodings,
-            box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND:
-                class_predictions_with_background}
+    masks = zero + tf.zeros(
+        (batch_size, num_anchors, self.num_classes, DEFAULT_MASK_SIZE,
+         DEFAULT_MASK_SIZE),
+        dtype=tf.float32)
+    predictions_dict = {
+        box_predictor.BOX_ENCODINGS:
+            box_encodings,
+        box_predictor.CLASS_PREDICTIONS_WITH_BACKGROUND:
+            class_predictions_with_background
+    }
+    if self._predict_mask:
+      predictions_dict[box_predictor.MASK_PREDICTIONS] = masks
+    return predictions_dict
 
 
 class MockAnchorGenerator(anchor_generator.AnchorGenerator):

--- a/research/object_detection/utils/test_utils.py
+++ b/research/object_detection/utils/test_utils.py
@@ -129,7 +129,7 @@ class MockAnchorGenerator(anchor_generator.AnchorGenerator):
 class MockMatcher(matcher.Matcher):
   """Simple matcher that matches first anchor to first groundtruth box."""
 
-  def _match(self, similarity_matrix):
+  def _match(self, similarity_matrix, valid_rows):
     return tf.constant([0, -1, -1, -1], dtype=tf.int32)
 
 

--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -19,6 +19,8 @@ These functions often receive an image, perform some visualization on the image.
 The functions do not return a value, instead they modify the image itself.
 
 """
+from abc import ABCMeta
+from abc import abstractmethod
 import collections
 import functools
 # Set headless-friendly backend.
@@ -731,3 +733,158 @@ def add_hist_image_summary(values, bins, name):
     return image
   hist_plot = tf.py_func(hist_plot, [values, bins], tf.uint8)
   tf.summary.image(name, hist_plot)
+
+
+class EvalMetricOpsVisualization(object):
+  """Abstract base class responsible for visualizations during evaluation.
+
+  Currently, summary images are not run during evaluation. One way to produce
+  evaluation images in Tensorboard is to provide tf.summary.image strings as
+  `value_ops` in tf.estimator.EstimatorSpec's `eval_metric_ops`. This class is
+  responsible for accruing images (with overlaid detections and groundtruth)
+  and returning a dictionary that can be passed to `eval_metric_ops`.
+  """
+  __metaclass__ = ABCMeta
+
+  def __init__(self,
+               category_index,
+               max_examples_to_draw=5,
+               max_boxes_to_draw=20,
+               min_score_thresh=0.2,
+               use_normalized_coordinates=True,
+               summary_name_prefix='evaluation_image'):
+    """Creates an EvalMetricOpsVisualization.
+
+    Args:
+      category_index: A category index (dictionary) produced from a labelmap.
+      max_examples_to_draw: The maximum number of example summaries to produce.
+      max_boxes_to_draw: The maximum number of boxes to draw for detections.
+      min_score_thresh: The minimum score threshold for showing detections.
+      use_normalized_coordinates: Whether to assume boxes and kepoints are in
+        normalized coordinates (as opposed to absolute coordiantes).
+        Default is True.
+      summary_name_prefix: A string prefix for each image summary.
+    """
+
+    self._category_index = category_index
+    self._max_examples_to_draw = max_examples_to_draw
+    self._max_boxes_to_draw = max_boxes_to_draw
+    self._min_score_thresh = min_score_thresh
+    self._use_normalized_coordinates = use_normalized_coordinates
+    self._summary_name_prefix = summary_name_prefix
+    self._images = []
+
+  def clear(self):
+    self._images = []
+
+  def add_images(self, images):
+    """Store a list of images, each with shape [1, H, W, C]."""
+    if len(self._images) >= self._max_examples_to_draw:
+      return
+
+    # Store images and clip list if necessary.
+    self._images.extend(images)
+    if len(self._images) > self._max_examples_to_draw:
+      self._images[self._max_examples_to_draw:] = []
+
+  def get_estimator_eval_metric_ops(self, eval_dict):
+    """Returns metric ops for use in tf.estimator.EstimatorSpec.
+
+    Args:
+      eval_dict: A dictionary that holds an image, groundtruth, and detections
+        for a single example. See eval_util.result_dict_for_single_example() for
+        a convenient method for constructing such a dictionary. The dictionary
+        contains
+        fields.InputDataFields.original_image: [1, H, W, 3] image.
+        fields.InputDataFields.groundtruth_boxes - [num_boxes, 4] float32
+          tensor with groundtruth boxes in range [0.0, 1.0].
+        fields.InputDataFields.groundtruth_classes - [num_boxes] int64
+          tensor with 1-indexed groundtruth classes.
+        fields.InputDataFields.groundtruth_instance_masks - (optional)
+          [num_boxes, H, W] int64 tensor with instance masks.
+        fields.DetectionResultFields.detection_boxes - [max_num_boxes, 4]
+          float32 tensor with detection boxes in range [0.0, 1.0].
+        fields.DetectionResultFields.detection_classes - [max_num_boxes]
+          int64 tensor with 1-indexed detection classes.
+        fields.DetectionResultFields.detection_scores - [max_num_boxes]
+          float32 tensor with detection scores.
+        fields.DetectionResultFields.detection_masks - (optional)
+          [max_num_boxes, H, W] float32 tensor of binarized masks.
+        fields.DetectionResultFields.detection_keypoints - (optional)
+          [max_num_boxes, num_keypoints, 2] float32 tensor with keypooints.
+
+    Returns:
+      A dictionary of image summary names to tuple of (value_op, update_op). The
+      `update_op` is the same for all items in the dictionary, and is
+      responsible for saving a single side-by-side image with detections and
+      groundtruth. Each `value_op` holds the tf.summary.image string for a given
+      image.
+    """
+    images = self.images_from_evaluation_dict(eval_dict)
+
+    def get_images():
+      """Returns a list of images, padded to self._max_images_to_draw."""
+      images = self._images
+      while len(images) < self._max_examples_to_draw:
+        images.append(np.array(0, dtype=np.uint8))
+      self.clear()
+      return images
+
+    def image_summary_or_default_string(summary_name, image):
+      """Returns image summaries for non-padded elements."""
+      return tf.cond(
+          tf.equal(tf.size(tf.shape(image)), 4),
+          lambda: tf.summary.image(summary_name, image),
+          lambda: tf.constant(''))
+
+    update_op = tf.py_func(self.add_images, [images], [])
+    image_tensors = tf.py_func(
+        get_images, [], [tf.uint8] * self._max_examples_to_draw)
+    eval_metric_ops = {}
+    for i, image in enumerate(image_tensors):
+      summary_name = self._summary_name_prefix + '/' + str(i)
+      value_op = image_summary_or_default_string(summary_name, image)
+      eval_metric_ops[summary_name] = (value_op, update_op)
+    return eval_metric_ops
+
+  @abstractmethod
+  def images_from_evaluation_dict(self, eval_dict):
+    """Converts evaluation dictionary into a list of image tensors.
+
+    To be overridden by implementations.
+
+    Args:
+      eval_dict: A dictionary with all the necessary information for producing
+        visualizations.
+
+    Returns:
+      A list of [1, H, W, C] uint8 tensors.
+    """
+    raise NotImplementedError
+
+
+class VisualizeSingleFrameDetections(EvalMetricOpsVisualization):
+  """Class responsible for single-frame object detection visualizations."""
+
+  def __init__(self,
+               category_index,
+               max_examples_to_draw=5,
+               max_boxes_to_draw=20,
+               min_score_thresh=0.2,
+               use_normalized_coordinates=True,
+               summary_name_prefix='Detections_Left_Groundtruth_Right'):
+    super(VisualizeSingleFrameDetections, self).__init__(
+        category_index=category_index,
+        max_examples_to_draw=max_examples_to_draw,
+        max_boxes_to_draw=max_boxes_to_draw,
+        min_score_thresh=min_score_thresh,
+        use_normalized_coordinates=use_normalized_coordinates,
+        summary_name_prefix=summary_name_prefix)
+
+  def images_from_evaluation_dict(self, eval_dict):
+    return [draw_side_by_side_evaluation_image(
+        eval_dict,
+        self._category_index,
+        self._max_boxes_to_draw,
+        self._min_score_thresh,
+        self._use_normalized_coordinates)]


### PR DESCRIPTION
212389173  by Zhichao Lu:

    1. Replace tf.boolean_mask with tf.where

--
212282646  by Zhichao Lu:

    1. Fix a typo in model_builder.py and add a test to cover it.

--
212142989  by Zhichao Lu:

    Only resize masks in meta architecture if it has not already been resized in the input pipeline.

--
212136935  by Zhichao Lu:

    Choose matmul or native crop_and_resize in the model builder instead of faster r-cnn meta architecture.

--
211907984  by Zhichao Lu:

    Make eval input reader repeated field and update config util to handle this field.

--
211858098  by Zhichao Lu:

    Change the implementation of merge_boxes_with_multiple_labels.

--
211843915  by Zhichao Lu:

    Add Mobilenet v2 + FPN support.

--
211655076  by Zhichao Lu:

    Bug fix for generic keys in config overrides

    In generic configuration overrides, we had a duplicate entry for train_input_config and we were missing the eval_input_config and eval_config.

    This change also introduces testing for all config overrides.

--
211157501  by Zhichao Lu:

    Make the locally-modified conv defs a copy.

    So that it doesn't modify MobileNet conv defs globally for other code that
    transitively imports this package.

--
211112813  by Zhichao Lu:

    Refactoring visualization tools for Estimator's eval_metric_ops. This will make it easier for future models to take advantage of a single interface and mechanics.

--
211109571  by Zhichao Lu:

    A test decorator.

--
210747685  by Zhichao Lu:

    For FPN, when use_depthwise is set to true, use slightly modified mobilenet v1 config.

--
210723882  by Zhichao Lu:

    Integrating the losses mask into the meta architectures. When providing groundtruth, one can optionally specify annotation information (i.e. which images are labeled vs. unlabeled). For any image that is unlabeled, there is no loss accumulation.

--
210673675  by Zhichao Lu:

    Internal change.

--
210546590  by Zhichao Lu:

    Internal change.

--
210529752  by Zhichao Lu:

    Support batched inputs with ops.matmul_crop_and_resize.

    With this change the new inputs are images of shape [batch, heigh, width, depth] and boxes of shape [batch, num_boxes, 4]. The output tensor is of the shape [batch, num_boxes, crop_height, crop_width, depth].

--
210485912  by Zhichao Lu:

    Fix TensorFlow version check in object_detection_tutorial.ipynb

--
210484076  by Zhichao Lu:

    Reduce TPU memory required for single image matmul_crop_and_resize.

    Using tf.einsum eliminates intermediate tensors, tiling and expansion. for an image of size [40, 40, 1024] and boxes of shape [300, 4] HBM memory usage goes down from 3.52G to 1.67G.

--
210468361  by Zhichao Lu:

    Remove PositiveAnchorLossCDF/NegativeAnchorLossCDF to resolve "Main thread is not in main loop error" issue in local training.

--
210100253  by Zhichao Lu:

    Pooling pyramid feature maps: add option to replace max pool with convolution layers.

--
209995842  by Zhichao Lu:

    Fix a bug which prevents variable sharing in Faster RCNN.

--
209965526  by Zhichao Lu:

    Add support for enabling export_to_tpu through the estimator.

--
209946440  by Zhichao Lu:

    Replace deprecated tf.train.Supervisor with tf.train.MonitoredSession. MonitoredSession also takes away the hassle of starting queue runners.

--
209888003  by Zhichao Lu:

    Implement function to handle data where source_id is not set.

    If the field source_id is found to be the empty string for any image during runtime, it will be replaced with a random string. This avoids hash-collisions on dataset where many examples do not have source_id set. Those hash-collisions have unintended site effects and may lead to bugs in the detection pipeline.

--
209842134  by Zhichao Lu:

    Converting loss mask into multiplier, rather than using it as a boolean mask (which changes tensor shape). This is necessary, since other utilities (e.g. hard example miner) require a loss matrix with the same dimensions as the original prediction tensor.

--
209768066  by Zhichao Lu:

    Adding ability to remove loss computation from specific images in a batch, via an optional boolean mask.

--
209722556  by Zhichao Lu:

    Remove dead code.

    (_USE_C_API was flipped to True by default in TensorFlow 1.8)

--
209701861  by Zhichao Lu:

    This CL cleans-up some tf.Example creation snippets, by reusing the convenient tf.train.Feature building functions in dataset_util.

--
209697893  by Zhichao Lu:

    Do not overwrite num_epoch for eval input. This leads to errors in some cases.

--
209694652  by Zhichao Lu:

    Sample boxes by jittering around the currently given boxes.

--
209550300  by Zhichao Lu:

    `create_category_index_from_labelmap()` function now accepts `use_display_name` parameter.
    Also added create_categories_from_labelmap function for convenience

--
209490273  by Zhichao Lu:

    Check result_dict type before accessing image_id via key.

--
209442529  by Zhichao Lu:

    Introducing the capability to sample examples for evaluation. This makes it easy to specify one full epoch of evaluation, or a subset (e.g. sample 1 of every N examples).

--
208941150  by Zhichao Lu:

    Adding the capability of exporting the results in json format.

--
208888798  by Zhichao Lu:

    Fixes wrong dictionary key for num_det_boxes_per_image.

--
208873549  by Zhichao Lu:

    Reduce the number of HLO ops created by matmul_crop_and_resize.

    Do not unroll along the channels dimension. Instead, transpose the input image dimensions, apply tf.matmul and transpose back.

    The number of HLO instructions for 1024 channels reduce from 12368 to 110.

--
208844315  by Zhichao Lu:

    Add an option to use tf.non_maximal_supression_padded in SSD post-process

--
208731380  by Zhichao Lu:

    Add field in box_predictor config to enable mask prediction and update builders accordingly.

--
208699405  by Zhichao Lu:

    This CL creates a keras-based multi-resolution feature map extractor.

--
208557208  by Zhichao Lu:

    Add TPU tests for Faster R-CNN Meta arch.

    * Tests that two_stage_predict and total_loss tests run successfully on TPU.
    * Small mods to multiclass_non_max_suppression to preserve static shapes.

--
208499278  by Zhichao Lu:

    This CL makes sure the Keras convolutional box predictor & head layers apply activation layers *after* normalization (as opposed to before).

--
208391694  by Zhichao Lu:

    Updating visualization tool to produce multiple evaluation images.

--
208275961  by Zhichao Lu:

    This CL adds a Keras version of the Convolutional Box Predictor, as well as more general infrastructure for making Keras Prediction heads & Keras box predictors.

--
208275585  by Zhichao Lu:

    This CL enables the Keras layer hyperparameter object to build a dedicated activation layer, and to disable activation by default in the op layer construction kwargs.

    This is necessary because in most cases the normalization layer must be applied before the activation layer. So, in Keras models we must set the convolution activation in a dedicated layer after normalization is applied, rather than setting it in the convolution layer construction args.

--
208263792  by Zhichao Lu:

    Add a new SSD mask meta arch that can predict masks for SSD models.
    Changes including:
     - overwrite loss function to add mask loss computation.
     - update ssd_meta_arch to handle masks if predicted in predict and postprocessing.

--
208000218  by Zhichao Lu:

    Make FasterRCNN choose static shape operations only in training mode.

--
207997797  by Zhichao Lu:

    Add static boolean_mask op to box_list_ops.py and use that in faster_rcnn_meta_arch.py to support use_static_shapes option.

--
207993460  by Zhichao Lu:

    Include FGVC detection models in model zoo.

--
207971213  by Zhichao Lu:

    remove the restriction to run tf.nn.top_k op on CPU

--
207961187  by Zhichao Lu:

    Build the first stage NMS function in the model builder and pass it to FasterRCNN meta arch.

--
207960608  by Zhichao Lu:

    Internal Change.

--
207927015  by Zhichao Lu:

    Have an option to use the TPU compatible NMS op cl/206673787, in the batch_multiclass_non_max_suppression function. On setting pad_to_max_output_size to true, the output nmsed boxes are padded to be of length max_size_per_class.

    This can be used in first stage Region Proposal Network in FasterRCNN model by setting the first_stage_nms_pad_to_max_proposals field to true in config proto.

--
207809668  by Zhichao Lu:

    Add option to use depthwise separable conv instead of conv2d in FPN and WeightSharedBoxPredictor. More specifically, there are two related configs:
    - SsdFeatureExtractor.use_depthwise
    - WeightSharedConvolutionalBoxPredictor.use_depthwise

--
207808651  by Zhichao Lu:

    Fix the static balanced positive negative sampler's TPU tests

--
207798658  by Zhichao Lu:

    Fixes a post-refactoring bug where the pre-prediction convolution layers in the convolutional box predictor are ignored.

--
207796470  by Zhichao Lu:

    Make slim endpoints visible in FasterRCNNMetaArch.

--
207787053  by Zhichao Lu:

    Refactor ssd_meta_arch so that the target assigner instance is passed into the SSDMetaArch constructor rather than constructed inside.

--

PiperOrigin-RevId: 212389173