### PR TITLE
fix bug in research/deep_speech model when is_bidirectional == False

### DIFF
--- a/research/deep_speech/deep_speech_model.py
+++ b/research/deep_speech/deep_speech_model.py
@@ -121,7 +121,7 @@ def _rnn_layer(inputs, rnn_cell, rnn_hidden_size, layer_id, is_batch_norm,
         swap_memory=True)
     rnn_outputs = tf.concat(outputs, -1)
   else:
-    rnn_outputs = tf.nn.dynamic_rnn(
+    rnn_outputs, _ = tf.nn.dynamic_rnn(
         fw_cell, inputs, dtype=tf.float32, swap_memory=True)
 
   return rnn_outputs


### PR DESCRIPTION
When is_bidirectional == False, the original version passes the output tuple (output tensor and state tensor) of unidirectional RNN to the rnn_outputs. However, it should pass the exact output tensor instead of the tuple to the rnn_outputs.