### PR TITLE
Fix bug in dataset.py when batch_size==max_length.

### DIFF
--- a/official/transformer/utils/dataset.py
+++ b/official/transformer/utils/dataset.py
@@ -154,8 +154,8 @@ def _batch_examples(dataset, batch_size, max_length):
   buckets_min, buckets_max = _create_min_max_boundaries(max_length)
 
   # Create list of batch sizes for each bucket_id, so that
-  # bucket_batch_size[bucket_id] * buckets_max[bucket_id] <= batch_size
-  bucket_batch_sizes = [batch_size // x for x in buckets_max]
+  # bucket_batch_size[bucket_id] * (buckets_max[bucket_id] - 1) <= batch_size
+  bucket_batch_sizes = [batch_size // (x - 1) for x in buckets_max]
   # bucket_id will be a tensor, so convert this list to a tensor as well.
   bucket_batch_sizes = tf.constant(bucket_batch_sizes, dtype=tf.int64)
 


### PR DESCRIPTION
Each batch contains sequences of length in [buckets_min, buckets_max), so that the longest instance in a batch will have length buckets_max - 1. Without this fix, instances with length == batch_size will result in buckets of zero elements, causing the dataset iterator to crash.

As a bonus this adds an extra instance per batch.