### PR TITLE
Revert "Specify NCCL as the all reduce algorithm (#6662)"

### DIFF
--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -124,8 +124,7 @@ def run(flags_obj):
   strategy = distribution_utils.get_distribution_strategy(
       distribution_strategy=flags_obj.distribution_strategy,
       num_gpus=flags_obj.num_gpus,
-      num_workers=distribution_utils.configure_cluster(),
-      all_reduce_alg='nccl')
+      num_workers=distribution_utils.configure_cluster())
 
   strategy_scope = distribution_utils.get_strategy_scope(strategy)
 


### PR DESCRIPTION
Reason: test failures because contrib is not available in V2

This reverts commit 325dd7612a10a73364d334b7513dd65c7e98eb50.