### PR TITLE
Wait longer for async process to spawn.

### DIFF
--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -452,7 +452,7 @@ def instantiate_pipeline(dataset, data_dir, batch_size, eval_batch_size,
   atexit.register(tf.gfile.DeleteRecursively,
                   ncf_dataset.cache_paths.cache_root)
 
-  for _ in range(15):
+  for _ in range(300):
     if tf.gfile.Exists(ncf_dataset.cache_paths.subproc_alive):
       break
     time.sleep(1)  # allow `alive` file to be written


### PR DESCRIPTION
Sometimes it takes longer than 15 seconds, and even longer than 1 minute, to spawn and create the alive file.