### PR TITLE
Drop references to `is_single_tower`.

### DIFF
--- a/official/utils/misc/distribution_utils_test.py
+++ b/official/utils/misc/distribution_utils_test.py
@@ -27,21 +27,18 @@ class GetDistributionStrategyTest(tf.test.TestCase):
   """Tests for get_distribution_strategy."""
   def test_one_device_strategy_cpu(self):
     ds = distribution_utils.get_distribution_strategy(0)
-    self.assertTrue(ds.is_single_tower)
     self.assertEquals(ds.num_towers, 1)
     self.assertEquals(len(ds.worker_devices), 1)
     self.assertIn('CPU', ds.worker_devices[0])
 
   def test_one_device_strategy_gpu(self):
     ds = distribution_utils.get_distribution_strategy(1)
-    self.assertTrue(ds.is_single_tower)
     self.assertEquals(ds.num_towers, 1)
     self.assertEquals(len(ds.worker_devices), 1)
     self.assertIn('GPU', ds.worker_devices[0])
 
   def test_mirrored_strategy(self):
     ds = distribution_utils.get_distribution_strategy(5)
-    self.assertFalse(ds.is_single_tower)
     self.assertEquals(ds.num_towers, 5)
     self.assertEquals(len(ds.worker_devices), 5)
     for device in ds.worker_devices:


### PR DESCRIPTION
Since we plan on deleting this method, as it is only used in distribution_utils_test.py.