### PR TITLE
Replace deprecated native git_repository rule with Skylark version

### DIFF
--- a/research/brain_coder/IAM.txt
+++ b/research/brain_coder/IAM.txt
@@ -1,0 +1,53 @@
+// Policy Role for Code Deploy
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoscalingGroups",
+        "autoscaling:PutInstanceInStandby",
+        "autoscaling:PutInstanceInService",
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+
+// Policy Trust for Code Deploy
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.us-west-2.amazonaws.com",
+          "codedeploy.us-east-1.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+
+// Instance Role for EC2 Instance
+{ 
+    "Version": "2012-10-17", 
+    "Statement": [   
+      {     
+          "Action": [       
+              "s3:Get*",       
+              "s3:List*"     
+          ],     
+          "Effect": "Allow",     
+          "Resource": "*"   
+      } 
+    ]
+}

--- a/research/brain_coder/WORKSPACE
+++ b/research/brain_coder/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl",
+     "git_repository")
 git_repository(
     name = "subpar",
     remote = "https://github.com/google/subpar",


### PR DESCRIPTION
The native git_repository rule has been deprecated. Use the Skylark version available via load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") instead.
Using git_repository method gives following error:
ERROR: Skipping 'single_task:run.par': error loading package 'single_task': Encountered error while reading extension file 'subpar.bzl': no such package '@subpar//': The native git_repository rule is deprecated. load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") for a replacement.
Use --incompatible_remove_native_git_repository=false to temporarily continue using the native rule.
[Source](https://blog.bazel.build/2018/04/11/bazel-0.12.html)