### PR TITLE
Work-around to prevent OOM with --static_batch=False.

### DIFF
--- a/official/transformer/v2/data_pipeline.py
+++ b/official/transformer/v2/data_pipeline.py
@@ -252,7 +252,7 @@ def _read_and_batch_from_files(
   else:
     # Group and batch such that each batch has examples of similar length.
     # TODO: _batch_examples might need to do something special for num_replicas.
-    dataset = _batch_examples(dataset, batch_size, max_length)
+    dataset = _batch_examples(dataset, batch_size // num_replicas, max_length)
 
   dataset = dataset.repeat(repeat)
 

--- a/official/transformer/v2/data_pipeline.py
+++ b/official/transformer/v2/data_pipeline.py
@@ -252,7 +252,9 @@ def _read_and_batch_from_files(
   else:
     # Group and batch such that each batch has examples of similar length.
     # TODO(xunkai): _batch_examples might need to do something special for
-    # num_replicas.
+    # num_replicas.  
+    # TODO(b/133904104):  The division by num_replicas shouldn't be needed if 
+    # the fix to b/133904104 works as intended.
     dataset = _batch_examples(dataset, batch_size // num_replicas, max_length)
 
   dataset = dataset.repeat(repeat)


### PR DESCRIPTION
Re-batching currently doesn't happen when the batch size isn't constant as is the case with the dynamic batch.  There is an internal fix submitted, but until that makes its ways to nightly and gets verified this work around allows to prevent OOM.

The resulting model is still not as fast as it could be, because the underlying tf.function gets retraced for every unique shape of the dynamic batch size.  I'm looking into that now.