### PR TITLE
Revert "Use explicit relative import syntax for python 3 compatibility in audioset."

### DIFF
--- a/research/audioset/vggish_inference_demo.py
+++ b/research/audioset/vggish_inference_demo.py
@@ -46,15 +46,15 @@ Usage:
 
 from __future__ import print_function
 
-from . import vggish_input
-from . import vggish_params
-from . import vggish_postprocess
-from . import vggish_slim
-
 import numpy as np
 from scipy.io import wavfile
 import six
 import tensorflow as tf
+
+import vggish_input
+import vggish_params
+import vggish_postprocess
+import vggish_slim
 
 flags = tf.app.flags
 

--- a/research/audioset/vggish_input.py
+++ b/research/audioset/vggish_input.py
@@ -15,12 +15,12 @@
 
 """Compute input examples for VGGish from audio waveform."""
 
-from . import mel_features
-from . import vggish_params
-
 import numpy as np
 import resampy
 from scipy.io import wavfile
+
+import mel_features
+import vggish_params
 
 
 def waveform_to_examples(data, sample_rate):

--- a/research/audioset/vggish_postprocess.py
+++ b/research/audioset/vggish_postprocess.py
@@ -15,9 +15,9 @@
 
 """Post-process embeddings from VGGish."""
 
-from . import vggish_params
-
 import numpy as np
+
+import vggish_params
 
 
 class Postprocessor(object):

--- a/research/audioset/vggish_slim.py
+++ b/research/audioset/vggish_slim.py
@@ -30,8 +30,8 @@ For comparison, here is TF-Slim's VGG definition:
 https://github.com/tensorflow/models/blob/master/research/slim/nets/vgg.py
 """
 
-from . import vggish_params as params
 import tensorflow as tf
+import vggish_params as params
 
 slim = tf.contrib.slim
 

--- a/research/audioset/vggish_smoke_test.py
+++ b/research/audioset/vggish_smoke_test.py
@@ -31,13 +31,13 @@ Usage:
 
 from __future__ import print_function
 
-from . import vggish_input
-from . import vggish_params
-from . import vggish_postprocess
-from . import vggish_slim
-
 import numpy as np
 import tensorflow as tf
+
+import vggish_input
+import vggish_params
+import vggish_postprocess
+import vggish_slim
 
 print('\nTesting your install of VGGish\n')
 

--- a/research/audioset/vggish_train_demo.py
+++ b/research/audioset/vggish_train_demo.py
@@ -47,12 +47,12 @@ from __future__ import print_function
 
 from random import shuffle
 
-from . import vggish_input
-from . import vggish_params
-from . import vggish_slim
-
 import numpy as np
 import tensorflow as tf
+
+import vggish_input
+import vggish_params
+import vggish_slim
 
 flags = tf.app.flags
 slim = tf.contrib.slim


### PR DESCRIPTION
As discussed in the original PR (tensorflow/models#5677), this introduces issues when running the existing code as a script.

Reverts tensorflow/models#5677