### PR TITLE
Adds keras imagenet benchmarks which use tf.data's `experimental_slack` option.

### DIFF
--- a/official/resnet/imagenet_main.py
+++ b/official/resnet/imagenet_main.py
@@ -168,7 +168,9 @@ def input_fn(is_training,
              num_parallel_batches=1,
              parse_record_fn=parse_record,
              input_context=None,
-             drop_remainder=False):
+             drop_remainder=False,
+             tf_data_experimental_slack=False,
+             ):
   """Input function which provides batches for train or eval.
 
   Args:
@@ -184,6 +186,8 @@ def input_fn(is_training,
       `tf.distribute.Strategy`.
     drop_remainder: A boolean indicates whether to drop the remainder of the
       batches. If True, the batch dimension will be static.
+    tf_data_experimental_slack: Whether to enable tf.data's
+      `experimental_slack` option.
 
   Returns:
     A dataset that can be used for iteration.
@@ -221,7 +225,8 @@ def input_fn(is_training,
       dtype=dtype,
       datasets_num_private_threads=datasets_num_private_threads,
       num_parallel_batches=num_parallel_batches,
-      drop_remainder=drop_remainder
+      drop_remainder=drop_remainder,
+      tf_data_experimental_slack=tf_data_experimental_slack,
   )
 
 

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -285,7 +285,7 @@ def define_keras_flags():
       'Note that profiler has a non-trivial performance overhead, and the '
       'output file can be gigantic if profiling many steps.')
   flags.DEFINE_boolean(
-      name='data_prefetch_with_slack', default=False,
+      name='data_delay_prefetch', default=False,
       help='Add a small delay in tf.data prefetch to prioritize memory copy of '
       'other tensors over the data minibatch for the (T+1)th step. It should '
       'help improve performance using EagerIterator and function. The codepath '
@@ -356,7 +356,7 @@ def is_v2_0():
   return tf.__version__.startswith('2')
 
 
-def data_prefetch_with_slack():
+def data_delay_prefetch():
   """Use unstable code for perf tuning purposes."""
   if not FLAGS.use_synthetic_data:
     _monkey_patch_org_create_device_dataset()

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -280,7 +280,23 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.dtype = 'fp16'
     FLAGS.batch_size = 256
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_1_gpu_fp16_tfdata_exp(self):
+    """Test Keras model with XLA, 1 GPU, fp16, and experimental tf.data
+       functionality."""
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_1_gpu_fp16_tfdata_exp')
+    FLAGS.dtype = 'fp16'
+    FLAGS.batch_size = 256
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_1_gpu_fp16_dynamic(self):
@@ -362,6 +378,24 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
+  def benchmark_graph_xla_1_gpu_fp16_tfdata_exp(self):
+    """Test Keras model in legacy graph mode with 1 GPU, fp16, XLA, and
+       experimental tf.data functionality.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = False
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_graph_xla_1_gpu_fp16_tfdata_exp')
+    FLAGS.dtype = 'fp16'
+    FLAGS.batch_size = 256
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
+    self._run_and_report_benchmark()
+
   def benchmark_8_gpu(self):
     """Test Keras model with 8 GPUs."""
     self._setup()
@@ -395,7 +429,20 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tweaked')
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     FLAGS.datasets_num_private_threads = 14
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_tfdata_exp(self):
+    """Test Keras model with experimental tf.data functionality and 8 GPUs."""
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
+    FLAGS.batch_size = 128 * 8  # 8 GPUs
+    FLAGS.datasets_num_private_threads = 14
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu(self):
@@ -423,7 +470,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     self._run_and_report_benchmark()
 
   def benchmark_8_gpu_fp16_tweaked(self):
-    """Test Keras model with 8 GPUs and fp16."""
+    """Test Keras model with 8 GPUs, fp16, and manual config tuning."""
     self._setup()
 
     FLAGS.num_gpus = 8
