### PR TITLE
Properly use steps_per_epoch and num_epoch in BERT classify benchmark

### DIFF
--- a/official/bert/benchmark/bert_benchmark.py
+++ b/official/bert/benchmark/bert_benchmark.py
@@ -100,12 +100,12 @@ class BertClassifyBenchmarkReal(BertClassifyBenchmarkBase):
     self.eval_data_path = CLASSIFIER_EVAL_DATA_PATH
     self.bert_config_file = MODEL_CONFIG_FILE_PATH
     self.input_meta_data_path = CLASSIFIER_INPUT_META_DATA_PATH
-    # Since we only care about performance metrics, we limit
-    # the number of training steps and epochs to prevent unnecessarily
-    # long tests.
 
     super(BertClassifyBenchmarkReal, self).__init__(output_dir=output_dir)
 
+    # Since we only care about performance metrics, we limit
+    # the number of training steps and epochs to prevent unnecessarily
+    # long tests.
     self.num_steps_per_epoch = 110
     self.num_epochs = 1
 

--- a/official/bert/benchmark/bert_benchmark.py
+++ b/official/bert/benchmark/bert_benchmark.py
@@ -103,10 +103,11 @@ class BertClassifyBenchmarkReal(BertClassifyBenchmarkBase):
     # Since we only care about performance metrics, we limit
     # the number of training steps and epochs to prevent unnecessarily
     # long tests.
-    self.num_steps_per_epoch = 110
-    self.num_epochs = 1
 
     super(BertClassifyBenchmarkReal, self).__init__(output_dir=output_dir)
+
+    self.num_steps_per_epoch = 110
+    self.num_epochs = 1
 
   def _run_and_report_benchmark(self,
                                 training_summary_path,

--- a/official/bert/benchmark/bert_benchmark.py
+++ b/official/bert/benchmark/bert_benchmark.py
@@ -96,12 +96,12 @@ class BertClassifyBenchmarkReal(BertClassifyBenchmarkBase):
   """
 
   def __init__(self, output_dir=None, **kwargs):
+    super(BertClassifyBenchmarkReal, self).__init__(output_dir=output_dir)
+
     self.train_data_path = CLASSIFIER_TRAIN_DATA_PATH
     self.eval_data_path = CLASSIFIER_EVAL_DATA_PATH
     self.bert_config_file = MODEL_CONFIG_FILE_PATH
     self.input_meta_data_path = CLASSIFIER_INPUT_META_DATA_PATH
-
-    super(BertClassifyBenchmarkReal, self).__init__(output_dir=output_dir)
 
     # Since we only care about performance metrics, we limit
     # the number of training steps and epochs to prevent unnecessarily


### PR DESCRIPTION
The super `__init__` call was overriding steps_per_epoch and num_epochs to None, so this moves them after.