### PR TITLE
Support accepting JPEG image bytes for inference 

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -238,7 +238,8 @@ def define_cifar_flags():
                           resnet_size='56',
                           train_epochs=182,
                           epochs_between_evals=10,
-                          batch_size=128)
+                          batch_size=128,
+                          image_bytes_as_serving_input=False)
 
 
 def run_cifar(flags_obj):
@@ -247,6 +248,11 @@ def run_cifar(flags_obj):
   Args:
     flags_obj: An object containing parsed flag values.
   """
+  if flags_obj.image_bytes_as_serving_input:
+    tf.logging.fatal('--image_bytes_as_serving_input cannot be set to True '
+                     'for CIFAR. This flag is only applicable to ImageNet.')
+    return
+
   input_function = (flags_obj.use_synthetic_data and
                     get_synth_input_fn(flags_core.get_tf_dtype(flags_obj)) or
                     input_fn)


### PR DESCRIPTION
Add `--image_bytes_as_serving_input` flag to export SavedModel with
serving signature that accepts JPEG image bytes instead of a fixed size
[HxWxC] image tensor.

Passing JPEG image bytes is easier for inference/serving use cases.
The model internally resizes/crops the image to required [HxWxC]
shaped tensor before passing it on for actual model inference.

This change aligns with Cloud TPU/ResNet-50 model that offers a
similar interface (jpeg bytes) for inferencing here:
https://github.com/tensorflow/tpu/tree/master/models/official/resnet

NOTE: This flag is set to `True` by default.