### PR TITLE
WIP: 2.0 Reference Models: MobileNetv2 (TPU with dist strat and Keras)

### DIFF
--- a/research/object_detection/mobilenet_v2_example.ipynb
+++ b/research/object_detection/mobilenet_v2_example.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "T_cETKXHDTXu"
+   },
+   "source": [
+    "# Prerequisites (clone tensorflow_models)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 121
+    },
+    "colab_type": "code",
+    "id": "zo5GyseklSVH",
+    "outputId": "195816ba-c710-4484-d465-705383706d55"
+   },
+   "outputs": [],
+   "source": [
+    "!git clone -q https://github.com/rok/models\n",
+    "!cd models && git checkout mobilenet_v2_tpu_with_dist_strat_and_keras\n",
+    "\n",
+    "!pip install -q tf-nightly-2.0-preview"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Yd3J7y8WgvGk"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('/content/models/research/')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "fxMe7_pkk_Vo"
+   },
+   "source": [
+    "# Checkpoint based inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "zgg3rQe8gX8K"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tensorflow as tf\n",
+    "from object_detection.models.keras_models import mobilenet_v2\n",
+    "from matplotlib import pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "0EWMXeADc1Lp"
+   },
+   "outputs": [],
+   "source": [
+    "file = tf.keras.utils.get_file(\n",
+    "    \"panda.jpg\",\n",
+    "    \"https://upload.wikimedia.org/wikipedia/commons/f/fe/Giant_Panda_in_Beijing_Zoo_1.JPG\")\n",
+    "img = tf.keras.preprocessing.image.load_img(file, target_size=[224, 224])\n",
+    "plt.imshow(img)\n",
+    "plt.axis('off')\n",
+    "\n",
+    "x = tf.keras.applications.mobilenet_v2.preprocess_input(np.array(img)[tf.newaxis,...])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 103
+    },
+    "colab_type": "code",
+    "id": "UdMgJw96egUR",
+    "outputId": "1a408e11-fd6d-408f-876d-4efa837e8ab0"
+   },
+   "outputs": [],
+   "source": [
+    "pretrained_model = tf.keras.applications.MobileNetV2()\n",
+    "result = pretrained_model.predict(x)\n",
+    "tf.keras.applications.mobilenet_v2.decode_predictions(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "PlwvpK3ElBk6"
+   },
+   "source": [
+    "# Frozen inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Vwk_F--IhP7O"
+   },
+   "outputs": [],
+   "source": [
+    "tf.saved_model.save(pretrained_model, \"/tmp/mobilenet_v2/1/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 103
+    },
+    "colab_type": "code",
+    "id": "ZueWAD78Yvw6",
+    "outputId": "11d76922-0c31-4c4f-d8f1-43f3f8a9afae"
+   },
+   "outputs": [],
+   "source": [
+    "loaded = tf.saved_model.load(\"/tmp/mobilenet_v2/1/\")\n",
+    "infer = loaded.signatures['serving_default']\n",
+    "labeling = infer(tf.constant(x))['Logits']\n",
+    "\n",
+    "tf.keras.applications.mobilenet_v2.decode_predictions(labeling.numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "b5luo9sLoT7s"
+   },
+   "source": [
+    "# TPU inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "KqcgH-Gjo91z",
+    "outputId": "6781210a-03c8-4d9c-99bb-52fdcb645bba"
+   },
+   "outputs": [],
+   "source": [
+    "if 'COLAB_TPU_ADDR' not in os.environ:\n",
+    "  print('ERROR: Not connected to a TPU runtime.')\n",
+    "else:\n",
+    "  tpu_address = 'grpc://' + os.environ['COLAB_TPU_ADDR']\n",
+    "  print ('TPU address is', tpu_address)\n",
+    "\n",
+    "  tf.config.experimental_connect_to_host(tpu_address)\n",
+    "\n",
+    "\n",
+    "resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu_address)\n",
+    "tf.tpu.experimental.initialize_tpu_system(resolver)\n",
+    "tpu_strategy = tf.distribute.experimental.TPUStrategy(resolver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "i1s8yelLvmci"
+   },
+   "outputs": [],
+   "source": [
+    "# TPU models are not available in TF2 yet\n",
+    "# model = tf.keras.applications.MobileNetV2()\n",
+    "# tpu_model = tf.contrib.tpu.keras_to_tpu_model(model, strategy=tpu_strategy)"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "TPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Copy of Mobilenet Example.ipynb",
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/research/object_detection/mobilenet_v2_example.ipynb
+++ b/research/object_detection/mobilenet_v2_example.ipynb
@@ -4,6 +4,23 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
+    "id": "348dFJxRogSv"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/rok/models/blob/mobilenet_v2_tpu_with_dist_strat_and_keras/research/object_detection/mobilenet_v2_example.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/rok/models/blob/mobilenet_v2_tpu_with_dist_strat_and_keras/research/object_detection/mobilenet_v2_example.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
     "id": "T_cETKXHDTXu"
    },
    "source": [
@@ -14,13 +31,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 121
-    },
+    "colab": {},
     "colab_type": "code",
