### PR TITLE
Cast range results to string before use as eval_spec_names

### DIFF
--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -641,7 +641,7 @@ def create_train_and_eval_specs(train_input_fn,
       input_fn=train_input_fn, max_steps=train_steps)
 
   if eval_spec_names is None:
-    eval_spec_names = range(len(eval_input_fns))
+    eval_spec_names = [str(i) for i in range(len(eval_input_fns))]
 
   eval_specs = []
   for eval_spec_name, eval_input_fn in zip(eval_spec_names, eval_input_fns):


### PR DESCRIPTION
This fixes an error where tensorflow training.py expects string values instead of ints:

```
    if name is not None and not isinstance(name, six.string_types):
      raise TypeError('`name` must be string, given: {}'.format(name))
```