### PR TITLE
Reorder NCF data pipeline

### DIFF
--- a/official/recommendation/constants.py
+++ b/official/recommendation/constants.py
@@ -35,11 +35,7 @@ class Paths(object):
                                              "positive_shard_{}.pickle")
     self.train_epoch_dir = os.path.join(self.cache_root, "training_epochs")
     self.eval_data_subdir = os.path.join(self.cache_root, "eval_data")
-    self.eval_raw_file = os.path.join(self.eval_data_subdir, "raw.pickle")
-    self.eval_record_template_temp = os.path.join(self.eval_data_subdir,
-                                                  "eval_records.temp")
-    self.eval_record_template = os.path.join(
-        self.eval_data_subdir, "padded_eval_batch_size_{}.tfrecords")
+
     self.subproc_alive = os.path.join(self.cache_root, "subproc.alive")
 
 
@@ -72,7 +68,9 @@ FLAGFILE_TEMP = "flagfile.temp"
 FLAGFILE = "flagfile"
 READY_FILE_TEMP = "ready.json.temp"
 READY_FILE = "ready.json"
+
 TRAIN_RECORD_TEMPLATE = "train_{}.tfrecords"
+EVAL_RECORD_TEMPLATE = "eval_{}.tfrecords"
 
 TIMEOUT_SECONDS = 3600 * 2  # If the train loop goes more than two hours without
                             # consuming an epoch of data, this is a good

--- a/official/recommendation/constants.py
+++ b/official/recommendation/constants.py
@@ -45,6 +45,10 @@ class Paths(object):
 
 APPROX_PTS_PER_TRAIN_SHARD = 128000
 
+# Keys for data shards
+TRAIN_KEY = "train"
+EVAL_KEY = "eval"
+
 # In both datasets, each user has at least 20 ratings.
 MIN_NUM_RATINGS = 20
 

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -99,9 +99,9 @@ def _process_shard(args):
 
   if not is_training:
     # For eval, there is one positive which was held out from the training set.
