### PR TITLE
Fix parameter error in new evaluation script

### DIFF
--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -86,7 +86,7 @@ def main(unused_argv):
       input_fn = eval_input_fns[0]
     if FLAGS.run_once:
       estimator.evaluate(input_fn,
-                         num_eval_steps=None,
+                         steps=None,
                          checkpoint_path=tf.train.latest_checkpoint(
                              FLAGS.checkpoint_dir))
     else:


### PR DESCRIPTION
As https://github.com/tensorflow/models/issues/5059#issuecomment-451654039 suggested, num_examples is deprecated, however, when setting run_once flag in new evaluation script, it would raise parameter not found error. Therefore, this PR has fix it.