### PR TITLE
[Object detection] Removed num_eval_steps kwarg from estimator.evaluate() call in model_main.py

### DIFF
--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -86,7 +86,6 @@ def main(unused_argv):
       input_fn = eval_input_fns[0]
     if FLAGS.run_once:
       estimator.evaluate(input_fn,
-                         num_eval_steps=None,
                          checkpoint_path=tf.train.latest_checkpoint(
                              FLAGS.checkpoint_dir))
     else:


### PR DESCRIPTION
When using the run_once flag ` estimator.evaluate(input_fn, num_eval_steps=None, checkpoint_path=tf.train.latest_checkpoint(FLAGS.checkpoint_dir))` is called, but [tf.estimator.Estimator.evaluate()](https://www.tensorflow.org/api_docs/python/tf/estimator/Estimator#evaluate) has no num_eval_steps kwarg. This leads to "TypeError: evaluate() got an unexpected keyword argument 'num_eval_steps'". Fixed by removing the argument.