### PR TITLE
Python 3 fixes for cognitive_planning

### DIFF
--- a/research/cognitive_planning/embedders.py
+++ b/research/cognitive_planning/embedders.py
@@ -19,6 +19,7 @@ import abc
 import numpy as np
 import tensorflow as tf
 import preprocessing
+from six.moves import xrange
 from tensorflow.contrib.slim.nets import resnet_v2
 
 slim = tf.contrib.slim

--- a/research/cognitive_planning/envs/active_vision_dataset_env.py
+++ b/research/cognitive_planning/envs/active_vision_dataset_env.py
@@ -22,6 +22,7 @@
    in each environment. For more details, refer:
    http://cs.unc.edu/~ammirato/active_vision_dataset_website/.
 """
+from __future__ import print_function
 import tensorflow as tf
 import collections
 import copy
@@ -41,6 +42,7 @@ import cv2
 import label_map_util
 import visualization_utils as vis_util
 from envs import task_env
+from six.moves import xrange
 
 
 register(
@@ -937,7 +939,7 @@ class ActiveVisionDatasetEnv(task_env.TaskEnv):
                               self._cur_graph.id_to_index[image_id],
                               super_source)
     except:
-      print 'path not found, image_id = ', self._cur_world, self._cur_image_id
+      print('path not found, image_id = ', self._cur_world, self._cur_image_id)
       raise
     return path[:-1]
 
@@ -996,10 +998,10 @@ class ActiveVisionDatasetEnv(task_env.TaskEnv):
     """
     obs = self._reset_env(new_world=world, new_goal=goal)
     if not obs:
-      print '{} is not availble in {}'.format(goal, world)
+      print('{} is not availble in {}'.format(goal, world))
       return True
     for image_id in self._world_id_dict[self._cur_world]:
-      print 'check image_id = {}'.format(image_id)
+      print('check image_id = {}'.format(image_id))
       self._cur_image_id = image_id
       path = self.path_to_goal()
       actions = []

--- a/research/cognitive_planning/tasks.py
+++ b/research/cognitive_planning/tasks.py
@@ -21,6 +21,7 @@ tasks. See go/navigation_tasks for a list.
 
 import abc
 import collections
+import logging
 import math
 import threading
 import networkx as nx

--- a/research/cognitive_planning/train_supervised_active_vision.py
+++ b/research/cognitive_planning/train_supervised_active_vision.py
@@ -49,6 +49,7 @@ python train_supervised_active_vision.py
   --gin_params='ActiveVisionDatasetEnv.dataset_root="$datadir"' \
   --logtostderr
 """
+from __future__ import print_function
 
 import collections
 import os
@@ -182,7 +183,7 @@ def create_task_io_config(
   inputs[task_env.ModalityTypes.PREV_ACTION] = (tf.float32, [
       sequence_length, action_size + 1
   ])
-  print inputs
+  print(inputs)
   return tasks.UnrolledTaskIOConfig(
       inputs=inputs,
       output=(tf.float32, [sequence_length, action_size]),
@@ -366,7 +367,7 @@ def unroll_policy_for_eval(
   # logging.info('distance = %d, id = %s, #steps = %d', distances_to_goal[-1],
   output_path = os.path.join(output_folder, unique_id + '.npy')
   with tf.gfile.Open(output_path, 'w') as f:
-    print 'saving path information to {}'.format(output_path)
+    print('saving path information to {}'.format(output_path))
     np.save(f, {'states': states, 'distance': distances_to_goal})
   return states, distances_to_goal
 
@@ -425,7 +426,7 @@ def test():
     while not sv.should_stop():
       while True:
         new_checkpoint = tf.train.latest_checkpoint(FLAGS.logdir)
-        print 'new_checkpoint ', new_checkpoint
+        print('new_checkpoint ', new_checkpoint)
         if not new_checkpoint:
           time.sleep(1)
           continue
@@ -440,14 +441,14 @@ def test():
 
       checkpoint_step = int(new_checkpoint[new_checkpoint.rfind('-') + 1:])
       sv.saver.restore(sess, new_checkpoint)
-      print '--------------------'
-      print 'evaluating checkpoint {}'.format(new_checkpoint)
+      print('--------------------')
+      print('evaluating checkpoint {}'.format(new_checkpoint))
       folder_path = os.path.join(FLAGS.logdir, 'evals', str(checkpoint_step))
       if not tf.gfile.Exists(folder_path):
         tf.gfile.MakeDirs(folder_path)
       eval_stats = {c: [] for c in env.possible_targets}
       for test_iter in range(FLAGS.test_iters):
-        print 'evaluating {} of {}'.format(test_iter, FLAGS.test_iters)
+        print('evaluating {} of {}'.format(test_iter, FLAGS.test_iters))
         _, distance_to_goal = unroll_policy_for_eval(
             sess,
             env,
@@ -457,11 +458,11 @@ def test():
             FLAGS.max_eval_episode_length,
             folder_path,
         )
-        print 'goal = {}'.format(env.goal_string)
+        print('goal = {}'.format(env.goal_string))
         eval_stats[env.goal_string].append(float(distance_to_goal[-1] <= 7))
       eval_stats = {k: np.mean(v) for k, v in eval_stats.iteritems()}
       eval_stats['mean'] = np.mean(eval_stats.values())
-      print eval_stats
+      print(eval_stats)
       feed_dict = {summary_op[1][c]: eval_stats[c] for c in eval_stats}
       summary_str = sess.run(summary_op[0], feed_dict=feed_dict)
       writer = sv.summary_writer

--- a/research/cognitive_planning/viz_active_vision_dataset_main.py
+++ b/research/cognitive_planning/viz_active_vision_dataset_main.py
@@ -37,6 +37,7 @@ python viz_active_vision_dataset_main -- \
 python viz_active_vision_dataset_main.py --mode=eval --eval_folder=/usr/local/google/home/$USER/checkin_log_det/evals/ --output_folder=/usr/local/google/home/$USER/test_imgs/ --gin_config=envs/configs/active_vision_config.gin
 
 """
