### PR TITLE
Add perf args

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -109,8 +109,9 @@ def preprocess_image(image, is_training):
   return image
 
 
-def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
-             dtype=tf.float32):
+def input_fn(is_training, data_dir, batch_size, num_epochs=1,
+             dtype=tf.float32, datasets_num_private_threads=None,
+             num_parallel_batches=1):
   """Input function which provides batches for train or eval.
 
   Args:
@@ -118,8 +119,9 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
     data_dir: The directory containing the input data.
     batch_size: The number of samples per batch.
     num_epochs: The number of epochs to repeat the dataset.
-    num_gpus: The number of gpus used for training.
     dtype: Data type to use for images/features
+    datasets_num_private_threads: Number of private threads for tf.data.
+    num_parallel_batches: Number of parallel batches for tf.data.
 
   Returns:
     A dataset that can be used for iteration.
@@ -134,9 +136,9 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
       shuffle_buffer=_NUM_IMAGES['train'],
       parse_record_fn=parse_record,
       num_epochs=num_epochs,
-      num_gpus=num_gpus,
-      examples_per_epoch=_NUM_IMAGES['train'] if is_training else None,
-      dtype=dtype
+      dtype=dtype,
+      datasets_num_private_threads=datasets_num_private_threads,
+      num_parallel_batches=num_parallel_batches
   )
 
 

--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -158,8 +158,9 @@ def parse_record(raw_record, is_training, dtype):
   return image, label
 
 
-def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
-             dtype=tf.float32):
+def input_fn(is_training, data_dir, batch_size, num_epochs=1,
+             dtype=tf.float32, datasets_num_private_threads=None,
+             num_parallel_batches=1):
   """Input function which provides batches for train or eval.
 
   Args:
@@ -167,8 +168,9 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
     data_dir: The directory containing the input data.
     batch_size: The number of samples per batch.
     num_epochs: The number of epochs to repeat the dataset.
-    num_gpus: The number of gpus used for training.
     dtype: Data type to use for images/features
+    datasets_num_private_threads: Number of private threads for tf.data.
+    num_parallel_batches: Number of parallel batches for tf.data.
 
   Returns:
     A dataset that can be used for iteration.
@@ -195,9 +197,9 @@ def input_fn(is_training, data_dir, batch_size, num_epochs=1, num_gpus=None,
       shuffle_buffer=_SHUFFLE_BUFFER,
       parse_record_fn=parse_record,
       num_epochs=num_epochs,
-      num_gpus=num_gpus,
-      examples_per_epoch=_NUM_IMAGES['train'] if is_training else None,
-      dtype=dtype
+      dtype=dtype,
+      datasets_num_private_threads=datasets_num_private_threads,
+      num_parallel_batches=num_parallel_batches
   )
 
 

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -91,7 +91,7 @@ def process_record_dataset(dataset,
       tf.contrib.data.map_and_batch(
           lambda value: parse_record_fn(value, is_training, dtype),
           batch_size=batch_size,
-          num_parallel_calls=num_parallel_batches,
+          num_parallel_batches=num_parallel_batches,
           drop_remainder=False))
 
   # Operations between the final prefetch and the get_next call to the iterator

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -431,25 +431,25 @@ def resnet_model_fn(features, labels, mode, model_class,
     train_op = None
 
   accuracy = tf.metrics.accuracy(labels, predictions['classes'])
-  #accuracy_top_5 = tf.metrics.mean(tf.nn.in_top_k(predictions=logits,
-  #                                                targets=labels,
-  #                                                k=5,
-  #                                                name='top_5_op'))
-  metrics = {'accuracy': accuracy}
-          #   'accuracy_top_5': accuracy_top_5}
+  accuracy_top_5 = tf.metrics.mean(tf.nn.in_top_k(predictions=logits,
+                                                  targets=labels,
+                                                  k=5,
+                                                  name='top_5_op'))
+  metrics = {'accuracy': accuracy,
+             'accuracy_top_5': accuracy_top_5}
 
   # Create a tensor named train_accuracy for logging purposes
   tf.identity(accuracy[1], name='train_accuracy')
-  #tf.identity(accuracy_top_5[1], name='train_accuracy_top_5')
+  tf.identity(accuracy_top_5[1], name='train_accuracy_top_5')
   tf.summary.scalar('train_accuracy', accuracy[1])
-  #tf.summary.scalar('train_accuracy_top_5', accuracy_top_5[1])
+  tf.summary.scalar('train_accuracy_top_5', accuracy_top_5[1])
 
   return tf.estimator.EstimatorSpec(
       mode=mode,
       predictions=predictions,
       loss=loss,
-      train_op=train_op)
-      #eval_metric_ops=metrics)
+      train_op=train_op,
+      eval_metric_ops=metrics)
 
 
 def resnet_main(

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -180,7 +180,7 @@ def image_bytes_serving_input_fn(image_shape, dtype=tf.float32):
       images, {'image_bytes': image_bytes_list})
 
 
