### PR TITLE
Transformer Keras: Use add_loss instead of loss layer

### DIFF
--- a/official/transformer/v2/data_pipeline.py
+++ b/official/transformer/v2/data_pipeline.py
@@ -268,10 +268,10 @@ def _generate_synthetic_data(params):
   dataset = model_helpers.generate_synthetic_data(
       input_shape=tf.TensorShape([length]),
       input_value=1,
-      input_dtype=tf.int32,
+      input_dtype=tf.int64,
       label_shape=tf.TensorShape([length]),
       label_value=1,
-      label_dtype=tf.int32,
+      label_dtype=tf.int64,
   )
   return dataset.batch(batch)
 

--- a/official/transformer/v2/metrics.py
+++ b/official/transformer/v2/metrics.py
@@ -181,4 +181,3 @@ def transformer_loss(logits, labels, smoothing, vocab_size):
   xentropy, weights = padded_cross_entropy_loss(logits, labels, smoothing,
                                                 vocab_size)
   return tf.reduce_sum(xentropy) / tf.reduce_sum(weights)
-

--- a/official/transformer/v2/metrics.py
+++ b/official/transformer/v2/metrics.py
@@ -182,24 +182,3 @@ def transformer_loss(logits, labels, smoothing, vocab_size):
                                                 vocab_size)
   return tf.reduce_sum(xentropy) / tf.reduce_sum(weights)
 
-
-class LossLayer(tf.keras.layers.Layer):
-  """Custom a layer of transformer loss for Transformer model."""
-
-  def __init__(self, vocab_size, label_smoothing):
-    super(LossLayer, self).__init__()
-    self.vocab_size = vocab_size
-    self.label_smoothing = label_smoothing
-
-  def get_config(self):
-    return {
-        "vocab_size": self.vocab_size,
-        "label_smoothing": self.label_smoothing,
-    }
-
-  def call(self, inputs):
-    logits, targets = inputs[0], inputs[1]
-    loss = transformer_loss(logits, targets, self.label_smoothing,
-                            self.vocab_size)
-    self.add_loss(loss)
-    return logits

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -44,10 +44,11 @@ def create_model(params, is_train):
       label_smoothing = params["label_smoothing"]
       if params["enable_metrics_in_training"]:
         logits = metrics.MetricLayer(vocab_size)([logits, targets])
-      logits = metrics.LossLayer(vocab_size, label_smoothing)([logits, targets])
       logits = tf.keras.layers.Lambda(lambda x: x, name="logits")(logits)
-      return tf.keras.Model([inputs, targets], logits)
-
+      model = tf.keras.Model([inputs, targets], logits)
+      loss = metrics.transformer_loss(logits, targets, label_smoothing, vocab_size)
+      model.add_loss(loss)
+      return model
     else:
       inputs = tf.keras.layers.Input((None,), dtype="int64", name="inputs")
       internal_model = Transformer(params, name="transformer_v2")

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -46,7 +46,8 @@ def create_model(params, is_train):
         logits = metrics.MetricLayer(vocab_size)([logits, targets])
       logits = tf.keras.layers.Lambda(lambda x: x, name="logits")(logits)
       model = tf.keras.Model([inputs, targets], logits)
-      loss = metrics.transformer_loss(logits, targets, label_smoothing, vocab_size)
+      loss = metrics.transformer_loss(
+        logits, targets, label_smoothing, vocab_size)
       model.add_loss(loss)
       return model
     else:

--- a/official/transformer/v2/transformer.py
+++ b/official/transformer/v2/transformer.py
@@ -47,7 +47,7 @@ def create_model(params, is_train):
       logits = tf.keras.layers.Lambda(lambda x: x, name="logits")(logits)
       model = tf.keras.Model([inputs, targets], logits)
       loss = metrics.transformer_loss(
-        logits, targets, label_smoothing, vocab_size)
+          logits, targets, label_smoothing, vocab_size)
       model.add_loss(loss)
       return model
     else:

--- a/official/transformer/v2/transformer_layers_test.py
+++ b/official/transformer/v2/transformer_layers_test.py
@@ -77,16 +77,6 @@ class TransformerLayersTest(tf.test.TestCase):
     output_logits = metrics.MetricLayer(vocab_size)([logits, targets])
     self.assertEqual(output_logits.shape.as_list(), [None, None, vocab_size,])
 
