### PR TITLE
Use more warmup steps for 96 core tests

### DIFF
--- a/official/resnet/keras/keras_benchmark.py
+++ b/official/resnet/keras/keras_benchmark.py
@@ -96,6 +96,12 @@ class KerasBenchmark(tf.test.Benchmark):
       num_examples = (
           total_batch_size * log_steps * (len(time_log) - warmup - 1))
       examples_per_sec = num_examples / elapsed
+      print('HZDEBUG: stats ---------------------------------------------------')
+      print('num_examples =', num_examples)
+      print('len(time_log) =', len(time_log))
+      print('time_log[-1].timestamp =', time_log[-1].timestamp)
+      print('time_log[warmup].timestamp =', time_log[warmup].timestamp)
+      print('stats =', stats)
       metrics.append({'name': 'exp_per_second',
                       'value': examples_per_sec})
 

--- a/official/resnet/keras/keras_benchmark.py
+++ b/official/resnet/keras/keras_benchmark.py
@@ -96,12 +96,6 @@ class KerasBenchmark(tf.test.Benchmark):
       num_examples = (
           total_batch_size * log_steps * (len(time_log) - warmup - 1))
       examples_per_sec = num_examples / elapsed
-      print('HZDEBUG: stats ---------------------------------------------------')
-      print('num_examples =', num_examples)
-      print('len(time_log) =', len(time_log))
-      print('time_log[-1].timestamp =', time_log[-1].timestamp)
-      print('time_log[warmup].timestamp =', time_log[warmup].timestamp)
-      print('stats =', stats)
       metrics.append({'name': 'exp_per_second',
                       'value': examples_per_sec})
 

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -173,7 +173,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     wall_time_sec = time.time() - start_time_sec
     # Number of logged step time entries that are excluded in performance
     # report. We keep results from last 100 batches in this case.
-    warmup = (FLAGS.train_steps - 100) / FLAGS.log_steps
+    warmup = (FLAGS.train_steps - 100) // FLAGS.log_steps
 
     super(Resnet50KerasBenchmarkBase, self)._report_benchmark(
         stats,

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -15,7 +15,6 @@
 """Executes Keras benchmarks and accuracy tests."""
 from __future__ import print_function
 
-import multiprocessing
 import os
 import time
 
@@ -573,6 +572,26 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.data_delay_prefetch = True
     self._run_and_report_benchmark()
 
+  def benchmark_xla_8_gpu_fp16_tweaked_delay_measure(self):
+    """Test Keras model with manual config tuning, XLA, 8 GPUs and fp16. Delay
+       performance measurement for stable performance on 96 vCPU platforms.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_xla_8_gpu_fp16_tweaked_delay_measure')
+    FLAGS.batch_size = 256 * 8  # 8 GPUs
+    FLAGS.use_tensor_lr = True
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.data_delay_prefetch = True
+    FLAGS.train_steps = 310
+    self._run_and_report_benchmark()
+
   def benchmark_xla_8_gpu_fp16_tweaked_optional_next(self):
     """Test Keras model with manual config tuning, XLA, 8 GPUs, fp16.
 
@@ -729,6 +748,26 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.tf_gpu_thread_mode = 'gpu_private'
     self._run_and_report_benchmark()
 
+  def benchmark_graph_xla_8_gpu_fp16_tweaked_delay_measure(self):
+    """Test Keras model in legacy graph mode with manual config tuning, XLA,
+       8 GPUs and fp16. Delay performance measurement for stable performance
+       on 96 vCPU platforms.
+    """
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = False
+    FLAGS.enable_xla = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_graph_xla_8_gpu_fp16_tweaked_delay_measure')
+    FLAGS.batch_size = 256 * 8
+    FLAGS.use_tensor_lr = True
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.train_steps = 310
+    self._run_and_report_benchmark()
+
   def benchmark_graph_xla_8_gpu_fp16_tweaked_optional_next(self):
     """Test Keras model in legacy graph mode with manual config tuning, XLA,
        8 GPUs and fp16.
@@ -815,8 +854,7 @@ class Resnet50KerasBenchmarkSynth(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['use_synthetic_data'] = True
-    # TODO(b/132970486): Giving more time to 96 core platform to stabilize.
-    def_flags['train_steps'] = 310 if multiprocessing.cpu_count() == 96 else 110
+    def_flags['train_steps'] = 110
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkSynth, self).__init__(
@@ -831,8 +869,7 @@ class Resnet50KerasBenchmarkReal(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['data_dir'] = os.path.join(root_data_dir, 'imagenet')
-    # TODO(b/132970486): Giving more time to 96 core platform to stabilize.
-    def_flags['train_steps'] = 310 if multiprocessing.cpu_count() == 96 else 110
+    def_flags['train_steps'] = 110
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkReal, self).__init__(

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -799,7 +799,8 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     super(Resnet50KerasBenchmarkBase, self).fill_report_object(
         stats,
         total_batch_size=FLAGS.batch_size,
-        log_steps=FLAGS.log_steps)
+        log_steps=FLAGS.log_steps,
+        warmup=20)
 
 
 class Resnet50KerasBenchmarkSynth(Resnet50KerasBenchmarkBase):
@@ -810,7 +811,7 @@ class Resnet50KerasBenchmarkSynth(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['use_synthetic_data'] = True
-    def_flags['train_steps'] = 110
+    def_flags['train_steps'] = 300
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkSynth, self).__init__(
@@ -825,7 +826,7 @@ class Resnet50KerasBenchmarkReal(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['data_dir'] = os.path.join(root_data_dir, 'imagenet')
-    def_flags['train_steps'] = 110
+    def_flags['train_steps'] = 300
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkReal, self).__init__(

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -175,7 +175,8 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
         stats,
         wall_time_sec,
         total_batch_size=FLAGS.batch_size,
-        log_steps=FLAGS.log_steps)
+        log_steps=FLAGS.log_steps,
+        warmup=20)
 
   def benchmark_1_gpu_no_dist_strat(self):
     """Test Keras model with 1 GPU, no distribution strategy."""
@@ -799,8 +800,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     super(Resnet50KerasBenchmarkBase, self).fill_report_object(
         stats,
         total_batch_size=FLAGS.batch_size,
-        log_steps=FLAGS.log_steps,
-        warmup=20)
+        log_steps=FLAGS.log_steps)
 
 
 class Resnet50KerasBenchmarkSynth(Resnet50KerasBenchmarkBase):
@@ -811,7 +811,7 @@ class Resnet50KerasBenchmarkSynth(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['use_synthetic_data'] = True
-    def_flags['train_steps'] = 300
+    def_flags['train_steps'] = 310
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkSynth, self).__init__(
@@ -826,7 +826,7 @@ class Resnet50KerasBenchmarkReal(Resnet50KerasBenchmarkBase):
     def_flags['skip_eval'] = True
     def_flags['report_accuracy_metrics'] = False
     def_flags['data_dir'] = os.path.join(root_data_dir, 'imagenet')
-    def_flags['train_steps'] = 300
+    def_flags['train_steps'] = 310
     def_flags['log_steps'] = 10
 
     super(Resnet50KerasBenchmarkReal, self).__init__(


### PR DESCRIPTION
Increase the number of warmup steps for 96 core platforms. Hope this can stabilize the reported performance.