### PR TITLE
Improve performance of Keras ResNet models when not using distribution strategy

### DIFF
--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -193,6 +193,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     self._setup()
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = True
+    FLAGS.explicit_gpu_placement = True
     FLAGS.distribution_strategy = 'off'
     FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir(

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -185,8 +185,18 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'off'
-    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_dist_strat')
+    FLAGS.batch_size = 128
+    self._run_and_report_benchmark()
+
+  def benchmark_1_gpu_no_dist_strat_tweaked(self):
+    self._setup()
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'off'
+    FLAGS.set_learning_phase_to_train = False
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_1_gpu_no_dist_strat_tweaked')
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
@@ -195,7 +205,6 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = False
     FLAGS.distribution_strategy = 'off'
-    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_no_dist_strat')
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -83,6 +83,7 @@ class Resnet56KerasAccuracy(keras_benchmark.KerasBenchmark):
     """Test keras based model with eager and no dist strat."""
     self._setup()
     FLAGS.num_gpus = 1
+    FLAGS.explicit_gpu_placement = True
     FLAGS.data_dir = self.data_dir
     FLAGS.batch_size = 128
     FLAGS.train_epochs = 182

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -191,6 +191,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     self._run_and_report_benchmark()
 
   def benchmark_1_gpu_no_dist_strat_tweaked(self):
+    """Test no distribution strategy with manual config."""
     self._setup()
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = True

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -185,6 +185,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'off'
+    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_no_dist_strat')
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
@@ -194,6 +195,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = False
     FLAGS.distribution_strategy = 'off'
+    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_no_dist_strat')
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -178,7 +178,8 @@ def run(flags_obj):
   if not strategy and flags_obj.num_gpus == 1:
     # TODO(b/135607227): Add device scope automatically in Keras training loop
     # when not using distribition strategy.
-    tf.device('/device:GPU:0').__enter__()
+    no_dist_strat_device = tf.device('/device:GPU:0')
+    no_dist_strat_device.__enter__()
 
   history = model.fit(train_input_dataset,
                       epochs=train_epochs,
@@ -195,7 +196,7 @@ def run(flags_obj):
                                  verbose=2)
 
   if not strategy and flags_obj.num_gpus == 1:
-    tf.device('/device:GPU:0').__exit__()
+    no_dist_strat_device.__exit__()
 
   stats = keras_common.build_stats(history, eval_output, callbacks)
   return stats

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -175,7 +175,7 @@ def run(flags_obj):
     num_eval_steps = None
     validation_data = None
 
-  if not strategy and flags_obj.num_gpus == 1:
+  if not strategy and flags_obj.explicit_gpu_placement:
     # TODO(b/135607227): Add device scope automatically in Keras training loop
     # when not using distribition strategy.
     no_dist_strat_device = tf.device('/device:GPU:0')
@@ -195,7 +195,7 @@ def run(flags_obj):
                                  steps=num_eval_steps,
                                  verbose=2)
 
-  if not strategy and flags_obj.num_gpus == 1:
+  if not strategy and flags_obj.explicit_gpu_placement:
     no_dist_strat_device.__exit__()
 
   stats = keras_common.build_stats(history, eval_output, callbacks)

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -168,7 +168,6 @@ def run(flags_obj):
 
   validation_data = eval_input_dataset
   if flags_obj.skip_eval:
-    tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
     validation_data = None
 

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -168,6 +168,10 @@ def run(flags_obj):
 
   validation_data = eval_input_dataset
   if flags_obj.skip_eval:
+    if strategy:
+      # TODO(haoyuzhang): Understand slowdown of setting learning phase when
+      # not using distribution strategy.
+      tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
     validation_data = None
 

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -258,7 +258,8 @@ def define_keras_flags():
   flags.DEFINE_boolean(name='skip_eval', default=False, help='Skip evaluation?')
   # TODO(b/135607288): Remove this flag once we understand the root cause of
   # slowdown when setting the learning phase in Keras backend.
