### PR TITLE
Add examples per second history to Estimator hook.

### DIFF
--- a/official/resnet/estimator_cifar_benchmark.py
+++ b/official/resnet/estimator_cifar_benchmark.py
@@ -125,7 +125,8 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
         eval_results['accuracy_top_5'].item())
     if examples_per_sec_hook:
       exp_per_second_list = examples_per_sec_hook.current_examples_per_sec_list
-      exp_per_sec = sum(exp_per_second_list[1:]) / (len(exp_per_second_list)-1)
+      # ExamplesPerSecondHook skips the first 10 steps.
+      exp_per_sec = sum(exp_per_second_list) / (len(exp_per_second_list))
       extras['exp_per_second'] = self._json_description(exp_per_sec)
 
     self.report_benchmark(

--- a/official/resnet/estimator_cifar_benchmark.py
+++ b/official/resnet/estimator_cifar_benchmark.py
@@ -96,7 +96,6 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     """A lightweight test that can finish quickly."""
     self._setup()
     flags.FLAGS.num_gpus = 1
-    flags.FLAGS.turn_off_distribution_strategy = True
     flags.FLAGS.data_dir = DATA_DIR
     flags.FLAGS.batch_size = 128
     flags.FLAGS.train_epochs = 1

--- a/official/resnet/estimator_cifar_benchmark.py
+++ b/official/resnet/estimator_cifar_benchmark.py
@@ -27,6 +27,7 @@ from absl.testing import flagsaver
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.resnet import cifar10_main as cifar_main
+from official.utils.logs import hooks
 
 DATA_DIR = '/data/cifar10_data/cifar-10-batches-bin'
 
@@ -49,6 +50,7 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     flags.FLAGS.model_dir = self._get_model_dir('resnet56_1_gpu')
     flags.FLAGS.resnet_size = 56
     flags.FLAGS.dtype = 'fp32'
+    flags.FLAGS.hooks = ['ExamplesPerSecondHook']
     self._run_and_report_benchmark()
 
   def resnet56_fp16_1_gpu(self):
@@ -61,6 +63,7 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     flags.FLAGS.model_dir = self._get_model_dir('resnet56_fp16_1_gpu')
     flags.FLAGS.resnet_size = 56
     flags.FLAGS.dtype = 'fp16'
+    flags.FLAGS.hooks = ['ExamplesPerSecondHook']
     self._run_and_report_benchmark()
 
   def resnet56_2_gpu(self):
@@ -73,6 +76,7 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     flags.FLAGS.model_dir = self._get_model_dir('resnet56_2_gpu')
     flags.FLAGS.resnet_size = 56
     flags.FLAGS.dtype = 'fp32'
+    flags.FLAGS.hooks = ['ExamplesPerSecondHook']
     self._run_and_report_benchmark()
 
   def resnet56_fp16_2_gpu(self):
@@ -85,18 +89,21 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     flags.FLAGS.model_dir = self._get_model_dir('resnet56_fp16_2_gpu')
     flags.FLAGS.resnet_size = 56
     flags.FLAGS.dtype = 'fp16'
+    flags.FLAGS.hooks = ['ExamplesPerSecondHook']
     self._run_and_report_benchmark()
 
   def unit_test(self):
     """A lightweight test that can finish quickly."""
     self._setup()
     flags.FLAGS.num_gpus = 1
+    flags.FLAGS.turn_off_distribution_strategy = True
     flags.FLAGS.data_dir = DATA_DIR
     flags.FLAGS.batch_size = 128
     flags.FLAGS.train_epochs = 1
     flags.FLAGS.model_dir = self._get_model_dir('resnet56_1_gpu')
     flags.FLAGS.resnet_size = 8
     flags.FLAGS.dtype = 'fp32'
+    flags.FLAGS.hooks = ['ExamplesPerSecondHook']
     self._run_and_report_benchmark()
 
   def _run_and_report_benchmark(self):
@@ -104,15 +111,28 @@ class EstimatorCifar10BenchmarkTests(tf.test.Benchmark):
     stats = cifar_main.run_cifar(flags.FLAGS)
     wall_time_sec = time.time() - start_time_sec
 
+    examples_per_sec_hook = None
+    for hook in stats['train_hooks']:
+      if isinstance(hook, hooks.ExamplesPerSecondHook):
+        examples_per_sec_hook = hook
+        break
+
+    eval_results = stats['eval_results']
+    extras = {}
+    extras['accuracy_top_1'] = self._json_description(
+        eval_results['accuracy'].item(),
+        priority=0)
+    extras['accuracy_top_5'] = self._json_description(
+        eval_results['accuracy_top_5'].item())
+    if examples_per_sec_hook:
+      exp_per_second_list = examples_per_sec_hook.current_examples_per_sec_list
+      exp_per_sec = sum(exp_per_second_list[1:]) / (len(exp_per_second_list)-1)
+      extras['exp_per_second'] = self._json_description(exp_per_sec)
+
     self.report_benchmark(
-        iters=stats['global_step'],
+        iters=eval_results['global_step'],
         wall_time=wall_time_sec,
-        extras={
-            'accuracy_top_1':
-                self._json_description(stats['accuracy'].item(), priority=0),
-            'accuracy_top_5':
-                self._json_description(stats['accuracy_top_5'].item()),
-        })
+        extras=extras)
 
   def _json_description(self,
                         value,

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -592,7 +592,13 @@ def resnet_main(
           shape, batch_size=flags_obj.batch_size, dtype=export_dtype)
     classifier.export_savedmodel(flags_obj.export_dir, input_receiver_fn,
                                  strip_default_attrs=True)
-  return eval_results
+
+  stats = {}
+  stats['eval_results'] = eval_results
+  stats['train_hooks'] = train_hooks
+
+  return stats
+
 
 def define_resnet_flags(resnet_size_choices=None):
   """Add flags and validators for ResNet."""

--- a/official/utils/logs/hooks.py
+++ b/official/utils/logs/hooks.py
@@ -73,6 +73,8 @@ class ExamplesPerSecondHook(tf.estimator.SessionRunHook):
     self._total_steps = 0
     self._batch_size = batch_size
     self._warm_steps = warm_steps
+    # List of examples per second logged every_n_steps.
+    self.current_examples_per_sec_list = []
 
   def begin(self):
     """Called once before using the session to check global step."""
@@ -117,7 +119,8 @@ class ExamplesPerSecondHook(tf.estimator.SessionRunHook):
         # and training time per batch
         current_examples_per_sec = self._batch_size * (
             elapsed_steps / elapsed_time)
-
+        # Logs entries to be read from hook during or after run.
+        self.current_examples_per_sec_list.append(current_examples_per_sec)
         self._logger.log_metric(
             "average_examples_per_sec", average_examples_per_sec,
             global_step=global_step)


### PR DESCRIPTION
Keep in mind this will be "dead code" at some point soon.  I did not want to rework it to track the time like we do for the keras hook.  I just wanted an approximation of average examples_per_second minus a small warmup.  I am not too worried about a perfect test, but if I want to make it better I can share the log_steps from keras with this in the future.  

Adding this will also allow me to add short estimator tests.