### PR TITLE
Do not return immediately after train_and_evaluate.

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -654,7 +654,7 @@ def resnet_main(
     tf.estimator.train_and_evaluate(classifier, train_spec, eval_spec)
     # tf.estimator.train_and_evalute doesn't return anything in multi-worker
     # case.
-    return {}
+    eval_results = {}
   else:
     if train_epochs == 0:
       # If --eval_only is set, perform a single loop with zero train epochs.


### PR DESCRIPTION
This change will lead to a consistent return value from `resnet_main`.  The `eval_results` will be empty in the case of `train_and_evaluate`.