### PR TITLE
Fix: added missing input argument to export_tflite_ssd_graph.py

### DIFF
--- a/research/object_detection/export_tflite_ssd_graph.py
+++ b/research/object_detection/export_tflite_ssd_graph.py
@@ -136,7 +136,8 @@ def main(argv):
   export_tflite_ssd_graph_lib.export_tflite_graph(
       pipeline_config, FLAGS.trained_checkpoint_prefix, FLAGS.output_directory,
       FLAGS.add_postprocessing_op, FLAGS.max_detections,
-      FLAGS.max_classes_per_detection, FLAGS.use_regular_nms)
+      FLAGS.max_classes_per_detection, FLAGS.detections_per_class,
+      FLAGS.use_regular_nms)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In file `export_tflite_ssd_graph.py` input argument `detections_per_class` was missed whereas there is a flag which indicates this argument. 

This fix added missing input parameter