### PR TITLE
Update installation.md

### DIFF
--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -69,7 +69,7 @@ file.
 git clone https://github.com/cocodataset/cocoapi.git
 cd cocoapi/PythonAPI
 make
-cp -r pycocotools <path_to_tensorflow>/models/research/
+cp -r pycocotools <path_to_models>/research/
 ```
 
 ## Protobuf Compilation

--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+You must clone this repository if you have not done so already. The models directory is not part of the TensorFlow installation from pip.
+
 ## Dependencies
 
 Tensorflow Object Detection API depends on the following libraries:

--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -59,7 +59,7 @@ If that is your case, try the [manual](#Manual-protobuf-compiler-installation-an
 
 Download the
 [cocoapi](https://github.com/cocodataset/cocoapi) and
-copy the pycocotools subfolder to the tensorflow/models/research directory if
+copy the pycocotools subfolder to the <path_to_models>/research directory if
 you are interested in using COCO evaluation metrics. The default metrics are
 based on those used in Pascal VOC evaluation. To use the COCO object detection
 metrics add `metrics_set: "coco_detection_metrics"` to the `eval_config` message
@@ -79,11 +79,11 @@ cp -r pycocotools <path_to_models>/research/
 The Tensorflow Object Detection API uses Protobufs to configure model and
 training parameters. Before the framework can be used, the Protobuf libraries
 must be compiled. This should be done by running the following command from
-the tensorflow/models/research/ directory:
+the <path_to_models>/research/ directory:
 
 
 ``` bash
-# From tensorflow/models/research/
+# From <path_to_models>/research/
 protoc object_detection/protos/*.proto --python_out=.
 ```
 
@@ -96,7 +96,7 @@ protoc object_detection/protos/*.proto --python_out=.
 Download and install the 3.0 release of protoc, then unzip the file.
 
 ```bash
-# From tensorflow/models/research/
+# From <path_to_models>/research/
 wget -O protobuf.zip https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip
 unzip protobuf.zip
 ```
@@ -104,7 +104,7 @@ unzip protobuf.zip
 Run the compilation process again, but use the downloaded version of protoc
 
 ```bash
-# From tensorflow/models/research/
+# From <path_to_models>/research/
 ./bin/protoc object_detection/protos/*.proto --python_out=.
 ```
 
@@ -123,7 +123,7 @@ rm -f $PROTOC_ZIP
 Run the compilation process again:
 
 ``` bash
-# From tensorflow/models/research/
+# From <path_to_models>/research/
 protoc object_detection/protos/*.proto --python_out=.
 ```
 
@@ -135,7 +135,7 @@ tensorflow/models/research/:
 
 
 ``` bash
-# From tensorflow/models/research/
+# From <path_to_models>/research/
 export PYTHONPATH=$PYTHONPATH:`pwd`:`pwd`/slim
 ```
 


### PR DESCRIPTION
When I read these instructions, I thought that the models/research directory was something that was located in my tensorflow directory that pip created. I did not realize that this repository had to be cloned. It seems that other people were confused by this as well: https://github.com/tensorflow/models/issues/2253

I have updated the instructions to try to indicate that the models directory is the root of this repository, and not part of pip's TensorFlow installation.