### PR TITLE
TypeError: 'dict_keys' object does not support indexing

### DIFF
--- a/research/object_detection/exporter.py
+++ b/research/object_detection/exporter.py
@@ -402,7 +402,7 @@ def _export_inference_graph(input_type,
       f.write(str(inference_graph_def))
 
   if additional_output_tensor_names is not None:
-    output_node_names = ','.join(outputs.keys()+additional_output_tensor_names)
+    output_node_names = ','.join(list(outputs.keys())+additional_output_tensor_names)
   else:
     output_node_names = ','.join(outputs.keys())
 

--- a/research/object_detection/models/feature_map_generators.py
+++ b/research/object_detection/models/feature_map_generators.py
@@ -542,7 +542,7 @@ def pooling_pyramid_feature_maps(base_feature_map_depth, num_layers,
   """
   if len(image_features) != 1:
     raise ValueError('image_features should be a dictionary of length 1.')
-  image_features = image_features[image_features.keys()[0]]
+  image_features = image_features.values()[0]
 
   feature_map_keys = []
   feature_maps = []

--- a/research/object_detection/utils/visualization_utils_test.py
+++ b/research/object_detection/utils/visualization_utils_test.py
@@ -314,7 +314,7 @@ class VisualizationUtilsTest(tf.test.TestCase):
             groundtruth_classes
     }
     metric_ops = eval_metric_ops.get_estimator_eval_metric_ops(eval_dict)
-    _, update_op = metric_ops[metric_ops.keys()[0]]
+    _, update_op = metric_ops.values()[0]
 
     with self.test_session() as sess:
       sess.run(tf.global_variables_initializer())

--- a/research/object_detection/utils/vrd_evaluation.py
+++ b/research/object_detection/utils/vrd_evaluation.py
@@ -352,7 +352,7 @@ class VRDPhraseDetectionEvaluator(VRDDetectionEvaluator):
         where the named bounding box is computed as an enclosing bounding box
         of all bounding boxes of the i-th input structure.
     """
-    first_box_key = groundtruth_box_tuples.dtype.fields.keys()[0]
+    first_box_key = list(groundtruth_box_tuples.dtype.fields.keys())[0]
     miny = groundtruth_box_tuples[first_box_key][:, 0]
     minx = groundtruth_box_tuples[first_box_key][:, 1]
     maxy = groundtruth_box_tuples[first_box_key][:, 2]
@@ -388,7 +388,7 @@ class VRDPhraseDetectionEvaluator(VRDDetectionEvaluator):
         where the named bounding box is computed as an enclosing bounding box
         of all bounding boxes of the i-th input structure.
     """
-    first_box_key = detections_box_tuples.dtype.fields.keys()[0]
+    first_box_key = list(detections_box_tuples.dtype.fields.keys())[0]
     miny = detections_box_tuples[first_box_key][:, 0]
     minx = detections_box_tuples[first_box_key][:, 1]
     maxy = detections_box_tuples[first_box_key][:, 2]


### PR DESCRIPTION
When I try to train the `ssd_mobilenet_v1_coco` downloaded from object_detection model zoo,
with `samples/configs/ssd_mobilenet_v1_ppn_shared_box_predictor_300x300_coco14_sync.config`.
There occured an TypeError as mentioned above, so I use list() function to wrap the dict_keys object of the following line in `models/feature_map_generators.py`:
```python
image_features = image_features[image_features.keys()[0]]           # problem solved !
```

Then I think, maybe there are some other similar problem which not have been fixed, so I use `grep` recursively search them and fix them. Hopefully, I have fixed most of that.