### PR TITLE
Adding from_detection_checkpoint flag in the sample config for oid

### DIFF
--- a/research/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_oid.config
+++ b/research/object_detection/samples/configs/faster_rcnn_inception_resnet_v2_atrous_oid.config
@@ -106,6 +106,7 @@ train_config: {
   }
   gradient_clipping_by_norm: 10.0
   fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  from_detection_checkpoint: true
   # Note: The below line limits the training process to 800K steps, which we
   # empirically found to be sufficient enough to train the Open Images dataset.
   # This effectively bypasses the learning rate schedule (the learning rate will


### PR DESCRIPTION
This is to ensure consistency with the other checkpoints of the faster_rcnn_inception_resnet_v2_atrous configs (coco, pets etc)
This was pointed out in #3562