### PR TITLE
log verbosity=2 logs every epoch no progress bars

### DIFF
--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -178,7 +178,7 @@ def run(flags_obj):
                       ],
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
-                      verbose=1)
+                      verbose=2)
   eval_output = None
   if not flags_obj.skip_eval:
     eval_output = model.evaluate(eval_input_dataset,

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -170,7 +170,7 @@ def run(flags_obj):
                       ],
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
-                      verbose=1)
+                      verbose=2)
 
   eval_output = None
   if not flags_obj.skip_eval:


### PR DESCRIPTION
This greatly reduces the log size and readability.

Logging of loss/accuracy will only occur every epoch and no progress bars.  All other hooks logs as expected.  So much nicer.  