### PR TITLE
Compute per category metrics

### DIFF
--- a/research/object_detection/metrics/coco_tools.py
+++ b/research/object_detection/metrics/coco_tools.py
@@ -236,7 +236,9 @@ class COCOEvalWrapper(cocoeval.COCOeval):
     self.evaluate()
     self.accumulate()
     self.summarize()
-
+    if include_metrics_per_category is True:
+        self.summarize_per_category()
+        
     summary_metrics = OrderedDict([
         ('Precision/mAP', self.stats[0]),
         ('Precision/mAP@.50IOU', self.stats[1]),


### PR DESCRIPTION
Inspired by 
[https://github.com/tensorflow/models/issues/5010](https://github.com/tensorflow/models/issues/5010)
[https://github.com/tensorflow/models/issues/4778#issuecomment-430262110](https://github.com/tensorflow/models/issues/4778#issuecomment-430262110)

I would like to submit this pull request to tensorflow object detection API to enable everyone to readily compute per category metrics. 

Three code additions are listed below:
1.addtion in "pycocotools/cocoeval.py":from line 499 to line 648
I made a pull request on: https://github.com/cocodataset/cocoapi/pull/282

2.addtion in "tensorflow/models/research/object_detetcion/metrics/coco_tools.py":from line 240 to line 244

3.add
{
    metrics_set: "coco_detection_metrics" 
    include_metrics_per_category: true 
}
to "eval_config" part in pipeline config file.
For instance:
eval_config: {
  num_examples: 8000
  # Note: The below line limits the evaluation process to 10 evaluations.
  # Remove the below line to evaluate indefinitely.
  max_evals: 10
  num_visualizations: 20
  metrics_set: "coco_detection_metrics" 
  include_metrics_per_category: true   
}


The code changes are tested in my code and see per category metrics stats successfully plotted in tensorboard.  This is my first ever pull request, any feedback would be appreciated.


