### PR TITLE
Add --fp16_implementation option.

### DIFF
--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -347,10 +347,11 @@ def imagenet_model_fn(features, labels, mode, params):
   )
 
 
-def define_imagenet_flags(dynamic_loss_scale=False):
+def define_imagenet_flags(dynamic_loss_scale=False, fp16_implementation=False):
   resnet_run_loop.define_resnet_flags(
       resnet_size_choices=['18', '34', '50', '101', '152', '200'],
-      dynamic_loss_scale=dynamic_loss_scale)
+      dynamic_loss_scale=dynamic_loss_scale,
+      fp16_implementation=fp16_implementation)
   flags.adopt_module_key_flags(resnet_run_loop)
   flags_core.set_defaults(train_epochs=90)
 
@@ -377,5 +378,5 @@ def main(_):
 
 if __name__ == '__main__':
   tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
-  define_imagenet_flags()
+  define_imagenet_flags(dynamic_loss_scale=True, fp16_implementation=True)
   absl_app.run(main)

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -451,6 +451,10 @@ def resnet_model_fn(features, labels, mode, model_class,
           momentum=momentum
       )
 
+    if flags.FLAGS.fp16_implementation == 'graph_rewrite':
+      optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(
+          optimizer, loss_scale=loss_scale)
+
     def _dense_grad_filter(gvs):
       """Only apply gradient updates to the final layer.
 
@@ -463,7 +467,8 @@ def resnet_model_fn(features, labels, mode, model_class,
       """
       return [(g, v) for g, v in gvs if 'dense' in v.name]
 
-    if loss_scale != 1:
+    if (loss_scale != 1 and
+        not flags.FLAGS.fp16_implementation == 'graph_rewrite'):
       # When computing fp16 gradients, often intermediate tensor values are
       # so small, they underflow to 0. To avoid this, we multiply the loss by
       # loss_scale to make these tensor values loss_scale times bigger.
@@ -706,14 +711,16 @@ def resnet_main(
   return stats
 
 
-def define_resnet_flags(resnet_size_choices=None, dynamic_loss_scale=False):
+def define_resnet_flags(resnet_size_choices=None, dynamic_loss_scale=False,
+                        fp16_implementation=False):
   """Add flags and validators for ResNet."""
   flags_core.define_base()
   flags_core.define_performance(num_parallel_calls=False,
                                 tf_gpu_thread_mode=True,
                                 datasets_num_private_threads=True,
                                 datasets_num_parallel_batches=True,
-                                dynamic_loss_scale=dynamic_loss_scale)
+                                dynamic_loss_scale=dynamic_loss_scale,
+                                fp16_implementation=fp16_implementation)
   flags_core.define_image()
   flags_core.define_benchmark()
   flags.adopt_module_key_flags(flags_core)

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -451,7 +451,8 @@ def resnet_model_fn(features, labels, mode, model_class,
           momentum=momentum
       )
 
-    if flags.FLAGS.fp16_implementation == 'graph_rewrite':
+    fp16_implementation = getattr(flags.FLAGS, 'fp16_implementation', None)
+    if fp16_implementation == 'graph_rewrite':
       optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(
           optimizer, loss_scale=loss_scale)
 
