### PR TITLE
update to tf r1.11 and use distribute strategy

### DIFF
--- a/tutorials/image/cifar10_estimator/README.md
+++ b/tutorials/image/cifar10_estimator/README.md
@@ -13,8 +13,27 @@ Before trying to run the model we highly encourage you to read all the README.
 
 ## Prerequisite
 
-1. [Install](https://www.tensorflow.org/install/) TensorFlow version 1.9.0 or
-later.
+1. [Install](https://www.tensorflow.org/install/) TensorFlow version 1.11.0 or
+later. Be sure to fix a bug before installing tf as followed:
+
+modify the source code in tensorflow/python/estimator/estimator.py
+
+```
+def get_hooks_from_the_first_device(per_device_hooks):
+  return [
+      self._distribution.unwrap(per_device_hook)[0]
+      for per_device_hook in per_device_hooks
+  ]
+```
+to 
+```
+def get_hooks_from_the_first_device(per_device_hooks):
+  return [
+      self._train_distribution.unwrap(per_device_hook)[0]
+      for per_device_hook in per_device_hooks
+  ]
+```
+then build tensorflow from source code.
 
 2. Download the CIFAR-10 dataset and generate TFRecord files using the provided
 script.  The script and associated command below will download the CIFAR-10
@@ -102,7 +121,12 @@ gcloud ml-engine jobs submit training cifarmultigpu \
     --num-gpus=4 \
     --train-steps=1000
 ```
+### Set distrbute strategy in the code
+Here's an example of distribute strategy.
 
+distribution = tf.contrib.distribute.ParameterServerStrategy()
+
+Note: CollectiveAllReduceStrategy will raise error.
 
 ### Set TF_CONFIG
 


### PR DESCRIPTION
This cifar10_ResNet has been updated to r1.11 and used tf.estimator.train_and_evaluate to train model, with the new feature of using distribute strategy(set to None for local training).

Please modify the source code as README.md says and build tensorflow from source code.
Don't use CollectiveAllReduceStrategy and SyncReplicasOptimizer temporarily, because they will raise error. By default, the strategy will be None and start local training. 

The ParameterServerStrategy is available for distributed training.