### PR TITLE
move flags validator before tf.app.run()

### DIFF
--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -53,6 +53,8 @@ flags.DEFINE_boolean(
     'run_once', False, 'If running in eval-only mode, whether to run just '
     'one round of eval vs running continuously (default).'
 )
+flags.mark_flag_as_required('model_dir')
+flags.mark_flag_as_required('pipeline_config_path')
 FLAGS = flags.FLAGS
 
 
@@ -104,6 +106,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  flags.mark_flag_as_required('model_dir')
-  flags.mark_flag_as_required('pipeline_config_path')
   tf.app.run()

--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -57,8 +57,6 @@ FLAGS = flags.FLAGS
 
 
 def main(unused_argv):
-  flags.mark_flag_as_required('model_dir')
-  flags.mark_flag_as_required('pipeline_config_path')
   config = tf.estimator.RunConfig(model_dir=FLAGS.model_dir)
 
   train_and_eval_dict = model_lib.create_estimator_and_inputs(
@@ -106,4 +104,6 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
+  flags.mark_flag_as_required('model_dir')
+  flags.mark_flag_as_required('pipeline_config_path')
   tf.app.run()


### PR DESCRIPTION
absl.flags validation happens at tf.app.run(). See https://github.com/abseil/abseil-py/blob/master/absl/flags/_validators.py#L329

The flags validator was not working in the previous code, and the error message would be "TypeError: Expected binary or unicode string, got None" when required flags were not correctly provided in arguments, which is not very helpful for debugging.
After the modification, the error message will be like "absl.flags._exceptions.IllegalFlagValueError: flag --pipeline_config_path=None: Flag --pipeline_config_path must be specified".