-  def test_loss_layer(self):
-    vocab_size, label_smoothing = 50, 0.1
-    logits = tf.keras.layers.Input((None, vocab_size),
-                                   dtype="float32",
-                                   name="logits")
-    targets = tf.keras.layers.Input((None,), dtype="int64", name="targets")
-    output_logits = metrics.LossLayer(vocab_size,
-                                      label_smoothing)([logits, targets])
-    self.assertEqual(output_logits.shape.as_list(), [None, None, vocab_size,])
-
 
 if __name__ == "__main__":
   tf.test.main()

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -28,6 +28,7 @@ import tensorflow as tf
 
 from official.transformer.v2 import misc
 from official.transformer.v2 import transformer_main as tm
+from tensorflow.python.eager import context
 
 FLAGS = flags.FLAGS
 FIXED_TIMESTAMP = 'my_time_stamp'
@@ -85,13 +86,14 @@ class TransformerTaskTest(tf.test.TestCase):
     t = tm.TransformerTask(FLAGS)
     t.train()
 
-  @unittest.skipUnless(tf.test.is_built_with_cuda(), 'requires GPU')
-  def test_train_1_gpu_with_dist_strat(self):
+  def test_train_dist_strat(self):
     FLAGS.distribution_strategy = 'one_device'
     t = tm.TransformerTask(FLAGS)
     t.train()
 
-  @unittest.skipUnless(tf.test.is_built_with_cuda(), 'requires GPU')
+  @unittest.skipUnless(
+    tf.test.is_built_with_cuda() and context.num_gpus() >=2,
+    'requires 2 GPUs')
   def test_train_2_gpu(self):
     FLAGS.distribution_strategy = 'mirrored'
     FLAGS.num_gpus = 2

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -92,8 +92,8 @@ class TransformerTaskTest(tf.test.TestCase):
     t.train()
 
   @unittest.skipUnless(
-    tf.test.is_built_with_cuda() and context.num_gpus() >=2,
-    'requires 2 GPUs')
+      tf.test.is_built_with_cuda() and context.num_gpus() >= 2,
+      'requires 2 GPUs')
   def test_train_2_gpu(self):
     FLAGS.distribution_strategy = 'mirrored'
     FLAGS.num_gpus = 2

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -77,11 +77,13 @@ class TransformerTaskTest(tf.test.TestCase):
   def _assert_exists(self, filepath):
     self.assertTrue(os.path.exists(filepath))
 
-  def test_train(self):
+  def test_train_no_dist_strat(self):
+    FLAGS.distribution_strategy = 'off'
     t = tm.TransformerTask(FLAGS)
     t.train()
 
   def test_train_static_batch(self):
+    FLAGS.distribution_strategy = 'one_device'
     FLAGS.static_batch = True
     t = tm.TransformerTask(FLAGS)
     t.train()

--- a/official/transformer/v2/transformer_main_test.py
+++ b/official/transformer/v2/transformer_main_test.py
@@ -84,7 +84,6 @@ class TransformerTaskTest(tf.test.TestCase):
     t = tm.TransformerTask(FLAGS)
     t.train()
 
-  @unittest.skipUnless(keras_utils.is_v2_0(), 'TF 2.0 only test.')
   def test_train_static_batch(self):
     FLAGS.distribution_strategy = 'one_device'
     FLAGS.static_batch = True
@@ -92,14 +91,12 @@ class TransformerTaskTest(tf.test.TestCase):
     t.train()
 
   @unittest.skipUnless(tf.test.is_built_with_cuda(), 'requires GPU')
-  @unittest.skipUnless(keras_utils.is_v2_0(), 'TF 2.0 only test.')
   def test_train_1_gpu_with_dist_strat(self):
     FLAGS.distribution_strategy = 'one_device'
     t = tm.TransformerTask(FLAGS)
     t.train()
 
   @unittest.skipUnless(tf.test.is_built_with_cuda(), 'requires GPU')
-  @unittest.skipUnless(keras_utils.is_v2_0(), 'TF 2.0 only test.')
   def test_train_2_gpu(self):
     if context.num_gpus() < 2:
       self.skipTest(
@@ -112,7 +109,6 @@ class TransformerTaskTest(tf.test.TestCase):
     t.train()
 
   @unittest.skipUnless(tf.test.is_built_with_cuda(), 'requires GPU')
-  @unittest.skipUnless(keras_utils.is_v2_0(), 'TF 2.0 only test.')
   def test_train_2_gpu_fp16(self):
     if context.num_gpus() < 2:
       self.skipTest(


### PR DESCRIPTION
model.add_loss is (1) simpler (2) works in both 1.x and 2.0 with distribution strategy.
Using the loss layer has a bug with 1.x + distribution strategy that we do not have an easy way to fix. 