### PR TITLE
Add synthetic data monkey patch to OneDeviceStrategy as well

### DIFF
--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -198,6 +198,7 @@ def _undo_monkey_patch_dataset_method(strategy):
 
 
 def set_up_synthetic_data():
+  _monkey_patch_dataset_method(tf.distribute.OneDeviceStrategy)
   _monkey_patch_dataset_method(tf.distribute.MirroredStrategy)
   # TODO(tobyboyd): Remove when contrib.distribute is all in core.
   if hasattr(tf, 'contrib'):
@@ -208,6 +209,7 @@ def set_up_synthetic_data():
 
 
 def undo_set_up_synthetic_data():
+  _undo_monkey_patch_dataset_method(tf.distribute.OneDeviceStrategy)
   _undo_monkey_patch_dataset_method(tf.distribute.MirroredStrategy)
   # TODO(tobyboyd): Remove when contrib.distribute is all in core.
   if hasattr(tf, 'contrib'):


### PR DESCRIPTION
It explains why synthetic data is slower than real data in 1GPU TF 2.0 (b/129691769).