### PR TITLE
Fix setup steps in mobilenet_example.ipynb

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -121,8 +121,8 @@
         "print('Downloading from ', url)\n",
         "!wget {url}\n",
         "print('Unpacking')\n",
-        "!tar -xvf {base_name}.tgz\n",
-        "checkpoint = base_name + '.ckpt'\n",
+        "!tar -xvf {checkpoint_name}.tgz\n",
+        "checkpoint = checkpoint_name + '.ckpt'\n",
         "\n",
         "display.clear_output()\n",
         "print('Successfully downloaded checkpoint from ', url,\n",
@@ -349,7 +349,7 @@
       "source": [
         "import numpy as np\n",
         "img = np.array(PIL.Image.open('panda.jpg').resize((224, 224))).astype(np.float) / 128 - 1\n",
-        "gd = tf.GraphDef.FromString(open(base_name + '_frozen.pb', 'rb').read())\n",
+        "gd = tf.GraphDef.FromString(open(checkpoint_name + '_frozen.pb', 'rb').read())\n",
         "inp, predictions = tf.import_graph_def(gd,  return_elements = ['input:0', 'MobilenetV2/Predictions/Reshape_1:0'])"
       ]
     },

--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -199,7 +199,7 @@
       "source": [
         "# setup path\n",
         "import sys\n",
-        "sys.path.append('/content/models/research/slim')"
+        "sys.path.append('models/research/slim')"
       ]
     },
     {


### PR DESCRIPTION
Fix the setup steps in `mobilenet_example.ipynb`.

1. The existing Jupyter notebook interchangeably uses `base_name` and `checkpoint_name`, but `base_name` is never defined.

This leads to the vanilla setup to fail with `NameError`:
<img width="922" alt="screenshot 2018-11-13 13 07 12" src="https://user-images.githubusercontent.com/1895508/48443272-63ec7280-e745-11e8-83d2-8b0833c46f71.png">

This PR replaces all `base_name` references to `checkpoint_name`.

2. Fix an incorrect `slim` path.
