### PR TITLE
#5525 Fix predict.py read_and_process_light_curve()

### DIFF
--- a/research/astronet/astronet/predict.py
+++ b/research/astronet/astronet/predict.py
@@ -102,8 +102,9 @@ def _process_tce(feature_config):
         "Only 'global_view' and 'local_view' features are supported.")
 
   # Read and process the light curve.
-  time, flux = preprocess.read_and_process_light_curve(FLAGS.kepler_id,
-                                                       FLAGS.kepler_data_dir)
+  all_time, all_flux = preprocess.read_light_curve(FLAGS.kepler_id,
+                                                   FLAGS.kepler_data_dir)
+  time, flux = preprocess.process_light_curve(all_time, all_flux)
   time, flux = preprocess.phase_fold_and_sort_light_curve(
       time, flux, FLAGS.period, FLAGS.t0)
 


### PR DESCRIPTION
#5525
Updated predict.py to make seperate calls to `read_light_curve()` and `process_light_curve()` to eliminate **AttributeError: 'module' object has no attribute 'read_and_process_light_curve'**
