### PR TITLE
fix training crash with Unicode labels

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -703,7 +703,7 @@ def visualize_boxes_and_labels_on_image_array(
               class_name = category_index[classes[i]]['name']
             else:
               class_name = 'N/A'
-            display_str = str(class_name)
+            display_str = str(class_name.encode(errors='ignore').decode())
         if not skip_scores:
           if not display_str:
             display_str = '{}%'.format(int(100*scores[i]))


### PR DESCRIPTION
The training seems to crash on both Python 2 and Python 3 with the presence of Unicode characters in the labels.