### PR TITLE
Fix V2_DEF overwriting problem in ssd_mobilenet_v2

### DIFF
--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor.py
@@ -38,9 +38,6 @@ def _create_modified_mobilenet_config():
   return conv_defs
 
 
-_CONV_DEFS = _create_modified_mobilenet_config()
-
-
 class SSDMobileNetV2FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
   """SSD Feature Extractor using MobilenetV2 FPN features."""
 
@@ -142,7 +139,7 @@ class SSDMobileNetV2FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
               ops.pad_to_multiple(preprocessed_inputs, self._pad_to_multiple),
               final_endpoint='layer_19',
               depth_multiplier=self._depth_multiplier,
-              conv_defs=_CONV_DEFS if self._use_depthwise else None,
+              conv_defs=_create_modified_mobilenet_config() if self._use_depthwise else None,
               use_explicit_padding=self._use_explicit_padding,
               scope=scope)
       depth_fn = lambda d: max(int(d * self._depth_multiplier), self._min_depth)


### PR DESCRIPTION
The `_create_modified_mobilenet_config()`[1] function would change the
`mobilenet_v2.V2_DEF` and cause `num_outputs` inconsistency(256 vs 1280) in `layer_19` in ssd_mobilenet_v2_feature_extractor.py[2]



```python
root@pc:/workspace/projects/models/research# export PYTHONPATH=$PYTHONPATH:`pwd`:`pwd`/slim
root@pc:/workspace/projects/models/research# python
Python 3.5.2 (default, Nov 23 2017, 16:37:01) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import copy
>>> import tensorflow as tf
>>> from nets.mobilenet import mobilenet
>>> from nets.mobilenet import mobilenet_v2
>>> slim = tf.contrib.slim
>>> 
>>> def _create_modified_mobilenet_config():
...   conv_defs = copy.copy(mobilenet_v2.V2_DEF)
...   conv_defs['spec'][-1] = mobilenet.op(
...       slim.conv2d, stride=1, kernel_size=[1, 1], num_outputs=256)
...   return conv_defs
... 
>>> # before
...                    
>>> mobilenet_v2.V2_DEF['spec'][-1].params['num_outputs']
1280
>>> # after
...
>>> _CONV_DEFS = _create_modified_mobilenet_config()
>>> mobilenet_v2.V2_DEF['spec'][-1].params['num_outputs']
256
```

Ref:

- [1] https://github.com/tensorflow/models/blob/master/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor.py#L41
- [2] https://github.com/tensorflow/models/blob/master/research/object_detection/models/ssd_mobilenet_v2_feature_extractor.py#L108
- [3] https://github.com/tensorflow/models/blob/master/research/object_detection/builders/model_builder.py#L49
- [4] https://arxiv.org/abs/1801.04381