@@ -433,11 +480,29 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_fp16_tweaked')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_fp16_tfdata_exp(self):
+    """Test Keras model with 8 GPUs, fp16, and experimental tf.data 
+       functionality.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_fp16_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_8_gpu_fp16_dynamic_tweaked(self):
-    """Test Keras model with 8 GPUs, fp16, and dynamic loss scaling."""
+    """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and manual
+       config tuning.
+    """
     self._setup()
 
     FLAGS.num_gpus = 8
@@ -449,7 +514,25 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_fp16_dynamic_tfdata_exp(self):
+    """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and
+       experimental tf.data functionality.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_8_gpu_fp16_dynamic_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.loss_scale = 'dynamic'
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_fp16(self):
@@ -477,7 +560,24 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_fp16_tweaked')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     # FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_8_gpu_fp16_tfdata_exp(self):
+    """Test Keras model with experimental tf.data functionality, XLA, 8 GPUs
+       and fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_fp16_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    # FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_fp16_dynamic_tweaked(self):
@@ -494,7 +594,26 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_8_gpu_fp16_dynamic_tfdata_exp(self):
+    """Test Keras model with experimental tf.data functionality, XLA, 8 GPUs 
+       and dynamic fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_xla_8_gpu_fp16_dynamic_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.loss_scale = 'dynamic'
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_fp16_tensorboard_tweaked(self):
@@ -510,7 +629,24 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_xla_8_gpu_fp16_tensorboard_tweaked')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    FLAGS.enable_tensorboard = True
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_8_gpu_fp16_tensorboard_tfdata_exp(self):
+    """Test to track Tensorboard performance overhead."""
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_xla_8_gpu_fp16_tensorboard_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     FLAGS.enable_tensorboard = True
     self._run_and_report_benchmark()
 
@@ -577,6 +713,22 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
+  def benchmark_graph_8_gpu_fp16_tfdata_exp(self):
+    """Test Keras model in legacy graph mode with experimental tf.data
+       functionality, 8 GPUs and fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = False
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_fp16_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
+    self._run_and_report_benchmark()
+
   def benchmark_graph_xla_8_gpu_fp16_tweaked(self):
     """Test Keras model in legacy graph mode with manual config tuning, XLA,
        8 GPUs and fp16.
@@ -594,6 +746,24 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
+  def benchmark_graph_xla_8_gpu_fp16_tfdata_exp(self):
+    """Test Keras model in legacy graph mode with experimental tf.data 
+       functionality, XLA, 8 GPUs and fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = False
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_graph_xla_8_gpu_fp16_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
+    self._run_and_report_benchmark()
+
   def benchmark_graph_8_gpu_fp16_dynamic_tweaked(self):
     """Test graph Keras with config tuning, 8 GPUs and dynamic fp16."""
     self._setup()
@@ -607,6 +777,24 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    self._run_and_report_benchmark()
+
+  def benchmark_graph_8_gpu_fp16_dynamic_tfdata_exp(self):
+    """Test graph Keras with experimental tf.data functionality, 8 GPUs and 
+       dynamic fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = False
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_graph_8_gpu_fp16_dynamic_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.loss_scale = 'dynamic'
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_graph_xla_8_gpu_fp16_dynamic_tweaked(self):
@@ -623,6 +811,25 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    self._run_and_report_benchmark()
+
+  def benchmark_graph_xla_8_gpu_fp16_dynamic_tfdata_exp(self):
+    """Test graph Keras with experimental tf.data functionality, XLA, 8 GPUs 
+       and dynamic fp16.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = False
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_graph_xla_8_gpu_fp16_dynamic_tfdata_exp')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.loss_scale = 'dynamic'
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def fill_report_object(self, stats):
@@ -745,7 +952,21 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tweaked')
     FLAGS.batch_size = 256 * 8
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.data_prefetch_with_slack = True
+    FLAGS.data_delay_prefetch = True
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_tfdata_exp(self):
+    """Test trivial Keras model (input pipeline) with manual config tuning and
+       8 GPUs.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.enable_eager = True
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
+    FLAGS.batch_size = 256 * 8
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_graph_8_gpu(self):
@@ -771,6 +992,20 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_tweaked')
     FLAGS.batch_size = 256 * 8
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    self._run_and_report_benchmark()
+
+  def benchmark_graph_8_gpu_tfdata_exp(self):
+    """Test trivial Keras model (input pipeline) in legacy graph mode with
+       manual config tuning and 8 GPUs.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.enable_eager = False
+    FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_tfdata_exp')
+    FLAGS.batch_size = 256 * 8
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def fill_report_object(self, stats):

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -283,8 +283,8 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
-  def benchmark_xla_1_gpu_fp16_tfdata_exp(self):
-    """Test Keras model with XLA, 1 GPU, fp16, and experimental tf.data
+  def benchmark_xla_1_gpu_fp16_slack(self):
+    """Test Keras model with XLA, 1 GPU, fp16, and tf.data's experimental_slack
        functionality."""
     self._setup()
 
