### PR TITLE
set strip_default_attrs=True for SavedModel exports

### DIFF
--- a/official/boosted_trees/train_higgs.py
+++ b/official/boosted_trees/train_higgs.py
@@ -249,7 +249,8 @@ def train_boosted_trees(flags_obj):
         _make_csv_serving_input_receiver_fn(
             column_names=feature_names,
             # columns are all floats.
-            column_defaults=[[0.0]] * len(feature_names)))
+            column_defaults=[[0.0]] * len(feature_names)),
+        strip_default_attrs=True)
 
 
 def main(_):

--- a/official/mnist/mnist.py
+++ b/official/mnist/mnist.py
@@ -222,7 +222,8 @@ def run_mnist(flags_obj):
     input_fn = tf.estimator.export.build_raw_serving_input_receiver_fn({
         'image': image,
     })
-    mnist_classifier.export_savedmodel(flags_obj.export_dir, input_fn)
+    mnist_classifier.export_savedmodel(flags_obj.export_dir, input_fn,
+                                       strip_default_attrs=True)
 
 
 def main(_):

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -534,7 +534,8 @@ def resnet_main(
       input_receiver_fn = functools.partial(image_bytes_serving_input_fn, shape)
     else:
       input_receiver_fn = export.build_tensor_serving_input_receiver_fn(
-          shape, batch_size=flags_obj.batch_size)
+          shape, batch_size=flags_obj.batch_size,
+          dtype=flags_core.get_tf_dtype(flags_obj))
     classifier.export_savedmodel(flags_obj.export_dir, input_receiver_fn,
                                  strip_default_attrs=True)
 

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -535,7 +535,8 @@ def resnet_main(
     else:
       input_receiver_fn = export.build_tensor_serving_input_receiver_fn(
           shape, batch_size=flags_obj.batch_size)
-    classifier.export_savedmodel(flags_obj.export_dir, input_receiver_fn)
+    classifier.export_savedmodel(flags_obj.export_dir, input_receiver_fn,
+                                 strip_default_attrs=True)
 
 
 def define_resnet_flags(resnet_size_choices=None):

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -171,7 +171,7 @@ def image_bytes_serving_input_fn(image_shape, dtype=tf.float32):
   image_bytes_list = tf.placeholder(
       shape=[None], dtype=tf.string, name='input_tensor')
   images = tf.map_fn(
-      _preprocess_image, image_bytes_list, back_prop=False, dtype=tf.float32)
+      _preprocess_image, image_bytes_list, back_prop=False, dtype=dtype)
   return tf.estimator.export.TensorServingInputReceiver(
       images, {'image_bytes': image_bytes_list})
 
@@ -530,7 +530,7 @@ def resnet_main(
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.
-    export_dtype=flags_core.get_tf_dtype(flags_obj)
+    export_dtype = flags_core.get_tf_dtype(flags_obj)
     if flags_obj.image_bytes_as_serving_input:
       input_receiver_fn = functools.partial(
           image_bytes_serving_input_fn, shape, dtype=export_dtype)
@@ -568,7 +568,7 @@ def define_resnet_flags(resnet_size_choices=None):
       help=flags_core.help_wrap('Skip training and only perform evaluation on '
                                 'the latest checkpoint.'))
   flags.DEFINE_boolean(
-      name="image_bytes_as_serving_input", default=True,
+      name="image_bytes_as_serving_input", default=False,
       help=flags_core.help_wrap(
           'If True exports savedmodel with serving signature that accepts '
           'JPEG image bytes instead of a fixed size [HxWxC] tensor that '

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -156,13 +156,13 @@ def get_synth_input_fn(height, width, num_channels, num_classes,
   return input_fn
 
 
-def image_bytes_serving_input_fn(image_shape):
+def image_bytes_serving_input_fn(image_shape, dtype=tf.float32):
   """Serving input fn for raw jpeg images."""
 
   def _preprocess_image(image_bytes):
     """Preprocess a single raw image."""
     # Bounding box around the whole image.
-    bbox = tf.constant([0.0, 0.0, 1.0, 1.0], dtype=tf.float32, shape=[1, 1, 4])
+    bbox = tf.constant([0.0, 0.0, 1.0, 1.0], dtype=dtype, shape=[1, 1, 4])
     height, width, num_channels = image_shape
     image = imagenet_preprocessing.preprocess_image(
         image_bytes, bbox, height, width, num_channels, is_training=False)
@@ -530,12 +530,13 @@ def resnet_main(
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.
+    export_dtype=flags_core.get_tf_dtype(flags_obj)
     if flags_obj.image_bytes_as_serving_input:
-      input_receiver_fn = functools.partial(image_bytes_serving_input_fn, shape)
+      input_receiver_fn = functools.partial(
+          image_bytes_serving_input_fn, shape, dtype=export_dtype)
     else:
       input_receiver_fn = export.build_tensor_serving_input_receiver_fn(
-          shape, batch_size=flags_obj.batch_size,
-          dtype=flags_core.get_tf_dtype(flags_obj))
+          shape, batch_size=flags_obj.batch_size, dtype=export_dtype)
     classifier.export_savedmodel(flags_obj.export_dir, input_receiver_fn,
                                  strip_default_attrs=True)
 

--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -621,7 +621,8 @@ def run_transformer(flags_obj):
     # an extra asset rather than a core asset.
     estimator.export_savedmodel(
         flags_obj.export_dir, serving_input_fn,
-        assets_extra={"vocab.txt": flags_obj.vocab_file})
+        assets_extra={"vocab.txt": flags_obj.vocab_file},
+        strip_default_attrs=True)
 
 
 def main(_):

--- a/official/wide_deep/wide_deep_run_loop.py
+++ b/official/wide_deep/wide_deep_run_loop.py
@@ -73,7 +73,8 @@ def export_model(model, model_type, export_dir, model_column_fn):
   feature_spec = tf.feature_column.make_parse_example_spec(columns)
   example_input_fn = (
       tf.estimator.export.build_parsing_serving_input_receiver_fn(feature_spec))
-  model.export_savedmodel(export_dir, example_input_fn)
+  model.export_savedmodel(export_dir, example_input_fn,
+                          strip_default_attrs=True)
 
 
 def run_loop(name, train_input_fn, eval_input_fn, model_column_fn,


### PR DESCRIPTION
Stripping default attributes is recommended practice for wider SavedModel portability between TensorFlow versions. (https://www.tensorflow.org/guide/saved_model#manually_build_a_savedmodel) This PR update official models to follow the convention of setting `strip_default_attrs=True` when exporting SavedModels.