### PR TITLE
Transformer 2.0: Make metrics layer optional

### DIFF
--- a/official/transformer/v2/metrics.py
+++ b/official/transformer/v2/metrics.py
@@ -160,9 +160,16 @@ class MetricLayer(tf.keras.layers.Layer):
 
   def call(self, inputs):
     logits, targets = inputs[0], inputs[1]
-    for mean, fn in self.metric_mean_fns:
-      m = mean(*fn(logits, targets))
-      self.add_metric(m)
+    rc = tf.distribute.get_replica_context()
+    def merge_fn(_):
+      return 1
+    if rc:
+      pass
+      #rc.merge_call(merge_fn)                    
+    
+    #for mean, fn in self.metric_mean_fns:
+    #  m = mean(*fn(logits, targets))
+    #  self.add_metric(m)
     return logits
 
 

--- a/official/transformer/v2/metrics.py
+++ b/official/transformer/v2/metrics.py
@@ -160,16 +160,9 @@ class MetricLayer(tf.keras.layers.Layer):
 
   def call(self, inputs):
     logits, targets = inputs[0], inputs[1]
-    rc = tf.distribute.get_replica_context()
-    def merge_fn(_):
-      return 1
-    if rc:
-      pass
-      #rc.merge_call(merge_fn)                    
-    
-    #for mean, fn in self.metric_mean_fns:
-    #  m = mean(*fn(logits, targets))
-    #  self.add_metric(m)
+    for mean, fn in self.metric_mean_fns:
+      m = mean(*fn(logits, targets))
+      self.add_metric(m)
     return logits
 
 

--- a/official/transformer/v2/misc.py
+++ b/official/transformer/v2/misc.py
@@ -102,6 +102,9 @@ def define_transformer_flags():
   flags.DEFINE_boolean(
       name='enable_tensorboard', default=False,
       help='Whether to enable Tensorboard callback.')
+  flags.DEFINE_boolean(
+      name='enable_metrics_in_training', default=False,
+      help='Whether to enable metrics during training.')
   flags.DEFINE_string(
       name='profile_steps', default=None,
       help='Save profiling data to model dir at given range of steps. The '

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -42,7 +42,8 @@ def create_model(params, is_train):
       logits = internal_model([inputs, targets], training=is_train)
       vocab_size = params["vocab_size"]
       label_smoothing = params["label_smoothing"]
-      logits = metrics.MetricLayer(vocab_size)([logits, targets])
+      if params["enable_metrics_in_training"]:
+        logits = metrics.MetricLayer(vocab_size)([logits, targets])
       logits = metrics.LossLayer(vocab_size, label_smoothing)([logits, targets])
       logits = tf.keras.layers.Lambda(lambda x: x, name="logits")(logits)
       return tf.keras.Model([inputs, targets], logits)

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -119,6 +119,7 @@ class TransformerTask(object):
     params["batch_size"] = flags_obj.batch_size or params["default_batch_size"]
     params["repeat_dataset"] = None
     params["dtype"] = flags_core.get_tf_dtype(flags_obj)
+    params["enable_metrics_in_training"] = flags_obj.enable_metrics_in_training
 
   def train(self):
     """Trains the model."""

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -169,7 +169,6 @@ class TransformerTask(object):
           # If TimeHistory is enabled, progress bar would be messy. Increase the
           # verbose level to get rid of it.
           verbose=(2 if flags_obj.enable_time_history else 1))
-      print("Model.losses=", model.losses)
       print("End train iteration:{}/{} global step:{}".format(
           i,
           iterations,

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -168,6 +168,7 @@ class TransformerTask(object):
           # If TimeHistory is enabled, progress bar would be messy. Increase the
           # verbose level to get rid of it.
           verbose=(2 if flags_obj.enable_time_history else 1))
+      print("Model.losses=", model.losses)
       print("End train iteration:{}/{} global step:{}".format(
           i,
           iterations,


### PR DESCRIPTION
Custom metrics during training seem to have a reasonable overhead, so making them optional with a flag. 
For 1 GPU, base, it increases ex/s from 16.8k to 19k/s
For 8 GPU, base, it increases from 111k to 125k/s. 