### PR TITLE
Multi-worker support for Resnet.

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -552,63 +552,61 @@ def resnet_main(
         num_epochs=1,
         dtype=flags_core.get_tf_dtype(flags_obj))
 
-  if flags_obj.eval_only or not flags_obj.train_epochs:
-    # If --eval_only is set, perform a single loop with zero train epochs.
-    schedule, n_loops = [0], 1
-  else:
-    # Compute the number of times to loop while training. All but the last
-    # pass will train for `epochs_between_evals` epochs, while the last will
-    # train for the number needed to reach `training_epochs`. For instance if
-    #   train_epochs = 25 and epochs_between_evals = 10
-    # schedule will be set to [10, 10, 5]. That is to say, the loop will:
-    #   Train for 10 epochs and then evaluate.
-    #   Train for another 10 epochs and then evaluate.
-    #   Train for a final 5 epochs (to reach 25 epochs) and then evaluate.
-    n_loops = math.ceil(flags_obj.train_epochs / flags_obj.epochs_between_evals)
-    schedule = [flags_obj.epochs_between_evals for _ in range(int(n_loops))]
-    schedule[-1] = flags_obj.train_epochs - sum(schedule[:-1])  # over counting.
+  train_epochs = (0 if flags_obj.eval_only or not flags_obj.train_epochs else
+                  flags_obj.train_epochs)
 
-  use_train_and_evaluate = isinstance(
+  use_train_and_evaluate = flags_obj.use_train_and_evaluate or isinstance(
       distribution_strategy, tf.contrib.distribute.CollectiveAllReduceStrategy)
-  for cycle_index, num_train_epochs in enumerate(schedule):
-    tf.compat.v1.logging.info('Starting cycle: %d/%d', cycle_index,
-                              int(n_loops))
+  if use_train_and_evaluate:
+    train_spec = tf.estimator.TrainSpec(
+        input_fn=lambda: input_fn_train(train_epochs), hooks=train_hooks,
+        max_steps=flags_obj.max_train_steps)
+    eval_spec = tf.estimator.EvalSpec(input_fn=input_fn_eval,
+                                      steps=flags_obj.max_train_steps)
+    tf.compat.v1.logging.info('Starting to train and evaluate.')
+    eval_results, _ = tf.estimator.train_and_evaluate(classifier, train_spec,
+                                                      eval_spec)
+    benchmark_logger.log_evaluation_result(eval_results)
+  else:
+    if train_epochs == 0:
+      # If --eval_only is set, perform a single loop with zero train epochs.
+      schedule, n_loops = [0], 1
+    else:
+      # Compute the number of times to loop while training. All but the last
+      # pass will train for `epochs_between_evals` epochs, while the last will
+      # train for the number needed to reach `training_epochs`. For instance if
+      #   train_epochs = 25 and epochs_between_evals = 10
+      # schedule will be set to [10, 10, 5]. That is to say, the loop will:
+      #   Train for 10 epochs and then evaluate.
+      #   Train for another 10 epochs and then evaluate.
+      #   Train for a final 5 epochs (to reach 25 epochs) and then evaluate.
+      n_loops = math.ceil(train_epochs / flags_obj.epochs_between_evals)
+      schedule = [flags_obj.epochs_between_evals for _ in range(int(n_loops))]
+      schedule[-1] = train_epochs - sum(schedule[:-1])  # over counting.
 
-    if num_train_epochs:
-      if use_train_and_evaluate:
-        train_spec = tf.estimator.TrainSpec(
-            input_fn=lambda: input_fn_train(num_train_epochs), hooks=train_hooks,
-            max_steps=flags_obj.max_train_steps)
-      else:
+    for cycle_index, num_train_epochs in enumerate(schedule):
+      tf.compat.v1.logging.info('Starting cycle: %d/%d', cycle_index,
+                                int(n_loops))
+
+      if num_train_epochs:
         classifier.train(input_fn=lambda: input_fn_train(num_train_epochs),
                          hooks=train_hooks, max_steps=flags_obj.max_train_steps)
-    elif use_train_and_evaluate:
-      train_spec = tf.estimator.TrainSpec(
-          input_fn=lambda: None, hooks=train_hooks,
-          max_steps=flags_obj.max_train_steps)
 
-    # flags_obj.max_train_steps is generally associated with testing and
-    # profiling. As a result it is frequently called with synthetic data, which
-    # will iterate forever. Passing steps=flags_obj.max_train_steps allows the
-    # eval (which is generally unimportant in those circumstances) to terminate.
-    # Note that eval will run for max_train_steps each loop, regardless of the
-    # global_step count.
-    if use_train_and_evaluate:
-      eval_spec = tf.estimator.EvalSpec(input_fn=input_fn_eval,
-                                        steps=flags_obj.max_train_steps)
-      tf.compat.v1.logging.info('Starting to train and evaluate.')
-      eval_results, _ = tf.estimator.train_and_evaluate(classifier, train_spec,
-                                                        eval_spec)
-    else:
+      # flags_obj.max_train_steps is generally associated with testing and
+      # profiling. As a result it is frequently called with synthetic data,
+      # which will iterate forever. Passing steps=flags_obj.max_train_steps
+      # allows the eval (which is generally unimportant in those circumstances)
+      # to terminate.  Note that eval will run for max_train_steps each loop,
+      # regardless of the global_step count.
       tf.compat.v1.logging.info('Starting to evaluate.')
       eval_results = classifier.evaluate(input_fn=input_fn_eval,
                                          steps=flags_obj.max_train_steps)
 
-    benchmark_logger.log_evaluation_result(eval_results)
+      benchmark_logger.log_evaluation_result(eval_results)
 
-    if model_helpers.past_stop_threshold(
-        flags_obj.stop_threshold, eval_results['accuracy']):
-      break
+      if model_helpers.past_stop_threshold(
+          flags_obj.stop_threshold, eval_results['accuracy']):
+        break
 
   if flags_obj.export_dir is not None:
     # Exports a saved model for the given classifier.
@@ -667,15 +665,22 @@ def define_resnet_flags(resnet_size_choices=None):
           'the expense of image resize/cropping being done as part of model '
           'inference. Note, this flag only applies to ImageNet and cannot '
           'be used for CIFAR.'))
