### PR TITLE
Fix training crash on visualizing Unicode

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -172,9 +172,11 @@ def draw_bounding_box_on_image(image,
   draw.line([(left, top), (left, bottom), (right, bottom),
              (right, top), (left, top)], width=thickness, fill=color)
   try:
-    font = ImageFont.truetype('arial.ttf', 24)
+    font = ImageFont.truetype('arial.ttf', 24, encoding='UTF-8')
   except IOError:
     font = ImageFont.load_default()
+    display_str_list = [ds.encode('latin-1', errors='ignore').decode() for ds in display_str_list]
+   
 
   # If the total height of the display strings added to the top of the bounding
   # box exceeds the top of the image, stack the strings below the bounding box


### PR DESCRIPTION
When the font `arial.ttf` is not found it loads the default font and crashes whenever it finds Unicode characters on both Python 2 and 3. A warning should be shown first before filtering all non-ASCII characters in case the user used all-Unicode-labels. 

The same error is shown when somebody tries `'百'.encode('latin-1')` in a Python interpreter.