### PR TITLE
Switching to more robust pysoundfile for reading wav files

### DIFF
--- a/research/audioset/README.md
+++ b/research/audioset/README.md
@@ -49,6 +49,7 @@ VGGish depends on the following Python packages:
 * [`resampy`](http://resampy.readthedocs.io/en/latest/)
 * [`tensorflow`](http://www.tensorflow.org/)
 * [`six`](https://pythonhosted.org/six/)
+* [`pysoundfile`](https://pysoundfile.readthedocs.io/)
 
 These are all easily installable via, e.g., `pip install numpy` (as in the
 example command sequence below).

--- a/research/audioset/vggish_input.py
+++ b/research/audioset/vggish_input.py
@@ -17,10 +17,11 @@
 
 import numpy as np
 import resampy
-from scipy.io import wavfile
 
 import mel_features
 import vggish_params
+
+import soundfile as sf
 
 
 def waveform_to_examples(data, sample_rate):
@@ -80,7 +81,7 @@ def wavfile_to_examples(wav_file):
   Returns:
     See waveform_to_examples.
   """
-  sr, wav_data = wavfile.read(wav_file)
+  wav_data, sr = sf.read(wav_file, dtype='int16')
   assert wav_data.dtype == np.int16, 'Bad sample type: %r' % wav_data.dtype
   samples = wav_data / 32768.0  # Convert to [-1.0, +1.0]
   return waveform_to_examples(samples, sr)


### PR DESCRIPTION
Scipy struggles with some WAV formats (e.g. when there is additional metadata present: https://stackoverflow.com/a/18958665/1194335). Reading the same files using the Pysoundfile works.