### PR TITLE
absl_app.run() fails without including `main` as an argument

### DIFF
--- a/official/mnist/mnist_tpu.py
+++ b/official/mnist/mnist_tpu.py
@@ -198,4 +198,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-  absl_app.run()
+  absl_app.run(main)


### PR DESCRIPTION
After the change (https://github.com/tensorflow/models/pull/6846/files#diff-965780bf33f2aeca41a33f8eba197c79) I receive the following error:

File "./models/official/mnist/mnist_tpu.py", line 202, in <module>
    absl_app.run()
TypeError: run() missing 1 required positional argument: 'main'

I added main as an argument and it seems to be working fine now.