@@ -467,8 +468,7 @@ def resnet_model_fn(features, labels, mode, model_class,
       """
       return [(g, v) for g, v in gvs if 'dense' in v.name]
 
-    if (loss_scale != 1 and
-        not flags.FLAGS.fp16_implementation == 'graph_rewrite'):
+    if loss_scale != 1 and fp16_implementation != 'graph_rewrite':
       # When computing fp16 gradients, often intermediate tensor values are
       # so small, they underflow to 0. To avoid this, we multiply the loss by
       # loss_scale to make these tensor values loss_scale times bigger.

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -184,6 +184,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
       @flags.multi_flags_validator(['fp16_implementation', 'dtype',
                                     'loss_scale'])
       def _check_fp16_implementation(flags_dict):
+        """Validator to check fp16_implementation flag is valid."""
         if (flags_dict['fp16_implementation'] == 'graph_rewrite' and
             flags_dict['dtype'] != 'fp16'):
           raise flags.ValidationError('--fp16_implementation should not be '

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -171,14 +171,15 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
 
     if fp16_implementation:
       # Currently, this flag is only defined for the estimator resnet model.
-      flags.DEFINE_enum(name="fp16_implementation", default='casting',
-                        enum_values=('casting', 'graph_rewrite'),
-                        help=help_wrap(
-            "When --dtype=fp16, how fp16 should be implemented. This has no "
-            "impact on correctness. 'casting' will cause manual tf.casts to be "
-            "inserted in the model. 'graph_rewrite' means "
-            "tf.train.experimental.enable_mixed_precision_graph_rewrite will "
-            "be used to automatically use fp16 without any manual casts."))
+      flags.DEFINE_enum(
+          name="fp16_implementation", default='casting',
+          enum_values=('casting', 'graph_rewrite'),
+          help=help_wrap(
+              "When --dtype=fp16, how fp16 should be implemented. This has no "
+              "impact on correctness. 'casting' will cause manual tf.casts to "
+              "be inserted in the model. 'graph_rewrite' means "
+              "tf.train.experimental.enable_mixed_precision_graph_rewrite will "
+              "be used to automatically use fp16 without any manual casts."))
 
       @flags.multi_flags_validator(['fp16_implementation', 'dtype',
                                     'loss_scale'])

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -170,6 +170,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
       return loss_scale > 0
 
     if fp16_implementation:
+      # Currently, this flag is only defined for the estimator resnet model.
       flags.DEFINE_enum(name="fp16_implementation", default='casting',
                         enum_values=('casting', 'graph_rewrite'),
                         help=help_wrap(

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -34,6 +34,10 @@ DTYPE_MAP = {
 
 
 def get_tf_dtype(flags_obj):
+  if getattr(flags_obj, 'fp16_implementation', None) == 'graph_rewrite':
+    # If the graph_rewrite is used, we build the graph with fp32, and let the
+    # graph rewrite change ops to fp16.
+    return tf.float32
   return DTYPE_MAP[flags_obj.dtype][0]
 
 
@@ -50,7 +54,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
                        all_reduce_alg=True, tf_gpu_thread_mode=False,
                        datasets_num_private_threads=False,
                        datasets_num_parallel_batches=False,
-                       dynamic_loss_scale=False):
+                       dynamic_loss_scale=False, fp16_implementation=False):
   """Register flags for specifying performance tuning arguments.
 
   Args:
@@ -68,6 +72,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
     parallel when using map and batch from tf.data.
     dynamic_loss_scale: Allow the "loss_scale" flag to take on the value
       "dynamic". Only valid if `dtype` is True.
+    fp16_implementation: Create fp16_implementation flag.
 
   Returns:
     A list of flags for core.py to marks as key flags.
@@ -163,6 +168,30 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
         return False
 
       return loss_scale > 0
+
+    if fp16_implementation:
+      flags.DEFINE_enum(name="fp16_implementation", default='casting',
+                        enum_values=('casting', 'graph_rewrite'),
+                        help=help_wrap(
+            "When --dtype=fp16, how fp16 should be implemented. This has no "
+            "impact on correctness. 'casting' will cause manual tf.casts to be "
+            "inserted in the model. 'graph_rewrite' means "
+            "tf.train.experimental.enable_mixed_precision_graph_rewrite will "
+            "be used to automatically use fp16 without any manual casts."))
+
+      @flags.multi_flags_validator(['fp16_implementation', 'dtype',
+                                    'loss_scale'])
+      def _check_fp16_implementation(flags_dict):
+        if (flags_dict['fp16_implementation'] == 'graph_rewrite' and
+            flags_dict['dtype'] != 'fp16'):
+          raise flags.ValidationError('--fp16_implementation should not be '
+                                      'specified unless --dtype=fp16')
+        if (flags_dict['fp16_implementation'] != 'graph_rewrite' and
+            flags_dict['loss_scale'] == 'dynamic'):
+          raise flags.ValidationError('--loss_scale=dynamic is only supported '
+                                      'when '
+                                      '--fp16_implementation=graph_rewrite')
+        return True
 
   if all_reduce_alg:
     flags.DEFINE_string(


### PR DESCRIPTION
This options allows the new tf.train.experimental.enable_mixed_precision_graph_rewrite() function to be used for fp16, instead of manual casts.

To test convergence, I ran
```
python imagenet_main.py --num_gpus=8 --data_dir=/data/imagenet/imagenet --batch_size=1024 --train_epochs=90 --epochs_between_evals=10 --model_dir ~/model_dir_amp --dtype=fp16 --hooks=ExamplesPerSecondHook --fp16_implementation=graph_rewrite
```

I got 76.26% accuracy.

To test performance, I ran

```
python imagenet_main.py --clean --synth --num_gpus=8 --batch_size=1024 --train_epochs=1 --model_dir ~/model_dir_test --dtype=fp16 --hooks=ExamplesPerSecondHook,ProfilerHook
```
I added --fp16_implementation=graph_rewrite to use enable_mixed_precision_graph_rewrite(), and I removed --synth and added --data_dir when using real data. Results (images/sec):

| |casting|graph_rewrite|
|--|--|--|
|Real data|5104|4005|
|Synthetic data|4682|4522|

On synthetic data, the graph rewrite is only 3.5% slower than manual casting. But on real data, it's 27% slower. And the fact that real data is faster than synthetic data with manual casting is very unusual.