### PR TITLE
cross_tower_ops -> cross_device_ops

### DIFF
--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -42,7 +42,7 @@ def get_distribution_strategy(num_gpus, all_reduce_alg=None):
     if all_reduce_alg:
       return tf.contrib.distribute.MirroredStrategy(
           num_gpus=num_gpus,
-          cross_tower_ops=tf.contrib.distribute.AllReduceCrossDeviceOps(
+          cross_device_ops=tf.contrib.distribute.AllReduceCrossDeviceOps(
               all_reduce_alg, num_packs=2))
     else:
       return tf.contrib.distribute.MirroredStrategy(num_gpus=num_gpus)


### PR DESCRIPTION
Update to the new name for an argument to the __init__() method of MirroredStrategy.