### PR TITLE
Bug fix of cifar10_eval.py

### DIFF
--- a/tutorials/image/cifar10/cifar10_eval.py
+++ b/tutorials/image/cifar10/cifar10_eval.py
@@ -117,7 +117,7 @@ def evaluate():
   """Eval CIFAR-10 for a number of steps."""
   with tf.Graph().as_default() as g:
     # Get images and labels for CIFAR-10.
-    eval_data = FLAGS.eval_data == 'test'
+    eval_data = FLAGS.eval_data
     images, labels = cifar10.inputs(eval_data=eval_data)
 
     # Build a Graph that computes the logits predictions from the

--- a/tutorials/image/cifar10/cifar10_eval.py
+++ b/tutorials/image/cifar10/cifar10_eval.py
@@ -117,8 +117,7 @@ def evaluate():
   """Eval CIFAR-10 for a number of steps."""
   with tf.Graph().as_default() as g:
     # Get images and labels for CIFAR-10.
-    eval_data = FLAGS.eval_data
-    images, labels = cifar10.inputs(eval_data=eval_data)
+    images, labels = cifar10.inputs(eval_data=FLAGS.eval_data)
 
     # Build a Graph that computes the logits predictions from the
     # inference model.


### PR DESCRIPTION
line 120: changed from eval_data = FLAGS.eval_data == 'test'
to: eval_data = FLAGS.eval_data
comment: the original code assigns 'true' to eval_data, when the script is being used to evaluate networks on the evaluation set, it DOES NOT load the evaluation set as intended, but actually loads the trainning set (line 105 of cifar10_input.py).