-def override_flags_and_set_envars_for_gpu_private_threads(flags_obj):
+def override_flags_and_set_envars_for_gpu_thread_pool(flags_obj):
   """Override flags and set env_vars for performance.
 
   These settings exist to test the difference between using stock settings
@@ -457,9 +457,9 @@ def resnet_main(
 
   model_helpers.apply_clean(flags.FLAGS)
 
-  # Ensures flog override logic is only executed if explicitly triggered
+  # Ensures flag override logic is only executed if explicitly triggered.
   if flags_obj.tf_gpu_thread_mode:
-    override_flags_and_set_envars_for_gpu_private_threads(flags_obj)
+    override_flags_and_set_envars_for_gpu_thread_pool(flags_obj)
 
   # Create session config based on values of inter_op_parallelism_threads and
   # intra_op_parallelism_threads. Note that we default to having

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -25,13 +25,13 @@ from __future__ import print_function
 
 import functools
 import math
+import multiprocessing
 import os
 
 # pylint: disable=g-bad-import-order
 from absl import flags
 import tensorflow as tf
 from tensorflow.contrib.data.python.ops import threadpool
-import multiprocessing
 
 from official.resnet import resnet_model
 from official.utils.flags import core as flags_core

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -45,7 +45,8 @@ def get_loss_scale(flags_obj):
 
 def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
                        synthetic_data=True, max_train_steps=True, dtype=True,
-                       all_reduce_alg=True):
+                       all_reduce_alg=True, tf_gpu_thread_mode=True,
+                       datasets_num_private_threads=True):
   """Register flags for specifying performance tuning arguments.
 
   Args:
@@ -56,7 +57,9 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
     max_train_steps: Create a flags to allow specification of maximum number
       of training steps
     dtype: Create flags for specifying dtype.
-
+    all_reduce_alg: If set forces a specific algorithm for multi-gpu.
+    tf_gpu_thread_mode: gpu_private triggers us of private thread pool.
+    datasets_num_private_threads: Number of private threads for datasets.
   Returns:
     A list of flags for core.py to marks as key flags.
   """
@@ -65,7 +68,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
   if num_parallel_calls:
     flags.DEFINE_integer(
         name="num_parallel_calls", short_name="npc",
-        default=multiprocessing.cpu_count(),
+        default=1,
         help=help_wrap("The number of records that are  processed in parallel "
                        "during input processing. This can be optimized per "
                        "data set but for generally homogeneous data sets, "
@@ -137,5 +140,20 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
                        "See tf.contrib.distribute.AllReduceCrossTowerOps for "
                        "more details and available options."))
 
+  if tf_gpu_thread_mode:
+    flags.DEFINE_string(
+        name="tf_gpu_thread_mode", short_name="gt_mode", default="global",
+        help=help_wrap(
+            "Whether and how the GPU device uses its own threadpool.")
+    )
+
+  if datasets_num_private_threads:
+    flags.DEFINE_integer(
+        name="datasets_num_private_threads", short_name="dataset_thread_count",
+        default=None,
+        help=help_wrap(
+            "Number of threads for a private threadpool created for all"
+            "datasets computation..")
+    )
 
   return key_flags

--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -42,7 +42,7 @@ def get_distribution_strategy(num_gpus, all_reduce_alg=None):
       return tf.contrib.distribute.MirroredStrategy(
           num_gpus=num_gpus,
           cross_tower_ops=tf.contrib.distribute.AllReduceCrossTowerOps(
-              all_reduce_alg, num_packs=num_gpus))
+              all_reduce_alg, num_packs=2))
     else:
       return tf.contrib.distribute.MirroredStrategy(num_gpus=num_gpus)
 


### PR DESCRIPTION
Adds the smallest number of perf args to allow a test of "stock" vs. manual tuned (preset) for the latest hardware.  This will allow me to move my perf testing from my fork to here which benefits everyone.

There are a few ways to do this so I am totally cool taking our time on this PR to get it right.

For ResNet V1 on GCE 8xV100s
- Stock (no perf flags): ~5100 images/sec
- Manual flags:  ~5400 images/sec
- benchmark code (non-xla), 5,700 images/sec

```bash
python -m official.resnet.imagenet_main --all_reduce_alg nccl --batch_size 2048 --data_dir /data/imagenet --dtype fp16 --epochs_between_evals 4 --hooks ExamplesPerSecondHook LoggingTensorHook --intra_op_parallelism_threads 1 --model_dir /workspace/tmp/81_eval_4_tuned_full_2 --num_gpus 8 --datasets_num_parallel_batches 2 --resnet_size 50 --resnet_version 1 --tf_gpu_thread_mode gpu_private --train_epochs=81
```