### PR TITLE
Re-enable checkpoints for multi worker GPU strategies.

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -550,14 +550,10 @@ def resnet_main(
 
   # Creates a `RunConfig` that checkpoints every 24 hours which essentially
   # results in checkpoints determined only by `epochs_between_evals`.
-  # TODO(ayushd,yuefengz): re-enable checkpointing for multi-worker strategy.
-  save_checkpoints_secs = (None if distribution_strategy.__class__.__name__ in
-                           ['CollectiveAllReduceStrategy',
-                            'MultiWorkerMirroredStrategy'] else 60*60*24)
   run_config = tf.estimator.RunConfig(
       train_distribute=distribution_strategy,
       session_config=session_config,
-      save_checkpoints_secs=save_checkpoints_secs,
+      save_checkpoints_secs=60*60*24,
       save_checkpoints_steps=None)
 
   # Initializes model with all but the dense layer from pretrained ResNet.


### PR DESCRIPTION
Checkpointing with NCCL should be fixed after [`e103f6ab`](https://github.com/tensorflow/tensorflow/commit/e103f6ab3141b101c5d2da320def51278b1a0e5b).