### PR TITLE
Add --use_while_loop option.

### DIFF
--- a/official/recommendation/constants.py
+++ b/official/recommendation/constants.py
@@ -58,6 +58,10 @@ HR_KEY = "HR"
 NDCG_KEY = "NDCG"
 DUPLICATE_MASK = "duplicate_mask"
 
+# Metric names
+HR_METRIC_NAME = "HR_METRIC"
+NDCG_METRIC_NAME = "NDCG_METRIC"
+
 # ==============================================================================
 # == Subprocess Data Generation ================================================
 # ==============================================================================

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -257,6 +257,14 @@ class NcfTest(tf.test.TestCase):
     flags.FLAGS.ml_perf = True
     ncf_main.main(None)
 
+  @flagsaver.flagsaver(use_estimator=False, use_while_loop=True,
+                       **_BASE_END_TO_END_FLAGS)
+  @mock.patch.object(data_preprocessing, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
+  def test_end_to_end_while_loop(self):
+    ncf_main.main(None)
+    flags.FLAGS.ml_perf = True
+    ncf_main.main(None)
+
 
 if __name__ == "__main__":
   tf.logging.set_verbosity(tf.logging.INFO)

--- a/official/recommendation/neumf_model.py
+++ b/official/recommendation/neumf_model.py
@@ -404,8 +404,10 @@ def compute_eval_loss_and_metrics(logits,              # type: tf.Tensor
 
   def metric_fn(top_k_tensor, ndcg_tensor, weight_tensor):
     return {
-        rconst.HR_KEY: tf.metrics.mean(top_k_tensor, weights=weight_tensor),
-        rconst.NDCG_KEY: tf.metrics.mean(ndcg_tensor, weights=weight_tensor),
+        rconst.HR_KEY: tf.metrics.mean(top_k_tensor, weights=weight_tensor,
+                                       name=rconst.HR_METRIC_NAME),
+        rconst.NDCG_KEY: tf.metrics.mean(ndcg_tensor, weights=weight_tensor,
+                                         name=rconst.NDCG_METRIC_NAME),
     }
 
   if use_tpu_spec:


### PR DESCRIPTION
## Benchmark results
I ran the following command on a Volta DGX1, with tf-nightly-gpu==1.13.0.dev20181027, Cuda 9.0, cuDNN 7.3.0, with a single V100 by setting CUDA_VISIBLE_DEVICES=0. I ran with and without while loops, 3 times each, with #5652 also patched in. I measured the average per-epoch time, skipping the first two epochs as warmups.

```
python ncf_main.py --model_dir=/home/reedwm/ncf_model_dir_gpu_1 --data_dir=/home/reedwm/ncf_data_dir_gpu_1 --dataset ml-20m --hooks= --num_gpus -1 --clean --train_epochs 14 --batch_size 65536 --eval_batch_size 65536 --layers 256,256,128,64 --num_factors 64 --hr_threshold 0.99 --learning_rate=0.00281936 --beta1=0.0490852 --beta2=0.965095 --epsilon=1.23757e-08 --ml_perf --use_xla_for_gpu --nouse_estimator --use_while_loop=$USE_WHILE_LOOP --output_ml_perf_compliance_logging
```

Without while loops, the average per-epoch time was 22.05 seconds. With while loops, the average per-epoch time was 21.22 seconds, a 3.9% improvement.