### PR TITLE
NCF keras: Add custom loss and metrics

### DIFF
--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -104,8 +104,6 @@ def parse_flags(flags_obj):
       "epsilon": flags_obj.epsilon,
       "match_mlperf": flags_obj.ml_perf,
       "use_xla_for_gpu": flags_obj.use_xla_for_gpu,
-      "clone_model_in_keras_dist_strat":
-          flags_obj.clone_model_in_keras_dist_strat,
       "epochs_between_evals": FLAGS.epochs_between_evals,
       "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
       "keras_use_ctl": flags_obj.keras_use_ctl,
@@ -315,13 +313,6 @@ def define_ncf_flags():
   @flags.multi_flags_validator(["use_xla_for_gpu", "tpu"], message=xla_message)
   def xla_validator(flag_dict):
     return not flag_dict["use_xla_for_gpu"] or not flag_dict["tpu"]
-
-  flags.DEFINE_bool(
-      name="clone_model_in_keras_dist_strat",
-      default=True,
-      help=flags_core.help_wrap(
-          "If False, then the experimental code path is used that does not "
-          "clone models for distribution."))
 
   flags.DEFINE_bool(
       name="early_stopping",

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -62,14 +62,12 @@ class MetricLayer(tf.keras.layers.Layer):
   def __init__(self, params):
     super(MetricLayer, self).__init__()
     self.params = params
-
-  def build(self, input_shape):
     self.metric = tf.keras.metrics.Mean(name=rconst.HR_METRIC_NAME)
-
+  
   def call(self, inputs):
     logits, dup_mask = inputs
     in_top_k, metric_weights = metric_fn(logits, dup_mask, self.params)
-    self.add_metric(self.metric(in_top_k, metric_weights))
+    self.add_metric(self.metric(in_top_k, sample_weight=metric_weights))
     return logits
 
 

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -385,9 +385,7 @@ def run_ncf(_):
   else:
     with distribution_utils.get_strategy_scope(strategy):
 
-      keras_model.compile(
-          optimizer=optimizer,
-          cloning=params["clone_model_in_keras_dist_strat"])
+      keras_model.compile(optimizer=optimizer)
 
       history = keras_model.fit(train_input_dataset,
                                 steps_per_epoch=num_train_steps,

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -225,12 +225,12 @@ def _get_keras_model(params):
   softmax_logits = MetricLayer(params)([softmax_logits, dup_mask_input])
 
   keras_model = tf.keras.Model(
-      inputs=[
-          user_input,
-          item_input,
-          valid_pt_mask_input,
-          dup_mask_input,
-          label_input],
+      inputs={
+          movielens.USER_COLUMN: user_input,
+          movielens.ITEM_COLUMN: item_input,
+          rconst.VALID_POINT_MASK: valid_pt_mask_input,
+          rconst.DUPLICATE_MASK: dup_mask_input,
+          rconst.TRAIN_LABEL_KEY: label_input},
       outputs=softmax_logits)
 
   loss_obj = tf.keras.losses.SparseCategoricalCrossentropy(

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -45,53 +45,30 @@ from official.utils.misc import model_helpers
 FLAGS = flags.FLAGS
 
 
-def _keras_loss(y_true, y_pred):
-  # Here we are using the exact same loss used by the estimator
-  loss = tf.keras.losses.sparse_categorical_crossentropy(
-      y_pred=y_pred,
-      y_true=tf.cast(y_true, tf.int32),
-      from_logits=True)
-  return loss
+class MetricLayer(tf.keras.layers.Layer):
+  """Custom layer of metrics for NCF model."""
+
+  def __init__(self, params):
+    super(MetricLayer, self).__init__()
+    self.params = params
+
+  def build(self, input_shape):
+    self.metric = tf.keras.metrics.Mean(name=rconst.HR_METRIC_NAME)
+
+  def call(self, inputs):
+    logits, dup_mask = inputs
+    dup_mask = tf.cast(dup_mask, tf.float32)
+    logits = tf.slice(logits, [0, 0, 1], [-1, -1, -1])
+    in_top_k, _, metric_weights, _ = neumf_model.compute_top_k_and_ndcg(
+        logits,
+        dup_mask,
+        self.params["match_mlperf"])
+    metric_weights = tf.cast(metric_weights, tf.float32)
+    self.add_metric(self.metric(in_top_k, metric_weights))
+    return inputs[0]
 
 
-def _get_metric_fn(params):
-  """Get the metrix fn used by model compile."""
-  batch_size = params["batch_size"]
-
-  def metric_fn(y_true, y_pred):
-    """Returns the in_top_k metric."""
-    softmax_logits = y_pred[0, :]
-    logits = tf.slice(softmax_logits, [0, 1], [batch_size, 1])
-
-    # The dup mask should be obtained from input data, but we did not yet find
-    # a good way of getting it with keras, so we set it to zeros to neglect the
-    # repetition correction
-    dup_mask = tf.zeros([batch_size, 1])
-
-    _, _, in_top_k, _, _ = (
-        neumf_model.compute_eval_loss_and_metrics_helper(
-            logits,
-            softmax_logits,
-            dup_mask,
-            params["num_neg"],
-            params["match_mlperf"],
-            params["use_xla_for_gpu"]))
-
-    is_training = tf.keras.backend.learning_phase()
-    if isinstance(is_training, int):
-      is_training = tf.constant(bool(is_training), dtype=tf.bool)
-
-    in_top_k = tf.cond(
-        is_training,
-        lambda: tf.zeros(shape=in_top_k.shape, dtype=in_top_k.dtype),
-        lambda: in_top_k)
-
-    return in_top_k
-
-  return metric_fn
-
-
-def _get_train_and_eval_data(producer, params):
+  def _get_train_and_eval_data(producer, params):
   """Returns the datasets for training and evalutating."""
 
   def preprocess_train_input(features, labels):
@@ -104,9 +81,10 @@ def _get_train_and_eval_data(producer, params):
       fit.
     - The label needs to be extended to be used in the loss fn
     """
-    if not params["keras_use_ctl"]:
-      features.pop(rconst.VALID_POINT_MASK)
     labels = tf.expand_dims(labels, -1)
+    fake_dup_mask = tf.zeros_like(features[movielens.USER_COLUMN])
+    features[rconst.DUPLICATE_MASK] = fake_dup_mask
+    features[rconst.TRAIN_LABEL_KEY] = labels
     return features, labels
 
   train_input_fn = producer.make_input_fn(is_training=True)
@@ -125,10 +103,12 @@ def _get_train_and_eval_data(producer, params):
       fit.
     - The label needs to be extended to be used in the loss fn
     """
-    if not params["keras_use_ctl"]:
-      features.pop(rconst.DUPLICATE_MASK)
-    labels = tf.zeros_like(features[movielens.USER_COLUMN])
+    labels = tf.cast(tf.zeros_like(features[movielens.USER_COLUMN]), tf.bool)
     labels = tf.expand_dims(labels, -1)
+    fake_valit_pt_mask = tf.cast(
+        tf.zeros_like(features[movielens.USER_COLUMN]), tf.bool)
+    features[rconst.VALID_POINT_MASK] = fake_valit_pt_mask
+    features[rconst.TRAIN_LABEL_KEY] = labels
     return features, labels
 
   eval_input_fn = producer.make_input_fn(is_training=False)
@@ -202,6 +182,24 @@ def _get_keras_model(params):
       batch_size=params["batches_per_step"],
       name=movielens.ITEM_COLUMN,
       dtype=tf.int32)
+  
+  valid_pt_mask_input = tf.keras.layers.Input(
+      shape=(batch_size,),
+      batch_size=params["batches_per_step"],
+      name=rconst.VALID_POINT_MASK,
+      dtype=tf.bool)
+
+  dup_mask_input = tf.keras.layers.Input(
+      shape=(batch_size,),
+      batch_size=params["batches_per_step"],
+      name=rconst.DUPLICATE_MASK,
+      dtype=tf.int32)
+
+  label_input = tf.keras.layers.Input(
+      shape=(batch_size, 1),
+      batch_size=params["batches_per_step"],
+      name=rconst.TRAIN_LABEL_KEY,
+      dtype=tf.bool)
 
   base_model = neumf_model.construct_model(
       user_input, item_input, params, need_strip=True)
@@ -219,9 +217,25 @@ def _get_keras_model(params):
       [zeros, logits],
       axis=-1)
 
+  softmax_logits = MetricLayer(params)([softmax_logits, dup_mask_input])
+
   keras_model = tf.keras.Model(
-      inputs=[user_input, item_input],
+      inputs=[
+          user_input,
+          item_input,
+          valid_pt_mask_input,
+          dup_mask_input,
+          label_input],
       outputs=softmax_logits)
+
+  loss_obj = tf.keras.losses.SparseCategoricalCrossentropy(
+      from_logits=True,
+      reduction="sum")
+
+  keras_model.add_loss(loss_obj(
+      y_true=label_input,
+      y_pred=softmax_logits,
+      sample_weight=valid_pt_mask_input) * 1.0 / batch_size)
 
   keras_model.summary()
   return keras_model
@@ -269,7 +283,7 @@ def run_ncf(_):
 
   time_callback = keras_utils.TimeHistory(batch_size, FLAGS.log_steps)
   per_epoch_callback = IncrementEpochCallback(producer)
-  callbacks = [per_epoch_callback, time_callback]
+  callbacks = [per_epoch_callback] #, time_callback]
 
   if FLAGS.early_stopping:
     early_stopping_callback = CustomEarlyStopping(
@@ -374,8 +388,6 @@ def run_ncf(_):
     with distribution_utils.get_strategy_scope(strategy):
 
       keras_model.compile(
-          loss=_keras_loss,
-          metrics=[_get_metric_fn(params)],
           optimizer=optimizer,
           cloning=params["clone_model_in_keras_dist_strat"])
 
@@ -385,7 +397,7 @@ def run_ncf(_):
                                 callbacks=callbacks,
                                 validation_data=eval_input_dataset,
                                 validation_steps=num_eval_steps,
-                                verbose=2)
+                                verbose=1)
 
       logging.info("Training done. Start evaluating")
 

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -63,7 +63,7 @@ class MetricLayer(tf.keras.layers.Layer):
     super(MetricLayer, self).__init__()
     self.params = params
     self.metric = tf.keras.metrics.Mean(name=rconst.HR_METRIC_NAME)
