### PR TITLE
Handle empty eval results in estimator_benchmark.

### DIFF
--- a/official/resnet/estimator_benchmark.py
+++ b/official/resnet/estimator_benchmark.py
@@ -109,7 +109,7 @@ class EstimatorBenchmark(tf.test.Benchmark):
                       'value': exp_per_sec})
     flags_str = flags_core.get_nondefault_flags_as_str()
     self.report_benchmark(
-        iters=eval_results['global_step'],
+        iters=eval_results.get('global_step', None),
         wall_time=wall_time_sec,
         metrics=metrics,
         extras={'flags': flags_str})

--- a/official/resnet/estimator_benchmark.py
+++ b/official/resnet/estimator_benchmark.py
@@ -309,8 +309,8 @@ class Resnet50EstimatorBenchmark(EstimatorBenchmark):
     wall_time_sec = time.time() - start_time_sec
     print(stats)
     # Remove values to skip triggering accuracy check.
-    del stats['eval_results']['accuracy']
-    del stats['eval_results']['accuracy_top_5']
+    stats['eval_results'].pop('accuracy', None)
+    stats['eval_results'].pop('accuracy_top_5', None)
 
     self._report_benchmark(stats,
                            wall_time_sec)


### PR DESCRIPTION
MultiWorkerMirroredStrategy calls `train_and_evaluate` which does not return eval results like `classifier.evaluate`.  https://github.com/tensorflow/estimator/blob/9374304b02bd327126ba69c29f0d76353389357a/tensorflow_estimator/python/estimator/training.py#L448