### PR TITLE
Python typing: Use 'str', not 'string'

### DIFF
--- a/official/recommendation/data_pipeline.py
+++ b/official/recommendation/data_pipeline.py
@@ -343,7 +343,7 @@ class BaseDataConstructor(threading.Thread):
                batches_per_eval_step,   # type: int
                stream_files,            # type: bool
                deterministic=False,     # type: bool
-               epoch_dir=None           # type: string
+               epoch_dir=None           # type: str
               ):
     # General constants
     self._maximum_number_epochs = maximum_number_epochs


### PR DESCRIPTION
https://mypy.readthedocs.io/en/latest/cheat_sheet.html

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/models on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./official/recommendation/data_pipeline.py:346:41: F821 undefined name 'string'
               epoch_dir=None           # type: string
                                        ^
```