### PR TITLE
fix OneDeviceStrategy error

### DIFF
--- a/official/utils/misc/distribution_utils.py
+++ b/official/utils/misc/distribution_utils.py
@@ -127,12 +127,12 @@ def get_distribution_strategy(distribution_strategy="default",
   if (distribution_strategy == "one_device" or
       (distribution_strategy == "default" and num_gpus <= 1)):
     if num_gpus == 0:
-      return tf.distribute.OneDeviceStrategy("device:CPU:0")
+      return tf.contrib.distribute.OneDeviceStrategy("device:CPU:0")
     else:
       if num_gpus > 1:
         raise ValueError("`OneDeviceStrategy` can not be used for more than "
                          "one device.")
-      return tf.distribute.OneDeviceStrategy("device:GPU:0")
+      return tf.contrib.distribute.OneDeviceStrategy("device:GPU:0")
 
   if distribution_strategy in ("mirrored", "default"):
     if num_gpus == 0:


### PR DESCRIPTION
fix AttributeError: module 'tensorflow._api.v1.distribute' has no attribute 'OneDeviceStrategy' when running models/official/mnist/mnist.py