### PR TITLE
reshape only applies to numpy arrays, it was however being used again…

### DIFF
--- a/research/deep_contextual_bandits/bandits/data/data_sampler.py
+++ b/research/deep_contextual_bandits/bandits/data/data_sampler.py
@@ -71,7 +71,7 @@ def sample_mushroom_data(file_name,
       size=num_contexts)
   eat_reward = r_eat_safe * df.iloc[ind, 0]
   eat_reward += np.multiply(random_poison, df.iloc[ind, 1])
-  eat_reward = eat_reward.reshape((num_contexts, 1))
+  eat_reward = eat_reward.to_numpy().reshape((num_contexts, 1))
 
   # compute optimal expected reward and optimal actions
   exp_eat_poison_reward = r_eat_poison_bad * prob_poison_bad


### PR DESCRIPTION
`eat_reward` is a Pandas DataFrame, as such it can't be `reshape` without first being converted to a Numpy array.