-  
+
   def call(self, inputs):
     logits, dup_mask = inputs
     in_top_k, metric_weights = metric_fn(logits, dup_mask, self.params)
@@ -185,7 +185,7 @@ def _get_keras_model(params):
       batch_size=params["batches_per_step"],
       name=movielens.ITEM_COLUMN,
       dtype=tf.int32)
-  
+
   valid_pt_mask_input = tf.keras.layers.Input(
       shape=(batch_size,),
       batch_size=params["batches_per_step"],
@@ -340,7 +340,7 @@ def run_ncf(_):
         features, _ = inputs
         softmax_logits = keras_model(features)
         in_top_k, metric_weights = metric_fn(
-          softmax_logits, features[rconst.DUPLICATE_MASK], params)
+            softmax_logits, features[rconst.DUPLICATE_MASK], params)
         hr_sum = tf.reduce_sum(in_top_k*metric_weights)
         hr_count = tf.reduce_sum(metric_weights)
         return hr_sum, hr_count


### PR DESCRIPTION
Added custom loss (using model.add_loss) and custom metrics (using custom layer) so that we can account for weights in those computations.
The results with this change seem similar to those with custom training loop:

```
Epoch 1/10
994/994 [==============================] - 46s 47ms/step - loss: 0.2469 - HR_METRIC: 0.0104 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.5334
Epoch 2/10
994/994 [==============================] - 29s 29ms/step - loss: 0.1873 - HR_METRIC: 0.0100 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.5875
Epoch 3/10
994/994 [==============================] - 29s 29ms/step - loss: 0.1689 - HR_METRIC: 0.0098 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6166
Epoch 4/10
994/994 [==============================] - 29s 29ms/step - loss: 0.1569 - HR_METRIC: 0.0101 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6203
Epoch 5/10
994/994 [==============================] - 27s 27ms/step - loss: 0.1487 - HR_METRIC: 0.0100 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6273
Epoch 6/10
994/994 [==============================] - 27s 27ms/step - loss: 0.1426 - HR_METRIC: 0.0103 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6305
Epoch 7/10
994/994 [==============================] - 26s 27ms/step - loss: 0.1383 - HR_METRIC: 0.0101 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6353
Epoch 8/10
994/994 [==============================] - 26s 27ms/step - loss: 0.1349 - HR_METRIC: 0.0106 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6347
Epoch 9/10
994/994 [==============================] - 27s 27ms/step - loss: 0.1322 - HR_METRIC: 0.0099 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6366
Epoch 10/10
994/994 [==============================] - 26s 27ms/step - loss: 0.1297 - HR_METRIC: 0.0098 - val_loss: 0.0000e+00 - val_HR_METRIC: 0.6361
```

Also removed the cloning flag as cloning is False by default now.