### PR TITLE
Fix ncf test for keras

### DIFF
--- a/official/recommendation/data_pipeline.py
+++ b/official/recommendation/data_pipeline.py
@@ -640,6 +640,9 @@ class DummyConstructor(threading.Thread):
   def stop_loop(self):
     pass
 
+  def increment_request_epoch(self):
+    pass
+
   @staticmethod
   def make_input_fn(is_training):
     """Construct training input_fn that uses synthetic data."""

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -151,18 +151,20 @@ def _get_keras_model(params):
 
 def run_ncf(_):
   """Run NCF training and eval with Keras."""
-  # TODO(seemuch): This model does not support eval_batch_size to be
-  # different from batch_size, because in the input layers, it explicitly
-  # the batch_size to 'batch_size'
-  FLAGS.eval_batch_size = FLAGS.batch_size
+  # TODO(seemuch): Support different train and eval batch sizes
+  if FLAGS.eval_batch_size != FLAGS.batch_size:
+    tf.logging.warning(
+        "The Keras implementation of NCF currently does not support batch_size "
+        "!= eval_batch_size ({} vs. {}). Overriding eval_batch_size to match "
+        "batch_size".format(FLAGS.eval_batch_size, FLAGS.batch_size)
+        )
+    FLAGS.eval_batch_size = FLAGS.batch_size
 
   params = ncf_common.parse_flags(FLAGS)
 
-  # TODO(seemuch): now that the eval_batch_size might have been adjusted, asign
-  # it back to batch_size. This is not needed once the batch_size issue is
-  # fixed.
-  if params['batch_size'] != params['eval_batch_size']:
-    params['batch_size'] = params['eval_batch_size']
+  # ncf_common rounds eval_batch_size (this is needed due to a reshape during
+  # eval). This carries over that rounding to batch_size as well.
+  params['batch_size'] = params['eval_batch_size']
 
   num_users, num_items, num_train_steps, num_eval_steps, producer = (
       ncf_common.get_inputs(params))

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -157,7 +157,7 @@ def run_ncf(_):
   # different from batch_size, because in the input layers, it explicitly
   # the batch_size to 'batch_size'
   if params['batch_size'] != params['eval_batch_size']:
-    param['eval_batch_size'] = param['batch_size']
+    params['eval_batch_size'] = params['batch_size']
 
   num_users, num_items, num_train_steps, num_eval_steps, producer = (
       ncf_common.get_inputs(params))

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -153,6 +153,12 @@ def run_ncf(_):
   """Run NCF training and eval with Keras."""
   params = ncf_common.parse_flags(FLAGS)
 
+  # TODO(seemuch): This model does not support eval_batch_size to be
+  # different from batch_size, because in the input layers, it explicitly
+  # the batch_size to 'batch_size'
+  if params['batch_size'] != params['eval_batch_size']:
+    param['eval_batch_size'] = param['batch_size']
+
   num_users, num_items, num_train_steps, num_eval_steps, producer = (
       ncf_common.get_inputs(params))
 

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -151,13 +151,18 @@ def _get_keras_model(params):
 
 def run_ncf(_):
   """Run NCF training and eval with Keras."""
-  params = ncf_common.parse_flags(FLAGS)
-
   # TODO(seemuch): This model does not support eval_batch_size to be
   # different from batch_size, because in the input layers, it explicitly
   # the batch_size to 'batch_size'
+  FLAGS.eval_batch_size = FLAGS.batch_size
+
+  params = ncf_common.parse_flags(FLAGS)
+
+  # TODO(seemuch): now that the eval_batch_size might have been adjusted, asign
+  # it back to batch_size. This is not needed once the batch_size issue is
+  # fixed.
   if params['batch_size'] != params['eval_batch_size']:
-    params['eval_batch_size'] = params['batch_size']
+    params['batch_size'] = params['eval_batch_size']
 
   num_users, num_items, num_train_steps, num_eval_steps, producer = (
       ncf_common.get_inputs(params))

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -185,7 +185,8 @@ class NcfTest(tf.test.TestCase):
     self.assertAlmostEqual(ndcg, (1 + math.log(2) / math.log(3) +
                                   2 * math.log(2) / math.log(4)) / 4)
 
