### PR TITLE
Add XLA support to NCF

### DIFF
--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -511,8 +511,8 @@ def make_deserialize(params, batch_size, training=False):
     items = tf.reshape(tf.decode_raw(
         features[movielens.ITEM_COLUMN], tf.uint16), (batch_size,))
 
-    if params["use_tpu"]:
-      items = tf.cast(items, tf.int32)  # TPU doesn't allow uint16 infeed.
+    if params["use_tpu"] or params["use_xla_for_gpu"]:
+      items = tf.cast(items, tf.int32)  # TPU and XLA disallows uint16 infeed.
 
     if not training:
       dupe_mask = tf.reshape(tf.cast(tf.decode_raw(

--- a/official/recommendation/ncf_main.py
+++ b/official/recommendation/ncf_main.py
@@ -415,7 +415,7 @@ def define_ncf_flags():
   ))
 
   flags.DEFINE_bool(
-      name="use_xla_for_gpu", default=True, help=flags_core.help_wrap(
+      name="use_xla_for_gpu", default=False, help=flags_core.help_wrap(
           "If True, use XLA for the model function. Only works when using a "
           "GPU. On TPUs, XLA is always used"))
 

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -42,6 +42,7 @@ import tensorflow as tf
 from official.datasets import movielens  # pylint: disable=g-bad-import-order
 from official.recommendation import constants as rconst
 from official.recommendation import stat_utils
+from tensorflow.contrib.compiler import xla
 
 
 def _sparse_to_dense_grads(grads_and_vars):
@@ -132,6 +133,9 @@ def neumf_model_fn(features, labels, mode, params):
 
   else:
     raise NotImplementedError
+
+
+xla_neumf_model_fn = xla.estimator_model_fn(neumf_model_fn)
 
 
 def construct_model(users, items, params):

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -42,7 +42,6 @@ import tensorflow as tf
 from official.datasets import movielens  # pylint: disable=g-bad-import-order
 from official.recommendation import constants as rconst
 from official.recommendation import stat_utils
-from tensorflow.contrib.compiler import xla
 
 
 def _sparse_to_dense_grads(grads_and_vars):
@@ -98,7 +97,8 @@ def neumf_model_fn(features, labels, mode, params):
     duplicate_mask = tf.cast(features[rconst.DUPLICATE_MASK], tf.float32)
     return compute_eval_loss_and_metrics(
         logits, softmax_logits, duplicate_mask, params["num_neg"],
-        params["match_mlperf"], params["use_tpu"])
+        params["match_mlperf"],
+        use_tpu_spec=params["use_tpu"] or params["use_xla_for_gpu"])
 
   elif mode == tf.estimator.ModeKeys.TRAIN:
     labels = tf.cast(labels, tf.int32)
@@ -133,9 +133,6 @@ def neumf_model_fn(features, labels, mode, params):
 
   else:
     raise NotImplementedError
-
-
-xla_neumf_model_fn = xla.estimator_model_fn(neumf_model_fn)
 
 
 def construct_model(users, items, params):
@@ -238,7 +235,7 @@ def compute_eval_loss_and_metrics(logits,              # type: tf.Tensor
                                   duplicate_mask,      # type: tf.Tensor
                                   num_training_neg,    # type: int
                                   match_mlperf=False,  # type: bool
-                                  use_tpu=False        # type: bool
+                                  use_tpu_spec=False   # type: bool
                                  ):
   # type: (...) -> tf.estimator.EstimatorSpec
   """Model evaluation with HR and NDCG metrics.
@@ -297,7 +294,9 @@ def compute_eval_loss_and_metrics(logits,              # type: tf.Tensor
 
     match_mlperf: Use the MLPerf reference convention for computing rank.
 
-    use_tpu: Should the evaluation be performed on a TPU.
+    use_tpu_spec: Should a TPUEstimatorSpec be returned instead of an
+      EstimatorSpec. Required for TPUs and if XLA is done on a GPU. Despite its
+      name, TPUEstimatorSpecs work with GPUs
 
   Returns:
     An EstimatorSpec for evaluation.
@@ -338,7 +337,7 @@ def compute_eval_loss_and_metrics(logits,              # type: tf.Tensor
         rconst.NDCG_KEY: tf.metrics.mean(ndcg_tensor, weights=weight_tensor),
     }
 
-  if use_tpu:
+  if use_tpu_spec:
     return tf.contrib.tpu.TPUEstimatorSpec(
         mode=tf.estimator.ModeKeys.EVAL, loss=cross_entropy,
         eval_metrics=(metric_fn, [in_top_k, ndcg, metric_weights]))


### PR DESCRIPTION
I verified convergence, by running the following command 100 times with 1.13.0.dev20181017 and converging to 0.635 92% of the time.
```
python ncf_main.py --model_dir=$HOME/ncf_model_dir_gpu_0 --data_dir=$HOME/ncf_data_dir_gpu_0 --dataset ml-20m --hooks= --num_gpus -1 --clean --train_epochs 14 --batch_size 65536 --eval_batch_size 65536 --layers 256,256,128,64 --num_factors 64 --hr_threshold 0.99 --ml_perf --learning_rate=0.00281936 --beta1=0.0490852 --beta2=0.965095 --epsilon=1.23757e-08 --use_xla_for_gpu
```

I obtained the following training performance results on a Z840 with a Titan V, with TensorFlow 1.13.0.dev20181018, Cuda 9.0 with cuDNN 7.2.1 and the `ptxas` binary from Cuda 9.2 patched in, as recommended by XLA. I ran the following command, both with and without `--use_xla_for_gpu`, five times each and took the averages.

```
python ncf_main.py --model_dir=$HOME/ncf_model_dir_1 --data_dir=$HOME/ncf_data_dir_1 --dataset ml-20m --num_gpus -1 --clean --train_epochs 1 --batch_size 65536 --layers 256,256,128,64 --num_factors 64 --use_synthetic_data --ml_perf --hooks=examplespersecondhook
```

Without `--use_xla_for_gpu`, the training performance was 5038888 examples/sec and with `--use_xla_for_gpu`, the training performance was 6132903 examples/sec, a 21.7% improvement.