### PR TITLE
Imagenet downloader - update of data builder

### DIFF
--- a/research/slim/datasets/build_imagenet_data.py
+++ b/research/slim/datasets/build_imagenet_data.py
@@ -172,6 +172,8 @@ def _float_feature(value):
 
 def _bytes_feature(value):
   """Wrapper for inserting bytes features into Example proto."""
+  if isinstance(value, str): # Byteslist need bytes, not str (for color space and other features)
+    value = value.encode()
   return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
 
 
@@ -314,7 +316,7 @@ def _process_image(filename, coder):
     width: integer, image width in pixels.
   """
   # Read the image file.
-  image_data = tf.gfile.FastGFile(filename, 'r').read()
+  image_data = tf.gfile.FastGFile(filename, 'rb').read()
 
   # Clean the dirty data.
   if _is_png(filename):
@@ -524,7 +526,7 @@ def _find_image_files(data_dir, labels_file):
   # Shuffle the ordering of all image files in order to guarantee
   # random ordering of the images with respect to label in the
   # saved TFRecord files. Make the randomization repeatable.
-  shuffled_index = range(len(filenames))
+  shuffled_index = list(range(len(filenames)))
   random.seed(12345)
   random.shuffle(shuffled_index)
 


### PR DESCRIPTION
Imagenet downloader did not worked with Python 3. Following updates were implemented to the original code

JPEG file opening
-------
Without `r**b**` flag the UTF-8 error was raised

Index shuffling
------
In Python3 is not possible to shuffle `range`, must be converted to `list`

Bytes features
-------
Te features such as _colorspace_ are encoded as string. But the framework excepts them as bytes list.