+from __future__ import print_function
 
 import matplotlib
 # pylint: disable=g-import-not-at-top
@@ -52,6 +53,8 @@ import gin
 import cv2
 from envs import active_vision_dataset_env
 from envs import task_env
+
+from six.moves import input
 
 
 VIS_MODE = 'vis'
@@ -95,7 +98,7 @@ def benchmark(env, targets):
     for a in new_actions:
       all_actions[a] += new_actions[a] / FLAGS.benchmark_iter
     start_image_id, world, goal = env.get_init_config(path)
-    print world
+    print(world)
     if world not in all_init_configs:
       all_init_configs[world] = set()
     all_init_configs[world].add((start_image_id, goal, len(actions)))
@@ -137,7 +140,7 @@ def human(env, targets):
     steps = -1
     action = None
     while True:
-      print 'distance = ', obs[task_env.ModalityTypes.DISTANCE]
+      print('distance = ', obs[task_env.ModalityTypes.DISTANCE])
       steps += 1
       depth_value = obs[task_env.ModalityTypes.DEPTH][:, :, 0]
       depth_mask = obs[task_env.ModalityTypes.DEPTH][:, :, 1]
@@ -164,7 +167,7 @@ def human(env, targets):
       plt.title('goal={}'.format(targets[env.goal_index]))
       plt.draw()
       while True:
-        s = raw_input('key = ')
+        s = input('key = ')
         if np.random.rand() > 0.5:
           key_map = string_key_map
         else:
@@ -173,14 +176,14 @@ def human(env, targets):
           action = key_map[s]
           break
         else:
-          print 'invalid action'
-      print 'action = {}'.format(action)
+          print('invalid action')
+      print('action = {}'.format(action))
       if action == 'stop':
-        print 'dist to goal: {}'.format(len(env.path_to_goal()) - 2)
+        print('dist to goal: {}'.format(len(env.path_to_goal()) - 2))
         break
       obs, reward, done, info = env.step(action)
-      print 'reward = {}, done = {}, success = {}'.format(
-          reward, done, info['success'])
+      print('reward = {}, done = {}, success = {}'.format(
+          reward, done, info['success']))
 
 
 def visualize_random_step_sequence(env):
@@ -188,7 +191,7 @@ def visualize_random_step_sequence(env):
   plt.ion()
   for _ in range(20):
     path, actions, _, step_outputs = env.random_step_sequence(max_len=30)
-    print 'path = {}'.format(path)
+    print('path = {}'.format(path))
     for action, step_output in zip(actions, step_outputs):
       obs, _, done, _ = step_output
       depth_value = obs[task_env.ModalityTypes.DEPTH][:, :, 0]
@@ -212,10 +215,10 @@ def visualize_random_step_sequence(env):
       plt.imshow(det_mask)
       plt.title('det')
       plt.subplot(236)
