### PR TITLE
avoid class index overflow when using OIDv4 labels

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -387,7 +387,7 @@
         "      # all outputs are float32 numpy arrays, so convert types as appropriate\n",
         "      output_dict['num_detections'] = int(output_dict['num_detections'][0])\n",
         "      output_dict['detection_classes'] = output_dict[\n",
-        "          'detection_classes'][0].astype(np.uint8)\n",
+        "          'detection_classes'][0].astype(np.int64)\n",
         "      output_dict['detection_boxes'] = output_dict['detection_boxes'][0]\n",
         "      output_dict['detection_scores'] = output_dict['detection_scores'][0]\n",
         "      if 'detection_masks' in output_dict:\n",


### PR DESCRIPTION
np.uint8 to np.int64 for detection class label index overflow when using OIDv4 labels