### PR TITLE
Update lite path + fix --config option

### DIFF
--- a/research/object_detection/g3doc/running_on_mobile_tensorflowlite.md
+++ b/research/object_detection/g3doc/running_on_mobile_tensorflowlite.md
@@ -82,7 +82,7 @@ parameters and can be run via the TensorFlow Lite interpreter on the Android
 device. For a floating point model, run this from the tensorflow/ directory:
 
 ```shell
-bazel run --config=opt tensorflow/contrib/lite/toco:toco -- \
+bazel run -c opt tensorflow/lite/toco:toco -- \
 --input_file=$OUTPUT_DIR/tflite_graph.pb \
 --output_file=$OUTPUT_DIR/detect.tflite \
 --input_shapes=1,300,300,3 \


### PR DESCRIPTION
`lite` is no longer under `contrib`. 

Additionally, `--config=opt` fails, see: https://github.com/tensorflow/serving/issues/517