### PR TITLE
Update imagenet_preprocessing.py

### DIFF
--- a/official/resnet/imagenet_preprocessing.py
+++ b/official/resnet/imagenet_preprocessing.py
@@ -218,7 +218,7 @@ def _resize_image(image, height, width):
     resized_image: A 3-D tensor containing the resized image. The first two
       dimensions have the shape [height, width].
   """
-  return tf.image.resize(
+  return tf.compat.v1.image.resize(
       image, [height, width], method=tf.image.ResizeMethod.BILINEAR,
       align_corners=False)
 


### PR DESCRIPTION
Shift to tf.compat.v1.image.resize because of the recent API changes to tf.image.resize. It no longer takes the align_corners argument.