### PR TITLE
Enable CuDNN BatchNorm spatial persistent by default

### DIFF
--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -291,9 +291,13 @@ def define_keras_flags():
       'help improve performance using EagerIterator and function. The codepath '
       'when enabling this feature is experimental and will be removed once the '
       'corresponding performance features are fully supported in TensorFlow.')
-  flags.DEFINE_boolean(name='clone_model_in_keras_dist_strat', default=True,
-                       help='If False, then the experimental code path is used'
-                       ' that doesn\'t clone models for distribution.')
+  flags.DEFINE_boolean(
+      name='batchnorm_spatial_persistent', default=True,
+      help='Enable the spacial persistent mode for CuDNN batch norm kernel.')
+  flags.DEFINE_boolean(
+      name='clone_model_in_keras_dist_strat', default=True,
+      help='If False, then the experimental code path is used that doesn\'t '
+           'clone models for distribution.')
 
 
 def get_synth_input_fn(height, width, num_channels, num_classes,
@@ -356,6 +360,15 @@ def data_prefetch_with_slack():
   """Use unstable code for perf tuning purposes."""
   if not FLAGS.use_synthetic_data:
     _monkey_patch_org_create_device_dataset()
+
+
+def set_cudnn_batchnorm_mode():
+  """Set CuDNN batchnorm mode for better performance. Note that the spatial
+     persistent mode may lead to accuracy losses for certain models."""
+  if FLAGS.batchnorm_spatial_persistent:
+    os.environ['TF_USE_CUDNN_BATCHNORM_SPATIAL_PERSISTENT'] = '1'
+  else:
+    os.environ.pop('TF_USE_CUDNN_BATCHNORM_SPATIAL_PERSISTENT', None)
 
 
 def _monkey_patch_org_assert_broadcastable():

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -368,7 +368,7 @@ def set_cudnn_batchnorm_mode():
   if FLAGS.batchnorm_spatial_persistent:
     os.environ['TF_USE_CUDNN_BATCHNORM_SPATIAL_PERSISTENT'] = '1'
   else:
-    os.environ.pop('TF_USE_CUDNN_BATCHNORM_SPATIAL_PERSISTENT', None)
+    del os.environ['TF_USE_CUDNN_BATCHNORM_SPATIAL_PERSISTENT']
 
 
 def _monkey_patch_org_assert_broadcastable():

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -109,6 +109,7 @@ def run(flags_obj):
     keras_common.set_gpu_thread_mode_and_count(flags_obj)
   if flags_obj.data_prefetch_with_slack:
     keras_common.data_prefetch_with_slack()
+  keras_common.set_cudnn_batchnorm_mode()
 
   dtype = flags_core.get_tf_dtype(flags_obj)
   if dtype == 'float16':

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -216,7 +216,8 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                                 epsilon=BATCH_NORM_EPSILON,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
-  x = layers.MaxPooling2D((3, 3), strides=(2, 2), padding='same')(x)
+  x = layers.ZeroPadding2D(padding=(1, 1), name='pool1_pad')(x)
+  x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
 
   x = conv_block(x, 3, [64, 64, 256], stage=2, block='a', strides=(1, 1))
   x = identity_block(x, 3, [64, 64, 256], stage=2, block='b')

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -208,7 +208,6 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                                 epsilon=BATCH_NORM_EPSILON,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
-  x = layers.ZeroPadding2D(padding=(1, 1), name='pool1_pad')(x)
   x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
 
   x = conv_block(x, 3, [64, 64, 256], stage=2, block='a', strides=(1, 1))

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -224,8 +224,7 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                                 fused=True,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
-  x = layers.ZeroPadding2D(padding=(1, 1), name='pool1_pad')(x)
-  x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
+  x = layers.MaxPooling2D((3, 3), strides=(2, 2), padding='same')(x)
 
   x = conv_block(x, 3, [64, 64, 256], stage=2, block='a', strides=(1, 1))
   x = identity_block(x, 3, [64, 64, 256], stage=2, block='b')

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -72,7 +72,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2a')(x)
   x = layers.Activation('relu')(x)
 
@@ -85,7 +84,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
@@ -97,7 +95,6 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2c')(x)
 
   x = layers.add([x, input_tensor])
@@ -145,7 +142,6 @@ def conv_block(input_tensor,
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2a')(x)
   x = layers.Activation('relu')(x)
 
@@ -157,7 +153,6 @@ def conv_block(input_tensor,
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
@@ -169,7 +164,6 @@ def conv_block(input_tensor,
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name=bn_name_base + '2c')(x)
 
   shortcut = layers.Conv2D(filters3, (1, 1), strides=strides, use_bias=False,
@@ -180,7 +174,6 @@ def conv_block(input_tensor,
                                        scale=False,
                                        momentum=BATCH_NORM_DECAY,
                                        epsilon=BATCH_NORM_EPSILON,
-                                       fused=True,
                                        name=bn_name_base + '1')(shortcut)
 
   x = layers.add([x, shortcut])
@@ -221,7 +214,6 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                                 scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
-                                fused=True,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
   x = layers.MaxPooling2D((3, 3), strides=(2, 2), padding='same')(x)

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -69,8 +69,10 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2a')(input_tensor)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2a')(x)
   x = layers.Activation('relu')(x)
 
@@ -80,8 +82,10 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2b')(x)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
@@ -90,8 +94,10 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2c')(x)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2c')(x)
 
   x = layers.add([x, input_tensor])
@@ -136,8 +142,10 @@ def conv_block(input_tensor,
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2a')(input_tensor)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2a')(x)
   x = layers.Activation('relu')(x)
 
@@ -146,8 +154,10 @@ def conv_block(input_tensor,
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2b')(x)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2b')(x)
   x = layers.Activation('relu')(x)
 
@@ -156,8 +166,10 @@ def conv_block(input_tensor,
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name=conv_name_base + '2c')(x)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name=bn_name_base + '2c')(x)
 
   shortcut = layers.Conv2D(filters3, (1, 1), strides=strides, use_bias=False,
@@ -165,8 +177,10 @@ def conv_block(input_tensor,
                            kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                            name=conv_name_base + '1')(input_tensor)
   shortcut = layers.BatchNormalization(axis=bn_axis,
+                                       scale=False,
                                        momentum=BATCH_NORM_DECAY,
                                        epsilon=BATCH_NORM_EPSILON,
+                                       fused=True,
                                        name=bn_name_base + '1')(shortcut)
 
   x = layers.add([x, shortcut])
@@ -204,8 +218,10 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                     kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                     name='conv1')(x)
   x = layers.BatchNormalization(axis=bn_axis,
+                                scale=False,
                                 momentum=BATCH_NORM_DECAY,
                                 epsilon=BATCH_NORM_EPSILON,
+                                fused=True,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
   x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -224,6 +224,7 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
                                 fused=True,
                                 name='bn_conv1')(x)
   x = layers.Activation('relu')(x)
+  x = layers.ZeroPadding2D(padding=(1, 1), name='pool1_pad')(x)
   x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
 
   x = conv_block(x, 3, [64, 64, 256], stage=2, block='a', strides=(1, 1))


### PR DESCRIPTION
* Enable CuDNN BatchNorm spatial persistent by default

* Consistently set `scale=False` and `fused=True` in all the batchnorm layers.

* Also, replace the zero padding layer with a padding attribute in max pooling layer. Zero padding adds both forward and backprop (Split) ops, each taking 1.5--2ms. Now the overhead is removed.