### PR TITLE
Update crate_dataset.py

### DIFF
--- a/tutorials/rnn/quickdraw/create_dataset.py
+++ b/tutorials/rnn/quickdraw/create_dataset.py
@@ -120,7 +120,7 @@ def convert_data(trainingdata_dir,
           break
 
   writers = []
-  for i in range(FLAGS.output_shards):
+  for i in range(output_shards):
     writers.append(
         tf.python_io.TFRecordWriter("%s-%05i-of-%05i" % (output_file, i,
                                                          output_shards)))


### PR DESCRIPTION
In the loop for initializing writers, Flags.output_shards is being used even though output_shards is passed as a parameter to the function "convert_data()".