### PR TITLE
Create a unit test for Keras application models in TF 2.0

### DIFF
--- a/official/keras_application_models/benchmark_main.py
+++ b/official/keras_application_models/benchmark_main.py
@@ -26,25 +26,12 @@ import tensorflow as tf
 
 from official.keras_application_models import dataset
 from official.keras_application_models import model_callbacks
+from official.keras_application_models import models
 from official.utils.flags import core as flags_core
 from official.utils.logs import logger
 from official.utils.misc import distribution_utils
 
-# Define a dictionary that maps model names to their model classes inside Keras
-MODELS = {
-    "vgg16": tf.keras.applications.VGG16,
-    "vgg19": tf.keras.applications.VGG19,
-    "inceptionv3": tf.keras.applications.InceptionV3,
-    "xception": tf.keras.applications.Xception,
-    "resnet50": tf.keras.applications.ResNet50,
-    "inceptionresnetv2": tf.keras.applications.InceptionResNetV2,
-    "mobilenet": tf.keras.applications.MobileNet,
-    "densenet121": tf.keras.applications.DenseNet121,
-    "densenet169": tf.keras.applications.DenseNet169,
-    "densenet201": tf.keras.applications.DenseNet201,
-    "nasnetlarge": tf.keras.applications.NASNetLarge,
-    "nasnetmobile": tf.keras.applications.NASNetMobile,
-}
+MODELS = models.MODELS
 
 
 def run_keras_model_benchmark(_):

--- a/official/keras_application_models/models.py
+++ b/official/keras_application_models/models.py
@@ -1,0 +1,34 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Keras application models."""
+
+import tensorflow as tf
+
+# Define a dictionary that maps model names to their model classes inside Keras
+MODELS = {
+    "vgg16": tf.keras.applications.VGG16,
+    "vgg19": tf.keras.applications.VGG19,
+    "inceptionv3": tf.keras.applications.InceptionV3,
+    "xception": tf.keras.applications.Xception,
+    "resnet50": tf.keras.applications.ResNet50,
+    "inceptionresnetv2": tf.keras.applications.InceptionResNetV2,
+    "mobilenet": tf.keras.applications.MobileNet,
+    "mobilenetv2": tf.keras.applications.MobileNetV2,
+    "densenet121": tf.keras.applications.DenseNet121,
+    "densenet169": tf.keras.applications.DenseNet169,
+    "densenet201": tf.keras.applications.DenseNet201,
+    "nasnetlarge": tf.keras.applications.NASNetLarge,
+    "nasnetmobile": tf.keras.applications.NASNetMobile,
+}

--- a/official/keras_application_models/models_v2_test.py
+++ b/official/keras_application_models/models_v2_test.py
@@ -1,0 +1,59 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Test keras application models in TF v2."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from absl.testing import parameterized
+from official.keras_application_models import dataset
+from official.keras_application_models import models
+
+# Small batch to speed up the time-consuming test.
+_BATCH_SIZE = 5
+_NUM_IMAGES = 10
+
+_MODELS = models.MODELS
+_MODEL_KEYS = models.MODELS.keys()
+
+
+class BenchmarkTests(tf.test.TestCase, parameterized.TestCase):
+
+  @parameterized.parameters(*_MODEL_KEYS)
+  def test_model(self, model_key):
+    self._run_model(model_key)
+
+  def _run_model(self, model_key):
+    train_dataset = dataset.generate_synthetic_input_dataset(
+        model_key, _BATCH_SIZE)
+    keras_model = _MODELS[model_key]
+    model = keras_model(weights=None)
+    model.compile(loss="categorical_crossentropy",
+                  optimizer=tf.keras.optimizers.SGD(0.001),
+                  metrics=["accuracy"])
+    model.fit(
+      train_dataset,
+      epochs=1,
+      steps_per_epoch=int(np.ceil(_NUM_IMAGES / _BATCH_SIZE))
+    )
+    self.assertTrue(model.built)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/official/keras_application_models/models_v2_test.py
+++ b/official/keras_application_models/models_v2_test.py
@@ -29,7 +29,6 @@ from official.keras_application_models import models
 _BATCH_SIZE = 5
 _NUM_IMAGES = 10
 
-
 _MODELS = models.MODELS
 _MODEL_KEYS = models.MODELS.keys()
 


### PR DESCRIPTION
Create a unit test for Keras application models in TF 2.0. (Named models_v2_test.py)

Minor: move the shared model definition in models.py.

Tested in tf-nightly-2.0-preview. 
$ python official/keras_application_models/models_v2_test.py