### PR TITLE
Spelling mistake, a extra 't'

### DIFF
--- a/research/attention_ocr/python/inception_preprocessing.py
+++ b/research/attention_ocr/python/inception_preprocessing.py
@@ -250,7 +250,7 @@ def preprocess_for_eval(image,
   If height and width are specified it would output an image with that size by
   applying resize_bilinear.
 
-  If central_fraction is specified it would cropt the central fraction of the
+  If central_fraction is specified it would crop the central fraction of the
   input image.
 
   Args:


### PR DESCRIPTION
It may be 'crop', not 'cropt'.
--by a OCD patient:)