### PR TITLE
Do not toggle eager if tf 2.0 is used.

### DIFF
--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -97,7 +97,9 @@ def run(flags_obj):
   Returns:
     Dictionary of training and eval stats.
   """
-  if flags_obj.enable_eager:
+  # TODO(tobyboyd): Remove eager flag when tf 1.0 testing ends.
+  # Eager is default in tf 2.0 and should not be toggled
+  if flags_obj.enable_eager and not keras_common.is_v2_0():
     tf.compat.v1.enable_eager_execution()
 
   dtype = flags_core.get_tf_dtype(flags_obj)

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -252,6 +252,11 @@ def get_synth_input_fn(height, width, num_channels, num_classes,
   return input_fn
 
 
+def is_v2_0():
+  """Returns true if using tf 2.0."""
+  return tf.__version__.startswith('2')
+
+
 def get_strategy_scope(strategy):
   if strategy:
     strategy_scope = strategy.scope()

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -87,7 +87,9 @@ def run(flags_obj):
   Raises:
     ValueError: If fp16 is passed as it is not currently supported.
   """
-  if flags_obj.enable_eager:
+  # TODO(tobyboyd): Remove eager flag when tf 1.0 testing ends.
+  # Eager is default in tf 2.0 and should not be toggled
+  if flags_obj.enable_eager and not keras_common.is_v2_0():
     tf.compat.v1.enable_eager_execution()
 
   dtype = flags_core.get_tf_dtype(flags_obj)


### PR DESCRIPTION
As discussed.  Open to changes.  Things look different when done vs. verbally discussing.  This really is not a big deal as the the tests for eager all set eager=True.  What this does is ensure a user that uses the code will not end up running a weird code path with tf.enable.eager=False.  And in a month or so I will remove this If all together.  Once tf 2.0 performance matches tf 1.0 eager and we feel good about it we can kind of shutdown tf 1.0 testing of keras or make branch until tf 1.0 is done.

I have no idea how this works internally, e.g. how do know you are running TF 2.0?  