-  _BASE_END_TO_END_FLAGS_ESTIMATOR = ['-batch_size', '1024', '-train_epochs', '1']
+  _BASE_END_TO_END_FLAGS_ESTIMATOR = [
+      '-batch_size', '1024', '-train_epochs', '1']
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_estimator(self):
@@ -200,9 +201,9 @@ class NcfTest(tf.test.TestCase):
         extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + ['-ml_perf', 'True'])
 
   _BASE_END_TO_END_FLAGS_KERAS = [
-          '-batch_size','150000',
-          '-eval_batch_size','150000',
-          '-train_epochs', '1']
+      '-batch_size', '150000',
+      '-eval_batch_size', '150000',
+      '-train_epochs', '1']
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras(self):

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -198,7 +198,8 @@ class NcfTest(tf.test.TestCase):
   def test_end_to_end_estimator_mlperf(self):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + ['-ml_perf', 'True'])
+        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + [
+          '-ml_perf', 'True'])
 
   _BASE_END_TO_END_FLAGS_KERAS = [
       '-batch_size', '150000',

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -199,7 +199,7 @@ class NcfTest(tf.test.TestCase):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
         extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + [
-          '-ml_perf', 'True'])
+            '-ml_perf', 'True'])
 
   _BASE_END_TO_END_FLAGS_KERAS = [
       '-batch_size', '150000',

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -185,34 +185,37 @@ class NcfTest(tf.test.TestCase):
     self.assertAlmostEqual(ndcg, (1 + math.log(2) / math.log(3) +
                                   2 * math.log(2) / math.log(4)) / 4)
 
-  _BASE_END_TO_END_FLAGS = ['-batch_size', '1024', '-train_epochs', '1']
+  _BASE_END_TO_END_FLAGS_ESTIMATOR = ['-batch_size', '1024', '-train_epochs', '1']
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_estimator(self):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS)
+        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR)
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_estimator_mlperf(self):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS + ['-ml_perf', 'True'])
+        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + ['-ml_perf', 'True'])
+
+  _BASE_END_TO_END_FLAGS_KERAS = [
+          '-batch_size','150000',
+          '-eval_batch_size','150000',
+          '-train_epochs', '1']
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras(self):
-    self.skipTest("TODO: fix synthetic data with keras")
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS +
+        extra_flags=self._BASE_END_TO_END_FLAGS_KERAS +
         ['-distribution_strategy', 'off'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras_mlperf(self):
-    self.skipTest("TODO: fix synthetic data with keras")
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS +
+        extra_flags=self._BASE_END_TO_END_FLAGS_KERAS +
         ['-ml_perf', 'True', '-distribution_strategy', 'off'])
 
 

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -185,39 +185,32 @@ class NcfTest(tf.test.TestCase):
     self.assertAlmostEqual(ndcg, (1 + math.log(2) / math.log(3) +
                                   2 * math.log(2) / math.log(4)) / 4)
 
-  _BASE_END_TO_END_FLAGS_ESTIMATOR = [
-      '-batch_size', '1024', '-train_epochs', '1']
+  _BASE_END_TO_END_FLAGS = ['-batch_size', '1024', '-train_epochs', '1']
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_estimator(self):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR)
+        extra_flags=self._BASE_END_TO_END_FLAGS)
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_estimator_mlperf(self):
     integration.run_synthetic(
         ncf_estimator_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS_ESTIMATOR + [
-            '-ml_perf', 'True'])
-
-  _BASE_END_TO_END_FLAGS_KERAS = [
-      '-batch_size', '150000',
-      '-eval_batch_size', '150000',
-      '-train_epochs', '1']
+        extra_flags=self._BASE_END_TO_END_FLAGS + ['-ml_perf', 'True'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras(self):
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS_KERAS +
+        extra_flags=self._BASE_END_TO_END_FLAGS +
         ['-distribution_strategy', 'off'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras_mlperf(self):
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS_KERAS +
+        extra_flags=self._BASE_END_TO_END_FLAGS +
         ['-ml_perf', 'True', '-distribution_strategy', 'off'])
 
 


### PR DESCRIPTION
The failure is mostly caused by the flag values passed in. 
The Keras implementation is sensitive about the batch_size, which needs to be dividable by (NUM_EVAL_NEGATIVES+1). In the test, the NUM_EVAL_NEGATIVES is set to 2, while in an ordinary run, it is 999. 