### PR TITLE
Update object_detection_evaluation.py for some fixes relating to issue #5924

### DIFF
--- a/research/object_detection/metrics/tf_example_parser.py
+++ b/research/object_detection/metrics/tf_example_parser.py
@@ -44,9 +44,10 @@ class StringParser(data_parser.DataToNumpyParser):
     self.field_name = field_name
 
   def parse(self, tf_example):
-    return "".join(tf_example.features.feature[self.field_name]
-                   .bytes_list.value) if tf_example.features.feature[
-                       self.field_name].HasField("bytes_list") else None
+    return b"".join(tf_example.features.feature[
+                        self.field_name].bytes_list.value) \
+        if tf_example.features.feature[self.field_name].HasField("bytes_list") \
+        else None
 
 
 class Int64Parser(data_parser.DataToNumpyParser):

--- a/research/object_detection/utils/object_detection_evaluation.py
+++ b/research/object_detection/utils/object_detection_evaluation.py
@@ -210,7 +210,11 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
       if idx + self._label_id_offset in category_index:
         category_name = category_index[idx + self._label_id_offset]['name']
         try:
-          category_name = unicode(category_name, 'utf-8')
+            import sys
+            if sys.version_info >= (3, 0):
+                category_name = str(category_name, 'utf-8')
+            else:
+                category_name = unicode(category_name, 'utf-8')
         except TypeError:
           pass
         category_name = unicodedata.normalize('NFKD', category_name).encode(
@@ -348,7 +352,11 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
       if idx + self._label_id_offset in category_index:
         category_name = category_index[idx + self._label_id_offset]['name']
         try:
-          category_name = unicode(category_name, 'utf-8')
+            import sys
+            if sys.version_info >= (3, 0):
+                category_name = str(category_name, 'utf-8')
+            else:
+                category_name = unicode(category_name, 'utf-8')
         except TypeError:
           pass
         category_name = unicodedata.normalize(
@@ -606,7 +614,7 @@ class OpenImagesDetectionEvaluator(ObjectDetectionEvaluator):
     # (unless there are no annotations for the groundtruth on this image)
     # use values from the dictionary or insert None otherwise.
     if (standard_fields.InputDataFields.groundtruth_group_of in
-        groundtruth_dict.keys() and
+        groundtruth_dict.keys() and not (groundtruth_dict[standard_fields.InputDataFields.groundtruth_group_of] == None) and
         (groundtruth_dict[standard_fields.InputDataFields.groundtruth_group_of]
          .size or not groundtruth_classes.size)):
       groundtruth_group_of = groundtruth_dict[


### PR DESCRIPTION
fixed unicode category_name for compatibility with python 3.x
fixed bug where `groundtruth_dict[standard_fields.InputDataFields.groundtruth_group_of]` of NoneType would throw an error in the if statement