### PR TITLE
Update create_pet_tf_record.py

### DIFF
--- a/research/object_detection/dataset_tools/create_pet_tf_record.py
+++ b/research/object_detection/dataset_tools/create_pet_tf_record.py
@@ -153,10 +153,10 @@ def dict_to_tf_example(data,
         ymin = float(obj['bndbox']['ymin'])
         ymax = float(obj['bndbox']['ymax'])
       else:
-        xmin = float(np.min(nonzero_x_indices))
-        xmax = float(np.max(nonzero_x_indices))
-        ymin = float(np.min(nonzero_y_indices))
-        ymax = float(np.max(nonzero_y_indices))
+        xmin = float(np.min(nonzero_x_indices[0]))
+        xmax = float(np.max(nonzero_x_indices[0]))
+        ymin = float(np.min(nonzero_y_indices[0]))
+        ymax = float(np.max(nonzero_y_indices[0]))
 
       xmins.append(xmin / width)
       ymins.append(ymin / height)


### PR DESCRIPTION
```
nonzero_x_indices = np.where(nonbackground_indices_x)
nonzero_y_indices = np.where(nonbackground_indices_y)
```

returns tuple of 2 ndarrays like


```
(array([*x_position1*, *x_position2*, ..., *x_position_max*]), 
array([*Red_channel_position*, *Green_channel_position*, *Blue_channel_position*]))
```

i.e.


```
(array([10, 10, 10, 11, 11, 11, ..., 720, 720, 720]), array([0, 1, 2, 0, 1, 2, ..., 0, 1, 2]))
if our mask starts at x pixel value == 10
```

so the following code

```
else :
    xmin = float(np.min(nonzero_x_indices))
    xmax = float(np.max(nonzero_x_indices))
    ymin = float(np.min(nonzero_y_indices))
    ymax = float(np.max(nonzero_y_indices))
```

sometimes returns wrong values because it looks for minimal value in the second array