### PR TITLE
Add keypoint setting support to dataset builder

### DIFF
--- a/research/object_detection/builders/dataset_builder.py
+++ b/research/object_detection/builders/dataset_builder.py
@@ -120,6 +120,7 @@ def build(input_reader_config, batch_size=None, transform_input_data_fn=None):
         instance_mask_type=input_reader_config.mask_type,
         label_map_proto_file=label_map_proto_file,
         use_display_name=input_reader_config.use_display_name,
+        num_keypoints=input_reader_config.num_keypoints,
         num_additional_channels=input_reader_config.num_additional_channels)
 
     def process_fn(value):


### PR DESCRIPTION
Take `num_keypoints` setting in input_reader_config to read groundtruth_keypoints
with TfExampleDecoder.

Ref:

- https://github.com/tensorflow/models/blob/master/research/object_detection/data_decoders/tf_example_decoder.py#L263