### PR TITLE
TF 2.0 Transformer: Remove metrics hack

### DIFF
--- a/official/transformer/v2/data_pipeline.py
+++ b/official/transformer/v2/data_pipeline.py
@@ -265,14 +265,15 @@ def _read_and_batch_from_files(
 def _generate_synthetic_data(params):
   """Create synthetic data based on the parameter batch size."""
   batch = length = int(math.sqrt(params["batch_size"]))
-  return model_helpers.generate_synthetic_data(
-      input_shape=tf.TensorShape([batch, length]),
+  dataset = model_helpers.generate_synthetic_data(
+      input_shape=tf.TensorShape([length]),
       input_value=1,
       input_dtype=tf.int32,
-      label_shape=tf.TensorShape([batch, length]),
+      label_shape=tf.TensorShape([length]),
       label_value=1,
       label_dtype=tf.int32,
   )
+  return dataset.batch(batch)
 
 
 def train_input_fn(params):

--- a/official/transformer/v2/metrics.py
+++ b/official/transformer/v2/metrics.py
@@ -160,13 +160,9 @@ class MetricLayer(tf.keras.layers.Layer):
 
   def call(self, inputs):
     logits, targets = inputs[0], inputs[1]
-    # TODO(guptapriya): Remove this check when underlying issue to create
-    # metrics with dist strat in cross replica context is fixed.
-    if (tf.distribute.has_strategy() and
-        not tf.distribute.in_cross_replica_context()):
-      for mean, fn in self.metric_mean_fns:
-        m = mean(*fn(logits, targets))
-        self.add_metric(m)
+    for mean, fn in self.metric_mean_fns:
+      m = mean(*fn(logits, targets))
+      self.add_metric(m)
     return logits
 
 

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -99,10 +99,11 @@ class TransformerTask(object):
 
     print("Running transformer with num_gpus =", num_gpus)
     if self.distribution_strategy:
-      print("For training, using distribution strategy: ", self.distribution_strategy)
+      print("For training, using distribution strategy: ",
+            self.distribution_strategy)
     else:
       print("Not using any distribution strategy.")
-    
+
     self.params = params = misc.get_model_params(flags_obj.param_set, num_gpus)
 
     params["num_gpus"] = num_gpus
@@ -197,7 +198,7 @@ class TransformerTask(object):
     with tf.name_scope("model"):
       model = transformer.create_model(params, is_train)
       self._load_weights_if_possible(
-        model, tf.train.latest_checkpoint(self.flags_obj.model_dir))
+          model, tf.train.latest_checkpoint(self.flags_obj.model_dir))
       model.summary()
     subtokenizer = tokenizer.Subtokenizer(flags_obj.vocab_file)
 

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -190,7 +190,8 @@ class TransformerTask(object):
 
     with tf.name_scope("model"):
       model = transformer.create_model(params, is_train)
-      self._load_weights_if_possible(model, flags_obj.init_weight_path)
+      self._load_weights_if_possible(
+        model, tf.train.latest_checkpoint(self.flags_obj.model_dir))
       model.summary()
     subtokenizer = tokenizer.Subtokenizer(flags_obj.vocab_file)
 

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -97,6 +97,12 @@ class TransformerTask(object):
         distribution_strategy=flags_obj.distribution_strategy,
         num_gpus=flags_core.get_num_gpus(flags_obj))
 
+    print("Running transformer with num_gpus =", num_gpus)
+    if self.distribution_strategy:
+      print("For training, using distribution strategy: ", self.distribution_strategy)
+    else:
+      print("Not using any distribution strategy.")
+    
     self.params = params = misc.get_model_params(flags_obj.param_set, num_gpus)
 
     params["num_gpus"] = num_gpus

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -43,7 +43,7 @@ class TransformerTaskTest(tf.test.TestCase):
   def setUp(self):
     temp_dir = self.get_temp_dir()
     FLAGS.model_dir = os.path.join(temp_dir, FIXED_TIMESTAMP)
-    FLAGS.param_set = param_set = "tiny"
+    FLAGS.param_set = "tiny"
     FLAGS.use_synthetic_data = True
     FLAGS.steps_between_evals = 1
     FLAGS.train_steps = 2
@@ -54,7 +54,7 @@ class TransformerTaskTest(tf.test.TestCase):
     self.model_dir = FLAGS.model_dir
     self.temp_dir = temp_dir
     self.vocab_file = os.path.join(temp_dir, "vocab")
-    self.vocab_size = misc.get_model_params(param_set, 0)["vocab_size"]
+    self.vocab_size = misc.get_model_params(FLAGS.param_set, 0)["vocab_size"]
     self.bleu_source = os.path.join(temp_dir, "bleu_source")
     self.bleu_ref = os.path.join(temp_dir, "bleu_ref")
 
@@ -78,6 +78,7 @@ class TransformerTaskTest(tf.test.TestCase):
   def test_train_2_gpu(self):
     FLAGS.distribution_strategy = "mirrored"
     FLAGS.num_gpus = 2
+    FLAGS.param_set = "base"
     t = tm.TransformerTask(FLAGS)
     t.train()
 

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -49,6 +49,8 @@ class TransformerTaskTest(tf.test.TestCase):
     FLAGS.train_steps = 2
     FLAGS.validation_steps = 1
     FLAGS.batch_size = 8
+    FLAGS.num_gpus = 1
+    FLAGS.distribution_strategy = "off"
     self.model_dir = FLAGS.model_dir
     self.temp_dir = temp_dir
     self.vocab_file = os.path.join(temp_dir, "vocab")
@@ -62,7 +64,23 @@ class TransformerTaskTest(tf.test.TestCase):
   def test_train(self):
     t = tm.TransformerTask(FLAGS)
     t.train()
-    
+
+  def test_train_static_batch(self):
+    FLAGS.static_batch = True
+    t = tm.TransformerTask(FLAGS)
+    t.train()
+
+  def test_train_1_gpu_with_dist_strat(self):
+    FLAGS.distribution_strategy = "one_device"
+    t = tm.TransformerTask(FLAGS)
+    t.train()
+
+  def test_train_2_gpu(self):
+    FLAGS.distribution_strategy = "mirrored"
+    FLAGS.num_gpus = 2
+    t = tm.TransformerTask(FLAGS)
+    t.train()
+
   def _prepare_files_and_flags(self, *extra_flags):
     # Make log dir.
     if not os.path.exists(self.temp_dir):


### PR DESCRIPTION
The underlying issue has been fixed so we can now create and update metrics in cross replica context. 

Also fixed existing unit tests and added more tests which test distribution strategy codepaths as well. 