### PR TITLE
AllReduceCrossTowerOps -> AllReduceCrossDeviceOps

### DIFF
--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -27,7 +27,7 @@ def get_distribution_strategy(num_gpus, all_reduce_alg=None):
   Args:
     num_gpus: Number of GPUs to run this model.
     all_reduce_alg: Specify which algorithm to use when performing all-reduce.
-      See tf.contrib.distribute.AllReduceCrossTowerOps for available algorithms.
+      See tf.contrib.distribute.AllReduceCrossDeviceOps for available algorithms.
       If None, DistributionStrategy will choose based on device topology.
 
   Returns:
@@ -41,7 +41,7 @@ def get_distribution_strategy(num_gpus, all_reduce_alg=None):
     if all_reduce_alg:
       return tf.contrib.distribute.MirroredStrategy(
           num_gpus=num_gpus,
-          cross_tower_ops=tf.contrib.distribute.AllReduceCrossTowerOps(
+          cross_tower_ops=tf.contrib.distribute.AllReduceCrossDeviceOps(
               all_reduce_alg, num_packs=2))
     else:
       return tf.contrib.distribute.MirroredStrategy(num_gpus=num_gpus)

--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -27,8 +27,9 @@ def get_distribution_strategy(num_gpus, all_reduce_alg=None):
   Args:
     num_gpus: Number of GPUs to run this model.
     all_reduce_alg: Specify which algorithm to use when performing all-reduce.
-      See tf.contrib.distribute.AllReduceCrossDeviceOps for available algorithms.
-      If None, DistributionStrategy will choose based on device topology.
+      See tf.contrib.distribute.AllReduceCrossDeviceOps for available
+      algorithms. If None, DistributionStrategy will choose based on device
+      topology.
 
   Returns:
     tf.contrib.distribute.DistibutionStrategy object.


### PR DESCRIPTION
Update to reflect new name of (contrib) AllReduceCrossTowerOps since we are moving away from the "tower" terminology.