### PR TITLE
autoaugment pil cutout no-op fixed.

### DIFF
--- a/research/autoaugment/augmentation_transforms.py
+++ b/research/autoaugment/augmentation_transforms.py
@@ -402,8 +402,8 @@ def _cutout_pil_impl(pil_img, level):
   _, upper_coord, lower_coord = (
       create_cutout_mask(img_height, img_width, num_channels, size))
   pixels = pil_img.load()  # create the pixel map
-  for i in range(upper_coord[0], lower_coord[0]):  # for every col:
-    for j in range(upper_coord[1], lower_coord[1]):  # For every row
+  for i in range(upper_coord[0], lower_coord[1]):  # for every col:
+    for j in range(upper_coord[0], lower_coord[1]):  # For every row
       pixels[i, j] = (125, 122, 113, 0)  # set the colour accordingly
   return pil_img
 


### PR DESCRIPTION
@BarretZoph autoaugment's PIL cutout appears to never modify any values! Was this bug present when the original search algorithm was run? 

Note: 
 - applying this fix without re-running the autoaugment search may have a negative impact on results
- applying this fix & updating the [good_policies()](https://github.com/tensorflow/models/blob/903194c51d4798df25334dd5ccecc2604974efd9/research/autoaugment/policies.py) could have a (potentially substantial) positive effect. 👍
- runtime performance of a double for loop for image pixels is probably quite slow.



Here are the two key lines:
https://github.com/tensorflow/models/blob/903194c51d4798df25334dd5ccecc2604974efd9/research/autoaugment/augmentation_transforms.py#L405
https://github.com/tensorflow/models/blob/903194c51d4798df25334dd5ccecc2604974efd9/research/autoaugment/augmentation_transforms.py#L406

I tested similar code on the command line, see how no pixels are visited?
```python
$ coord = (15, 31)
$ print([i for i in range(coord[0], coord[0])])
[]
```