@@ -292,7 +292,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     FLAGS.enable_xla = True
     FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_xla_1_gpu_fp16_tfdata_exp')
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_1_gpu_fp16_slack')
     FLAGS.dtype = 'fp16'
     FLAGS.batch_size = 256
     FLAGS.tf_data_experimental_slack = True
@@ -377,9 +377,9 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
-  def benchmark_graph_xla_1_gpu_fp16_tfdata_exp(self):
+  def benchmark_graph_xla_1_gpu_fp16_slack(self):
     """Test Keras model in legacy graph mode with 1 GPU, fp16, XLA, and
-       experimental tf.data functionality.
+       tf.data's experimental_slack functionality.
     """
     self._setup()
 
@@ -388,7 +388,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_xla = True
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir(
-        'benchmark_graph_xla_1_gpu_fp16_tfdata_exp')
+        'benchmark_graph_xla_1_gpu_fp16_slack')
     FLAGS.dtype = 'fp16'
     FLAGS.batch_size = 256
     FLAGS.tf_data_experimental_slack = True
@@ -430,14 +430,14 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
-  def benchmark_8_gpu_tfdata_exp(self):
-    """Test Keras model with experimental tf.data functionality and 8 GPUs."""
+  def benchmark_8_gpu_slack(self):
+    """Test Keras model with tf.data's experimental_slack and 8 GPUs."""
     self._setup()
 
     FLAGS.num_gpus = 8
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_slack')
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
@@ -480,21 +480,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
-  def benchmark_8_gpu_fp16_tfdata_exp(self):
-    """Test Keras model with 8 GPUs, fp16, and experimental tf.data 
-       functionality.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_fp16_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_data_experimental_slack = True
-    self._run_and_report_benchmark()
-
   def benchmark_8_gpu_fp16_dynamic_tweaked(self):
     """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and manual
        config tuning.
@@ -511,23 +496,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.data_delay_prefetch = True
-    self._run_and_report_benchmark()
-
-  def benchmark_8_gpu_fp16_dynamic_tfdata_exp(self):
-    """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and
-       experimental tf.data functionality.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir(
-        'benchmark_8_gpu_fp16_dynamic_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_fp16(self):
@@ -558,9 +526,9 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
-  def benchmark_xla_8_gpu_fp16_tfdata_exp(self):
-    """Test Keras model with experimental tf.data functionality, XLA, 8 GPUs
-       and fp16.
+  def benchmark_xla_8_gpu_fp16_slack(self):
+    """Test Keras model with tf.data's experimental_slack functionality, XLA,
+       8 GPUs and fp16.
     """
     self._setup()
 
@@ -569,7 +537,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     FLAGS.enable_xla = True
     FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_fp16_tfdata_exp')
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_fp16_slack')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
@@ -589,24 +557,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.data_delay_prefetch = True
-    self._run_and_report_benchmark()
-
-  def benchmark_xla_8_gpu_fp16_dynamic_tfdata_exp(self):
-    """Test Keras model with experimental tf.data functionality, XLA, 8 GPUs 
-       and dynamic fp16.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = True
-    FLAGS.enable_xla = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir(
-        'benchmark_xla_8_gpu_fp16_dynamic_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_fp16_tensorboard_tweaked(self):
@@ -689,21 +639,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
-  def benchmark_graph_8_gpu_fp16_tfdata_exp(self):
-    """Test Keras model in legacy graph mode with experimental tf.data
-       functionality, 8 GPUs and fp16.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = False
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_fp16_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_data_experimental_slack = True
-    self._run_and_report_benchmark()
-
   def benchmark_graph_xla_8_gpu_fp16_tweaked(self):
     """Test Keras model in legacy graph mode with manual config tuning, XLA,
        8 GPUs and fp16.
@@ -721,8 +656,8 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
-  def benchmark_graph_xla_8_gpu_fp16_tfdata_exp(self):
-    """Test Keras model in legacy graph mode with experimental tf.data 
+  def benchmark_graph_xla_8_gpu_fp16_slack(self):
+    """Test Keras model in legacy graph mode with tf.data's experimental_slack
        functionality, XLA, 8 GPUs and fp16.
     """
     self._setup()
