### PR TITLE
Move version check to a function

### DIFF
--- a/official/utils/logs/mlperf_helper.py
+++ b/official/utils/logs/mlperf_helper.py
@@ -94,7 +94,7 @@ def get_mlperf_log():
       version = tuple(int(i) for i in version.version.split("."))
       if version < _MIN_VERSION:
         tf.logging.warning(
-            "mlperf_compliance is version {}, must be at least version {}".format(
+            "mlperf_compliance is version {}, must be >= {}".format(
                 ".".join([str(i) for i in version]),
                 ".".join([str(i) for i in _MIN_VERSION])))
         raise ImportError

--- a/official/utils/logs/mlperf_helper.py
+++ b/official/utils/logs/mlperf_helper.py
@@ -89,6 +89,7 @@ def get_mlperf_log():
     import mlperf_compliance
 
     def test_mlperf_log_pip_version():
+      """Check that mlperf_compliance is up to date."""
       import pkg_resources
       version = pkg_resources.get_distribution("mlperf_compliance")
       version = tuple(int(i) for i in version.version.split("."))

--- a/official/utils/logs/mlperf_helper.py
+++ b/official/utils/logs/mlperf_helper.py
@@ -98,9 +98,9 @@ def get_mlperf_log():
                 ".".join([str(i) for i in version]),
                 ".".join([str(i) for i in _MIN_VERSION])))
         raise ImportError
+      return mlperf_compliance.mlperf_log
 
-    test_mlperf_log_pip_version()
-    mlperf_log = mlperf_compliance.mlperf_log
+    mlperf_log = test_mlperf_log_pip_version()
 
   except ImportError:
     mlperf_log = None

--- a/official/utils/logs/mlperf_helper.py
+++ b/official/utils/logs/mlperf_helper.py
@@ -86,18 +86,20 @@ def unparse_line(parsed_line): # type: (ParsedLine) -> str
 def get_mlperf_log():
   """Shielded import of mlperf_log module."""
   try:
-    import pkg_resources
     import mlperf_compliance
 
-    version = pkg_resources.get_distribution("mlperf_compliance")
-    version = tuple(int(i) for i in version.version.split("."))
-    if version < _MIN_VERSION:
-      tf.logging.warning(
-          "mlperf_compliance is version {}, must be at least version {}".format(
-              ".".join([str(i) for i in version]),
-              ".".join([str(i) for i in _MIN_VERSION])))
-      raise ImportError
+    def test_mlperf_log_pip_version():
+      import pkg_resources
+      version = pkg_resources.get_distribution("mlperf_compliance")
+      version = tuple(int(i) for i in version.version.split("."))
+      if version < _MIN_VERSION:
+        tf.logging.warning(
+            "mlperf_compliance is version {}, must be at least version {}".format(
+                ".".join([str(i) for i in version]),
+                ".".join([str(i) for i in _MIN_VERSION])))
+        raise ImportError
 
+    test_mlperf_log_pip_version()
     mlperf_log = mlperf_compliance.mlperf_log
 
   except ImportError:


### PR DESCRIPTION
The pip version check only makes sense in open source. This PR moves it to a function to make it easier to disable internally.