### PR TITLE
Added 'rb' as a parameter for FastGFile

### DIFF
--- a/research/compression/image_encoder/msssim.py
+++ b/research/compression/image_encoder/msssim.py
@@ -198,9 +198,9 @@ def main(_):
     print('\nCannot find --compared_image.\n')
     return
 
-  with tf.gfile.FastGFile(FLAGS.original_image) as image_file:
+  with tf.gfile.FastGFile(FLAGS.original_image, 'rb') as image_file:
     img1_str = image_file.read('rb')
-  with tf.gfile.FastGFile(FLAGS.compared_image) as image_file:
+  with tf.gfile.FastGFile(FLAGS.compared_image, 'rb') as image_file:
     img2_str = image_file.read('rb')
 
   input_img = tf.placeholder(tf.string)


### PR DESCRIPTION
If you do not add 'rb', python will think you're opening a text file, and the program would fail with an UnicodeDecodeError