### PR TITLE
Add gitignore entries for word-embedding tutorial training data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,4 +94,8 @@ ENV/
 # For mac
 .DS_Store
 
+# Training data for word embedding tutorial
+tutorials/embedding/text8
+tutorials/embedding/questions-words.txt
+
 samples/outreach/blogs/segmentation_blogpost/carvana-image-masking-challenge/


### PR DESCRIPTION
This PR contains two entries to the gitignore file for the data files that one downloads when following [word-embedding tutorial](https://github.com/tensorflow/models/blob/master/tutorials/embedding/README.md):

- `tutorials/embedding/text8`
- `tutorials/embedding/questions-words.txt`