### PR TITLE
Define a variable named base_name in Prerequisites step

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -116,7 +116,7 @@
       "source": [
         "from __future__ import print_function\n",
         "from IPython import display \n",
-        "checkpoint_name = 'mobilenet_v2_1.0_224' #@param\n",
+        "base_name = checkpoint_name = 'mobilenet_v2_1.0_224' #@param\n",
         "url = 'https://storage.googleapis.com/mobilenet_v2/checkpoints/' + checkpoint_name + '.tgz'\n",
         "print('Downloading from ', url)\n",
         "!wget {url}\n",


### PR DESCRIPTION
Currently, a variable named base_name is not defined.
So, occur error while extract from downloaded model file.

Signed-off-by: MyungSung Kwak <yesmung@gmail.com>