### PR TITLE
Update min/max threshold for NCF

### DIFF
--- a/official/recommendation/ncf_keras_benchmark.py
+++ b/official/recommendation/ncf_keras_benchmark.py
@@ -105,12 +105,12 @@ class KerasNCFRealData(KerasNCFBenchmarkBase):
     metrics.append({'name': 'exp_per_second',
                     'value': stats['avg_exp_per_second']})
 
-    # Target is 0.625, but some runs are below that level. Until we have
+    # Target is 0.635, but some runs are below that level. Until we have
     # multi-run tests, we have to accept a lower target.
     metrics.append({'name': 'hr_at_10',
                     'value': stats['eval_hit_rate'],
-                    'min_value': 0.618,
-                    'max_value': 0.635})
+                    'min_value': 0.630,
+                    'max_value': 0.640})
 
     metrics.append({'name': 'train_loss',
                     'value': stats['loss']})


### PR DESCRIPTION
The original max was low (63.5) as some runs would exceed that and fail. 