### PR TITLE
Keras-ify NCF TPU embedding lookup

### DIFF
--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -199,20 +199,22 @@ def construct_model(users, items, params):
   batch_size = user_input.get_shape()[0]
 
   if params["use_tpu"]:
+    cmb_embedding_user = tf.get_variable(
+      name="embeddings_mf_user",
+      shape=[num_users, mf_dim + model_layers[0] // 2],
+      initializer=tf.glorot_uniform_initializer())
+
+    cmb_embedding_item = tf.get_variable(
+      name="embeddings_mf_item",
+      shape=[num_items, mf_dim + model_layers[0] // 2],
+      initializer=tf.glorot_uniform_initializer())
+
     with tf.variable_scope("embed_weights", reuse=tf.AUTO_REUSE):
       cmb_user_latent = tf.keras.layers.Lambda(lambda ids: tf.gather(
-        tf.get_variable(
-          name="embeddings_mf_user",
-          shape=[num_users, mf_dim + model_layers[0] // 2],
-          initializer=tf.glorot_uniform_initializer()),
-        ids))(user_input)
+        cmb_embedding_user, ids))(user_input)
 
       cmb_item_latent = tf.keras.layers.Lambda(lambda ids: tf.gather(
-        tf.get_variable(
-          name="embeddings_mf_item",
-          shape=[num_items, mf_dim + model_layers[0] // 2],
-          initializer=tf.glorot_uniform_initializer()),
-      ids))(item_input)
+        cmb_embedding_item, ids))(item_input)
 
       mlp_user_latent = tf.keras.layers.Lambda(
         lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -214,10 +214,21 @@ def construct_model(users, items, params):
           initializer=tf.glorot_uniform_initializer()),
       ids))(item_input)
 
-      mlp_user_latent = tf.keras.layers.Lambda(lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2]))(cmb_user_latent)
-      mlp_item_latent = tf.keras.layers.Lambda(lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2]))(cmb_item_latent)
-      mf_user_latent = tf.keras.layers.Lambda(lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim]))(cmb_user_latent)
-      mf_item_latent = tf.keras.layers.Lambda(lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim]))(cmb_item_latent)
+      mlp_user_latent = tf.keras.layers.Lambda(
+        lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
+      )(cmb_user_latent)
+
+      mlp_item_latent = tf.keras.layers.Lambda(
+        lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
+      )(cmb_item_latent)
+
+      mf_user_latent = tf.keras.layers.Lambda(
+        lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
+      )(cmb_user_latent)
+
+      mf_item_latent = tf.keras.layers.Lambda(
+        lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
+      )(cmb_item_latent)
 
   else:
     # Initializer for embedding layers

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -199,17 +199,17 @@ def construct_model(users, items, params):
   batch_size = user_input.get_shape()[0]
 
   if params["use_tpu"]:
-    cmb_embedding_user = tf.get_variable(
-        name="embeddings_mf_user",
-        shape=[num_users, mf_dim + model_layers[0] // 2],
-        initializer=tf.glorot_uniform_initializer())
-
-    cmb_embedding_item = tf.get_variable(
-        name="embeddings_mf_item",
-        shape=[num_items, mf_dim + model_layers[0] // 2],
-        initializer=tf.glorot_uniform_initializer())
-
     with tf.variable_scope("embed_weights", reuse=tf.AUTO_REUSE):
+      cmb_embedding_user = tf.get_variable(
+          name="embeddings_mf_user",
+          shape=[num_users, mf_dim + model_layers[0] // 2],
+          initializer=tf.glorot_uniform_initializer())
+
+      cmb_embedding_item = tf.get_variable(
+          name="embeddings_mf_item",
+          shape=[num_items, mf_dim + model_layers[0] // 2],
+          initializer=tf.glorot_uniform_initializer())
+
       cmb_user_latent = tf.keras.layers.Lambda(lambda ids: tf.gather(
           cmb_embedding_user, ids))(user_input)
 

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -200,36 +200,36 @@ def construct_model(users, items, params):
 
   if params["use_tpu"]:
     cmb_embedding_user = tf.get_variable(
-      name="embeddings_mf_user",
-      shape=[num_users, mf_dim + model_layers[0] // 2],
-      initializer=tf.glorot_uniform_initializer())
+        name="embeddings_mf_user",
+        shape=[num_users, mf_dim + model_layers[0] // 2],
+        initializer=tf.glorot_uniform_initializer())
 
     cmb_embedding_item = tf.get_variable(
-      name="embeddings_mf_item",
-      shape=[num_items, mf_dim + model_layers[0] // 2],
-      initializer=tf.glorot_uniform_initializer())
+        name="embeddings_mf_item",
+        shape=[num_items, mf_dim + model_layers[0] // 2],
+        initializer=tf.glorot_uniform_initializer())
 
     with tf.variable_scope("embed_weights", reuse=tf.AUTO_REUSE):
       cmb_user_latent = tf.keras.layers.Lambda(lambda ids: tf.gather(
-        cmb_embedding_user, ids))(user_input)
+          cmb_embedding_user, ids))(user_input)
 
       cmb_item_latent = tf.keras.layers.Lambda(lambda ids: tf.gather(
-        cmb_embedding_item, ids))(item_input)
+          cmb_embedding_item, ids))(item_input)
 
       mlp_user_latent = tf.keras.layers.Lambda(
-        lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
+          lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
       )(cmb_user_latent)
 
       mlp_item_latent = tf.keras.layers.Lambda(
-        lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
+          lambda x: tf.slice(x, [0, 0], [batch_size, model_layers[0] // 2])
       )(cmb_item_latent)
 
       mf_user_latent = tf.keras.layers.Lambda(
-        lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
+          lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
       )(cmb_user_latent)
 
       mf_item_latent = tf.keras.layers.Lambda(
-        lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
+          lambda x: tf.slice(x, [0, model_layers[0] // 2], [batch_size, mf_dim])
       )(cmb_item_latent)
 
   else:


### PR DESCRIPTION
Keras throws
```
ValueError: Output tensors to a Model must be the output of a TensorFlow `Layer` (thus holding past layer metadata). Found: Tensor("rating/BiasAdd:0", shape=(12288, 1), dtype=float32)
```

when trying to run on the TPU since embedding lookups are tensors rather than Keras layers. This PR simply wraps the tensor operations in Lambda layers. There may be a more Keras-y way to do it, but this way at least works.

@tayo This doesn't seem to have a performance impact, but can you confirm that this is fine from your side?