### PR TITLE
Move references to `tf_record_iterator`.

### DIFF
--- a/official/transformer/data_download.py
+++ b/official/transformer/data_download.py
@@ -321,7 +321,7 @@ def shuffle_records(fname):
   tmp_fname = fname + ".unshuffled"
   tf.gfile.Rename(fname, tmp_fname)
 
-  reader = tf.python_io.tf_record_iterator(tmp_fname)
+  reader = tf.compat.v1.io.tf_record_iterator(tmp_fname)
   records = []
   for record in reader:
     records.append(record)


### PR DESCRIPTION
For tf2 this will only be available in `compat.v1`.