### PR TITLE
Resnet mlperf like

### DIFF
--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -117,6 +117,28 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
     FLAGS.use_tensor_lr = True
     self._run_and_report_benchmark()
 
+  def benchmark_8_gpu_mlperf_like(self):
+    """Tests similar to the rules for MLPerf 0.5.
+
+    Current differences to the spec, excluding any possible network issues:
+      - Eval is every 4 epochs and again at the end. ~2 too many times.
+      - Learning rate is not tuned to hit 75%, but we know the model is correct.
+    """
+    self._setup()
+    FLAGS.num_gpus = 8
+    FLAGS.data_dir = self.data_dir
+    FLAGS.batch_size = 256 * 8
+    FLAGS.train_epochs = 61
+    FLAGS.epochs_between_evals = 4
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_mlperf_like')
+    FLAGS.dtype = 'fp16'
+    FLAGS.enable_eager = True
+    FLAGS.enable_xla = True
+    # Thread tuning to improve performance.
+    FLAGS.data_delay_prefetch = True
+    FLAGS.use_tensor_lr = True
+    self._run_and_report_benchmark()
+
   def benchmark_xla_8_gpu_fp16_dynamic(self):
     """Test Keras model with XLA, eager, dist_strat, 8 GPUs, dynamic fp16."""
     self._setup()
@@ -541,9 +563,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     self._run_and_report_benchmark()
 
   def benchmark_8_gpu_fp16_dynamic_tweaked(self):
-    """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and manual
-       config tuning.
-    """
+    """Test Keras model with 8 GPUs, fp16, dynamic loss scaling, and tuned."""
     self._setup()
 
     FLAGS.num_gpus = 8

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -120,9 +120,14 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
   def benchmark_8_gpu_mlperf_like(self):
     """Tests similar to the rules for MLPerf 0.5.
 
-    Current differences to the spec, excluding any possible network issues:
-      - Eval is every 4 epochs and again at the end. ~2 too many times.
+    Listed below are reasons this comparison is not to the MLSpec, but this is
+    still a decent directional measurement:
+      - Eval is every 4 epochs and again at the end. ~2 extra times.
       - Learning rate is not tuned to hit 75%, but we know the model is correct.
+      - We measure total time and MLPerf 0.5 excluded some startup time.
+      - Eval is not on the total set, need to set eval batch_size where
+        8*batch_size/50K is even.  250 is a good number.
+      - Not sure if we are doing any extra or too few steps due to epoch bleed.
     """
     self._setup()
     FLAGS.num_gpus = 8

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -118,7 +118,7 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
     self._run_and_report_benchmark()
 
   def benchmark_8_gpu_mlperf_like(self):
-    """Tests similar to the rules for MLPerf 0.5.
+    """Test similar to the rules for MLPerf 0.5.
 
     Listed below are reasons this comparison is not to the MLSpec, but this is
     still a decent directional measurement:
@@ -126,7 +126,7 @@ class Resnet50KerasAccuracy(keras_benchmark.KerasBenchmark):
       - Learning rate is not tuned to hit 75%, but we know the model is correct.
       - We measure total time and MLPerf 0.5 excluded some startup time.
       - Eval is not on the total set, need to set eval batch_size where
-        8*batch_size/50K is even.  250 is a good number.
+        8*batch_size/50K is even. 250 is a good number.
       - Not sure if we are doing any extra or too few steps due to epoch bleed.
     """
     self._setup()


### PR DESCRIPTION
Adds a benchmark that is pretty close to MLPerf.  Early results were about 144 minutes, which is pretty good.  I list the off the cuff reasons this is not to spec, but taking that into account I think our theory that if we had address startup issues we might have won last time is pretty valid.

We are much faster comparing total time than images/sec compared to our MLPerf numbers from 0.5.  I will setup this job to only run on 96vCPUs.