### PR TITLE
Fixed misleading logging messaging in object_detection

### DIFF
--- a/research/object_detection/predictors/convolutional_box_predictor.py
+++ b/research/object_detection/predictors/convolutional_box_predictor.py
@@ -144,9 +144,9 @@ class ConvolutionalBoxPredictor(box_predictor.BoxPredictor):
             # Add additional conv layers before the class predictor.
             features_depth = static_shape.get_depth(image_feature.get_shape())
             depth = max(min(features_depth, self._max_depth), self._min_depth)
-            tf.logging.info('depth of additional conv before box predictor: {}'.
-                            format(depth))
             if depth > 0 and self._num_layers_before_predictor > 0:
+              tf.logging.info('depth of additional conv before box predictor: {}'.
+                              format(depth))
               for i in range(self._num_layers_before_predictor):
                 net = slim.conv2d(
                     net,


### PR DESCRIPTION
Logging reports that extra conv layers are added but that lies on a condition afterwards creating a wrong impression to anyone reading the logging