### PR TITLE
Add Combined NMS

### DIFF
--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -484,8 +484,7 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
       max_size_per_class=frcnn_config.first_stage_max_proposals,
       max_total_size=frcnn_config.first_stage_max_proposals,
-      use_static_shapes=use_static_shapes,
-      use_combined_nms=frcnn_config.use_first_stage_combined_nms)
+      use_static_shapes=use_static_shapes)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -484,7 +484,8 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
       max_size_per_class=frcnn_config.first_stage_max_proposals,
       max_total_size=frcnn_config.first_stage_max_proposals,
-      use_static_shapes=use_static_shapes)
+      use_static_shapes=use_static_shapes,
+      use_combined_nms=frcnn_config.use_first_stage_combined_nms)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -478,22 +478,14 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       first_stage_max_proposals):
     raise ValueError('second_stage_batch_size should be no greater than '
                      'first_stage_max_proposals.')
-  if (frcnn_config.first_stage_combined_nms):
-    first_stage_non_max_suppression_fn = functools.partial(
-        post_processing.combined_non_max_suppression,
-        score_thresh=frcnn_config.first_stage_nms_score_threshold,
-        iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
-        max_size_per_class=frcnn_config.first_stage_max_proposals,
-        max_total_size=frcnn_config.first_stage_max_proposals,
-        use_static_shapes=use_static_shapes)
-  else:
-    first_stage_non_max_suppression_fn = functools.partial(
-        post_processing.batch_multiclass_non_max_suppression,
-        score_thresh=frcnn_config.first_stage_nms_score_threshold,
-        iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
-        max_size_per_class=frcnn_config.first_stage_max_proposals,
-        max_total_size=frcnn_config.first_stage_max_proposals,
-        use_static_shapes=use_static_shapes)
+  first_stage_non_max_suppression_fn = functools.partial(
+      post_processing.batch_multiclass_non_max_suppression,
+      score_thresh=frcnn_config.first_stage_nms_score_threshold,
+      iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
+      max_size_per_class=frcnn_config.first_stage_max_proposals,
+      max_total_size=frcnn_config.first_stage_max_proposals,
+      use_static_shapes=use_static_shapes,
+      use_combined_nms=frcnn_config.use_first_stage_combined_nms)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -485,7 +485,7 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       max_size_per_class=frcnn_config.first_stage_max_proposals,
       max_total_size=frcnn_config.first_stage_max_proposals,
       use_static_shapes=use_static_shapes,
-      use_combined_nms=frcnn_config.use_first_stage_combined_nms)
+      use_combined_nms=frcnn_config.use_combined_nms_in_first_stage)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -478,13 +478,22 @@ def _build_faster_rcnn_model(frcnn_config, is_training, add_summaries):
       first_stage_max_proposals):
     raise ValueError('second_stage_batch_size should be no greater than '
                      'first_stage_max_proposals.')
-  first_stage_non_max_suppression_fn = functools.partial(
-      post_processing.batch_multiclass_non_max_suppression,
-      score_thresh=frcnn_config.first_stage_nms_score_threshold,
-      iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
-      max_size_per_class=frcnn_config.first_stage_max_proposals,
-      max_total_size=frcnn_config.first_stage_max_proposals,
-      use_static_shapes=use_static_shapes)
+  if (frcnn_config.first_stage_combined_nms):
+    first_stage_non_max_suppression_fn = functools.partial(
+        post_processing.combined_non_max_suppression,
+        score_thresh=frcnn_config.first_stage_nms_score_threshold,
+        iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
+        max_size_per_class=frcnn_config.first_stage_max_proposals,
+        max_total_size=frcnn_config.first_stage_max_proposals,
+        use_static_shapes=use_static_shapes)
+  else:
+    first_stage_non_max_suppression_fn = functools.partial(
+        post_processing.batch_multiclass_non_max_suppression,
+        score_thresh=frcnn_config.first_stage_nms_score_threshold,
+        iou_thresh=frcnn_config.first_stage_nms_iou_threshold,
+        max_size_per_class=frcnn_config.first_stage_max_proposals,
+        max_total_size=frcnn_config.first_stage_max_proposals,
+        use_static_shapes=use_static_shapes)
   first_stage_loc_loss_weight = (
       frcnn_config.first_stage_localization_loss_weight)
   first_stage_obj_loss_weight = frcnn_config.first_stage_objectness_loss_weight

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -88,9 +88,8 @@ def _build_non_max_suppressor(nms_config):
                      'max_total_detections.')
   if nms_config.soft_nms_sigma < 0.0:
     raise ValueError('soft_nms_sigma should be non-negative.')
