### PR TITLE
Change iteritems() to items() for python3

### DIFF
--- a/research/object_detection/metrics/coco_evaluation.py
+++ b/research/object_detection/metrics/coco_evaluation.py
@@ -568,7 +568,7 @@ class CocoMaskEvaluator(object_detection_evaluation.DetectionEvaluator):
         'annotations': self._groundtruth_list,
         'images': [{'id': image_id, 'height': shape[1], 'width': shape[2]}
                    for image_id, shape in self._image_id_to_mask_shape_map.
-                   iteritems()],
+                   items()],
         'categories': self._categories
     }
     coco_wrapped_groundtruth = coco_tools.COCOWrapper(
@@ -582,7 +582,7 @@ class CocoMaskEvaluator(object_detection_evaluation.DetectionEvaluator):
         include_metrics_per_category=self._include_metrics_per_category)
     mask_metrics.update(mask_per_category_ap)
     mask_metrics = {'DetectionMasks_'+ key: value
-                    for key, value in mask_metrics.iteritems()}
+                    for key, value in mask_metrics.items()}
     return mask_metrics
 
   def get_estimator_eval_metric_ops(self, eval_dict):


### PR DESCRIPTION
The evaluation crashes in python3 if iteritems() is used instead of items()