### PR TITLE
Prevents TypeError:'dict_keys' object does not support indexing

### DIFF
--- a/research/skip_thoughts/skip_thoughts/data/preprocess_dataset.py
+++ b/research/skip_thoughts/skip_thoughts/data/preprocess_dataset.py
@@ -121,8 +121,8 @@ def _build_vocabulary(input_files):
 
   tf.logging.info("Processed %d sentences total", num)
 
-  words = wordcount.keys()
-  freqs = wordcount.values()
+  words = list(wordcount)
+  freqs = list(wordcount.values())
   sorted_indices = np.argsort(freqs)[::-1]
 
   vocab = collections.OrderedDict()


### PR DESCRIPTION
The preprocessing script in skip_thoughts fails with Python3.6 because collections.Counter() keys and values return DictKey objects, throwing throws a TypeError. I believe this fix should be compatible with both Python 2.6.x and Python3.x