### PR TITLE
update mujoco and tensorflow 1.14/2.0 api calls in efficient-hrl

### DIFF
--- a/research/efficient-hrl/agents/circular_buffer.py
+++ b/research/efficient-hrl/agents/circular_buffer.py
@@ -47,7 +47,7 @@ class CircularBuffer(object):
     self._tensors = collections.OrderedDict()
     with tf.variable_scope(self._scope):
       self._num_adds = tf.Variable(0, dtype=tf.int64, name='num_adds')
-    self._num_adds_cs = tf.contrib.framework.CriticalSection(name='num_adds')
+    self._num_adds_cs = tf.CriticalSection(name='num_adds')
 
   @property
   def buffer_size(self):

--- a/research/efficient-hrl/environments/ant.py
+++ b/research/efficient-hrl/environments/ant.py
@@ -130,7 +130,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     return ori
 
   def set_xy(self, xy):
-    qpos = np.copy(self.data.qpos)
+    qpos = np.copy(self.physics.data.qpos)
     qpos[0] = xy[0]
     qpos[1] = xy[1]
 

--- a/research/efficient-hrl/environments/ant.py
+++ b/research/efficient-hrl/environments/ant.py
@@ -75,13 +75,13 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     # No cfrc observation
     if self._expose_all_qpos:
       obs = np.concatenate([
-          self.physics.data.qpos.flat[:15],  # Ensures only ant obs.
-          self.physics.data.qvel.flat[:14],
+          self.data.qpos.flat[:15],  # Ensures only ant obs.
+          self.data.qvel.flat[:14],
       ])
     else:
       obs = np.concatenate([
-          self.physics.data.qpos.flat[2:15],
-          self.physics.data.qvel.flat[:14],
+          self.data.qpos.flat[2:15],
+          self.data.qvel.flat[:14],
       ])
 
     if self._expose_body_coms is not None:
@@ -117,18 +117,18 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
   def get_ori(self):
     ori = [0, 1, 0, 0]
-    rot = self.model.data.qpos[self.__class__.ORI_IND:self.__class__.ORI_IND + 4]  # take the quaternion
+    rot = self.data.qpos[self.__class__.ORI_IND:self.__class__.ORI_IND + 4]  # take the quaternion
     ori = q_mult(q_mult(rot, ori), q_inv(rot))[1:3]  # project onto x-y plane
     ori = math.atan2(ori[1], ori[0])
     return ori
 
   def set_xy(self, xy):
-    qpos = np.copy(self.physics.data.qpos)
+    qpos = np.copy(self.data.qpos)
     qpos[0] = xy[0]
     qpos[1] = xy[1]
 
-    qvel = self.physics.data.qvel
+    qvel = self.data.qvel
     self.set_state(qpos, qvel)
 
   def get_xy(self):
-    return self.physics.data.qpos[:2]
+    return self.data.qpos[:2]

--- a/research/efficient-hrl/environments/ant.py
+++ b/research/efficient-hrl/environments/ant.py
@@ -51,7 +51,10 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
   @property
   def physics(self):
-    if mujoco_py.get_version() >= '2.0.2.0':
+    # check mujoco version is greater than version 1.50 to call correct physics
+    # model containing PyMjData object for getting and setting position/velocity
+    # check https://github.com/openai/mujoco-py/issues/80 for updates to api
+    if mujoco_py.get_version() >= '1.50':
       return self.sim
     else:
       return self.model

--- a/research/efficient-hrl/environments/maze_env.py
+++ b/research/efficient-hrl/environments/maze_env.py
@@ -228,7 +228,7 @@ class MazeEnv(gym.Env):
         raise Exception("Every geom of the torso must have a name "
                         "defined")
 
-    _, file_path = tempfile.mkstemp(text=True)
+    _, file_path = tempfile.mkstemp(text=True, suffix='.xml')
     tree.write(file_path)
 
     self.wrapped_env = model_cls(*args, file_path=file_path, **kwargs)

--- a/research/efficient-hrl/environments/point.py
+++ b/research/efficient-hrl/environments/point.py
@@ -34,7 +34,10 @@ class PointEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
   @property
   def physics(self):
-    if mujoco_py.get_version() >= '2.0.2.0':
+    # check mujoco version is greater than version 1.50 to call correct physics
+    # model containing PyMjData object for getting and setting position/velocity
+    # check https://github.com/openai/mujoco-py/issues/80 for updates to api
+    if mujoco_py.get_version() >= '1.50':  
       return self.sim
     else:
       return self.model

--- a/research/efficient-hrl/environments/point.py
+++ b/research/efficient-hrl/environments/point.py
@@ -40,7 +40,7 @@ class PointEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
   def step(self, action):
     action[0] = 0.2 * action[0]
-    qpos = np.copy(self.physics.data.qpos)
+    qpos = np.copy(self.data.qpos)
     qpos[2] += action[1]
     ori = qpos[2]
     # compute increment in each direction
@@ -49,7 +49,7 @@ class PointEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     # ensure that the robot is within reasonable range
     qpos[0] = np.clip(qpos[0] + dx, -100, 100)
     qpos[1] = np.clip(qpos[1] + dy, -100, 100)
-    qvel = self.physics.data.qvel
+    qvel = self.data.qvel
     self.set_state(qpos, qvel)
     for _ in range(0, self.frame_skip):
       self.physics.step()
@@ -62,11 +62,11 @@ class PointEnv(mujoco_env.MujocoEnv, utils.EzPickle):
   def _get_obs(self):
     if self._expose_all_qpos:
       return np.concatenate([
-          self.physics.data.qpos.flat[:3],  # Only point-relevant coords.
-          self.physics.data.qvel.flat[:3]])
+          self.data.qpos.flat[:3],  # Only point-relevant coords.
+          self.data.qvel.flat[:3]])
     return np.concatenate([
-        self.physics.data.qpos.flat[2:3],
-        self.physics.data.qvel.flat[:3]])
+        self.data.qpos.flat[2:3],
+        self.data.qvel.flat[:3]])
 
   def reset_model(self):
     qpos = self.init_qpos + self.np_random.uniform(
@@ -83,8 +83,8 @@ class PointEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     return self.model.data.qpos[self.__class__.ORI_IND]
 
   def set_xy(self, xy):
-    qpos = np.copy(self.physics.data.qpos)
+    qpos = np.copy(self.data.qpos)
     qpos[0] = xy[0]
     qpos[1] = xy[1]
 
-    qvel = self.physics.data.qvel
+    qvel = self.data.qvel

--- a/research/efficient-hrl/scripts/local_train.py
+++ b/research/efficient-hrl/scripts/local_train.py
@@ -28,7 +28,7 @@ CONFIGS_PATH = './configs'
 CONTEXT_CONFIGS_PATH = './context/configs'
 
 def main():
-  bb = './'
+  bb = '.'
   base_num_args = 6
   if len(sys.argv) < base_num_args:
     print(


### PR DESCRIPTION
Fixes issue addressed in #5321, updating mujoco calls to `self.data` and TensorFlow calls to `tf.CriticalSection` to reflect 1.14/2.0 standard.