### PR TITLE
syntaxnet: Old style exceptions are syntax errors in Python 3

### DIFF
--- a/research/syntaxnet/dragnn/python/graph_builder.py
+++ b/research/syntaxnet/dragnn/python/graph_builder.py
@@ -28,7 +28,7 @@ from syntaxnet.util import check
 
 try:
   tf.NotDifferentiable('ExtractFixedFeatures')
-except KeyError, e:
+except KeyError as e:
   logging.info(str(e))
 
 


### PR DESCRIPTION
@calberti @markomernick Can we please get your review on this simple change that is compatible with both Python 2 and Python 3.  This is a syntax error.