@@ -733,7 +668,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.enable_xla = True
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir(
-        'benchmark_graph_xla_8_gpu_fp16_tfdata_exp')
+        'benchmark_graph_xla_8_gpu_fp16_slack')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
@@ -753,23 +688,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
-  def benchmark_graph_8_gpu_fp16_dynamic_tfdata_exp(self):
-    """Test graph Keras with experimental tf.data functionality, 8 GPUs and 
-       dynamic fp16.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = False
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir(
-        'benchmark_graph_8_gpu_fp16_dynamic_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_data_experimental_slack = True
-    self._run_and_report_benchmark()
-
   def benchmark_graph_xla_8_gpu_fp16_dynamic_tweaked(self):
     """Test graph Keras with config tuning, XLA, 8 GPUs and dynamic fp16."""
     self._setup()
@@ -784,24 +702,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    self._run_and_report_benchmark()
-
-  def benchmark_graph_xla_8_gpu_fp16_dynamic_tfdata_exp(self):
-    """Test graph Keras with experimental tf.data functionality, XLA, 8 GPUs 
-       and dynamic fp16.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = False
-    FLAGS.enable_xla = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir(
-        'benchmark_graph_xla_8_gpu_fp16_dynamic_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def fill_report_object(self, stats):
@@ -927,15 +827,15 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
-  def benchmark_8_gpu_tfdata_exp(self):
-    """Test trivial Keras model (input pipeline) with manual config tuning and
-       8 GPUs.
+  def benchmark_8_gpu_slack(self):
+    """Test trivial Keras model (input pipeline) with tf.data's
+       experimental_slack and 8 GPUs.
     """
     self._setup()
 
     FLAGS.num_gpus = 8
     FLAGS.enable_eager = True
-    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_slack')
     FLAGS.batch_size = 256 * 8
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
@@ -963,19 +863,6 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_tweaked')
     FLAGS.batch_size = 256 * 8
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    self._run_and_report_benchmark()
-
-  def benchmark_graph_8_gpu_tfdata_exp(self):
-    """Test trivial Keras model (input pipeline) in legacy graph mode with
-       manual config tuning and 8 GPUs.
-    """
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.enable_eager = False
-    FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_tfdata_exp')
-    FLAGS.batch_size = 256 * 8
-    FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
   def fill_report_object(self, stats):

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -295,7 +295,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_xla_1_gpu_fp16_tfdata_exp')
     FLAGS.dtype = 'fp16'
     FLAGS.batch_size = 256
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -392,7 +391,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_graph_xla_1_gpu_fp16_tfdata_exp')
     FLAGS.dtype = 'fp16'
     FLAGS.batch_size = 256
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -441,7 +439,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
     FLAGS.batch_size = 128 * 8  # 8 GPUs
-    FLAGS.datasets_num_private_threads = 14
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -495,7 +492,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_fp16_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -531,7 +527,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_8_gpu_fp16_dynamic_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -576,7 +571,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_fp16_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
-    # FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -612,7 +606,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_xla_8_gpu_fp16_dynamic_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -630,23 +623,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.data_delay_prefetch = True
-    FLAGS.enable_tensorboard = True
-    self._run_and_report_benchmark()
-
-  def benchmark_xla_8_gpu_fp16_tensorboard_tfdata_exp(self):
-    """Test to track Tensorboard performance overhead."""
-    self._setup()
-
-    FLAGS.num_gpus = 8
-    FLAGS.dtype = 'fp16'
-    FLAGS.enable_eager = True
-    FLAGS.enable_xla = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir(
-        'benchmark_xla_8_gpu_fp16_tensorboard_tfdata_exp')
-    FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.tf_data_experimental_slack = True
     FLAGS.enable_tensorboard = True
     self._run_and_report_benchmark()
 
@@ -725,7 +701,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_fp16_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -760,7 +735,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.model_dir = self._get_model_dir(
         'benchmark_graph_xla_8_gpu_fp16_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -793,7 +767,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_graph_8_gpu_fp16_dynamic_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -828,7 +801,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         'benchmark_graph_xla_8_gpu_fp16_dynamic_tfdata_exp')
     FLAGS.batch_size = 256 * 8  # 8 GPUs
     FLAGS.loss_scale = 'dynamic'
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -965,7 +937,6 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = True
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_tfdata_exp')
     FLAGS.batch_size = 256 * 8
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 
@@ -1004,7 +975,6 @@ class TrivialKerasBenchmarkReal(keras_benchmark.KerasBenchmark):
     FLAGS.enable_eager = False
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_8_gpu_tfdata_exp')
     FLAGS.batch_size = 256 * 8
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
     FLAGS.tf_data_experimental_slack = True
     self._run_and_report_benchmark()
 

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -107,8 +107,8 @@ def run(flags_obj):
   # Execute flag override logic for better model performance
   if flags_obj.tf_gpu_thread_mode:
     keras_common.set_gpu_thread_mode_and_count(flags_obj)
-  if flags_obj.data_prefetch_with_slack:
-    keras_common.data_prefetch_with_slack()
+  if flags_obj.data_delay_prefetch:
+    keras_common.data_delay_prefetch()
   keras_common.set_cudnn_batchnorm_mode()
 
   dtype = flags_core.get_tf_dtype(flags_obj)

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -157,7 +157,9 @@ def run(flags_obj):
       parse_record_fn=parse_record_keras,
       datasets_num_private_threads=flags_obj.datasets_num_private_threads,
       dtype=dtype,
-      drop_remainder=drop_remainder)
+      drop_remainder=drop_remainder,
+      tf_data_experimental_slack=flags_obj.tf_data_experimental_slack,
+  )
 
   eval_input_dataset = None
   if not flags_obj.skip_eval:

--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -54,7 +54,9 @@ def process_record_dataset(dataset,
                            dtype=tf.float32,
                            datasets_num_private_threads=None,
                            num_parallel_batches=1,
-                           drop_remainder=False):
+                           drop_remainder=False,
+                           tf_data_experimental_slack=False,
+                           ):
   """Given a Dataset with raw records, return an iterator over the records.
 
   Args:
@@ -73,6 +75,8 @@ def process_record_dataset(dataset,
     num_parallel_batches: Number of parallel batches for tf.data.
     drop_remainder: A boolean indicates whether to drop the remainder of the
       batches. If True, the batch dimension will be static.
+    tf_data_experimental_slack: Whether to enable tf.data's
+      `experimental_slack` option.
 
   Returns:
     Dataset of (image, label) pairs ready for iteration.
@@ -114,6 +118,11 @@ def process_record_dataset(dataset,
   # allows DistributionStrategies to adjust how many batches to fetch based
   # on how many devices are present.
   dataset = dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)
+
+  if tf_data_experimental_slack:
+    options = tf.data.Options()
+    options.experimental_slack = True
+    dataset = dataset.with_options(options)
 
   return dataset
 
@@ -722,7 +731,9 @@ def define_resnet_flags(resnet_size_choices=None, dynamic_loss_scale=False,
                                 datasets_num_private_threads=True,
                                 datasets_num_parallel_batches=True,
                                 dynamic_loss_scale=dynamic_loss_scale,
-                                fp16_implementation=fp16_implementation)
+                                fp16_implementation=fp16_implementation,
+                                tf_data_experimental_slack=True,
+                                )
   flags_core.define_image()
   flags_core.define_benchmark()
   flags.adopt_module_key_flags(flags_core)

--- a/official/utils/flags/_performance.py
+++ b/official/utils/flags/_performance.py
@@ -55,7 +55,8 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
                        tf_gpu_thread_mode=False,
                        datasets_num_private_threads=False,
                        datasets_num_parallel_batches=False,
-                       dynamic_loss_scale=False, fp16_implementation=False):
+                       dynamic_loss_scale=False, fp16_implementation=False,
+                       tf_data_experimental_slack=False):
   """Register flags for specifying performance tuning arguments.
 
   Args:
@@ -76,6 +77,8 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
     dynamic_loss_scale: Allow the "loss_scale" flag to take on the value
       "dynamic". Only valid if `dtype` is True.
     fp16_implementation: Create fp16_implementation flag.
+    tf_data_experimental_slack: Determines whether to enable tf.data's
+      `experimental_slack` option.
 
   Returns:
     A list of flags for core.py to marks as key flags.
@@ -248,6 +251,14 @@ def define_performance(num_parallel_calls=True, inter_op=True, intra_op=True,
         help=help_wrap(
             "Determines how many batches to process in parallel when using "
             "map and batch from tf.data.")
+    )
+
+  if tf_data_experimental_slack:
+    flags.DEFINE_boolean(
+        name="tf_data_experimental_slack",
+        default=False,
+        help=help_wrap(
+            "Whether to enable tf.data's `experimental_slack` option.")
     )
 
   return key_flags


### PR DESCRIPTION
- Adds benchmarks to keras_imagenet_benchmark (suffixed with `tfdata_exp`) that have tf_data_experimental_slack enabled, for both graph and eager mode benchmarks. 
- Adds flag `tf_data_experimental_slack` to resnet -- when True, enables tf.data's experimental_slack option on the input pipeline. 
- Renames old flag `data_prefetch_with_slack` to `data_delay_prefetch` (i.e. temporary hack) to better disambiguate the two flags.