### PR TITLE
Simple fix for ICP implementation issues.

### DIFF
--- a/research/vid2depth/model.py
+++ b/research/vid2depth/model.py
@@ -229,7 +229,7 @@ class Model(object):
               estimated_cloud_b = cloud_a + tf.stack([egomotion[0][3],
                                                       egomotion[1][3],
                                                       egomotion[2][3]], axis=0)
-              residuals = -(cloud_b - estimated_cloud_b)
+              residuals = cloud_b - estimated_cloud_b
               self.residual_loss += 1.0 / (2**s) * tf.reduce_mean(
                 tf.abs(residuals))
 


### PR DESCRIPTION
As mentioned in the code line comment and as pointed out in the [paper](https://arxiv.org/abs/1802.05522), ICP is not differentiable. ICP algorithm can be wrapped in a TF graph using tf.py_func (simple example of py_func [gist](https://gist.github.com/kristijanbartol/1b7b7c5d431415284217bbf63ca25c66)). This way, we can provide gradients manually, i.e., override them in general. 

However, there is more to this... An important problem arises when we want to apply gradients for ego motion matrix, which has some special properties that are not allowed to be destroyed by improper gradient update. Therefore, gradients tried to be applied only for translation x-axis.

The project was broken in case of training using the provided code because of broken bazel build. 

It turns out there is a correct way to approximate gradients without overriding gradients and even using ICP and fighting bazel (as we are not interested in rotation; with translation it's trivial to obtain residuals). The code is also missing principal mask, but it can be added in another pull request.

As for this PR, it needs to be tested. ATM I don't have KITTI dataset locally to try it out, so this is **not ready for merge**. I wanted to point this trivial fix out.