### PR TITLE
Change function signature

### DIFF
--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -28,7 +28,6 @@ import typing
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-from NCF_input import NCFDataset
 # pylint: enable=wrong-import-order
 
 from official.datasets import movielens
@@ -178,7 +177,7 @@ def _filter_index_sort(raw_rating_path, cache_path):
 
 def instantiate_pipeline(dataset, data_dir, params, constructor_type=None,
                          deterministic=False, epoch_dir=None):
-  # type: (str, str, dict, typing.Optional[str], bool, typing.Optional[str]) -> (NCFDataset, typing.Callable)
+  # type: (str, str, dict, typing.Optional[str], bool, typing.Optional[str]) -> (int, int, data_pipeline.BaseDataConstructor)
   """Load and digest data CSV into a usable form.
 
   Args:

--- a/official/recommendation/data_preprocessing.py
+++ b/official/recommendation/data_preprocessing.py
@@ -28,6 +28,7 @@ import typing
 import numpy as np
 import pandas as pd
 import tensorflow as tf
+from NCF_input import NCFDataset
 # pylint: enable=wrong-import-order
 
 from official.datasets import movielens


### PR DESCRIPTION
The type __NCFDataset__ is used in the type declaration on line 81 but it is never imported.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/models on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./official/recommendation/data_preprocessing.py:180:3: F821 undefined name 'NCFDataset'
  # type: (str, str, dict, typing.Optional[str], bool, typing.Optional[str]) -> (NCFDataset, typing.Callable)
  ^
1    F821 undefined name 'NCFDataset'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree