### PR TITLE
Update object detection tutorial for use in Colab

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -15,6 +15,35 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
+        "id": "Wy72mWwAWKMK"
+      },
+      "source": [
+        "## Env setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        },
+        "colab_type": "code",
+        "id": "v7m_NY_aWKMK"
+      },
+      "outputs": [],
+      "source": [
+        "# This is needed to display the images.\n",
+        "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
         "id": "kFSqkTCdWKMI"
       },
       "source": [
@@ -56,35 +85,6 @@
         "\n",
         "if StrictVersion(tf.__version__) \u003c StrictVersion('1.9.0'):\n",
         "  raise ImportError('Please upgrade your TensorFlow installation to v1.9.* or later!')\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Wy72mWwAWKMK"
-      },
-      "source": [
-        "## Env setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        },
-        "colab_type": "code",
-        "id": "v7m_NY_aWKMK"
-      },
-      "outputs": [],
-      "source": [
-        "# This is needed to display the images.\n",
-        "%matplotlib inline"
       ]
     },
     {


### PR DESCRIPTION
Google Colab will only display image results if the `%matplotlib inline` _precedes_ `from matplotlib import pyplot as plt`. This pr moves the ENV code cell above the IMPORTS cell.