### PR TITLE
Removed INITIAL_DIR parameter from download_imagenet

### DIFF
--- a/research/inception/inception/data/download_imagenet.sh
+++ b/research/inception/inception/data/download_imagenet.sh
@@ -43,7 +43,6 @@ SYNSETS_FILE="${2:-./synsets.txt}"
 
 echo "Saving downloaded files to $OUTDIR"
 mkdir -p "${OUTDIR}"
-INITIAL_DIR=$(pwd)
 BBOX_DIR="${OUTDIR}bounding_boxes"
 mkdir -p "${BBOX_DIR}"
 cd "${OUTDIR}"
@@ -101,4 +100,4 @@ while read SYNSET; do
   rm -f "${SYNSET}.tar"
 
   echo "Finished processing: ${SYNSET}"
-done < "${INITIAL_DIR}/${SYNSETS_FILE}"
+done < "${SYNSETS_FILE}"


### PR DESCRIPTION
INITIAL_DIR variable is unuseful if the synsets file is not specified using a parameter because it is in the same directory as the running script, anyway probably the synsets parameter is always specified with its path and the INITIAL_DIR variable causes the script to point to a wrong non existent path.