### PR TITLE
Update train.proto

### DIFF
--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -20,7 +20,7 @@ message TrainConfig {
   optional bool sync_replicas = 3 [default=false];
 
   // How frequently to keep checkpoints.
-  optional uint32 keep_checkpoint_every_n_hours = 4 [default=1000];
+  optional float keep_checkpoint_every_n_hours = 4 [default=1000];
 
   // Optimizer used to train the DetectionModel.
   optional Optimizer optimizer = 5;


### PR DESCRIPTION
keep_checkpoint_every_n_hour (uint32 -> float)
Interpreted as a float in the API (saver.py).
https://github.com/tensorflow/tensorflow/blob/r1.11/tensorflow/python/training/saver.py#L699

Lets us save checkpoints more often than every hour