### PR TITLE
Added options to set validation frequency during training for Keras models

### DIFF
--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -78,6 +78,7 @@ class KerasCifar10BenchmarkTests(object):
     flags.FLAGS.model_dir = self._get_model_dir('keras_resnet56_eager_2_gpu')
     flags.FLAGS.dtype = 'fp32'
     flags.FLAGS.enable_eager = True
+    flags.FLAGS.validation_freq = 30
     stats = keras_cifar_main.run(flags.FLAGS)
     self._fill_report_object(stats)
 

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -165,6 +165,17 @@ def run(flags_obj):
                     flags_obj.batch_size)
 
   validation_data = eval_input_dataset
+  if flags_obj.validation_freq and flags_obj.validation_freq_list:
+    raise ValueError('At most one of --validation_freq and '
+                     '--validation_freq_list must be specified.')
+  validation_freq = flags_obj.validation_freq or 1
+  if flags_obj.validation_freq_list:
+    try:
+      validation_freq = map(int, flags_obj.validation_freq_list.split(','))
+    except ValueError:
+      raise ValueError('Param --validation_freq_list value of %s cannot be '
+                       'converted to a list of integers.' %
+                       (flags_obj.validation_freq_list))
   if flags_obj.skip_eval:
     tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
@@ -180,6 +191,7 @@ def run(flags_obj):
                       ],
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
+                      validation_freq=validation_freq,
                       verbose=1)
   eval_output = None
   if not flags_obj.skip_eval:

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -199,6 +199,14 @@ def define_keras_flags():
       help='For every log_steps, we log the timing information such as '
       'examples per second. Besides, for every log_steps, we store the '
       'timestamp of a batch end.')
+  flags.DEFINE_integer(
+      name='validation_freq', default=None,
+      help='Specify how many training epochs to run before invoking each '
+      'validation.')
+  flags.DEFINE_string(
+      name='validation_freq_list', default=None,
+      help='A comma separated list of integers specifying training epochs. '
+      'After each of these training epochs are finished, invoke validation.')
 
 
 def get_synth_input_fn(height, width, num_channels, num_classes,

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -60,6 +60,7 @@ class KerasImagenetBenchmarkTests(object):
     flags.FLAGS.model_dir = self._get_model_dir('keras_resnet50_eager_8_gpu')
     flags.FLAGS.dtype = 'fp32'
     flags.FLAGS.enable_eager = True
+    flags.FLAGS.validation_freq = 20
     stats = keras_imagenet_main.run(flags.FLAGS)
     self._fill_report_object(stats)
 

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -154,6 +154,17 @@ def run(flags_obj):
                     flags_obj.batch_size)
 
   validation_data = eval_input_dataset
+  if flags_obj.validation_freq and flags_obj.validation_freq_list:
+    raise ValueError('At most one of --validation_freq and '
+                     '--validation_freq_list must be specified.')
+  validation_freq = flags_obj.validation_freq or 1
+  if flags_obj.validation_freq_list:
+    try:
+      validation_freq = map(int, flags_obj.validation_freq_list.split(','))
+    except ValueError:
+      raise ValueError('Param --validation_freq_list value of %s cannot be '
+                       'converted to a list of integers.' %
+                       (flags_obj.validation_freq_list))
   if flags_obj.skip_eval:
     # Only build the training graph. This reduces memory usage introduced by
     # control flow ops in layers that have different implementations for
@@ -172,6 +183,7 @@ def run(flags_obj):
                       ],
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
+                      validation_freq=validation_freq,
                       verbose=1)
 
   eval_output = None


### PR DESCRIPTION
* Adding `--validation_freq` and `--validarion_freq_list` flags, which take an integer and a list of comma separated integers, to specify at which epochs to invoke validation during training.
* Reduce the validation frequency of eager benchmarks tests (for both imagenet and cifar10). This is a temporary fix due to b/122886254.