### PR TITLE
change tf.to_int32 to tf.cast

### DIFF
--- a/official/mnist/dataset.py
+++ b/official/mnist/dataset.py
@@ -97,7 +97,7 @@ def dataset(directory, images_file, labels_file):
   def decode_label(label):
     label = tf.decode_raw(label, tf.uint8)  # tf.string -> [tf.uint8]
     label = tf.reshape(label, [])  # label is a scalar
-    return tf.to_int32(label)
+    return tf.cast(label, tf.int32)
 
   images = tf.data.FixedLengthRecordDataset(
       images_file, 28 * 28, header_bytes=16).map(decode_image)


### PR DESCRIPTION
In models/official/mnist/dataset.py: the use of ```tf.to_int32``` raises deprecated warning.

I've changed ```tf.to_int32(label)``` to ```tf.cast(label, tf.int32)```