### PR TITLE
Fix help print error when stdout/stderr not use utf-8 encoding

### DIFF
--- a/official/utils/flags/_conventions.py
+++ b/official/utils/flags/_conventions.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 import codecs
 import functools
 
@@ -34,12 +35,19 @@ _help_wrap = functools.partial(flags.text_wrap, length=80, indent="",
 
 
 # Pretty formatting causes issues when utf-8 is not installed on a system.
-try:
-  codecs.lookup("utf-8")
+def _stdout_utf8():
+  try:
+    codecs.lookup("utf-8")
+  except LookupError:
+    return False
+  return sys.stdout.encoding == "UTF-8"
+
+
+if _stdout_utf8():
   help_wrap = _help_wrap
-except LookupError:
+else:
   def help_wrap(text, *args, **kwargs):
-    return _help_wrap(text, *args, **kwargs).replace("\ufeff", "")
+    return _help_wrap(text, *args, **kwargs).replace(u"\ufeff", u"")
 
 
 # Replace None with h to also allow -h


### PR DESCRIPTION
Fix help print error when stdout/stderr not use utf-8 encoding, like https://github.com/tensorflow/models/issues/5637

Main reason is the help wrap did not check the stdout encoding, even the system have installed utf-8 locale package