### PR TITLE
Rename "num_towers" to "num_replicas"

### DIFF
--- a/official/utils/misc/distribution_utils_test.py
+++ b/official/utils/misc/distribution_utils_test.py
@@ -27,19 +27,19 @@ class GetDistributionStrategyTest(tf.test.TestCase):
   """Tests for get_distribution_strategy."""
   def test_one_device_strategy_cpu(self):
     ds = distribution_utils.get_distribution_strategy(0)
-    self.assertEquals(ds.num_towers, 1)
+    self.assertEquals(ds.num_replicas, 1)
     self.assertEquals(len(ds.worker_devices), 1)
     self.assertIn('CPU', ds.worker_devices[0])
 
   def test_one_device_strategy_gpu(self):
     ds = distribution_utils.get_distribution_strategy(1)
-    self.assertEquals(ds.num_towers, 1)
+    self.assertEquals(ds.num_replicas, 1)
     self.assertEquals(len(ds.worker_devices), 1)
     self.assertIn('GPU', ds.worker_devices[0])
 
   def test_mirrored_strategy(self):
     ds = distribution_utils.get_distribution_strategy(5)
-    self.assertEquals(ds.num_towers, 5)
+    self.assertEquals(ds.num_replicas, 5)
     self.assertEquals(len(ds.worker_devices), 5)
     for device in ds.worker_devices:
       self.assertIn('GPU', device)


### PR DESCRIPTION
To match new terminology in DistributionStrategy.