### PR TITLE
Add custom training loop for transformer v2.

### DIFF
--- a/official/transformer/v2/misc.py
+++ b/official/transformer/v2/misc.py
@@ -148,20 +148,19 @@ def define_transformer_flags():
           'the vocab file.'))
   flags.DEFINE_string(
       name='mode', default='train',
-      help=flags_core.help_wrap('mode: train, eval, or predict'))
+      help=flags_core.help_wrap('mode: train, eval, predict, or custom_train'))
 
   flags_core.set_defaults(data_dir='/tmp/translate_ende',
                           model_dir='/tmp/transformer_model',
-                          batch_size=None,
-                          train_epochs=10)
+                          batch_size=None)
 
   # pylint: disable=unused-variable
   @flags.multi_flags_validator(
-      ['mode', 'train_epochs'],
-      message='--train_epochs must be defined in train mode')
+      ['mode', 'train_steps'],
+      message='--train_steps must be defined in train/custom_train mode')
   def _check_train_limits(flag_dict):
-    if flag_dict['mode'] == 'train':
-      return flag_dict['train_epochs'] is not None
+    if flag_dict['mode'] in {'train', 'custom_train'}:
+      return flag_dict['train_steps'] is not None
     return True
 
   @flags.multi_flags_validator(

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -123,7 +123,8 @@ class Transformer(tf.keras.Model):
       if target_seq is None:
         return self.predict(encoder_outputs, attention_bias, training)
       else:
-        logits = self.decode(target_seq, encoder_outputs, attention_bias, training)
+        logits = self.decode(target_seq, encoder_outputs, attention_bias,
+                             training)
         return logits
 
   def encode(self, inputs, attention_bias, training):

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -85,13 +85,13 @@ class Transformer(tf.keras.Model):
         "params": self.params,
     }
 
-  def call(self, x, training):
+  def call(self, inputs, training):
     """Calculate target logits or inferred target sequences.
 
     Args:
-      x: input tensor list of size 1 or 2.
-        First item, inputs: int tensor with shape [batch_size, input_length].
-        Second item (optional), targets: None or int tensor with shape
+      inputs: input tensor list of size 1 or 2.
+        First item, input_seq: int tensor with shape [batch_size, input_length].
+        Second item (optional), target_seq: None or int tensor with shape
           [batch_size, target_length].
       training: boolean, whether in training mode or not.
 
@@ -103,27 +103,27 @@ class Transformer(tf.keras.Model):
           outputs: [batch_size, decoded length]
           scores: [batch_size, float]}
     """
-    if len(x) == 2:
-      inputs, targets = x[0], x[1]
+    if len(inputs) == 2:
+      input_seq, target_seq = inputs[0], inputs[1]
     else:
-      inputs, targets = x[0], None
+      input_seq, target_seq = inputs[0], None
 
     # Variance scaling is used here because it seems to work in many problems.
     # Other reasonable initializers may also work just as well.
     with tf.name_scope("Transformer"):
       # Calculate attention bias for encoder self-attention and decoder
       # multi-headed attention layers.
-      attention_bias = model_utils.get_padding_bias(inputs)
+      attention_bias = model_utils.get_padding_bias(input_seq)
 
       # Run the inputs through the encoder layer to map the symbol
       # representations to continuous representations.
-      encoder_outputs = self.encode(inputs, attention_bias, training)
+      encoder_outputs = self.encode(input_seq, attention_bias, training)
       # Generate output sequence if targets is None, or return logits if target
       # sequence is known.
-      if targets is None:
+      if target_seq is None:
         return self.predict(encoder_outputs, attention_bias, training)
       else:
-        logits = self.decode(targets, encoder_outputs, attention_bias, training)
+        logits = self.decode(target_seq, encoder_outputs, attention_bias, training)
         return logits
 
   def encode(self, inputs, attention_bias, training):


### PR DESCRIPTION
Add custom training loop and eval in Transformer V2.

- Tested with the following command for TF V1 and V2:
```
python official/transformer/v2/transformer_main.py \
  --data_dir=${DATA_DIR} \
  --model_dir=${MODEL_DIR} \
  --vocab_file=${VOCAB_FILE} \
  --param_set=${PARAM_SET} \
  --bleu_source=${BLEU_SOURCE} \
  --bleu_ref=${BLEU_REF} \
  --train_steps=10 \
  --steps_between_evals=5 \
  --batch_size=2048 \
  --mode=custom_train
```
- Tested with larger train_steps, which shows the decreasing loss.