### PR TITLE
Add benchmarks with the --cloning flag to Resnet and NFC.

### DIFF
--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -104,7 +104,7 @@ def parse_flags(flags_obj):
       "epsilon": flags_obj.epsilon,
       "match_mlperf": flags_obj.ml_perf,
       "use_xla_for_gpu": flags_obj.use_xla_for_gpu,
-      "cloning": flags_obj.cloning,
+      "clone_model_in_keras_dist_strat": flags_obj.clone_model_in_keras_dist_strat,
       "epochs_between_evals": FLAGS.epochs_between_evals,
       "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
   }
@@ -314,7 +314,7 @@ def define_ncf_flags():
     return not flag_dict["use_xla_for_gpu"] or not flag_dict["tpu"]
 
   flags.DEFINE_bool(
-      name="cloning", default=True, help=flags_core.help_wrap(
+      name="clone_model_in_keras_dist_strat", default=True, help=flags_core.help_wrap(
           'If False, then the experimental code path is used that doesn\'t '
           'clone models for distribution.'))
 

--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -104,6 +104,7 @@ def parse_flags(flags_obj):
       "epsilon": flags_obj.epsilon,
       "match_mlperf": flags_obj.ml_perf,
       "use_xla_for_gpu": flags_obj.use_xla_for_gpu,
+      "cloning": flags_obj.cloning,
       "epochs_between_evals": FLAGS.epochs_between_evals,
       "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
   }
@@ -311,6 +312,11 @@ def define_ncf_flags():
   @flags.multi_flags_validator(["use_xla_for_gpu", "tpu"], message=xla_message)
   def xla_validator(flag_dict):
     return not flag_dict["use_xla_for_gpu"] or not flag_dict["tpu"]
+
+  flags.DEFINE_bool(
+      name="cloning", default=True, help=flags_core.help_wrap(
+          'If False, then the experimental code path is used that doesn\'t '
+          'clone models for distribution.'))
 
 
 def convert_to_softmax_logits(logits):

--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -104,7 +104,8 @@ def parse_flags(flags_obj):
       "epsilon": flags_obj.epsilon,
       "match_mlperf": flags_obj.ml_perf,
       "use_xla_for_gpu": flags_obj.use_xla_for_gpu,
-      "clone_model_in_keras_dist_strat": flags_obj.clone_model_in_keras_dist_strat,
+      "clone_model_in_keras_dist_strat":
+          flags_obj.clone_model_in_keras_dist_strat,
       "epochs_between_evals": FLAGS.epochs_between_evals,
       "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
   }

--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -314,9 +314,11 @@ def define_ncf_flags():
     return not flag_dict["use_xla_for_gpu"] or not flag_dict["tpu"]
 
   flags.DEFINE_bool(
-      name="clone_model_in_keras_dist_strat", default=True, help=flags_core.help_wrap(
+      name="clone_model_in_keras_dist_strat",
+      default=True,
+      help=flags_core.help_wrap(
           'If False, then the experimental code path is used that doesn\'t '
-          'clone models for distribution.'))
+          "clone models for distribution."))
 
 
 def convert_to_softmax_logits(logits):

--- a/official/recommendation/ncf_keras_benchmark.py
+++ b/official/recommendation/ncf_keras_benchmark.py
@@ -113,9 +113,20 @@ class KerasNCFRealData(KerasNCFBenchmarkBase):
     self._setup()
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_no_cloning(self):
+    self._setup()
+    FLAGS.cloning = False
+    self._run_and_report_benchmark()
+
   def benchmark_2_gpus(self):
     self._setup()
     FLAGS.num_gpus = 2
+    self._run_and_report_benchmark()
+
+  def benchmark_2_gpus_no_cloning(self):
+    self._setup()
+    FLAGS.num_gpus = 2
+    FLAGS.cloning = False
     self._run_and_report_benchmark()
 
 
@@ -155,7 +166,18 @@ class KerasNCFSyntheticData(KerasNCFBenchmarkBase):
     self._setup()
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_no_cloning(self):
+    self._setup()
+    FLAGS.cloning = False
+    self._run_and_report_benchmark()
+
   def benchmark_2_gpus(self):
     self._setup()
     FLAGS.num_gpus = 2
+    self._run_and_report_benchmark()
+
+  def benchmark_2_gpus_no_cloning(self):
+    self._setup()
+    FLAGS.num_gpus = 2
+    FLAGS.cloning = False
     self._run_and_report_benchmark()

--- a/official/recommendation/ncf_keras_benchmark.py
+++ b/official/recommendation/ncf_keras_benchmark.py
@@ -115,7 +115,7 @@ class KerasNCFRealData(KerasNCFBenchmarkBase):
 
   def benchmark_1_gpu_no_cloning(self):
     self._setup()
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()
 
   def benchmark_2_gpus(self):
