### PR TITLE
Nits in using_your_own_dataset.md

### DIFF
--- a/research/object_detection/g3doc/using_your_own_dataset.md
+++ b/research/object_detection/g3doc/using_your_own_dataset.md
@@ -177,7 +177,7 @@ Instead of writing all tf.Example protos to a single file as shown in
 
 ```python
 import contextlib2
-from google3.third_party.tensorflow_models.object_detection.dataset_tools import tf_record_creation_util
+from object_detection.dataset_tools import tf_record_creation_util
 
 num_shards=10
 output_filebase='/path/to/train_dataset.record'

--- a/research/object_detection/g3doc/using_your_own_dataset.md
+++ b/research/object_detection/g3doc/using_your_own_dataset.md
@@ -172,7 +172,8 @@ dataset into multiple files:
 *   tf.data.Dataset API can shuffle the examples better with sharded files which
     improves performance of the model slightly.
 
-Instead of writing all tf.Example protos to a single file, use the snippet below.
+Instead of writing all tf.Example protos to a single file as shown in
+[conversion script outline](#conversion-script-outline-conversion-script-outline), use the snippet below.
 
 ```python
 import contextlib2

--- a/research/object_detection/g3doc/using_your_own_dataset.md
+++ b/research/object_detection/g3doc/using_your_own_dataset.md
@@ -173,7 +173,8 @@ dataset into multiple files:
     improves performance of the model slightly.
 
 Instead of writing all tf.Example protos to a single file as shown in
-[conversion script outline](#conversion-script-outline-conversion-script-outline), use the snippet below.
+the conversion script outline in the previous section, the snippet below
+will shard the dataset across 10 TFRecords.
 
 ```python
 import contextlib2

--- a/research/object_detection/g3doc/using_your_own_dataset.md
+++ b/research/object_detection/g3doc/using_your_own_dataset.md
@@ -172,8 +172,7 @@ dataset into multiple files:
 *   tf.data.Dataset API can shuffle the examples better with sharded files which
     improves performance of the model slightly.
 
-Instead of writing all tf.Example protos to a single file as shown in
-[conversion script outline](#conversion-script-outline), use the snippet below.
+Instead of writing all tf.Example protos to a single file, use the snippet below.
 
 ```python
 import contextlib2


### PR DESCRIPTION
 * I might be misunderstanding (e.g. if the docs are compiled), but the [anchor on github](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/using_your_own_dataset.md#conversion-script-outline) is currently broken
 * Tutorials modify `PYTHONPATH` to resolve module imports directly out of `models/research`; the rest of the world doesn't have a `google3` namespace ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/models/5349)
<!-- Reviewable:end -->
