### PR TITLE
Include flags when reporting benchmark.

### DIFF
--- a/official/resnet/estimator_benchmark.py
+++ b/official/resnet/estimator_benchmark.py
@@ -26,6 +26,7 @@ import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 from official.resnet import cifar10_main as cifar_main
 from official.resnet import imagenet_main
+from official.utils.flags import core as flags_core
 from official.utils.logs import hooks
 
 IMAGENET_DATA_DIR_NAME = 'imagenet'
@@ -106,10 +107,12 @@ class EstimatorBenchmark(tf.test.Benchmark):
       exp_per_sec = sum(exp_per_second_list) / (len(exp_per_second_list))
       metrics.append({'name': 'exp_per_second',
                       'value': exp_per_sec})
+    flags_str = flags_core.get_nondefault_flags_as_str()
     self.report_benchmark(
         iters=eval_results['global_step'],
         wall_time=wall_time_sec,
-        metrics=metrics)
+        metrics=metrics,
+        extras={'flags': flags_str})
 
 
 class Resnet50EstimatorAccuracy(EstimatorBenchmark):

--- a/official/utils/flags/flags_test.py
+++ b/official/utils/flags/flags_test.py
@@ -102,6 +102,45 @@ class BaseTester(unittest.TestCase):
       flags_core.parse_flags([__file__, "--dtype", "fp16",
                               "--loss_scale", "abc"])
 
+  def test_get_nondefault_flags_as_str(self):
+    defaults = dict(
+        clean=True,
+        data_dir="abc",
+        hooks=["LoggingTensorHook"],
+        stop_threshold=1.5,
+        use_synthetic_data=False
+    )
+    flags_core.set_defaults(**defaults)
+    flags_core.parse_flags()
+
+    expected_flags = ""
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    flags.FLAGS.clean = False
+    expected_flags += "--noclean"
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    flags.FLAGS.data_dir = "xyz"
+    expected_flags += " --data_dir=xyz"
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    flags.FLAGS.hooks = ["aaa", "bbb", "ccc"]
+    expected_flags += " --hooks=aaa,bbb,ccc"
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    flags.FLAGS.stop_threshold = 3.
+    expected_flags += " --stop_threshold=3.0"
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    flags.FLAGS.use_synthetic_data = True
+    expected_flags += " --use_synthetic_data"
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
+
+    # Assert that explicit setting a flag to its default value does not cause it
+    # to appear in the string
+    flags.FLAGS.use_synthetic_data = False
+    expected_flags = expected_flags[:-len(" --use_synthetic_data")]
+    self.assertEqual(flags_core.get_nondefault_flags_as_str(), expected_flags)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This will allow one to easily reproduce a benchmark by running with the flags.