### PR TITLE
Use TensorFlow ops for Keras LearningRateSchedule

### DIFF
--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -119,6 +119,7 @@ class PiecewiseConstantDecayWithWarmup(
     return self.cached_learning_rate_op
 
   def _get_learning_rate(self, step):
+    """Compute learning rate at given step."""
     with tf.name_scope(self.name, 'PiecewiseConstantDecayWithWarmup', [
         self.rescaled_lr, self.step_boundaries, self.lr_values,
         self.warmup_steps, self.compute_lr_on_cpu]):

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -35,7 +35,6 @@ from official.utils.misc import model_helpers
 LR_SCHEDULE = [    # (multiplier, epoch to start) tuples
     (1.0, 5), (0.1, 30), (0.01, 60), (0.001, 80)
 ]
-TRAIN_EPOCH_SIZE = 1281167
 
 
 def learning_rate_schedule(current_epoch,
@@ -175,7 +174,7 @@ def run(flags_obj):
   if flags_obj.use_tensor_lr:
     lr_schedule = keras_common.PiecewiseConstantDecayWithWarmup(
         batch_size=flags_obj.batch_size,
-        epoch_size=TRAIN_EPOCH_SIZE,
+        epoch_size=imagenet_main.NUM_IMAGES['train'],
         warmup_epochs=LR_SCHEDULE[0][1],
         boundaries=list(p[1] for p in LR_SCHEDULE[1:]),
         multipliers=list(p[0] for p in LR_SCHEDULE),

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -172,16 +172,14 @@ def run(flags_obj):
         drop_remainder=drop_remainder)
 
   lr_schedule = 0.1
-  if flags_obj.use_tensor_lr:  # HZDEBUG
+  if flags_obj.use_tensor_lr:
     lr_schedule = keras_common.PiecewiseConstantDecayWithWarmup(
         batch_size=flags_obj.batch_size,
         epoch_size=TRAIN_EPOCH_SIZE,
         warmup_epochs=LR_SCHEDULE[0][1],
         boundaries=list(p[1] for p in LR_SCHEDULE[1:]),
-        multipliers=list(p[0] for p in LR_SCHEDULE))
-    # lr_schedule = tf.keras.optimizers.schedules.PiecewiseConstantDecay(
-    #     boundaries=list(p[1] * 1.0 for p in LR_SCHEDULE[1:]),
-    #     values=list(p[0] * 0.1 for p in LR_SCHEDULE))
+        multipliers=list(p[0] for p in LR_SCHEDULE),
+        compute_lr_on_cpu=True)
 
   with strategy_scope:
     optimizer = keras_common.get_optimizer(lr_schedule)


### PR DESCRIPTION
Create a piecewise learning rate schedule with warmup class and use it for in-graph learning rate computation. This change overlaps the learning rate calculation and assignment with other function execution and reduce the gaps between steps due to slow callbacks.