-      print 'action = {}'.format(action)
-      print 'done = {}'.format(done)
+      print('action = {}'.format(action))
+      print('done = {}'.format(done))
       plt.draw()
-      if raw_input('press \'n\' to go to the next random sequence. Otherwise, '
+      if input('press \'n\' to go to the next random sequence. Otherwise, '
                    'press any key to continue...') == 'n':
         break
 
@@ -246,13 +249,13 @@ def visualize(env, input_folder, output_root_folder):
       if name.find('npy') >= 0
   ]
   for i, npy_file in enumerate(npy_files):
-    print 'saving images {}/{}'.format(i, len(npy_files))
+    print('saving images {}/{}'.format(i, len(npy_files)))
     pure_name = npy_file[npy_file.rfind('/') + 1:-4]
     output_folder = os.path.join(output_images_folder, pure_name)
     if not tf.gfile.IsDirectory(output_folder):
       tf.gfile.MakeDirs(output_folder)
-    print '*******'
-    print pure_name[0:pure_name.find('_')]
+    print('*******')
+    print(pure_name[0:pure_name.find('_')])
     env.reset_for_eval(which_env(pure_name),
                        which_goal(pure_name),
                        pure_name[0:pure_name.find('_')],
@@ -265,7 +268,7 @@ def visualize(env, input_folder, output_root_folder):
       for j, img in enumerate(images):
         cv2.imwrite(os.path.join(output_folder, '{0:03d}'.format(j) + '.jpg'),
                     img[:, :, ::-1])
-      print 'converting to gif'
+      print('converting to gif')
       os.system(
           'convert -set delay 20 -colors 256 -dispose 1 {}/*.jpg {}.gif'.format(
               output_folder,
@@ -288,7 +291,7 @@ def evaluate_folder(env, folder_path):
 
   def evaluate_iteration(folder):
     """Evaluates the data from the folder of certain eval iteration."""
-    print folder
+    print(folder)
     npy_files = [
         os.path.join(folder, name)
         for name in tf.gfile.ListDirectory(folder)
@@ -303,7 +306,7 @@ def evaluate_folder(env, folder_path):
       eval_stats[category].append(float(dist <= 5))
     for c in eval_stats:
       if not eval_stats[c]:
-        print 'incomplete eval {}: empty class {}'.format(folder_path, c)
+        print('incomplete eval {}: empty class {}'.format(folder_path, c))
         return None
       eval_stats[c] = np.mean(eval_stats[c])
 
@@ -316,26 +319,26 @@ def evaluate_folder(env, folder_path):
       if tf.gfile.IsDirectory(folder_path + x)
   ]
 
-  print '{} folders found'.format(len(checkpoint_folders))
-  print '------------------------'
+  print('{} folders found'.format(len(checkpoint_folders)))
+  print('------------------------')
   all_iters = []
   all_accs = []
   for i, folder in enumerate(checkpoint_folders):
-    print 'processing {}/{}'.format(i, len(checkpoint_folders))
+    print('processing {}/{}'.format(i, len(checkpoint_folders)))
     eval_stats = evaluate_iteration(folder)
     if eval_stats is None:
       continue
     else:
       iter_no = int(folder[folder.rfind('/') + 1:])
-      print 'result ', iter_no, eval_stats['mean']
+      print('result ', iter_no, eval_stats['mean'])
       all_accs.append(eval_stats['mean'])
       all_iters.append(iter_no)
 
   all_accs = np.asarray(all_accs)
   all_iters = np.asarray(all_iters)
   idx = np.argmax(all_accs)
-  print 'best result at iteration {} was {}'.format(all_iters[idx],
-                                                    all_accs[idx])
+  print('best result at iteration {} was {}'.format(all_iters[idx],
+                                                    all_accs[idx]))
   order = np.argsort(all_iters)
   all_iters = all_iters[order]
   all_accs = all_accs[order]
@@ -345,7 +348,7 @@ def evaluate_folder(env, folder_path):
 
   best_iteration_folder = os.path.join(folder_path, str(all_iters[idx]))
 
-  print 'generating gifs and images for {}'.format(best_iteration_folder)
+  print('generating gifs and images for {}'.format(best_iteration_folder))
   visualize(env, best_iteration_folder, FLAGS.output_folder)
 
 


### PR DESCRIPTION
Python 3 treats legacy __print__ statements as syntax errors but __print()__ function works as expected in both Python 2 and Python 3.
* __xrange()__ --> __six.moves.xrange()__  # https://six.readthedocs.io
* __raw_input()__ --> __six.moves.input()__
* import logging