@@ -126,7 +126,7 @@ class KerasNCFRealData(KerasNCFBenchmarkBase):
   def benchmark_2_gpus_no_cloning(self):
     self._setup()
     FLAGS.num_gpus = 2
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()
 
 
@@ -168,7 +168,7 @@ class KerasNCFSyntheticData(KerasNCFBenchmarkBase):
 
   def benchmark_1_gpu_no_cloning(self):
     self._setup()
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()
 
   def benchmark_2_gpus(self):
@@ -179,5 +179,5 @@ class KerasNCFSyntheticData(KerasNCFBenchmarkBase):
   def benchmark_2_gpus_no_cloning(self):
     self._setup()
     FLAGS.num_gpus = 2
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -239,7 +239,7 @@ def run_ncf(_):
         loss=_keras_loss,
         metrics=[_get_metric_fn(params)],
         optimizer=optimizer,
-        cloning=params["cloning"])
+        cloning=params["clone_model_in_keras_dist_strat"])
 
     history = keras_model.fit(train_input_dataset,
                               epochs=FLAGS.train_epochs,

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -238,7 +238,8 @@ def run_ncf(_):
     keras_model.compile(
         loss=_keras_loss,
         metrics=[_get_metric_fn(params)],
-        optimizer=optimizer)
+        optimizer=optimizer,
+        cloning=params["cloning"])
 
     history = keras_model.fit(train_input_dataset,
                               epochs=FLAGS.train_epochs,

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -101,7 +101,7 @@ class Resnet56KerasAccuracy(keras_benchmark.KerasBenchmark):
     FLAGS.train_epochs = 182
     FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu_no_cloning')
     FLAGS.dtype = 'fp32'
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     FLAGS.enable_eager = True
     self._run_and_report_benchmark()
 
@@ -193,16 +193,6 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
-  def benchmark_1_gpu_no_cloning(self):
-    self._setup()
-    FLAGS.num_gpus = 1
-    FLAGS.enable_eager = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_cloning')
-    FLAGS.batch_size = 128
-    FLAGS.cloning = False
-    self._run_and_report_benchmark()
-
   def benchmark_graph_1_gpu(self):
     self._setup()
     FLAGS.num_gpus = 1
@@ -228,7 +218,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu_no_cloning')
     FLAGS.batch_size = 128 * 2  # 2 GPUs
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()
 
   def benchmark_graph_2_gpu(self):

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -92,6 +92,19 @@ class Resnet56KerasAccuracy(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     self._run_and_report_benchmark()
 
+  def benchmark_2_gpu_no_cloning(self):
+    """Test keras based model with eager, distributed no-cloning."""
+    self._setup()
+    FLAGS.num_gpus = 2
+    FLAGS.data_dir = self.data_dir
+    FLAGS.batch_size = 128
+    FLAGS.train_epochs = 182
+    FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu_no_cloning')
+    FLAGS.dtype = 'fp32'
+    FLAGS.cloning = False
+    FLAGS.enable_eager = True
+    self._run_and_report_benchmark()
+
   def benchmark_graph_2_gpu(self):
     """Test keras based model with Keras fit and distribution strategies."""
     self._setup()
@@ -180,6 +193,16 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_no_cloning(self):
+    self._setup()
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_cloning')
+    FLAGS.batch_size = 128
+    FLAGS.cloning = False
+    self._run_and_report_benchmark()
+
   def benchmark_graph_1_gpu(self):
     self._setup()
     FLAGS.num_gpus = 1
@@ -196,6 +219,16 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu')
     FLAGS.batch_size = 128 * 2  # 2 GPUs
+    self._run_and_report_benchmark()
+
+  def benchmark_2_gpu_no_cloning(self):
+    self._setup()
+    FLAGS.num_gpus = 2
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu_no_cloning')
+    FLAGS.batch_size = 128 * 2  # 2 GPUs
+    FLAGS.cloning = False
     self._run_and_report_benchmark()
 
   def benchmark_graph_2_gpu(self):

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -291,6 +291,9 @@ def define_keras_flags():
       'help improve performance using EagerIterator and function. The codepath '
       'when enabling this feature is experimental and will be removed once the '
       'corresponding performance features are fully supported in TensorFlow.')
+  flags.DEFINE_boolean(name='cloning', default=True, help='If False, then the '
+                       'experimental code path is used that doesn\'t clone '
+                       'models for distribution.')
 
 
 def get_synth_input_fn(height, width, num_channels, num_classes,

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -291,9 +291,9 @@ def define_keras_flags():
       'help improve performance using EagerIterator and function. The codepath '
       'when enabling this feature is experimental and will be removed once the '
       'corresponding performance features are fully supported in TensorFlow.')
-  flags.DEFINE_boolean(name='clone_model_in_keras_dist_strat', default=True, help='If False, then the '
-                       'experimental code path is used that doesn\'t clone '
-                       'models for distribution.')
+  flags.DEFINE_boolean(name='clone_model_in_keras_dist_strat', default=True,
+                       help='If False, then the experimental code path is used'
+                       ' that doesn\'t clone models for distribution.')
 
 
 def get_synth_input_fn(height, width, num_channels, num_classes,

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -291,7 +291,7 @@ def define_keras_flags():
       'help improve performance using EagerIterator and function. The codepath '
       'when enabling this feature is experimental and will be removed once the '
       'corresponding performance features are fully supported in TensorFlow.')
-  flags.DEFINE_boolean(name='cloning', default=True, help='If False, then the '
+  flags.DEFINE_boolean(name='clone_model_in_keras_dist_strat', default=True, help='If False, then the '
                        'experimental code path is used that doesn\'t clone '
                        'models for distribution.')
 

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -80,21 +80,6 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
     FLAGS.datasets_num_private_threads = 14
     self._run_and_report_benchmark()
 
-  def benchmark_8_gpu_no_cloning(self):
-    """Test Keras model with eager, dist_strat, 8 GPUs and no-cloning."""
-    self._setup()
-    FLAGS.num_gpus = 8
-    FLAGS.data_dir = self.data_dir
-    FLAGS.batch_size = 128 * 8
-    FLAGS.train_epochs = 90
-    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_no_cloning')
-    FLAGS.dtype = 'fp32'
-    FLAGS.enable_eager = True
-    FLAGS.cloning = False
-    # Add some thread tunings to improve performance.
-    FLAGS.datasets_num_private_threads = 14
-    self._run_and_report_benchmark()
-
   def benchmark_8_gpu_fp16(self):
     """Test Keras model with eager, dist_strat, 8 GPUs, and fp16."""
     self._setup()
@@ -225,7 +210,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_cloning')
     FLAGS.batch_size = 128
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     self._run_and_report_benchmark()
 
   def benchmark_xla_1_gpu(self):
@@ -391,7 +376,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_no_cloning')
-    FLAGS.cloning = False
+    FLAGS.clone_model_in_keras_dist_strat = False
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     self._run_and_report_benchmark()
 

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -80,6 +80,21 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
     FLAGS.datasets_num_private_threads = 14
     self._run_and_report_benchmark()
 
+  def benchmark_8_gpu_no_cloning(self):
+    """Test Keras model with eager, dist_strat, 8 GPUs and no-cloning."""
+    self._setup()
+    FLAGS.num_gpus = 8
+    FLAGS.data_dir = self.data_dir
+    FLAGS.batch_size = 128 * 8
+    FLAGS.train_epochs = 90
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_no_cloning')
+    FLAGS.dtype = 'fp32'
+    FLAGS.enable_eager = True
+    FLAGS.cloning = False
+    # Add some thread tunings to improve performance.
+    FLAGS.datasets_num_private_threads = 14
+    self._run_and_report_benchmark()
+
   def benchmark_8_gpu_fp16(self):
     """Test Keras model with eager, dist_strat, 8 GPUs, and fp16."""
     self._setup()
@@ -199,6 +214,18 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu')
     FLAGS.batch_size = 128
+    self._run_and_report_benchmark()
+
+  def benchmark_1_gpu_no_cloning(self):
+    """Test Keras model with 1 GPU and no-cloning."""
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_cloning')
+    FLAGS.batch_size = 128
+    FLAGS.cloning = False
     self._run_and_report_benchmark()
 
   def benchmark_xla_1_gpu(self):
@@ -353,6 +380,18 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu')
+    FLAGS.batch_size = 128 * 8  # 8 GPUs
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_no_cloning(self):
+    """Test Keras model with 8 GPUs and no-cloning."""
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_no_cloning')
+    FLAGS.cloning = False
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     self._run_and_report_benchmark()
 

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -197,7 +197,8 @@ def run(flags_obj):
 
     model.compile(loss='sparse_categorical_crossentropy',
                   optimizer=optimizer,
-                  metrics=['sparse_categorical_accuracy'])
+                  metrics=['sparse_categorical_accuracy'],
+                  cloning=flags_obj.cloning)
 
   callbacks = keras_common.get_callbacks(
       learning_rate_schedule, imagenet_main.NUM_IMAGES['train'])

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -198,7 +198,7 @@ def run(flags_obj):
     model.compile(loss='sparse_categorical_crossentropy',
                   optimizer=optimizer,
                   metrics=['sparse_categorical_accuracy'],
-                  cloning=flags_obj.cloning)
+                  cloning=flags_obj.clone_model_in_keras_dist_strat)
 
   callbacks = keras_common.get_callbacks(
       learning_rate_schedule, imagenet_main.NUM_IMAGES['train'])


### PR DESCRIPTION
This PR adds essential correctness and performance benchmarks for the new --cloning=False code path.  The feature was added https://github.com/tensorflow/tensorflow/commit/22962228c29fe454522ee39e2154f0703f981e3b and probably haven't made its way into tf-nightly yet.  Quite a bit of the verification happened in that feature PR.  This PR hopefully represents a trivial change that still needs to be tested as part of the performance framework.  I will do that tomorrow once tf-nightly is ready.