### PR TITLE
fixed scaling of channels

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -247,7 +247,8 @@ def mobilenet_base(  # pylint: disable=invalid-name
     scopes = {}
     for i, opdef in enumerate(conv_defs['spec']):
       params = dict(opdef.params)
-      opdef.multiplier_func(params, multiplier)
+      if i != len(conv_defs['spec']) - 1 or multiplier >= 1:
+        opdef.multiplier_func(params, multiplier)
       stride = params.get('stride', 1)
       if output_stride is not None and current_stride == output_stride:
         # If we have reached the target output_stride, then we need to employ


### PR DESCRIPTION
When loading weights for channel-scaled versions of mobilenet, such as `mobilenet_v2_0.75_224`, I get an error:

`Assign requires shapes of both tensors to match. lhs shape= [1,1,240,960] rhs shape= [1,1,240,1280]`.

This seems to stem from the fact that the layer just prior to avgpool is supposed to always have no less than 1280 channels -- yet it is incorrectly scaled down to 960 instead when the mutiplier is .75.

This PR fixes the issue that mobilenets appear to work as expected.