-    "id": "zo5GyseklSVH",
-    "outputId": "195816ba-c710-4484-d465-705383706d55"
+    "id": "zo5GyseklSVH"
    },
    "outputs": [],
    "source": [
@@ -75,9 +88,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 385
+    },
     "colab_type": "code",
-    "id": "0EWMXeADc1Lp"
+    "id": "0EWMXeADc1Lp",
+    "outputId": "8210b5de-6648-46b9-8356-fd7a9de51ea1"
    },
    "outputs": [],
    "source": [
@@ -97,11 +114,11 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 103
+     "height": 176
     },
     "colab_type": "code",
     "id": "UdMgJw96egUR",
-    "outputId": "1a408e11-fd6d-408f-876d-4efa837e8ab0"
+    "outputId": "f2b99c8c-28c3-4362-ac3d-9497d9bcd0f3"
    },
    "outputs": [],
    "source": [
@@ -139,11 +156,11 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 103
+     "height": 105
     },
     "colab_type": "code",
     "id": "ZueWAD78Yvw6",
-    "outputId": "11d76922-0c31-4c4f-d8f1-43f3f8a9afae"
+    "outputId": "4495d3b5-226c-4b33-c57f-ea0f494e3bfd"
    },
    "outputs": [],
    "source": [
@@ -168,13 +185,26 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "GV7MN9mx1Y88"
+   },
+   "outputs": [],
+   "source": [
+    "tf.compat.v1.disable_eager_execution()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 34
     },
     "colab_type": "code",
-    "id": "KqcgH-Gjo91z",
-    "outputId": "6781210a-03c8-4d9c-99bb-52fdcb645bba"
+    "id": "XeeJiDi8pAQ9",
+    "outputId": "5f3cddcc-7064-4b7b-e2ce-a9b92e1b6337"
    },
    "outputs": [],
    "source": [
@@ -184,12 +214,52 @@
     "  tpu_address = 'grpc://' + os.environ['COLAB_TPU_ADDR']\n",
     "  print ('TPU address is', tpu_address)\n",
     "\n",
-    "  tf.config.experimental_connect_to_host(tpu_address)\n",
-    "\n",
-    "\n",
+    "  tf.config.experimental_connect_to_host(tpu_address)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 54
+    },
+    "colab_type": "code",
+    "id": "KqcgH-Gjo91z",
+    "outputId": "d9d3b45d-0972-40cb-a827-27d8af15822e"
+   },
+   "outputs": [],
+   "source": [
     "resolver = tf.distribute.cluster_resolver.TPUClusterResolver(tpu_address)\n",
     "tf.tpu.experimental.initialize_tpu_system(resolver)\n",
     "tpu_strategy = tf.distribute.experimental.TPUStrategy(resolver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "rw82TzBH184s"
+   },
+   "outputs": [],
+   "source": [
+    "pretrained_model = tf.keras.applications.MobileNetV2()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "YMRAnDmd1P3K"
+   },
+   "outputs": [],
+   "source": [
+    "tpu_strategy.experimental_run_v2(pretrained_model)"
    ]
   },
   {
@@ -212,7 +282,7 @@
   "accelerator": "TPU",
   "colab": {
    "collapsed_sections": [],
-   "name": "Copy of Mobilenet Example.ipynb",
+   "name": "Mobilenet_v2 Example.ipynb",
    "provenance": [],
    "version": "0.3.2"
   },

--- a/research/object_detection/models/keras_models/mobilenet_v2.py
+++ b/research/object_detection/models/keras_models/mobilenet_v2.py
@@ -83,7 +83,7 @@ class _LayersOverride(object):
     self._use_explicit_padding = use_explicit_padding
     self._min_depth = min_depth
     self.regularizer = tf.keras.regularizers.l2(0.00004 * 0.5)
-    self.initializer = tf.truncated_normal_initializer(stddev=0.09)
+    self.initializer = tf.compat.v1.truncated_normal_initializer(stddev=0.09)
 
   def _FixedPaddingLayer(self, kernel_size):
     return tf.keras.layers.Lambda(lambda x: ops.fixed_padding(x, kernel_size))


### PR DESCRIPTION
See [Issue #26997](https://github.com/tensorflow/tensorflow/issues/26997).

This is to make `tensorflow.keras.applications.mobilenet_v2` compatible with TF2.0 and TPUs.