-  flags.DEFINE_boolean(name='set_learning_phase_to_train', default=True,
+  flags.DEFINE_boolean(
+      name='set_learning_phase_to_train', default=True,
       help='If skip eval, also set Keras learning phase to 1 (training).')
   flags.DEFINE_boolean(name='use_trivial_model', default=False,
                        help='Whether to use a trivial Keras model.')

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -261,6 +261,10 @@ def define_keras_flags():
   flags.DEFINE_boolean(
       name='set_learning_phase_to_train', default=True,
       help='If skip eval, also set Keras learning phase to 1 (training).')
+  flags.DEFINE_boolean(
+      name='explicit_gpu_placement', default=False,
+      help='If not using distribution strategy, explicitly set device scope '
+      'for the Keras training loop.')
   flags.DEFINE_boolean(name='use_trivial_model', default=False,
                        help='Whether to use a trivial Keras model.')
   flags.DEFINE_boolean(name='report_accuracy_metrics', default=True,

--- a/official/resnet/keras/keras_common.py
+++ b/official/resnet/keras/keras_common.py
@@ -256,6 +256,10 @@ def define_keras_flags():
       name='run_eagerly', default=False,
       help='Run the model op by op without building a model function.')
   flags.DEFINE_boolean(name='skip_eval', default=False, help='Skip evaluation?')
+  # TODO(b/135607288): Remove this flag once we understand the root cause of
+  # slowdown when setting the learning phase in Keras backend.
+  flags.DEFINE_boolean(name='set_learning_phase_to_train', default=True,
+      help='If skip eval, also set Keras learning phase to 1 (training).')
   flags.DEFINE_boolean(name='use_trivial_model', default=False,
                        help='Whether to use a trivial Keras model.')
   flags.DEFINE_boolean(name='report_accuracy_metrics', default=True,

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -281,7 +281,6 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = False
     FLAGS.distribution_strategy = 'off'
-    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_no_dist_strat')
     FLAGS.batch_size = 96  # BatchNorm is less efficient in legacy graph mode
                            # due to its reliance on v1 cond.

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -234,6 +234,19 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_no_dist_strat_tweaked(self):
+    """Test with 1 GPU, no distribution strategy, and manual tuning."""
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'off'
+    FLAGS.set_learning_phase_to_train = False
+    FLAGS.model_dir = self._get_model_dir(
+        'benchmark_1_gpu_no_dist_strat_tweaked')
+    FLAGS.batch_size = 128
+    self._run_and_report_benchmark()
+
   def benchmark_1_gpu_no_dist_strat_run_eagerly(self):
     """Test Keras model with 1 GPU, no distribution strategy, run eagerly."""
     self._setup()
@@ -268,6 +281,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.num_gpus = 1
     FLAGS.enable_eager = False
     FLAGS.distribution_strategy = 'off'
+    FLAGS.set_learning_phase_to_train = False
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_no_dist_strat')
     FLAGS.batch_size = 96  # BatchNorm is less efficient in legacy graph mode
                            # due to its reliance on v1 cond.

--- a/official/resnet/keras/keras_imagenet_benchmark.py
+++ b/official/resnet/keras/keras_imagenet_benchmark.py
@@ -239,6 +239,7 @@ class Resnet50KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     self._setup()
 
     FLAGS.num_gpus = 1
+    FLAGS.explicit_gpu_placement = True
     FLAGS.enable_eager = True
     FLAGS.distribution_strategy = 'off'
     FLAGS.set_learning_phase_to_train = False

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -236,7 +236,8 @@ def run(flags_obj):
   if not strategy and flags_obj.num_gpus == 1:
     # TODO(b/135607227): Add device scope automatically in Keras training loop
     # when not using distribition strategy.
-    tf.device('/device:GPU:0').__enter__()
+    no_dist_strat_device = tf.device('/device:GPU:0')
+    no_dist_strat_device.__enter__()
 
   history = model.fit(train_input_dataset,
                       epochs=train_epochs,
@@ -254,7 +255,7 @@ def run(flags_obj):
                                  verbose=2)
 
   if not strategy and flags_obj.num_gpus == 1:
-    tf.device('/device:GPU:0').__exit__()
+    no_dist_strat_device.__exit__()
 
   stats = keras_common.build_stats(history, eval_output, callbacks)
   return stats

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -233,7 +233,7 @@ def run(flags_obj):
     num_eval_steps = None
     validation_data = None
 
-  if not strategy and flags_obj.num_gpus == 1:
+  if not strategy and flags_obj.explicit_gpu_placement:
     # TODO(b/135607227): Add device scope automatically in Keras training loop
     # when not using distribition strategy.
     no_dist_strat_device = tf.device('/device:GPU:0')
@@ -254,7 +254,7 @@ def run(flags_obj):
                                  steps=num_eval_steps,
                                  verbose=2)
 
-  if not strategy and flags_obj.num_gpus == 1:
+  if not strategy and flags_obj.explicit_gpu_placement:
     no_dist_strat_device.__exit__()
 
   stats = keras_common.build_stats(history, eval_output, callbacks)

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -223,6 +223,13 @@ def run(flags_obj):
 
   validation_data = eval_input_dataset
   if flags_obj.skip_eval:
+    # Only build the training graph. This reduces memory usage introduced by
+    # control flow ops in layers that have different implementations for
+    # training and inference (e.g., batch norm).
+    if strategy:
+      # TODO(haoyuzhang): Understand slowdown of setting learning phase when
+      # not using distribution strategy.
+      tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
     validation_data = None
 

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -226,12 +226,17 @@ def run(flags_obj):
     # Only build the training graph. This reduces memory usage introduced by
     # control flow ops in layers that have different implementations for
     # training and inference (e.g., batch norm).
-    if strategy:
+    if flags_obj.set_learning_phase_to_train:
       # TODO(haoyuzhang): Understand slowdown of setting learning phase when
       # not using distribution strategy.
       tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
     validation_data = None
+
+  if not strategy and flags_obj.num_gpus == 1:
+    # TODO(b/135607227): Add device scope automatically in Keras training loop
+    # when not using distribition strategy.
+    tf.device('/device:GPU:0').__enter__()
 
   history = model.fit(train_input_dataset,
                       epochs=train_epochs,
@@ -247,6 +252,10 @@ def run(flags_obj):
     eval_output = model.evaluate(eval_input_dataset,
                                  steps=num_eval_steps,
                                  verbose=2)
+
+  if not strategy and flags_obj.num_gpus == 1:
+    tf.device('/device:GPU:0').__exit__()
+
   stats = keras_common.build_stats(history, eval_output, callbacks)
   return stats
 

--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -223,10 +223,6 @@ def run(flags_obj):
 
   validation_data = eval_input_dataset
   if flags_obj.skip_eval:
-    # Only build the training graph. This reduces memory usage introduced by
-    # control flow ops in layers that have different implementations for
-    # training and inference (e.g., batch norm).
-    tf.keras.backend.set_learning_phase(1)
     num_eval_steps = None
     validation_data = None
 


### PR DESCRIPTION
Setting the learning phase for some reason negatively affect the performance when not using distribution strategy. We observe additional FusedBachnorm Grad ops in the backward pass if the learning phase here is set to 1. The root cause is still unclear.