### PR TITLE
Do not use bias in conv2d layers in Keras ResNet model

### DIFF
--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -108,7 +108,11 @@ def run(flags_obj):
   per_device_batch_size = distribution_utils.per_device_batch_size(
       flags_obj.batch_size, flags_core.get_num_gpus(flags_obj))
 
-  tf.keras.backend.set_image_data_format(flags_obj.data_format)
+  data_format = flags_obj.data_format
+  if data_format is None:
+    data_format = ('channels_first'
+                   if tf.test.is_built_with_cuda() else 'channels_last')
+  tf.keras.backend.set_image_data_format(data_format)
 
   if flags_obj.use_synthetic_data:
     input_fn = keras_common.get_synth_input_fn(

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -95,7 +95,11 @@ def run(flags_obj):
     raise ValueError('dtype fp16 is not supported in Keras. Use the default '
                      'value(fp32).')
 
-  tf.keras.backend.set_image_data_format(flags_obj.data_format)
+  data_format = flags_obj.data_format
+  if data_format is None:
+    data_format = ('channels_first'
+                   if tf.test.is_built_with_cuda() else 'channels_last')
+  tf.keras.backend.set_image_data_format(data_format)
 
   per_device_batch_size = distribution_utils.per_device_batch_size(
       flags_obj.batch_size, flags_core.get_num_gpus(flags_obj))

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -64,7 +64,7 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
   conv_name_base = 'res' + str(stage) + block + '_branch'
   bn_name_base = 'bn' + str(stage) + block + '_branch'
 
-  x = layers.Conv2D(filters1, (1, 1),
+  x = layers.Conv2D(filters1, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
@@ -76,7 +76,7 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
   x = layers.Activation('relu')(x)
 
   x = layers.Conv2D(filters2, kernel_size,
-                    padding='same',
+                    padding='same', use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
@@ -87,7 +87,7 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
-  x = layers.Conv2D(filters3, (1, 1),
+  x = layers.Conv2D(filters3, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
@@ -134,7 +134,8 @@ def conv_block(input_tensor,
   conv_name_base = 'res' + str(stage) + block + '_branch'
   bn_name_base = 'bn' + str(stage) + block + '_branch'
 
-  x = layers.Conv2D(filters1, (1, 1), kernel_initializer='he_normal',
+  x = layers.Conv2D(filters1, (1, 1), use_bias=False,
+                    kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2a')(input_tensor)
@@ -145,7 +146,7 @@ def conv_block(input_tensor,
   x = layers.Activation('relu')(x)
 
   x = layers.Conv2D(filters2, kernel_size, strides=strides, padding='same',
-                    kernel_initializer='he_normal',
+                    use_bias=False, kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2b')(x)
@@ -155,7 +156,7 @@ def conv_block(input_tensor,
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
-  x = layers.Conv2D(filters3, (1, 1),
+  x = layers.Conv2D(filters3, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
@@ -165,7 +166,7 @@ def conv_block(input_tensor,
                                 epsilon=BATCH_NORM_EPSILON,
                                 name=bn_name_base + '2c')(x)
 
-  shortcut = layers.Conv2D(filters3, (1, 1), strides=strides,
+  shortcut = layers.Conv2D(filters3, (1, 1), strides=strides, use_bias=False,
                            kernel_initializer='he_normal',
                            kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                            bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
@@ -204,7 +205,7 @@ def resnet50(num_classes):
   x = layers.ZeroPadding2D(padding=(3, 3), name='conv1_pad')(x)
   x = layers.Conv2D(64, (7, 7),
                     strides=(2, 2),
-                    padding='valid',
+                    padding='valid', use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -67,7 +67,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
   x = layers.Conv2D(filters1, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2a')(input_tensor)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -79,7 +78,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                     padding='same', use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2b')(x)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -90,7 +88,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
   x = layers.Conv2D(filters3, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2c')(x)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -137,7 +134,6 @@ def conv_block(input_tensor,
   x = layers.Conv2D(filters1, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2a')(input_tensor)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -148,7 +144,6 @@ def conv_block(input_tensor,
   x = layers.Conv2D(filters2, kernel_size, strides=strides, padding='same',
                     use_bias=False, kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2b')(x)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -159,7 +154,6 @@ def conv_block(input_tensor,
   x = layers.Conv2D(filters3, (1, 1), use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2c')(x)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,
@@ -169,7 +163,6 @@ def conv_block(input_tensor,
   shortcut = layers.Conv2D(filters3, (1, 1), strides=strides, use_bias=False,
                            kernel_initializer='he_normal',
                            kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                           bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                            name=conv_name_base + '1')(input_tensor)
   shortcut = layers.BatchNormalization(axis=bn_axis,
                                        momentum=BATCH_NORM_DECAY,
@@ -208,7 +201,6 @@ def resnet50(num_classes):
                     padding='valid', use_bias=False,
                     kernel_initializer='he_normal',
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
-                    bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name='conv1')(x)
   x = layers.BatchNormalization(axis=bn_axis,
                                 momentum=BATCH_NORM_DECAY,


### PR DESCRIPTION
According to official ResNet model, we should not use bias in Conv2D layers. This also helps remove BiasAdd ops in all layers, which end up with a 8% throughput gain. Convergence tests show that the model still converges well.

```
... ...
Epoch 60/90 - val_loss: 1.9972 - val_sparse_categorical_accuracy: 0.6598
Epoch 61/90 - val_loss: 1.6311 - val_sparse_categorical_accuracy: 0.7411
Epoch 62/90 - val_loss: 1.6008 - val_sparse_categorical_accuracy: 0.7464
Epoch 63/90 - val_loss: 1.5808 - val_sparse_categorical_accuracy: 0.7496
Epoch 64/90 - val_loss: 1.5623 - val_sparse_categorical_accuracy: 0.7503
Epoch 65/90 - val_loss: 1.5507 - val_sparse_categorical_accuracy: 0.7504
Epoch 66/90 - val_loss: 1.5401 - val_sparse_categorical_accuracy: 0.7528
Epoch 67/90 - val_loss: 1.5228 - val_sparse_categorical_accuracy: 0.7538
Epoch 68/90 - val_loss: 1.5150 - val_sparse_categorical_accuracy: 0.7543
Epoch 69/90 - val_loss: 1.5072 - val_sparse_categorical_accuracy: 0.7548
Epoch 70/90 - val_loss: 1.4974 - val_sparse_categorical_accuracy: 0.7549
Epoch 71/90 - val_loss: 1.4883 - val_sparse_categorical_accuracy: 0.7549
Epoch 72/90 - val_loss: 1.4793 - val_sparse_categorical_accuracy: 0.7556
Epoch 73/90 - val_loss: 1.4707 - val_sparse_categorical_accuracy: 0.7559
Epoch 74/90 - val_loss: 1.4638 - val_sparse_categorical_accuracy: 0.7569
Epoch 75/90 - val_loss: 1.4606 - val_sparse_categorical_accuracy: 0.7567
Epoch 76/90 - val_loss: 1.4469 - val_sparse_categorical_accuracy: 0.7563
Epoch 77/90 - val_loss: 1.4419 - val_sparse_categorical_accuracy: 0.7564
Epoch 78/90 - val_loss: 1.4358 - val_sparse_categorical_accuracy: 0.7580
Epoch 79/90 - val_loss: 1.4297 - val_sparse_categorical_accuracy: 0.7567
Epoch 80/90 - val_loss: 1.4250 - val_sparse_categorical_accuracy: 0.7573
Epoch 81/90 - val_loss: 1.4017 - val_sparse_categorical_accuracy: 0.7618
Epoch 82/90 - val_loss: 1.3985 - val_sparse_categorical_accuracy: 0.7632
Epoch 83/90 - val_loss: 1.3963 - val_sparse_categorical_accuracy: 0.7636
Epoch 84/90 - val_loss: 1.3950 - val_sparse_categorical_accuracy: 0.7632
Epoch 85/90 - val_loss: 1.3930 - val_sparse_categorical_accuracy: 0.7644
Epoch 86/90 - val_loss: 1.3927 - val_sparse_categorical_accuracy: 0.7630
Epoch 87/90 - val_loss: 1.3912 - val_sparse_categorical_accuracy: 0.7647
Epoch 88/90 - val_loss: 1.3895 - val_sparse_categorical_accuracy: 0.7650
Epoch 89/90 - val_loss: 1.3892 - val_sparse_categorical_accuracy: 0.7644
Epoch 90/90 - val_loss: 1.3882 - val_sparse_categorical_accuracy: 0.7658
```