### PR TITLE
Disable Tensorboard callback by default in Keras ResNet models

### DIFF
--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -180,14 +180,14 @@ def run(flags_obj):
     num_eval_steps = None
     validation_data = None
 
+  callbacks = [time_callback, lr_callback]
+  if flags_obj.enable_tensorboard:
+    callbacks.append(tensorboard_callback)
+
   history = model.fit(train_input_dataset,
                       epochs=train_epochs,
                       steps_per_epoch=train_steps,
-                      callbacks=[
-                          time_callback,
-                          lr_callback,
-                          tensorboard_callback
-                      ],
+                      callbacks=callbacks,
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
                       validation_freq=flags_obj.epochs_between_evals,

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -257,6 +257,9 @@ def define_keras_flags():
       name='enable_xla', default=False,
       help='Whether to enable XLA auto jit compilation. This is still an '
       'experimental feature, and is not yet effective with TF 2.0.')
+  flags.DEFINE_boolean(
+      name='enable_tensorboard', default=False,
+      help='Whether to enable Tensorboard callback.')
   flags.DEFINE_integer(
       name='train_steps', default=None,
       help='The number of steps to run for training. If it is larger than '

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -193,14 +193,14 @@ def run(flags_obj):
     num_eval_steps = None
     validation_data = None
 
+  callbacks = [time_callback, lr_callback]
+  if flags_obj.enable_tensorboard:
+    callbacks.append(tensorboard_callback)
+
   history = model.fit(train_input_dataset,
                       epochs=train_epochs,
                       steps_per_epoch=train_steps,
-                      callbacks=[
-                          time_callback,
-                          lr_callback,
-                          tensorboard_callback
-                      ],
+                      callbacks=callbacks,
                       validation_steps=num_eval_steps,
                       validation_data=validation_data,
                       validation_freq=flags_obj.epochs_between_evals,


### PR DESCRIPTION
Tensorboard callback seems to introduce more overhead compared to before. Disabling it should make the performance for synthetic data go beyond 9K+ images/sec.