### PR TITLE
update offline_eval_map_corloc.py

### DIFF
--- a/research/object_detection/metrics/offline_eval_map_corloc.py
+++ b/research/object_detection/metrics/offline_eval_map_corloc.py
@@ -159,7 +159,7 @@ def main(argv):
       eval_config_path=FLAGS.eval_config_path)
 
   eval_config = configs['eval_config']
-  input_config = configs['eval_input_config']
+  input_config = configs['eval_input_configs']
 
   metrics = read_data_and_evaluate(input_config, eval_config)
 


### PR DESCRIPTION
in config_util.get_configs_from_multiple_files, the key of the dict seems to be eval_input_configs instead of eval_input_config. (a 's' is missing)
found that while following the Inference and evaluation on the Open Images dataset tutorial.
I was getting the error :
input_config = configs['eval_input_config']
KeyError: 'eval_input_config'