### PR TITLE
Fix class agnostic nms type incompatibility with map_fn definition

### DIFF
--- a/research/object_detection/core/post_processing.py
+++ b/research/object_detection/core/post_processing.py
@@ -428,7 +428,7 @@ def class_agnostic_non_max_suppression(boxes,
         tf.where(valid_nms_boxes_indx, nms_scores,
                  -1 * tf.ones(max_selection_size)))
     selected_classes = tf.gather(classes_with_max_scores, selected_indices)
-    nms_result.add_field(fields.BoxListFields.classes, selected_classes)
+    nms_result.add_field(fields.BoxListFields.classes, tf.cast(selected_classes, tf.float32))
     selected_boxes = nms_result
     sorted_boxes = box_list_ops.sort_by_field(selected_boxes,
                                               fields.BoxListFields.scores)


### PR DESCRIPTION
There's a type mismatch when using `use_class_agnostic_nms: True` in your pipeline configuration.
Even though the function class_agnostic_non_max_suppression works fine (see the [test](https://github.com/tensorflow/models/blob/master/research/object_detection/core/class_agnostic_nms_test.py)), it returns the nmsed classes with int type, while its [batch version](https://github.com/tensorflow/models/blob/master/research/object_detection/core/post_processing.py#L729) expects a float32 tensor.