### PR TITLE
Support fp16 in estimator NCF model

### DIFF
--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -108,6 +108,8 @@ def parse_flags(flags_obj):
           flags_obj.clone_model_in_keras_dist_strat,
       "epochs_between_evals": FLAGS.epochs_between_evals,
       "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
+      "dtype": flags_obj.dtype,
+      "loss_scale": flags_obj.loss_scale,
   }
 
 
@@ -163,7 +165,7 @@ def define_ncf_flags():
       intra_op=False,
       synthetic_data=True,
       max_train_steps=False,
-      dtype=False,
+      dtype=True,
       all_reduce_alg=False
   )
   flags_core.define_device(tpu=True)

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -23,6 +23,7 @@ from absl import flags
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.resnet import imagenet_main
+from official.resnet import resnet_run_loop
 from official.resnet.keras import keras_common
 from official.resnet.keras import resnet_model
 from official.resnet.keras import trivial_model
@@ -174,7 +175,7 @@ def run(flags_obj):
       # TODO(reedwm): Remove manually wrapping optimizer once mixed precision
       # can be enabled with a single line of code.
       optimizer = tf.keras.mixed_precision.experimental.LossScaleOptimizer(
-          optimizer, loss_scale=flags_core.get_loss_scale(flags_obj))
+          optimizer, loss_scale=resnet_run_loop.get_loss_scale(flags_obj))
 
     if flags_obj.enable_xla and not flags_obj.enable_eager:
       # TODO(b/129861005): Fix OOM issue in eager mode when setting

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -513,6 +513,18 @@ def resnet_model_fn(features, labels, mode, model_class,
       eval_metric_ops=metrics)
 
 
+def get_loss_scale(flags_obj):
+  if flags_obj.loss_scale == "dynamic":
+    return flags_obj.loss_scale
+  elif flags_obj.loss_scale is not None:
+    return float(flags_obj.loss_scale)
+  elif flags_obj.dtype == "fp16":
+    return 128
+  else:
+    assert flags_obj.dtype == "fp32"
+    return 1
+
+
 def resnet_main(
     flags_obj, model_function, input_function, dataset_name, shape=None):
   """Shared main loop for ResNet Models.
@@ -582,7 +594,7 @@ def resnet_main(
           'data_format': flags_obj.data_format,
           'batch_size': flags_obj.batch_size,
           'resnet_version': int(flags_obj.resnet_version),
-          'loss_scale': flags_core.get_loss_scale(flags_obj),
+          'loss_scale': get_loss_scale(flags_obj),
           'dtype': flags_core.get_tf_dtype(flags_obj),
           'fine_tune': flags_obj.fine_tune,
           'num_workers': num_workers,

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -26,10 +26,10 @@ import tensorflow as tf   # pylint: disable=g-bad-import-order
 from official.utils.flags._conventions import help_wrap
 
 
-# Map string to (TensorFlow dtype, default loss scale)
+# Map string to TensorFlow dtype
 DTYPE_MAP = {
-    "fp16": (tf.float16, 128),
-    "fp32": (tf.float32, 1),
+    "fp16": tf.float16,
+    "fp32": tf.float32,
 }
 
 
@@ -38,15 +38,7 @@ def get_tf_dtype(flags_obj):
     # If the graph_rewrite is used, we build the graph with fp32, and let the
     # graph rewrite change ops to fp16.
     return tf.float32
-  return DTYPE_MAP[flags_obj.dtype][0]
-
-
-def get_loss_scale(flags_obj):
-  if flags_obj.loss_scale == "dynamic":
-    return flags_obj.loss_scale
-  elif flags_obj.loss_scale is not None:
-    return float(flags_obj.loss_scale)
-  return DTYPE_MAP[flags_obj.dtype][1]
+  return DTYPE_MAP[flags_obj.dtype]
 
 
 def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
@@ -144,8 +136,7 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
       loss_scale_help_text = loss_scale_help_text.format(
           "This can be an int/float or the string 'dynamic'",
           " The string 'dynamic' can be used to dynamically determine the "
-          "optimal loss scale during training, but currently this "
-          "significantly slows down performance")
+          "optimal loss scale during training")
       loss_scale_validation_msg = ("loss_scale should be a positive int/float "
                                    "or the string 'dynamic'.")
     else:

--- a/official/utils/flags/core.py
+++ b/official/utils/flags/core.py
@@ -83,6 +83,5 @@ help_wrap = _conventions.help_wrap
 
 get_num_gpus = _base.get_num_gpus
 get_tf_dtype = _performance.get_tf_dtype
-get_loss_scale = _performance.get_loss_scale
 DTYPE_MAP = _performance.DTYPE_MAP
 require_cloud_storage = _device.require_cloud_storage

--- a/official/utils/flags/flags_test.py
+++ b/official/utils/flags/flags_test.py
@@ -83,17 +83,7 @@ class BaseTester(unittest.TestCase):
     for dtype_str, tf_dtype, loss_scale in [["fp16", tf.float16, 128],
                                             ["fp32", tf.float32, 1]]:
       flags_core.parse_flags([__file__, "--dtype", dtype_str])
-
       self.assertEqual(flags_core.get_tf_dtype(flags.FLAGS), tf_dtype)
-      self.assertEqual(flags_core.get_loss_scale(flags.FLAGS), loss_scale)
-
-      flags_core.parse_flags(
-          [__file__, "--dtype", dtype_str, "--loss_scale", "5"])
-      self.assertEqual(flags_core.get_loss_scale(flags.FLAGS), 5)
-
-      flags_core.parse_flags(
-          [__file__, "--dtype", dtype_str, "--loss_scale", "dynamic"])
-      self.assertEqual(flags_core.get_loss_scale(flags.FLAGS), "dynamic")
 
     with self.assertRaises(SystemExit):
       flags_core.parse_flags([__file__, "--dtype", "int8"])


### PR DESCRIPTION
fp16 is added with the new `tf.train.experimental.enable_mixed_precision_graph_rewrite` function.

Note: I moved the `get_loss_scale` function from _performance.py to resnet_run_loop.py, and added a similar function to the NCF model. This is because the default loss scale should be different for each model.

To test convergence, I ran:

```
python ncf_estimator_main.py --model_dir ~/ncf_model_dir --data_dir ~/ncf_data_dir --dataset=ml-20m --hooks= --num_gpus=1 --clean --train_epochs=14 --batch_size=98340 --learning_rate=0.00382059 --beta1=0.783529 --beta2=0.909003 --epsilon=1.45439e-07 --layers=256,256,128,64 --num_factors=64 --hr_threshold=0.635 --ml_perf --dtype=fp16
```
I got an HR of 0.6371 on epoch 8.

Performance gain is modest: From about 67 steps/sec to 75 steps/sec with a batch size of 98340 on a V100.

