### PR TITLE
Points default data_dir to child folder.

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -234,7 +234,7 @@ def cifar10_model_fn(features, labels, mode, params):
 def define_cifar_flags():
   resnet_run_loop.define_resnet_flags()
   flags.adopt_module_key_flags(resnet_run_loop)
-  flags_core.set_defaults(data_dir='/tmp/cifar10_data',
+  flags_core.set_defaults(data_dir='/tmp/cifar10_data/cifar-10-batches-bin',
                           model_dir='/tmp/cifar10_model',
                           resnet_size='56',
                           train_epochs=182,


### PR DESCRIPTION
Now if you run the README as-is it will work.  I made the default data_dir go deeper into the directory structure.  If a user does their own --data_dir there will still be a mismatch but this will improve the situation for anyone just running the command which I believe is the most normal.

The final fix would be to have download_and_extract move the data up a folder.  

This problem was created to fix tests in borg where the cifar-10 dataset is not nested under `cifar-10-batches-bin`.  Maybe that was a mistake, I don't think so but... shrug...open to opinion.