### PR TITLE
Fix typos in morph_net/framework/README.md

### DIFF
--- a/research/morph_net/README.md
+++ b/research/morph_net/README.md
@@ -23,9 +23,9 @@ subclasses of `NetworkRegularizer`. Each subclass represents a resource that we
 wish to target/constrain when optimizing the network. The MorphNet package
 provides several `NetworkRegularizer`s in the `network_regularizers` directory,
 as well as a framework for writing your own. The framework is described in
-detail [here](g3doc/regularizers_framework.md). The interface of
+detail [here](framework/README.md). The interface of
 `NetworkRegularizer` is given
-[here](g3doc/regularizers_framework.md?#network-regularizers).
+[here](framework/README.md?#network-regularizers).
 
 To apply a `NetworkRegularizer` to your network, your code would look similar to
 the example below. The example refers to a specific type of `NetworkRegularizer`

--- a/research/morph_net/framework/README.md
+++ b/research/morph_net/framework/README.md
@@ -38,7 +38,7 @@ single activation all the way to a full complex network.
 
 `OpRegularizer` is the most primitive element in the framework. An
 `OpRegularizer` refers to TensorFlow op, and has two methods,
-`regularization_vector` and `alive_vector`, both return `tf.Tensor`s or rank 1
+`regularization_vector` and `alive_vector`, both return `tf.Tensor`s of rank 1
 (vectors). `regularization_vector` is of type float, and its `i`-th entry is the
 regularizer of the `i`-th activation of the op the `OpRegularizer` refers to.
 In order to regularize away that activation, one would need to add the `i`-th
@@ -307,7 +307,7 @@ class NetworkRegularizer(object):
 
   @abc.abstractmethod
   def get_regularization_term(self, ops=None):
-    """Compute the FluidNet regularization term.
+    """Compute the MorphNet regularization term.
 
     Args:
       ops: A list of tf.Operation. If specified, only the regularization term


### PR DESCRIPTION
In reading the documentation, I found a reference to the [original name](https://arxiv.org/abs/1711.06798v1) of the paper and a typo regarding rank of a Tensor.

These are minor changes, but will prevent any confusion of future readers