+  flags.DEFINE_boolean(
+      name='use_train_and_evaluate', default=False,
+      help=flags_core.help_wrap(
+          'If True, uses `tf.estimator.train_and_evaluate` for the training '
+          'and evaluation loop, instead of separate calls to `classifier.train '
+          'and `classifier.evaluate`, which is the default behavior.'))
   flags.DEFINE_string(
       name='worker_hosts', default=None,
       help=flags_core.help_wrap(
           'Comma-separated list of worker ip:port pairs for running '
-          'multi-worker models with DistributionStrategy.'))
+          'multi-worker models with DistributionStrategy.  The user would '
+          'start the program on each host with identical value for this flag.'))
   flags.DEFINE_integer(
       name='task_index', default=-1,
       help=flags_core.help_wrap('If multi-worker training, the task_index of '
-                                'this worker'))
+                                'this worker.'))
   choice_kwargs = dict(
       name='resnet_size', short_name='rs', default='50',
       help=flags_core.help_wrap('The size of the ResNet model to use.'))

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -492,7 +492,10 @@ def resnet_main(
       allow_soft_placement=True)
 
   distribution_strategy = distribution_utils.get_distribution_strategy(
-      flags_core.get_num_gpus(flags_obj), flags_obj.all_reduce_alg, num_workers)
+      flags_core.get_num_gpus(flags_obj),
+      num_workers,
+      flags_obj.all_reduce_alg,
+      flags_obj.turn_off_distribution_strategy)
 
   # Creates a `RunConfig` that checkpoints every 24 hours which essentially
   # results in checkpoints determined only by `epochs_between_evals`.

