### PR TITLE
fix a bug in rnn\ptb model that deals with '\n' incorrectly

### DIFF
--- a/tutorials/rnn/ptb/reader.py
+++ b/tutorials/rnn/ptb/reader.py
@@ -30,9 +30,9 @@ Py3 = sys.version_info[0] == 3
 def _read_words(filename):
   with tf.gfile.GFile(filename, "r") as f:
     if Py3:
-      return f.read().replace("\n", "<eos>").split()
+      return f.read().replace("\n", " <eos> ").split()
     else:
-      return f.read().decode("utf-8").replace("\n", "<eos>").split()
+      return f.read().decode("utf-8").replace("\n", " <eos> ").split()
 
 
 def _build_vocab(filename):


### PR DESCRIPTION
In line:33 and line:35, if `'\n'` is replaced by '<eof>', the the `<eof>` will be concatenated with the word before it and after it.
**for example:**
>I would like\n
>Do you?

After processed in this initial code, it would become `like<eof>Do`
And this token makes no sense.

So I modify it to ' <eof> ' with two space before and after it.
Then after being splited, the example mentioned above would be 
> I would like \<eof\> Do you