-  non_max_suppressor_fn = functools.partial(
 
-  if(nms_config.combined_nms):
+  if nms_config.combined_nms:
     non_max_suppressor_fn = functools.partial(
       post_processing.combined_non_max_suppression,
       score_thresh=nms_config.score_threshold,
@@ -98,7 +97,6 @@ def _build_non_max_suppressor(nms_config):
       max_size_per_class=nms_config.max_detections_per_class,
       max_total_size=nms_config.max_total_detections,
       use_static_shapes=nms_config.use_static_shapes)
-
   else:
     non_max_suppressor_fn = functools.partial(
       post_processing.batch_multiclass_non_max_suppression,

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -89,6 +89,18 @@ def _build_non_max_suppressor(nms_config):
   if nms_config.soft_nms_sigma < 0.0:
     raise ValueError('soft_nms_sigma should be non-negative.')
   non_max_suppressor_fn = functools.partial(
+
+  if(nms_config.combined_nms):
+    non_max_suppressor_fn = functools.partial(
+      post_processing.combined_non_max_suppression,
+      score_thresh=nms_config.score_threshold,
+      iou_thresh=nms_config.iou_threshold,
+      max_size_per_class=nms_config.max_detections_per_class,
+      max_total_size=nms_config.max_total_detections,
+      use_static_shapes=nms_config.use_static_shapes)
+
+  else:
+    non_max_suppressor_fn = functools.partial(
       post_processing.batch_multiclass_non_max_suppression,
       score_thresh=nms_config.score_threshold,
       iou_thresh=nms_config.iou_threshold,

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -88,28 +88,21 @@ def _build_non_max_suppressor(nms_config):
                      'max_total_detections.')
   if nms_config.soft_nms_sigma < 0.0:
     raise ValueError('soft_nms_sigma should be non-negative.')
-
-  if nms_config.combined_nms:
+  if nms_config.use_combined_nms:
     if nms_config.use_class_agnostic_nms:
-      raise ValueError('combined_nms does not support use_class_agnostic_nms')
-    non_max_suppressor_fn = functools.partial(
-        post_processing.combined_non_max_suppression,
-        score_thresh=nms_config.score_threshold,
-        iou_thresh=nms_config.iou_threshold,
-        max_size_per_class=nms_config.max_detections_per_class,
-        max_total_size=nms_config.max_total_detections,
-        use_static_shapes=nms_config.use_static_shapes)
-  else:
-    non_max_suppressor_fn = functools.partial(
-        post_processing.batch_multiclass_non_max_suppression,
-        score_thresh=nms_config.score_threshold,
-        iou_thresh=nms_config.iou_threshold,
-        max_size_per_class=nms_config.max_detections_per_class,
-        max_total_size=nms_config.max_total_detections,
-        use_static_shapes=nms_config.use_static_shapes,
-        use_class_agnostic_nms=nms_config.use_class_agnostic_nms,
-        max_classes_per_detection=nms_config.max_classes_per_detection,
-        soft_nms_sigma=nms_config.soft_nms_sigma)
+      raise ValueError('combined_nms does not support class_agnostic_nms')
+
+  non_max_suppressor_fn = functools.partial(
+      post_processing.batch_multiclass_non_max_suppression,
+      score_thresh=nms_config.score_threshold,
+      iou_thresh=nms_config.iou_threshold,
+      max_size_per_class=nms_config.max_detections_per_class,
+      max_total_size=nms_config.max_total_detections,
+      use_static_shapes=nms_config.use_static_shapes,
+      use_class_agnostic_nms=nms_config.use_class_agnostic_nms,
+      max_classes_per_detection=nms_config.max_classes_per_detection,
+      soft_nms_sigma=nms_config.soft_nms_sigma,
+      use_combined_nms=nms_config.use_combined_nms)
   return non_max_suppressor_fn
 
 

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -88,8 +88,7 @@ def _build_non_max_suppressor(nms_config):
                      'max_total_detections.')
   if nms_config.soft_nms_sigma < 0.0:
     raise ValueError('soft_nms_sigma should be non-negative.')
-  if nms_config.use_combined_nms:
-    if nms_config.use_class_agnostic_nms:
+  if nms_config.use_combined_nms and nms_config.use_class_agnostic_nms:
       raise ValueError('combined_nms does not support class_agnostic_nms')
 
   non_max_suppressor_fn = functools.partial(

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -91,25 +91,25 @@ def _build_non_max_suppressor(nms_config):
 
   if nms_config.combined_nms:
     if nms_config.use_class_agnostic_nms:
-        raise ValueError('combined_nms does not support use_class_agnostic_nms')
+      raise ValueError('combined_nms does not support use_class_agnostic_nms')
     non_max_suppressor_fn = functools.partial(
-      post_processing.combined_non_max_suppression,
-      score_thresh=nms_config.score_threshold,
-      iou_thresh=nms_config.iou_threshold,
-      max_size_per_class=nms_config.max_detections_per_class,
-      max_total_size=nms_config.max_total_detections,
-      use_static_shapes=nms_config.use_static_shapes)
+        post_processing.combined_non_max_suppression,
+        score_thresh=nms_config.score_threshold,
+        iou_thresh=nms_config.iou_threshold,
+        max_size_per_class=nms_config.max_detections_per_class,
+        max_total_size=nms_config.max_total_detections,
+        use_static_shapes=nms_config.use_static_shapes)
   else:
     non_max_suppressor_fn = functools.partial(
-      post_processing.batch_multiclass_non_max_suppression,
-      score_thresh=nms_config.score_threshold,
-      iou_thresh=nms_config.iou_threshold,
-      max_size_per_class=nms_config.max_detections_per_class,
-      max_total_size=nms_config.max_total_detections,
-      use_static_shapes=nms_config.use_static_shapes,
-      use_class_agnostic_nms=nms_config.use_class_agnostic_nms,
-      max_classes_per_detection=nms_config.max_classes_per_detection,
-      soft_nms_sigma=nms_config.soft_nms_sigma)
+        post_processing.batch_multiclass_non_max_suppression,
+        score_thresh=nms_config.score_threshold,
+        iou_thresh=nms_config.iou_threshold,
+        max_size_per_class=nms_config.max_detections_per_class,
+        max_total_size=nms_config.max_total_detections,
+        use_static_shapes=nms_config.use_static_shapes,
+        use_class_agnostic_nms=nms_config.use_class_agnostic_nms,
+        max_classes_per_detection=nms_config.max_classes_per_detection,
+        soft_nms_sigma=nms_config.soft_nms_sigma)
   return non_max_suppressor_fn
 
 

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -90,6 +90,8 @@ def _build_non_max_suppressor(nms_config):
     raise ValueError('soft_nms_sigma should be non-negative.')
 
   if nms_config.combined_nms:
+    if nms_config.use_class_agnostic_nms:
+        raise ValueError('combined_nms does not support use_class_agnostic_nms')
     non_max_suppressor_fn = functools.partial(
       post_processing.combined_non_max_suppression,
       score_thresh=nms_config.score_threshold,

--- a/research/object_detection/core/batch_multiclass_nms_test.py
+++ b/research/object_detection/core/batch_multiclass_nms_test.py
@@ -663,8 +663,8 @@ class BatchMulticlassNonMaxSuppressionTest(test_case.TestCase,
                             exp_nms_additional_fields[key])
       self.assertAllClose(num_detections, [1, 1])
 
-  # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
   def test_combined_nms_with_batch_size_2(self):
+    """Test use_combined_nms"""
     boxes = tf.constant([[[[0, 0, 0.1, 0.1], [0, 0, 0.1, 0.1]],
                           [[0, 0.01, 1, 0.11], [0, 0.6, 0.1, 0.7]],
                           [[0, -0.01, 0.1, 0.09], [0, -0.1, 0.1, 0.09]],

--- a/research/object_detection/core/batch_multiclass_nms_test.py
+++ b/research/object_detection/core/batch_multiclass_nms_test.py
@@ -695,10 +695,11 @@ class BatchMulticlassNonMaxSuppressionTest(test_case.TestCase,
 
     (nmsed_boxes, nmsed_scores, nmsed_classes, nmsed_masks,
      nmsed_additional_fields, num_detections
-    ) = post_processing.combined_non_max_suppression(
+    ) = post_processing.batch_multiclass_non_max_suppression(
         boxes, scores, score_thresh, iou_thresh,
         max_size_per_class=max_output_size, max_total_size=max_output_size,
-        use_static_shapes=True)
+        use_static_shapes=True,
+        use_combined_nms=True)
 
     self.assertIsNone(nmsed_masks)
     self.assertIsNone(nmsed_additional_fields)

--- a/research/object_detection/core/batch_multiclass_nms_test.py
+++ b/research/object_detection/core/batch_multiclass_nms_test.py
@@ -711,7 +711,7 @@ class BatchMulticlassNonMaxSuppressionTest(test_case.TestCase,
       self.assertAllClose(nmsed_boxes, exp_nms_corners)
       self.assertAllClose(nmsed_scores, exp_nms_scores)
       self.assertAllClose(nmsed_classes, exp_nms_classes)
-      self.assertAllClose(num_detections, [3, 3])
+      self.assertListEqual(num_detections.tolist(), [3, 3])
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/core/batch_multiclass_nms_test.py
+++ b/research/object_detection/core/batch_multiclass_nms_test.py
@@ -664,7 +664,7 @@ class BatchMulticlassNonMaxSuppressionTest(test_case.TestCase,
       self.assertAllClose(num_detections, [1, 1])
 
   def test_combined_nms_with_batch_size_2(self):
-    """Test use_combined_nms"""
+    """Test use_combined_nms."""
     boxes = tf.constant([[[[0, 0, 0.1, 0.1], [0, 0, 0.1, 0.1]],
                           [[0, 0.01, 1, 0.11], [0, 0.6, 0.1, 0.7]],
                           [[0, -0.01, 0.1, 0.09], [0, -0.1, 0.1, 0.09]],

--- a/research/object_detection/core/batch_multiclass_nms_test.py
+++ b/research/object_detection/core/batch_multiclass_nms_test.py
@@ -664,6 +664,53 @@ class BatchMulticlassNonMaxSuppressionTest(test_case.TestCase,
       self.assertAllClose(num_detections, [1, 1])
 
   # TODO(bhattad): Remove conditional after CMLE moves to TF 1.9
+  def test_combined_nms_with_batch_size_2(self):
+    boxes = tf.constant([[[[0, 0, 0.1, 0.1], [0, 0, 0.1, 0.1]],
+                          [[0, 0.01, 1, 0.11], [0, 0.6, 0.1, 0.7]],
+                          [[0, -0.01, 0.1, 0.09], [0, -0.1, 0.1, 0.09]],
+                          [[0, 0.11, 0.1, 0.2], [0, 0.11, 0.1, 0.2]]],
+                         [[[0, 0, 0.2, 0.2], [0, 0, 0.2, 0.2]],
+                          [[0, 0.02, 0.2, 0.22], [0, 0.02, 0.2, 0.22]],
+                          [[0, -0.02, 0.2, 0.19], [0, -0.02, 0.2, 0.19]],
+                          [[0, 0.21, 0.2, 0.3], [0, 0.21, 0.2, 0.3]]]],
+                        tf.float32)
+    scores = tf.constant([[[.1, 0.9], [.75, 0.8],
+                           [.6, 0.3], [0.95, 0.1]],
+                          [[.1, 0.9], [.75, 0.8],
+                           [.6, .3], [.95, .1]]])
+    score_thresh = 0.1
+    iou_thresh = .5
+    max_output_size = 3
+
+    exp_nms_corners = np.array([[[0, 0.11, 0.1, 0.2],
+                                 [0, 0, 0.1, 0.1],
+                                 [0, 0.6, 0.1, 0.7]],
+                                [[0, 0.21, 0.2, 0.3],
+                                 [0, 0, 0.2, 0.2],
+                                 [0, 0.02, 0.2, 0.22]]])
+    exp_nms_scores = np.array([[.95, .9, 0.8],
+                               [.95, .9, .75]])
+    exp_nms_classes = np.array([[0, 1, 1],
+                                [0, 1, 0]])
+
+    (nmsed_boxes, nmsed_scores, nmsed_classes, nmsed_masks,
+     nmsed_additional_fields, num_detections
+    ) = post_processing.combined_non_max_suppression(
+        boxes, scores, score_thresh, iou_thresh,
+        max_size_per_class=max_output_size, max_total_size=max_output_size,
+        use_static_shapes=True)
+
+    self.assertIsNone(nmsed_masks)
+    self.assertIsNone(nmsed_additional_fields)
+
+    with self.test_session() as sess:
+      (nmsed_boxes, nmsed_scores, nmsed_classes,
+       num_detections) = sess.run([nmsed_boxes, nmsed_scores, nmsed_classes,
+                                   num_detections])
+      self.assertAllClose(nmsed_boxes, exp_nms_corners)
+      self.assertAllClose(nmsed_scores, exp_nms_scores)
+      self.assertAllClose(nmsed_classes, exp_nms_classes)
+      self.assertAllClose(num_detections, [3, 3])
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -867,7 +867,8 @@ def batch_multiclass_non_max_suppression(boxes,
       False.
     scope: tf scope name.
     use_static_shapes: If true, the output nmsed boxes are padded to be of
-      length `max_size_per_class` and it doesn't clip boxes to max_total_size.
+      length `minimum(max_total_size, max_size_per_class*num_classes)`.
+      If false, they are padded to be of length `max_total_size`.
       Defaults to false.
     parallel_iterations: (optional) number of batch items to process in
       parallel.

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -1135,9 +1135,21 @@ def combined_non_max_suppression(boxes,
                                  scope=None):
   """Multi-class version of non maximum suppression that operates on a batch.
 
-  This op is similar to `multiclass_non_max_suppression` but operates on a batch
-  of boxes and scores. See documentation for `multiclass_non_max_suppression`
-  for details.
+  This function uses TensorFlow operator "CombinedNonMaxSuppression".
+  It greedily selects a subset of detection bounding boxes, pruning away
+  boxes that have high IOU (intersection over union) overlap (> thresh) with
+  already selected boxes. It operates independently for each batch.
+  Within each batch, it operates independently for each class for which
+  scores are provided (via the scores field of the input box_list),
+  pruning boxes with score less than a provided threshold prior to applying NMS.
+  
+  Please note that this operation is performed on *all* batches and *all* classes
+  in the batch, therefore any background classes should be removed prior to
+  calling this function. 
+  
+  This op is similar to `multiclass_non_max_suppression` but operates on
+  a batch of boxes and scores. See documentation for
+  `multiclass_non_max_suppression` for additional details.
 
   Args:
     boxes: A [batch_size, num_anchors, q, 4] float32 tensor containing

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -883,9 +883,10 @@ def batch_multiclass_non_max_suppression(boxes,
       already selected boxes. It operates independently for each batch.
       Within each batch, it operates independently for each class for which
       scores are provided (via the scores field of the input box_list),
-      pruning boxes with score less than a provided threshold prior to applying NMS.
-      This operation is performed on *all* batches and *all* classes in the batch,
-      therefore any background classes should be removed prior to calling this function.
+      pruning boxes with score less than a provided threshold prior to applying
+      NMS. This operation is performed on *all* batches and *all* classes
+      in the batch, therefore any background classes should be removed prior to
+      calling this function.
       Masks and additional fields are not supported.
       See argument checks in the code below for unsupported arguments.
 
@@ -944,13 +945,13 @@ def batch_multiclass_non_max_suppression(boxes,
     with tf.name_scope(scope, 'CombinedNonMaxSuppression'):
       (batch_nmsed_boxes, batch_nmsed_scores, batch_nmsed_classes,
        batch_num_detections) = tf.image.combined_non_max_suppression(
-              boxes=boxes,
-              scores=scores,
-              max_output_size_per_class=max_size_per_class,
-              max_total_size=max_total_size,
-              iou_threshold=iou_thresh,
-              score_threshold=score_thresh,
-              pad_per_class=use_static_shapes)
+           boxes=boxes,
+           scores=scores,
+           max_output_size_per_class=max_size_per_class,
+           max_total_size=max_total_size,
+           iou_threshold=iou_thresh,
+           score_threshold=score_thresh,
+           pad_per_class=use_static_shapes)
       # Not supported by combined_non_max_suppression
       batch_nmsed_masks = None
       # Not supported by combined_non_max_suppression

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -1126,11 +1126,6 @@ def combined_non_max_suppression(boxes,
                                  iou_thresh,
                                  max_size_per_class,
                                  max_total_size=0,
-                                 clip_window=None,
-                                 change_coordinate_frame=False,
-                                 num_valid_boxes=None,
-                                 masks=None,
-                                 additional_fields=None,
                                  use_static_shapes=False,
                                  scope=None):
   """Multi-class version of non maximum suppression that operates on a batch.

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -1171,8 +1171,6 @@ def combined_non_max_suppression(boxes,
       valid detections per batch item. Only the top num_detections[i] entries in
       nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
       entries are zero paddings.
-    'selected_indices':  A [batch_size, max_detections] int32 tensor
-      containing the indices of the selected boxes
 
   Raises:
     ValueError: if `q` in boxes.shape is not 1 or not equal to number of
@@ -1180,7 +1178,7 @@ def combined_non_max_suppression(boxes,
   """
 
   with tf.name_scope(scope, 'CombinedNonMaxSuppression'):
-    nmsed_boxes, nmsed_scores, nmsed_classes, num_detections, selected_indices = tf.image.combined_non_max_suppression(
+    nmsed_boxes, nmsed_scores, nmsed_classes, num_detections = tf.image.combined_non_max_suppression(
             boxes, scores, max_size_per_class, max_total_size, iou_thresh,
             score_thresh, use_static_shapes)
 

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -918,29 +918,29 @@ def batch_multiclass_non_max_suppression(boxes,
     if change_coordinate_frame:
       raise ValueError(
           'change_coordinate_frame (normalizing coordinates'
-          ' relative to clip_window) is not supported by combined_nms')
+          ' relative to clip_window) is not supported by combined_nms.')
     if num_valid_boxes is not None:
-      raise ValueError('num_valid_boxes is not supported by combined_nms')
+      raise ValueError('num_valid_boxes is not supported by combined_nms.')
     if masks is not None:
-      raise ValueError('masks is not supported by combined_nms')
+      raise ValueError('masks is not supported by combined_nms.')
     if soft_nms_sigma != 0.0:
-      raise ValueError('Soft NMS is not supported by combined_nms')
+      raise ValueError('Soft NMS is not supported by combined_nms.')
     if use_class_agnostic_nms:
-      raise ValueError('class-agnostic NMS is not supported by combined_nms')
+      raise ValueError('class-agnostic NMS is not supported by combined_nms.')
     if clip_window is not None:
       tf.compat.v1.logging.warning(
           'clip_window is not supported by combined_nms unless it is'
-          ' [0. 0. 1. 1.] for each image')
+          ' [0. 0. 1. 1.] for each image.')
     if additional_fields is not None:
       tf.compat.v1.logging.warning(
-          'additional_fields is not supported by combined_nms')
+          'additional_fields is not supported by combined_nms.')
     if parallel_iterations != 32:
       tf.compat.v1.logging.warning(
           'Number of batch items to be processed in parallel is'
-          ' not configurable by combined_nms')
+          ' not configurable by combined_nms.')
     if max_classes_per_detection > 1:
       tf.compat.v1.logging.warning(
-          'max_classes_per_detection is not configurable by combined_nms')
+          'max_classes_per_detection is not configurable by combined_nms.')
 
     with tf.name_scope(scope, 'CombinedNonMaxSuppression'):
       (batch_nmsed_boxes, batch_nmsed_scores, batch_nmsed_classes,
@@ -952,9 +952,9 @@ def batch_multiclass_non_max_suppression(boxes,
            iou_threshold=iou_thresh,
            score_threshold=score_thresh,
            pad_per_class=use_static_shapes)
-      # Not supported by combined_non_max_suppression
+      # Not supported by combined_non_max_suppression.
       batch_nmsed_masks = None
-      # Not supported by combined_non_max_suppression
+      # Not supported by combined_non_max_suppression.
       batch_nmsed_additional_fields = None
       return (batch_nmsed_boxes, batch_nmsed_scores, batch_nmsed_classes,
               batch_nmsed_masks, batch_nmsed_additional_fields,
@@ -964,7 +964,7 @@ def batch_multiclass_non_max_suppression(boxes,
   num_classes = shape_utils.get_dim_as_int(scores.shape[2])
   if q != 1 and q != num_classes:
     raise ValueError('third dimension of boxes must be either 1 or equal '
-                     'to the third dimension of scores')
+                     'to the third dimension of scores.')
   if change_coordinate_frame and clip_window is None:
     raise ValueError('if change_coordinate_frame is True, then a clip_window'
                      'must be specified.')

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -1119,3 +1119,75 @@ def batch_multiclass_non_max_suppression(boxes,
     return (batch_nmsed_boxes, batch_nmsed_scores, batch_nmsed_classes,
             batch_nmsed_masks, batch_nmsed_additional_fields,
             batch_num_detections)
+
+def combined_non_max_suppression(boxes,
+                                 scores,
+                                 score_thresh,
+                                 iou_thresh,
+                                 max_size_per_class,
+                                 max_total_size=0,
+                                 clip_window=None,
+                                 change_coordinate_frame=False,
+                                 num_valid_boxes=None,
+                                 masks=None,
+                                 additional_fields=None,
+                                 use_static_shapes=False,
+                                 scope=None):
+  """Multi-class version of non maximum suppression that operates on a batch.
+
+  This op is similar to `multiclass_non_max_suppression` but operates on a batch
+  of boxes and scores. See documentation for `multiclass_non_max_suppression`
+  for details.
+
+  Args:
+    boxes: A [batch_size, num_anchors, q, 4] float32 tensor containing
+      detections. If `q` is 1 then same boxes are used for all classes
+        otherwise, if `q` is equal to number of classes, class-specific boxes
+        are used.
+    scores: A [batch_size, num_anchors, num_classes] float32 tensor containing
+      the scores for each of the `num_anchors` detections. The scores have to be
+      non-negative when use_static_shapes is set True.
+    score_thresh: scalar threshold for score (low scoring boxes are removed).
+    iou_thresh: scalar threshold for IOU (new boxes that have high IOU overlap
+      with previously selected boxes are removed).
+    max_size_per_class: maximum number of retained boxes per class.
+    max_total_size: maximum number of boxes retained over all classes. By
+      default returns all boxes retained after capping boxes per class.
+    use_static_shapes: If false, the outputs nmsed_boxes, scores, classes and
+      selected_indices are padded/clipped to `max_total_size`. If true, the
+      output nmsed boxes, scores, classes and selected_indices are
+      padded/clipped to be of length `max_size_per_class` or `max_total_size`.
+      Defaults to false.
+    scope: tf scope name.
+
+  Returns:
+    'nmsed_boxes': A [batch_size, max_detections, 4] float32 tensor
+      containing the non-max suppressed boxes.
+    'nmsed_scores': A [batch_size, max_detections] float32 tensor containing
+      the scores for the boxes.
+    'nmsed_classes': A [batch_size, max_detections] float32 tensor
+      containing the class for boxes.
+    'num_detections': A [batch_size] int32 tensor indicating the number of
+      valid detections per batch item. Only the top num_detections[i] entries in
+      nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
+      entries are zero paddings.
+    'selected_indices':  A [batch_size, max_detections] int32 tensor
+      containing the indices of the selected boxes
+
+  Raises:
+    ValueError: if `q` in boxes.shape is not 1 or not equal to number of
+      classes as inferred from scores.shape.
+  """
+
+  with tf.name_scope(scope, 'CombinedNonMaxSuppression'):
+    nmsed_boxes, nmsed_scores, nmsed_classes, num_detections, selected_indices = tf.image.combined_non_max_suppression(
+            boxes, scores, max_size_per_class, max_total_size, iou_thresh,
+            score_thresh, use_static_shapes)
+
+    batch_nmsed_masks = None
+    batch_nmsed_additional_fields = None
+    #TODO supriyar: Set static shapes here?
+    return (nmsed_boxes, nmsed_scores, nmsed_classes, batch_nmsed_masks,
+           batch_nmsed_additional_fields, num_detections)
+
+ 

--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -1158,7 +1158,7 @@ def combined_non_max_suppression(boxes,
 
   if change_coordinate_frame:
     raise ValueError('change_coordinate_frame (normalizing coordinates relative'
-                     'to clip_window) is not supported by combined_nms')
+                     ' to clip_window) is not supported by combined_nms')
   if num_valid_boxes is not None:
     raise ValueError('num_valid_boxes is not supported by combined_nms')
   if masks is not None:
@@ -1170,15 +1170,17 @@ def combined_non_max_suppression(boxes,
 
   if clip_window is not None:
     tf.compat.v1.logging.warning('clip_window is not supported by combined_nms'
-                       'unless it is [0. 0. 1. 1.] for each image')
+                                 ' unless it is [0. 0. 1. 1.] for each image')
   if additional_fields is not None:
-    tf.compat.v1.logging.warning('additional_fields is not supported by combined_nms')
+    tf.compat.v1.logging.warning(
+        'additional_fields is not supported by combined_nms')
   if parallel_iterations != 32:
-    tf.compat.v1.logging.warning('Number of batch items to be processed in parallel'
-                       'is not configurable by combined_nms')
+    tf.compat.v1.logging.warning(
+        'Number of batch items to be processed in parallel is'
+        ' not configurable by combined_nms')
   if max_classes_per_detection > 1:
     tf.compat.v1.logging.warning('max_classes_per_detection is not configurable'
-                       'by combined_nms')
+                                 ' by combined_nms')
   with tf.name_scope(scope, 'CombinedNonMaxSuppression'):
     nmsed_boxes, nmsed_scores, nmsed_classes, num_detections = \
         tf.image.combined_non_max_suppression(

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
@@ -1621,7 +1621,8 @@ class FasterRCNNMetaArch(model.DetectionModel):
         normalize_boxes,
         elems=[raw_proposal_boxes, image_shapes],
         dtype=tf.float32)
-    proposal_multiclass_scores = nmsed_additional_fields['multiclass_scores']
+    proposal_multiclass_scores = nmsed_additional_fields.get(
+        'multiclass_scores') if nmsed_additional_fields else None,
     return (normalized_proposal_boxes, proposal_scores,
             proposal_multiclass_scores, num_proposals,
             raw_normalized_proposal_boxes, rpn_objectness_softmax)

--- a/research/object_detection/meta_architectures/ssd_meta_arch.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch.py
@@ -746,7 +746,8 @@ class SSDMetaArch(model.DetectionModel):
           fields.DetectionResultFields.detection_classes:
               nmsed_classes,
           fields.DetectionResultFields.detection_multiclass_scores:
-              nmsed_additional_fields['multiclass_scores'],
+              nmsed_additional_fields.get(
+                  'multiclass_scores') if nmsed_additional_fields else None,
           fields.DetectionResultFields.num_detections:
               tf.cast(num_detections, dtype=tf.float32),
           fields.DetectionResultFields.raw_detection_boxes:

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -168,6 +168,9 @@ message FasterRcnn {
   // If True, uses implementation of ops with static shape guarantees when
   // running evaluation (specifically not is_training if False).
   optional bool use_static_shapes_for_eval = 37 [default = false];
+
+  // Whether to use Combined NMS for first stage.
+  optional bool first_stage_combined_nms = 38 [default=false];
 }
 
 

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -169,7 +169,7 @@ message FasterRcnn {
   // running evaluation (specifically not is_training if False).
   optional bool use_static_shapes_for_eval = 37 [default = false];
 
-  // Whether to use tf.image.combined_non_max_suppression
+  // Whether to use tf.image.combined_non_max_suppression.
   optional bool use_combined_nms_in_first_stage = 38 [default=false];
 }
 

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -168,9 +168,6 @@ message FasterRcnn {
   // If True, uses implementation of ops with static shape guarantees when
   // running evaluation (specifically not is_training if False).
   optional bool use_static_shapes_for_eval = 37 [default = false];
-
-  // Whether to use tf.image.combined_non_max_suppression
-  optional bool use_first_stage_combined_nms = 38 [default=false];
 }
 
 

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -170,7 +170,7 @@ message FasterRcnn {
   optional bool use_static_shapes_for_eval = 37 [default = false];
 
   // Whether to use tf.image.combined_non_max_suppression
-  optional bool use_first_stage_combined_nms = 38 [default=false];
+  optional bool use_combined_nms_in_first_stage = 38 [default=false];
 }
 
 

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -169,8 +169,8 @@ message FasterRcnn {
   // running evaluation (specifically not is_training if False).
   optional bool use_static_shapes_for_eval = 37 [default = false];
 
-  // Whether to use Combined NMS for first stage.
-  optional bool first_stage_combined_nms = 38 [default=false];
+  // Whether to use tf.image.combined_non_max_suppression
+  optional bool use_first_stage_combined_nms = 38 [default=false];
 }
 
 

--- a/research/object_detection/protos/faster_rcnn.proto
+++ b/research/object_detection/protos/faster_rcnn.proto
@@ -168,6 +168,9 @@ message FasterRcnn {
   // If True, uses implementation of ops with static shape guarantees when
   // running evaluation (specifically not is_training if False).
   optional bool use_static_shapes_for_eval = 37 [default = false];
+
+  // Whether to use tf.image.combined_non_max_suppression
+  optional bool use_first_stage_combined_nms = 38 [default=false];
 }
 
 

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -39,6 +39,9 @@ message BatchNonMaxSuppression {
 
   // Soft NMS sigma parameter; Bodla et al, https://arxiv.org/abs/1704.04503)
   optional float soft_nms_sigma = 9 [default = 0.0];
+
+  // Whether to use the Combined NMS op
+  optional bool combined_nms = 7 [default = false];
 }
 
 // Configuration proto for post-processing predicted boxes and

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -40,8 +40,8 @@ message BatchNonMaxSuppression {
   // Soft NMS sigma parameter; Bodla et al, https://arxiv.org/abs/1704.04503)
   optional float soft_nms_sigma = 9 [default = 0.0];
 
-  // Whether to use the Combined NMS op
-  optional bool combined_nms = 10 [default = false];
+  // Whether to use tf.image.combined_non_max_suppression
+  optional bool use_combined_nms = 10 [default = false];
 }
 
 // Configuration proto for post-processing predicted boxes and

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -40,7 +40,7 @@ message BatchNonMaxSuppression {
   // Soft NMS sigma parameter; Bodla et al, https://arxiv.org/abs/1704.04503)
   optional float soft_nms_sigma = 9 [default = 0.0];
 
-  // Whether to use tf.image.combined_non_max_suppression
+  // Whether to use tf.image.combined_non_max_suppression.
   optional bool use_combined_nms = 10 [default = false];
 }
 

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -41,7 +41,7 @@ message BatchNonMaxSuppression {
   optional float soft_nms_sigma = 9 [default = 0.0];
 
   // Whether to use the Combined NMS op
-  optional bool combined_nms = 7 [default = false];
+  optional bool combined_nms = 10 [default = false];
 }
 
 // Configuration proto for post-processing predicted boxes and


### PR DESCRIPTION
CombinedNMS op was recently added to TensorFlow.
https://github.com/tensorflow/tensorflow/pull/23567

This PR adds CombinedNMS to the object detection API in TensorFlow.

The main difference between this new op and the old ones is that it does all of NMS in one op.
It's much more efficient, and it's also easier to swap out with a more efficient version of it from TF custom backends such as TensorRT and XLA.