### PR TITLE
Remove progress indicator from Movielens download

### DIFF
--- a/official/datasets/movielens.py
+++ b/official/datasets/movielens.py
@@ -111,12 +111,7 @@ def _download_and_clean(dataset, data_dir):
   temp_dir = tempfile.mkdtemp()
   try:
     zip_path = os.path.join(temp_dir, "{}.zip".format(dataset))
-    def _progress(count, block_size, total_size):
-      sys.stdout.write("\r>> Downloading {} {:.1f}%".format(
-          zip_path, 100.0 * count * block_size / total_size))
-      sys.stdout.flush()
-
-    zip_path, _ = urllib.request.urlretrieve(url, zip_path, _progress)
+    zip_path, _ = urllib.request.urlretrieve(url, zip_path)
     statinfo = os.stat(zip_path)
     # A new line to clear the carriage return from download progress
     # tf.logging.info is not applicable here


### PR DESCRIPTION
The progress bar indicator, while mildly useful in interactive mode, is extremely troublesome when logs are caught.