-    test_positive_dict = {
-        k: v for k, v  in zip(shard[rconst.EVAL_KEY][movielens.USER_COLUMN],
-                              shard[rconst.EVAL_KEY][movielens.ITEM_COLUMN])}
+    test_positive_dict = dict(zip(
+        shard[rconst.EVAL_KEY][movielens.USER_COLUMN],
+        shard[rconst.EVAL_KEY][movielens.ITEM_COLUMN]))
 
   delta = users[1:] - users[:-1]
   boundaries = ([0] + (np.argwhere(delta)[:, 0] + 1).tolist() +

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -275,7 +275,7 @@ def _construct_records(
       # In order to have a full batch, randomly include points from earlier in
       # the batch.
       pad_sample_indices = np.random.randint(
-        low=0, high=num_pts, size=(num_padding,))
+          low=0, high=num_pts, size=(num_padding,))
       dest = np.arange(start=start_ind, stop=start_ind + num_padding)
       start_ind += num_padding
       for i in range(3):

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -261,22 +261,23 @@ def _construct_records(
   assert np.sum(data[0] == -1) == num_padding
 
   if is_training:
-    if num_padding:
-      # In order to have a full batch, randomly include points from earlier in
-      # the batch.
-      pad_sample_indices = np.random.randint(
-        low=0, high=num_pts, size=(num_padding,))
-      dest = np.arange(start=start_ind, stop=start_ind + num_padding)
-      start_ind += num_padding
-      for i in range(3):
-        data[i][dest] = data[i][pad_sample_indices]
+    pass
+    # if num_padding:
+    #   # In order to have a full batch, randomly include points from earlier in
+    #   # the batch.
+    #   pad_sample_indices = np.random.randint(
+    #     low=0, high=num_pts, size=(num_padding,))
+    #   dest = np.arange(start=start_ind, stop=start_ind + num_padding)
+    #   start_ind += num_padding
+    #   for i in range(3):
+    #     data[i][dest] = data[i][pad_sample_indices]
   else:
     # For Evaluation, padding is all zeros. The evaluation input_fn knows how
     # to interpret and discard the zero padded entries.
     data[0][num_pts:] = 0
 
-  # Check that no points were overlooked.
-  assert not np.sum(data[0] == -1)
+    # Check that no points were overlooked.
+    assert not np.sum(data[0] == -1)
 
   batches_per_file = np.ceil(num_pts_with_padding / batch_size / num_readers)
   current_file_id = -1

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -271,24 +271,23 @@ def _construct_records(
   assert np.sum(data[0] == -1) == num_padding
 
   if is_training:
-    pass
-    # TODO(robieta): go back to resampling if possible.
-    # if num_padding:
-    #   # In order to have a full batch, randomly include points from earlier in
-    #   # the batch.
-    #   pad_sample_indices = np.random.randint(
-    #     low=0, high=num_pts, size=(num_padding,))
-    #   dest = np.arange(start=start_ind, stop=start_ind + num_padding)
-    #   start_ind += num_padding
-    #   for i in range(3):
-    #     data[i][dest] = data[i][pad_sample_indices]
+    if num_padding:
+      # In order to have a full batch, randomly include points from earlier in
+      # the batch.
+      pad_sample_indices = np.random.randint(
+        low=0, high=num_pts, size=(num_padding,))
+      dest = np.arange(start=start_ind, stop=start_ind + num_padding)
+      start_ind += num_padding
+      for i in range(3):
+        data[i][dest] = data[i][pad_sample_indices]
   else:
     # For Evaluation, padding is all zeros. The evaluation input_fn knows how
     # to interpret and discard the zero padded entries.
     data[0][num_pts:] = 0
 
     # Check that no points were overlooked.
-    assert not np.sum(data[0] == -1)
+
+  assert not np.sum(data[0] == -1)
 
   batches_per_file = np.ceil(num_pts_with_padding / batch_size / num_readers)
   current_file_id = -1

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -308,6 +308,12 @@ def _construct_records(
     batches_by_file[current_file_id].append(current_batch_id)
 
   if is_training:
+    # Empirically it is observed that placing the batch with repeated values at
+    # the start rather than the end improves convergence.
+    batches_by_file[0][0], batches_by_file[-1][-1] = \
+      batches_by_file[-1][-1], batches_by_file[0][0]
+
+  if is_training:
     template = rconst.TRAIN_RECORD_TEMPLATE
     record_dir = os.path.join(cache_paths.train_epoch_dir,
                               get_cycle_folder_name(train_cycle))

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -99,8 +99,8 @@ def _process_shard(args):
 
   if not is_training:
     # For eval, there is one positive which was held out from the training set.
-    test_positive_dict = {zip(shard[rconst.EVAL_KEY][movielens.USER_COLUMN],
-                              shard[rconst.EVAL_KEY][movielens.ITEM_COLUMN])}
+    test_positive_dict = {k: v for k, v  in zip(shard[rconst.EVAL_KEY][movielens.USER_COLUMN],
+                                                shard[rconst.EVAL_KEY][movielens.ITEM_COLUMN])}
 
   delta = users[1:] - users[:-1]
   boundaries = ([0] + (np.argwhere(delta)[:, 0] + 1).tolist() +

--- a/official/recommendation/data_async_generation.py
+++ b/official/recommendation/data_async_generation.py
@@ -79,8 +79,13 @@ def _process_shard(args):
     seed: Random seed to be used when generating negatives.
     is_training: Generate training (True) or eval (False) data.
     match_mlperf: Match the MLPerf reference behavior
+    paddings_per_user: During training, we perform extra sampling and set it
+      aside to fill the last partial batch.
   """
-  shard_path, num_items, num_neg, seed, is_training, match_mlperf = args
+  (shard_path, num_items, num_neg, seed, is_training, match_mlperf,
+   paddings_per_user) = args
+  assert is_training or not paddings_per_user
+
   np.random.seed(seed)
 
   # The choice to store the training shards in files rather than in memory
@@ -110,6 +115,8 @@ def _process_shard(args):
   user_blocks = []
   item_blocks = []
   label_blocks = []
+  positive_fraction = 1 / (1 + num_neg)
+  pad_values = [[], [], []]
   for i in range(len(boundaries) - 1):
     assert len(set(users[boundaries[i]:boundaries[i+1]])) == 1
     current_user = users[boundaries[i]]
@@ -122,7 +129,18 @@ def _process_shard(args):
     if is_training:
       n_pos = len(positive_set)
       negatives = stat_utils.sample_with_exclusion(
-          num_items, positive_set, n_pos * num_neg, replacement=True)
+          num_items, positive_set, n_pos * num_neg + paddings_per_user,
+          replacement=True)
+      positive_set_list = list(positive_set)
+      extra_negatives = negatives[n_pos * num_neg:]
+      negatives = negatives[:n_pos * num_neg]
+
+      for j, neg in enumerate(extra_negatives):
+        # Randomly select positives to preserve the correct ratio
+        sample = ((current_user, np.random.choice(positive_set_list, 1)[0], 1)
+                  if np.random.random() < positive_fraction else
+                  (current_user, extra_negatives[j], 0))
+        [pad_values[k].append(sample[k]) for k in range(3)]
 
     else:
       if not match_mlperf:
@@ -135,14 +153,14 @@ def _process_shard(args):
 
       negatives = stat_utils.sample_with_exclusion(
           num_items, positive_set, num_neg, replacement=match_mlperf)
-      positive_set = [test_positive_dict[current_user]]
-      n_pos = len(positive_set)
+      positive_set_list = [test_positive_dict[current_user]]
+      n_pos = len(positive_set_list)
       assert n_pos == 1
 
     user_blocks.append(current_user * np.ones(
         (n_pos * (1 + num_neg),), dtype=np.int32))
-    item_blocks.append(
-        np.array(list(positive_set) + negatives, dtype=np.uint16))
+    item_blocks.append(np.array(
+        list(positive_set_list) + negatives, dtype=np.uint16))
     labels_for_user = np.zeros((n_pos * (1 + num_neg),), dtype=np.int8)
     labels_for_user[:n_pos] = 1
     label_blocks.append(labels_for_user)
@@ -152,7 +170,7 @@ def _process_shard(args):
   labels_out = np.concatenate(label_blocks)
 
   assert users_out.shape == items_out.shape == labels_out.shape
-  return users_out, items_out, labels_out
+  return users_out, items_out, labels_out, pad_values
 
 
 def _construct_record(users, items, labels=None, dupe_mask=None):
@@ -192,6 +210,7 @@ def _construct_records(
     num_neg,              # type: int
     num_positives,        # type: int
     num_items,            # type: int
+    num_users,            # type: int
     epochs_per_cycle,     # type: int
     batch_size,           # type: int
     training_shards,      # type: typing.List[str]
@@ -212,6 +231,7 @@ def _construct_records(
       to pre-allocate arrays while the imap is still running. (NumPy does not
       allow dynamic arrays.)
     num_items: The cardinality of the item set.
+    num_users: The cardinality of the user set.
     epochs_per_cycle: The number of epochs worth of data to construct.
     batch_size: The expected batch size used during training. This is used
       to properly batch data when writing TFRecords.
@@ -235,14 +255,19 @@ def _construct_records(
   num_pts_with_padding = (num_pts + batch_size - 1) // batch_size * batch_size
   num_padding = num_pts_with_padding - num_pts
 
+  paddings_per_user = ((num_padding + num_users - 1) // num_users if is_training
+                       else 0)
+
   # We choose a different random seed for each process, so that the processes
   # will not all choose the same random numbers.
   process_seeds = [stat_utils.random_int32()
                    for _ in training_shards * epochs_per_cycle]
   map_args = [
-      (shard, num_items, num_neg, process_seeds[i], is_training, match_mlperf)
+      (shard, num_items, num_neg, process_seeds[i], is_training, match_mlperf,
+       paddings_per_user)
       for i, shard in enumerate(training_shards * epochs_per_cycle)]
 
+  pad_values = [[], [], []]
   with popen_helper.get_pool(num_workers, init_worker) as pool:
     map_fn = pool.imap if deterministic else pool.imap_unordered  # pylint: disable=no-member
     data_generator = map_fn(_process_shard, map_args)
@@ -268,18 +293,25 @@ def _construct_records(
       for i in range(3):
         data[i][dest] = data_segment[i]
 
+      [pad_values[k].extend(data_segment[3][k]) for k in range(3)]
+
   assert np.sum(data[0] == -1) == num_padding
+  assert len(pad_values[0]) == len(pad_values[1]) == len(pad_values[2])
+
+  if is_training:
+    assert len(pad_values[0]) >= num_padding
+  else:
+    assert not pad_values[0]
 
   if is_training:
     if num_padding:
       # In order to have a full batch, randomly include points from earlier in
       # the batch.
-      pad_sample_indices = np.random.randint(
-        low=0, high=num_pts, size=(num_padding,))
+      pad_sample_indices = np.random.permutation(len(pad_values[0]))[:num_padding]
       dest = np.arange(start=start_ind, stop=start_ind + num_padding)
       start_ind += num_padding
       for i in range(3):
-        data[i][dest] = data[i][pad_sample_indices]
+        data[i][dest] = np.array(pad_values[i])[pad_sample_indices]
   else:
     # For Evaluation, padding is all zeros. The evaluation input_fn knows how
     # to interpret and discard the zero padded entries.
@@ -397,7 +429,7 @@ def _generation_loop(num_workers,           # type: int
 
   shared_kwargs = dict(
       num_workers=multiprocessing.cpu_count(), cache_paths=cache_paths,
-      num_readers=num_readers, num_items=num_items,
+      num_readers=num_readers, num_items=num_items, num_users=num_users,
       training_shards=training_shards, deterministic=deterministic,
       match_mlperf=match_mlperf
   )

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -657,7 +657,7 @@ def make_synthetic_input_fn(is_training):
   def input_fn(params):
     """Generated input_fn for the given epoch."""
     batch_size = (params["batch_size"] if is_training else
-                  params["eval_batch_size"])
+                  params["eval_batch_size"] or params["batch_size"])
     num_users = params["num_users"]
     num_items = params["num_items"]
 

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -342,31 +342,8 @@ def generate_train_eval_data(df, approx_num_shards, num_items, cache_paths,
   map_args = [(shards[i], i, num_items, cache_paths, process_seeds[i],
                match_mlperf)
               for i in range(approx_num_shards)]
-<<<<<<< HEAD
+
   with popen_helper.get_pool(multiprocessing.cpu_count()) as pool:
-    test_shards = pool.map(_train_eval_map_fn, map_args)  # pylint: disable=no-member
-
-  tf.logging.info("Merging test shards...")
-  test_users = np.concatenate([i[movielens.USER_COLUMN] for i in test_shards])
-  test_items = np.concatenate([i[movielens.ITEM_COLUMN] for i in test_shards])
-
-  assert test_users.shape == test_items.shape
-  assert test_items.shape[0] % (rconst.NUM_EVAL_NEGATIVES + 1) == 0
-
-  test_labels = np.zeros(shape=test_users.shape)
-  test_labels[0::(rconst.NUM_EVAL_NEGATIVES + 1)] = 1
-  eval_data = ({
-      movielens.USER_COLUMN: test_users,
-      movielens.ITEM_COLUMN: test_items,
-  }, test_labels)
-
-  tf.logging.info("Writing test data to file.")
-  tf.gfile.MakeDirs(cache_paths.eval_data_subdir)
-  with tf.gfile.Open(cache_paths.eval_raw_file, "wb") as f:
-    pickle.dump(eval_data, f, protocol=pickle.HIGHEST_PROTOCOL)
-=======
-  with contextlib.closing(
-      multiprocessing.Pool(multiprocessing.cpu_count())) as pool:
     pool.map(_train_eval_map_fn, map_args)  # pylint: disable=no-member
   #   test_shards = pool.map(_train_eval_map_fn, map_args)  # pylint: disable=no-member
   #
@@ -388,7 +365,6 @@ def generate_train_eval_data(df, approx_num_shards, num_items, cache_paths,
   # tf.gfile.MakeDirs(cache_paths.eval_data_subdir)
   # with tf.gfile.Open(cache_paths.eval_raw_file, "wb") as f:
   #   pickle.dump(eval_data, f, protocol=pickle.HIGHEST_PROTOCOL)
->>>>>>> intermediate commit
 
 
 def construct_cache(dataset, data_dir, num_data_readers, match_mlperf,

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -369,7 +369,7 @@ def generate_train_eval_data(df, approx_num_shards, num_items, cache_paths,
 
 def construct_cache(dataset, data_dir, num_data_readers, match_mlperf,
                     deterministic, cache_id=None):
-  # type: (str, str, int, bool, typing.Optional[int]) -> NCFDataset
+  # type: (str, str, int, bool, bool, typing.Optional[int]) -> NCFDataset
   """Load and digest data CSV into a usable form.
 
   Args:
@@ -467,6 +467,7 @@ def instantiate_pipeline(dataset, data_dir, batch_size, eval_batch_size,
       "num_neg": num_neg,
       "num_train_positives": ncf_dataset.num_train_positives,
       "num_items": ncf_dataset.num_items,
+      "num_users": ncf_dataset.num_users,
       "num_readers": ncf_dataset.num_data_readers,
       "epochs_per_cycle": epochs_per_cycle,
       "train_batch_size": batch_size,

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -670,20 +670,20 @@ def make_synthetic_input_fn(is_training):
       labels = tf.random_uniform([batch_size], dtype=tf.int32, minval=0,
                                  maxval=2)
       data = {
-               movielens.USER_COLUMN: users,
-               movielens.ITEM_COLUMN: items,
-             }, labels
+          movielens.USER_COLUMN: users,
+          movielens.ITEM_COLUMN: items,
+      }, labels
     else:
       dupe_mask = tf.cast(tf.random_uniform([batch_size], dtype=tf.int32,
                                             minval=0, maxval=2), tf.bool)
       data = {
-        movielens.USER_COLUMN: users,
-        movielens.ITEM_COLUMN: items,
-        rconst.DUPLICATE_MASK: dupe_mask,
+          movielens.USER_COLUMN: users,
+          movielens.ITEM_COLUMN: items,
+          rconst.DUPLICATE_MASK: dupe_mask,
       }
 
     dataset = tf.data.Dataset.from_tensors(data).repeat(
-      _SYNTHETIC_BATCHES_PER_EPOCH)
+        _SYNTHETIC_BATCHES_PER_EPOCH)
     dataset = dataset.prefetch(32)
     return dataset
 

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -57,7 +57,7 @@ DATASET_TO_NUM_USERS_AND_ITEMS = {
 # Number of batches to run per epoch when using synthetic data. At high batch
 # sizes, we run for more batches than with real data, which is good since
 # running more batches reduces noise when measuring the average batches/second.
-_SYNTHETIC_BATCHES_PER_EPOCH = 2000
+SYNTHETIC_BATCHES_PER_EPOCH = 2000
 
 
 class NCFDataset(object):
@@ -686,8 +686,8 @@ def make_synthetic_input_fn(is_training):
       }
 
     dataset = tf.data.Dataset.from_tensors(data).repeat(
-        _SYNTHETIC_BATCHES_PER_EPOCH)
+        SYNTHETIC_BATCHES_PER_EPOCH)
     dataset = dataset.prefetch(32)
     return dataset
 
-  return input_fn, None, _SYNTHETIC_BATCHES_PER_EPOCH
+  return input_fn, None, SYNTHETIC_BATCHES_PER_EPOCH

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -65,7 +65,7 @@ class NCFDataset(object):
 
   def __init__(self, user_map, item_map, num_data_readers, cache_paths,
                num_train_positives, deterministic=False):
-    # type: (dict, dict, int, rconst.Paths) -> None
+    # type: (dict, dict, int, rconst.Paths, int, bool) -> None
     """Assign key values for recommendation dataset.
 
     Args:
@@ -474,6 +474,7 @@ def instantiate_pipeline(dataset, data_dir, batch_size, eval_batch_size,
       "num_workers": num_workers,
       "redirect_logs": use_subprocess,
       "use_tf_logging": not use_subprocess,
+      "ml_perf": match_mlperf,
   }
 
   if ncf_dataset.deterministic:

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -178,7 +178,7 @@ class BaseTest(tf.test.TestCase):
       sharded_eval_data.append(data_async_generation._process_shard(
           (os.path.join(cache_paths.train_shard_subdir, raw_shards[i]),
            num_items, rconst.NUM_EVAL_NEGATIVES, stat_utils.random_int32(),
-           False, True)))
+           False, True, 0)))
 
     if sharded_eval_data[0][0][0] == 1:
       # Order is not assured for this part of the pipeline.

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -136,8 +136,6 @@ class BaseTest(tf.test.TestCase):
     for features, labels in first_epoch:
       for u, i, l in zip(features[movielens.USER_COLUMN],
                          features[movielens.ITEM_COLUMN], labels):
-        if u < 0:
-          continue  # Ignore padding
 
         u_raw = user_inv_map[u]
         i_raw = item_inv_map[i]
@@ -150,9 +148,7 @@ class BaseTest(tf.test.TestCase):
         train_examples[l].add((u_raw, i_raw))
     num_positives_seen = len(train_examples[True])
 
-    # The numbers don't match exactly because the last batch spills over into
-    # the next epoch
-    assert ncf_dataset.num_train_positives - num_positives_seen < BATCH_SIZE
+    assert ncf_dataset.num_train_positives == num_positives_seen
 
     # This check is more heuristic because negatives are sampled with
     # replacement. It only checks that negative generation is reasonably random.

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -191,8 +191,8 @@ class BaseTest(tf.test.TestCase):
     eval_data = [np.concatenate([shard[i] for shard in sharded_eval_data])
                  for i in range(3)]
     eval_data = {
-      movielens.USER_COLUMN: eval_data[0],
-      movielens.ITEM_COLUMN: eval_data[1],
+        movielens.USER_COLUMN: eval_data[0],
+        movielens.ITEM_COLUMN: eval_data[1],
     }
 
     eval_items_per_user = rconst.NUM_EVAL_NEGATIVES + 1

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -178,7 +178,7 @@ class BaseTest(tf.test.TestCase):
       sharded_eval_data.append(data_async_generation._process_shard(
           (os.path.join(cache_paths.train_shard_subdir, raw_shards[i]),
            num_items, rconst.NUM_EVAL_NEGATIVES, stat_utils.random_int32(),
-           False, True, 0)))
+           False, True)))
 
     if sharded_eval_data[0][0][0] == 1:
       # Order is not assured for this part of the pipeline.

--- a/official/recommendation/data_test.py
+++ b/official/recommendation/data_test.py
@@ -121,7 +121,7 @@ class BaseTest(tf.test.TestCase):
     g = tf.Graph()
     with g.as_default():
       input_fn, record_dir, batch_count = \
-        data_preprocessing.make_train_input_fn(ncf_dataset)
+        data_preprocessing.make_input_fn(ncf_dataset, True)
       dataset = input_fn({"batch_size": BATCH_SIZE, "use_tpu": False})
     first_epoch = self.drain_dataset(dataset=dataset, g=g)
     user_inv_map = {v: k for k, v in ncf_dataset.user_map.items()}

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -142,7 +142,8 @@ def run_ncf(_):
     cleanup_fn = lambda: None
     num_users, num_items = data_preprocessing.DATASET_TO_NUM_USERS_AND_ITEMS[
         FLAGS.dataset]
-    num_train_steps, num_eval_steps = None, None
+    num_train_steps = data_preprocessing.SYNTHETIC_BATCHES_PER_EPOCH
+    num_eval_steps = data_preprocessing.SYNTHETIC_BATCHES_PER_EPOCH
   else:
     ncf_dataset, cleanup_fn = data_preprocessing.instantiate_pipeline(
         dataset=FLAGS.dataset, data_dir=FLAGS.data_dir,

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -157,8 +157,8 @@ def run_ncf(_):
     num_users = ncf_dataset.num_users
     num_items = ncf_dataset.num_items
     num_train_steps = int(np.ceil(
-      FLAGS.epochs_between_evals * ncf_dataset.num_train_positives *
-      (1 + FLAGS.num_neg) / FLAGS.batch_size))
+        FLAGS.epochs_between_evals * ncf_dataset.num_train_positives *
+        (1 + FLAGS.num_neg) / FLAGS.batch_size))
     num_eval_steps = int(np.ceil((1 + rconst.NUM_EVAL_NEGATIVES) *
                                  ncf_dataset.num_users / eval_batch_size))
 
@@ -211,8 +211,6 @@ def run_ncf(_):
 
 
   pred_input_fn = None
-  # pred_input_fn = data_preprocessing.make_pred_input_fn(ncf_dataset=ncf_dataset)
-
   total_training_cycle = FLAGS.train_epochs // FLAGS.epochs_between_evals
   for cycle_index in range(total_training_cycle):
     tf.logging.info("Starting a training cycle: {}/{}".format(
@@ -221,12 +219,12 @@ def run_ncf(_):
     # Train the model
     train_input_fn, train_record_dir, batch_count = \
       data_preprocessing.make_input_fn(
-        ncf_dataset=ncf_dataset, is_training=True)
+          ncf_dataset=ncf_dataset, is_training=True)
 
     if batch_count != num_train_steps:
       raise ValueError(
-        "Step counts do not match. ({} vs. {}) The async process is producing "
-        "incorrect shards.".format(batch_count, num_train_steps))
+          "Step counts do not match. ({} vs. {}) The async process is "
+          "producing incorrect shards.".format(batch_count, num_train_steps))
 
     train_estimator.train(input_fn=train_input_fn, hooks=train_hooks,
                           steps=num_train_steps)
@@ -236,12 +234,13 @@ def run_ncf(_):
     tf.logging.info("Beginning evaluation.")
     if pred_input_fn is None:
       pred_input_fn, _, eval_batch_count = data_preprocessing.make_input_fn(
-        ncf_dataset=ncf_dataset, is_training=False)
+          ncf_dataset=ncf_dataset, is_training=False)
 
       if eval_batch_count != num_eval_steps:
         raise ValueError(
-          "Step counts do not match. ({} vs. {}) The async process is producing "
-          "incorrect shards.".format(eval_batch_count, num_eval_steps))
+            "Step counts do not match. ({} vs. {}) The async process is "
+            "producing incorrect shards.".format(
+                eval_batch_count, num_eval_steps))
 
     eval_results = eval_estimator.evaluate(pred_input_fn, steps=num_eval_steps)
     tf.logging.info("Evaluation complete.")

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -142,7 +142,7 @@ def run_ncf(_):
     cleanup_fn = lambda: None
     num_users, num_items = data_preprocessing.DATASET_TO_NUM_USERS_AND_ITEMS[
         FLAGS.dataset]
-    approx_train_steps = None
+    num_train_steps, num_eval_steps = None, None
   else:
     ncf_dataset, cleanup_fn = data_preprocessing.instantiate_pipeline(
         dataset=FLAGS.dataset, data_dir=FLAGS.data_dir,
@@ -156,8 +156,11 @@ def run_ncf(_):
         cache_id=FLAGS.cache_id)
     num_users = ncf_dataset.num_users
     num_items = ncf_dataset.num_items
-    approx_train_steps = int(ncf_dataset.num_train_positives
-                             * (1 + FLAGS.num_neg) // FLAGS.batch_size)
+    num_train_steps = int(np.ceil(
+      FLAGS.epochs_between_evals * ncf_dataset.num_train_positives *
+      (1 + FLAGS.num_neg) / FLAGS.batch_size))
+    num_eval_steps = int(np.ceil((1 + rconst.NUM_EVAL_NEGATIVES) *
+                                 ncf_dataset.num_users / eval_batch_size))
 
   model_helpers.apply_clean(flags.FLAGS)
 
@@ -206,7 +209,9 @@ def run_ncf(_):
       run_params=run_params,
       test_id=FLAGS.benchmark_test_id)
 
-  pred_input_fn = data_preprocessing.make_pred_input_fn(ncf_dataset=ncf_dataset)
+
+  pred_input_fn = None
+  # pred_input_fn = data_preprocessing.make_pred_input_fn(ncf_dataset=ncf_dataset)
 
   total_training_cycle = FLAGS.train_epochs // FLAGS.epochs_between_evals
   for cycle_index in range(total_training_cycle):
@@ -215,20 +220,30 @@ def run_ncf(_):
 
     # Train the model
     train_input_fn, train_record_dir, batch_count = \
-      data_preprocessing.make_train_input_fn(ncf_dataset=ncf_dataset)
+      data_preprocessing.make_input_fn(
+        ncf_dataset=ncf_dataset, is_training=True)
 
-    if approx_train_steps and np.abs(approx_train_steps - batch_count) > 1:
-      tf.logging.warning(
-          "Estimated ({}) and reported ({}) number of batches differ by more "
-          "than one".format(approx_train_steps, batch_count))
+    if batch_count != num_train_steps:
+      raise ValueError(
+        "Step counts do not match. ({} vs. {}) The async process is producing "
+        "incorrect shards.".format(batch_count, num_train_steps))
 
     train_estimator.train(input_fn=train_input_fn, hooks=train_hooks,
-                          steps=batch_count)
+                          steps=num_train_steps)
     if train_record_dir:
       tf.gfile.DeleteRecursively(train_record_dir)
 
     tf.logging.info("Beginning evaluation.")
-    eval_results = eval_estimator.evaluate(pred_input_fn)
+    if pred_input_fn is None:
+      pred_input_fn, _, eval_batch_count = data_preprocessing.make_input_fn(
+        ncf_dataset=ncf_dataset, is_training=False)
+
+      if eval_batch_count != num_eval_steps:
+        raise ValueError(
+          "Step counts do not match. ({} vs. {}) The async process is producing "
+          "incorrect shards.".format(eval_batch_count, num_eval_steps))
+
+    eval_results = eval_estimator.evaluate(pred_input_fn, steps=num_eval_steps)
     tf.logging.info("Evaluation complete.")
 
     # Benchmark the evaluation results

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -77,11 +77,11 @@ def neumf_model_fn(features, labels, mode, params):
   users = features[movielens.USER_COLUMN]
   items = tf.cast(features[movielens.ITEM_COLUMN], tf.int32)
 
+  padding_mask = tf.cast(tf.greater_equal(users, 0), tf.int32)
   if mode == tf.estimator.ModeKeys.TRAIN:
     # Padded values are encoded as -1. They are returned to zero to prevent a
     # key lookup error. Loss is multiplied by padding_mask to cancel
     # appropriately.
-    padding_mask = tf.cast(tf.greater_equal(users, 0), tf.int32)
     users *= padding_mask
 
   logits = construct_model(users=users, items=items, params=params)
@@ -117,7 +117,7 @@ def neumf_model_fn(features, labels, mode, params):
     loss = tf.losses.sparse_softmax_cross_entropy(
         labels=labels,
         logits=softmax_logits
-    ) * padding_mask
+    ) * tf.cast(padding_mask, tf.float32)
 
     # This tensor is used by logging hooks.
     tf.identity(loss, name="cross_entropy")

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -77,13 +77,6 @@ def neumf_model_fn(features, labels, mode, params):
   users = features[movielens.USER_COLUMN]
   items = tf.cast(features[movielens.ITEM_COLUMN], tf.int32)
 
-  padding_mask = tf.cast(tf.greater_equal(users, 0), tf.int32)
-  if mode == tf.estimator.ModeKeys.TRAIN:
-    # Padded values are encoded as -1. They are returned to zero to prevent a
-    # key lookup error. Loss is multiplied by padding_mask to cancel
-    # appropriately.
-    users *= padding_mask
-
   logits = construct_model(users=users, items=items, params=params)
 
   # Softmax with the first column of zeros is equivalent to sigmoid.
@@ -116,8 +109,7 @@ def neumf_model_fn(features, labels, mode, params):
 
     loss = tf.losses.sparse_softmax_cross_entropy(
         labels=labels,
-        logits=softmax_logits,
-        weights=padding_mask
+        logits=softmax_logits
     )
 
     # This tensor is used by logging hooks.

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -116,8 +116,9 @@ def neumf_model_fn(features, labels, mode, params):
 
     loss = tf.losses.sparse_softmax_cross_entropy(
         labels=labels,
-        logits=softmax_logits
-    ) * tf.cast(padding_mask, tf.float32)
+        logits=softmax_logits,
+        weights=padding_mask
+    )
 
     # This tensor is used by logging hooks.
     tf.identity(loss, name="cross_entropy")

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -77,6 +77,13 @@ def neumf_model_fn(features, labels, mode, params):
   users = features[movielens.USER_COLUMN]
   items = tf.cast(features[movielens.ITEM_COLUMN], tf.int32)
 
+  if mode == tf.estimator.ModeKeys.TRAIN:
+    # Padded values are encoded as -1. They are returned to zero to prevent a
+    # key lookup error. Loss is multiplied by padding_mask to cancel
+    # appropriately.
+    padding_mask = tf.cast(tf.greater_equal(users, 0), tf.int32)
+    users *= padding_mask
+
   logits = construct_model(users=users, items=items, params=params)
 
   # Softmax with the first column of zeros is equivalent to sigmoid.
@@ -110,7 +117,7 @@ def neumf_model_fn(features, labels, mode, params):
     loss = tf.losses.sparse_softmax_cross_entropy(
         labels=labels,
         logits=softmax_logits
-    )
+    ) * padding_mask
 
     # This tensor is used by logging hooks.
     tf.identity(loss, name="cross_entropy")

--- a/official/recommendation/run.sh
+++ b/official/recommendation/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-DATASET="ml-1m"
+DATASET="ml-20m"
 
 BUCKET=${BUCKET:-""}
 ROOT_DIR="${BUCKET:-/tmp}/MLPerf_NCF"
@@ -32,7 +32,7 @@ python ../datasets/movielens.py --data_dir ${DATA_DIR} --dataset ${DATASET}
 
 {
 
-for i in `seq 0 0`;
+for i in `seq 0 4`;
 do
   START_TIME=$(date +%s)
   MODEL_DIR="${TEST_DIR}/model_dir_${i}"
@@ -48,7 +48,7 @@ do
   # And to confirm that the pipeline is deterministic pass the flag:
   #   --hash_pipeline
   #
-  # (`--hash_pipeline` will slow down training)
+  # (`--hash_pipeline` will slow down training, though not as much as one might imagine.)
   python ncf_main.py --model_dir ${MODEL_DIR} \
                      --data_dir ${DATA_DIR} \
                      --dataset ${DATASET} --hooks "" \
@@ -59,10 +59,10 @@ do
                      --eval_batch_size 100000 \
                      --learning_rate 0.0005 \
                      --layers 256,256,128,64 --num_factors 64 \
-                     --hr_threshold 0.1 \
-                     --ml_perf # \
- # |& tee ${RUN_LOG} \
- # | grep --line-buffered  -E --regexp="(Iteration [0-9]+: HR = [0-9\.]+, NDCG = [0-9\.]+)|(pipeline_hash)"
+                     --hr_threshold 0.635 \
+                     --ml_perf \
+ |& tee ${RUN_LOG} \
+ | grep --line-buffered  -E --regexp="(Iteration [0-9]+: HR = [0-9\.]+, NDCG = [0-9\.]+)|(pipeline_hash)"
 
   END_TIME=$(date +%s)
   echo "Run ${i} complete: $(( $END_TIME - $START_TIME )) seconds."

--- a/official/recommendation/run.sh
+++ b/official/recommendation/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-DATASET="ml-20m"
+DATASET="ml-1m"
 
 BUCKET=${BUCKET:-""}
 ROOT_DIR="${BUCKET:-/tmp}/MLPerf_NCF"
@@ -32,7 +32,7 @@ python ../datasets/movielens.py --data_dir ${DATA_DIR} --dataset ${DATASET}
 
 {
 
-for i in `seq 0 4`;
+for i in `seq 0 0`;
 do
   START_TIME=$(date +%s)
   MODEL_DIR="${TEST_DIR}/model_dir_${i}"
@@ -59,10 +59,10 @@ do
                      --eval_batch_size 100000 \
                      --learning_rate 0.0005 \
                      --layers 256,256,128,64 --num_factors 64 \
-                     --hr_threshold 0.635 \
-                     --ml_perf \
-  |& tee ${RUN_LOG} \
-  | grep --line-buffered  -E --regexp="(Iteration [0-9]+: HR = [0-9\.]+, NDCG = [0-9\.]+)|(pipeline_hash)"
+                     --hr_threshold 0.1 \
+                     --ml_perf # \
+ # |& tee ${RUN_LOG} \
+ # | grep --line-buffered  -E --regexp="(Iteration [0-9]+: HR = [0-9\.]+, NDCG = [0-9\.]+)|(pipeline_hash)"
 
   END_TIME=$(date +%s)
   echo "Run ${i} complete: $(( $END_TIME - $START_TIME )) seconds."


### PR DESCRIPTION
This PR does two things:

1) It replaces the "spillover" mechanism with a more conventional padding which is ignored by the cross entropy. @shizhiw In the last batch the padded keys all lookup at index zero. Is this hot key going to be an issue? (If so I can spread out the keys; it's just easier to read if all the paddings have the same value.)

2) It consolidates a lot of the eval generation and merges the training and eval generation. This removes some duplicate code. However, it also makes the performance properties much better:
 * Training and eval now use the same base data shards, saving a ~2GB .npz intermediate file
 * The eval set is now computed after the first training epoch, so training can begin sooner.
 * The clock start can be moved to right before the subprocess starts, because the random sampling for eval no longer happens as part of the main thread data preprocessing.