--- a/official/utils/flags/_base.py
+++ b/official/utils/flags/_base.py
@@ -101,8 +101,9 @@ def define_base(data_dir=True, model_dir=True, clean=True, train_epochs=True,
         name="num_gpus", short_name="ng",
         default=1 if tf.test.is_gpu_available() else 0,
         help=help_wrap(
-            "How many GPUs to use with the DistributionStrategies API. The "
-            "default is 1 if TensorFlow can detect a GPU, and 0 otherwise."))
+            "How many GPUs to use at each worker with the "
+            "DistributionStrategies API. The default is 1 if TensorFlow can "
+            "detect a GPU, and 0 otherwise."))
 
   if hooks:
     # Construct a pretty summary of hooks.

--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -34,9 +34,10 @@ def get_distribution_strategy(distribution_strategy="default",
   Args:
     distribution_strategy: a string specify which distribution strategy to use.
       Accepted values are 'off', 'default', 'one_device', 'mirrored',
-      'parameter_server', 'collective', case insensitive. 'off' means not to use
-      Distribution Strategy; 'default' means to choose from `MirroredStrategy`
-      or `OneDeviceStrategy` according to the number of GPUs."
+      'parameter_server', 'multi_worker_mirrored', case insensitive. 'off' means
+      not to use Distribution Strategy; 'default' means to choose from
+      `MirroredStrategy`, `MultiWorkerMirroredStrategy`, or `OneDeviceStrategy`
+      according to the number of GPUs and number of workers.
     num_gpus: Number of GPUs to run this model.
     num_workers: Number of workers to run this model.
     all_reduce_alg: Optional. Specify which algorithm to use when performing
@@ -55,12 +56,13 @@ def get_distribution_strategy(distribution_strategy="default",
 
   distribution_strategy = distribution_strategy.lower()
   if distribution_strategy == "off":
-    if num_gpus > 1:
-      raise ValueError("When {} GPUs are specified, distribution_strategy flag "
-                       "cannot be set to 'off'.".format(num_gpus))
+    if num_gpus > 1 or num_workers > 1:
+      raise ValueError(
+          "When {} GPUs and  {} workers are specified, distribution_strategy "
+          "flag cannot be set to 'off'.".format(num_gpus, num_workers))
     return None
 
-  if distribution_strategy == "collective" or num_workers > 1:
+  if distribution_strategy == "multi_worker_mirrored" or num_workers > 1:
     return tf.contrib.distribute.CollectiveAllReduceStrategy(
         num_gpus_per_worker=num_gpus)
 

--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -22,12 +22,14 @@ import tensorflow as tf
 
 
 def get_distribution_strategy(num_gpus,
+                              num_workers=1,
                               all_reduce_alg=None,
                               turn_off_distribution_strategy=False):
   """Return a DistributionStrategy for running the model.
 
   Args:
-    num_gpus: Number of GPUs to run this model.
+    num_gpus: Number of GPUs per worker to run this model.
+    num_workers: Number of workers to run this model.
     all_reduce_alg: Specify which algorithm to use when performing all-reduce.
       See tf.contrib.distribute.AllReduceCrossDeviceOps for available
       algorithms. If None, DistributionStrategy will choose based on device
@@ -42,29 +44,28 @@ def get_distribution_strategy(num_gpus,
     ValueError: if turn_off_distribution_strategy is True and num_gpus is
     larger than 1
   """
-  if num_gpus == 0:
-    if turn_off_distribution_strategy:
-      return None
+  if turn_off_distribution_strategy:
+    if num_gpus > 1 or num_workers > 1:
+      raise ValueError("When {} GPUs and {} workers are specified, "
+                       "turn_off_distribution_strategy flag cannot be set to"
+                       "True.".format(num_gpus, num_workers))
     else:
-      return tf.contrib.distribute.OneDeviceStrategy("device:CPU:0")
-  elif num_gpus == 1:
-    if turn_off_distribution_strategy:
       return None
-    else:
-      return tf.contrib.distribute.OneDeviceStrategy("device:GPU:0")
-  elif turn_off_distribution_strategy:
-    raise ValueError("When {} GPUs are specified, "
-                     "turn_off_distribution_strategy flag cannot be set to"
-                     "True.".format(num_gpus))
-  else:  # num_gpus > 1 and not turn_off_distribution_strategy
-    devices = ["device:GPU:%d" % i for i in range(num_gpus)]
+  if all_reduce_alg == "collective" or num_workers > 1:
+    return tf.contrib.distribute.CollectiveAllReduceStrategy(
+        num_gpus_per_worker=num_gpus)
+  elif num_gpus <= 1:
+    device = "GPU" if num_gpus == 1 else "CPU"
+    return tf.contrib.distribute.OneDeviceStrategy("device:{}:0".format(device))
+  else:  # num_gpus > 1 and num_workers == 1
     if all_reduce_alg:
-      return tf.distribute.MirroredStrategy(
-          devices=devices,
-          cross_device_ops=tf.contrib.distribute.AllReduceCrossDeviceOps(
-              all_reduce_alg, num_packs=2))
+      cross_device_ops = tf.contrib.distribute.AllReduceCrossDeviceOps(
+          all_reduce_alg, num_packs=2)
     else:
-      return tf.distribute.MirroredStrategy(devices=devices)
+      cross_device_ops = None
+    return tf.distribute.MirroredStrategy(
+        devices=["device:GPU:%d" % i for i in range(num_gpus)],
+        cross_device_ops=cross_device_ops)
 
 
 def per_device_batch_size(batch_size, num_gpus):

--- a/official/utils/misc/distribution_utils_test.py
+++ b/official/utils/misc/distribution_utils_test.py
@@ -48,7 +48,7 @@ class GetDistributionStrategyTest(tf.test.TestCase):
     ds = distribution_utils.get_distribution_strategy(
         distribution_strategy='collective', num_gpus=2)
     self.assertTrue(
-            isinstance(ds, tf.contrib.distribute.CollectiveAllReduceStrategy))
+        isinstance(ds, tf.contrib.distribute.CollectiveAllReduceStrategy))
 
 
 class PerDeviceBatchSizeTest(tf.test.TestCase):

--- a/official/utils/misc/distribution_utils_test.py
+++ b/official/utils/misc/distribution_utils_test.py
@@ -44,11 +44,11 @@ class GetDistributionStrategyTest(tf.test.TestCase):
     for device in ds.extended.worker_devices:
       self.assertIn('GPU', device)
 
-  def test_turn_off_distribution_strategy(self):
-    self.assertEquals(distribution_utils.get_distribution_strategy(
-        0, turn_off_distribution_strategy=True), None)
-    self.assertEquals(distribution_utils.get_distribution_strategy(
-        1, turn_off_distribution_strategy=True), None)
+  def test_override_strategy(self):
+    ds = distribution_utils.get_distribution_strategy(
+        distribution_strategy='collective', num_gpus=2)
+    self.assertTrue(
+            isinstance(ds, tf.contrib.distribute.CollectiveAllReduceStrategy))
 
 
 class PerDeviceBatchSizeTest(tf.test.TestCase):

--- a/official/utils/misc/distribution_utils_test.py
+++ b/official/utils/misc/distribution_utils_test.py
@@ -44,6 +44,12 @@ class GetDistributionStrategyTest(tf.test.TestCase):
     for device in ds.extended.worker_devices:
       self.assertIn('GPU', device)
 
+  def test_turn_off_distribution_strategy(self):
+    self.assertEquals(distribution_utils.get_distribution_strategy(
+        0, turn_off_distribution_strategy=True), None)
+    self.assertEquals(distribution_utils.get_distribution_strategy(
+        1, turn_off_distribution_strategy=True), None)
+
 
 class PerDeviceBatchSizeTest(tf.test.TestCase):
   """Tests for per_device_batch_size."""


### PR DESCRIPTION
This change adds support for running on multiple workers using `CollectiveAllReduceStrategy`.  It adds 2 flags to `resnet_run_loop.py`: `worker_hosts` and `task_index`.  These flags provide information to each worker about peers in the multi-worker setup.

After this change, when the official resnet model runs with `tf.contrib.distribute.CollectiveAllReduceStrategy,` it uses `tf.estimator.train_and_evaluate` rather than separate `train` and `evaluate` calls.