### PR TITLE
Fix and improve NCF keras model

### DIFF
--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -105,7 +105,6 @@ def parse_flags(flags_obj):
       "match_mlperf": flags_obj.ml_perf,
       "use_xla_for_gpu": flags_obj.use_xla_for_gpu,
       "epochs_between_evals": FLAGS.epochs_between_evals,
-      "turn_off_distribution_strategy": FLAGS.turn_off_distribution_strategy,
       "keras_use_ctl": flags_obj.keras_use_ctl,
       "hr_threshold": flags_obj.hr_threshold,
   }
@@ -113,9 +112,6 @@ def parse_flags(flags_obj):
 
 def get_distribution_strategy(params):
   """Returns the distribution strategy to use."""
-  if params["turn_off_distribution_strategy"]:
-    return None
-
   if params["use_tpu"]:
     # Some of the networking libraries are quite chatty.
     for name in ["googleapiclient.discovery", "googleapiclient.discovery_cache",
@@ -291,12 +287,6 @@ def define_ncf_flags():
   flags.DEFINE_integer(
       name="seed", default=None, help=flags_core.help_wrap(
           "This value will be used to seed both NumPy and TensorFlow."))
-
-  flags.DEFINE_boolean(
-      name="turn_off_distribution_strategy",
-      default=False,
-      help=flags_core.help_wrap(
-          "If set, do not use any distribution strategy."))
 
   @flags.validator("eval_batch_size", "eval_batch_size must be at least {}"
                    .format(rconst.NUM_EVAL_NEGATIVES + 1))

--- a/official/recommendation/ncf_common.py
+++ b/official/recommendation/ncf_common.py
@@ -324,3 +324,8 @@ def convert_to_softmax_logits(logits):
   '''
   softmax_logits = tf.concat([logits * 0, logits], axis=1)
   return softmax_logits
+
+def is_tf_v2():
+  """Returns whether it is v2."""
+  from tensorflow.python import tf2 as tf2_internal
+  return tf2_internal.enabled()

--- a/official/recommendation/ncf_keras_benchmark.py
+++ b/official/recommendation/ncf_keras_benchmark.py
@@ -121,6 +121,12 @@ class KerasNCFRealData(KerasNCFBenchmarkBase):
     self._setup()
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_no_dist_strat_early_stop(self):
+    self._setup()
+    FLAGS.distribution_strategy = 'off'
+    FLAGS.early_stopping = True
+    self._run_and_report_benchmark()
+
   def benchmark_1_gpu_early_stop(self):
     self._setup()
     FLAGS.early_stopping = True

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -245,6 +245,10 @@ def _get_keras_model(params):
 
 
 def run_ncf(_):
+  if FLAGS.seed is not None:
+    print("Setting tf seed")
+    tf.random.set_seed(FLAGS.seed)
+  
   """Run NCF training and eval with Keras."""
   # TODO(seemuch): Support different train and eval batch sizes
   if FLAGS.eval_batch_size != FLAGS.batch_size:

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -309,7 +309,7 @@ def run_ncf(_):
         epsilon=params["epsilon"])
 
   if params["keras_use_ctl"]:
-    loss_object = tf.losses.SparseCategoricalCrossentropy(
+    loss_object = tf.keras.losses.SparseCategoricalCrossentropy(
         reduction=tf.keras.losses.Reduction.SUM,
         from_logits=True)
     train_input_iterator = strategy.make_dataset_iterator(train_input_dataset)

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -235,12 +235,10 @@ def _get_keras_model(params):
       from_logits=True,
       reduction="sum")
 
-  loss_scale_factor = (batch_size) #*
-                       #tf.distribute.get_strategy().num_replicas_in_sync)
   keras_model.add_loss(loss_obj(
       y_true=label_input,
       y_pred=softmax_logits,
-      sample_weight=valid_pt_mask_input) * 1.0 / loss_scale_factor)
+      sample_weight=valid_pt_mask_input) * 1.0 / batch_size)
 
   keras_model.summary()
   return keras_model

--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -294,7 +294,7 @@ def run_ncf(_):
 
   if FLAGS.early_stopping:
     early_stopping_callback = CustomEarlyStopping(
-        "val_metric_fn", desired_value=FLAGS.hr_threshold)
+        "val_HR_METRIC", desired_value=FLAGS.hr_threshold)
     callbacks.append(early_stopping_callback)
 
   strategy = distribution_utils.get_distribution_strategy(

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -201,22 +201,29 @@ class NcfTest(tf.test.TestCase):
         extra_flags=self._BASE_END_TO_END_FLAGS + ['-ml_perf', 'True'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
-  def test_end_to_end_keras(self):
+  def test_end_to_end_keras_no_dist_strat(self):
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
         extra_flags=self._BASE_END_TO_END_FLAGS +
         ['-distribution_strategy', 'off'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
-  def test_end_to_end_keras_mlperf(self):
+  def test_end_to_end_keras_dist_strat(self):
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS +
-        ['-ml_perf', 'True',
-         '-distribution_strategy', 'off'])
+        extra_flags=self._BASE_END_TO_END_FLAGS + ['-num_gpus', '0'])
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
-  def test_end_to_end_keras_1_gpu(self):
+  def test_end_to_end_keras_dist_strat_ctl(self):
+    flags = (self._BASE_END_TO_END_FLAGS +
+             ['-num_gpus', '0'] +
+             ['-keras_use_ctl', 'True'])
+    integration.run_synthetic(
+        ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
+        extra_flags=self._BASE_END_TO_END_FLAGS + ['-num_gpus', '0'])
+
+  @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
+  def test_end_to_end_keras_1_gpu_dist_strat(self):
     if context.num_gpus() < 1:
       self.skipTest(
           "{} GPUs are not available for this test. {} GPUs are available".

--- a/official/recommendation/ncf_test.py
+++ b/official/recommendation/ncf_test.py
@@ -220,7 +220,7 @@ class NcfTest(tf.test.TestCase):
              ['-keras_use_ctl', 'True'])
     integration.run_synthetic(
         ncf_keras_main.main, tmp_root=self.get_temp_dir(), max_train=None,
-        extra_flags=self._BASE_END_TO_END_FLAGS + ['-num_gpus', '0'])
+        extra_flags=flags)
 
   @mock.patch.object(rconst, "SYNTHETIC_BATCHES_PER_EPOCH", 100)
   def test_end_to_end_keras_1_gpu_dist_strat(self):


### PR DESCRIPTION
A number of changes are combined in this PR:
- Clean up some dist strat related flags
- Fix non dist strat version 
- use tf.keras.losses instead of tf.losses (temporary issue but might as well use the keras alias)
- Fix loss scaling with dist strat 
- Fix metric name in early stopping callback
- Added more test coverage for no strategy and CTL cases. 