### PR TITLE
Update readme.md to fix the issue #7040.

### DIFF
--- a/research/maskgan/README.md
+++ b/research/maskgan/README.md
@@ -98,7 +98,6 @@ python generate_samples.py \
    The issue arises if you saved the model with an earlier version (seq2seq is old) and restore with a recent one (saver.restore got updated).
    The naming convention for LSTM parameters changed, e.g. cell_0/basic_lstm_cell/weights became cell_0/basic_lstm_cell/kernel.
    Which is why you cannot restore them if you try to restore old checkpoints with recent TF.
-   Please edit the original maskGAN readme file and add this information.
    The below script will help rename the variables and everything will work as expected.
    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/tools/checkpoint_convert.py
 

--- a/research/maskgan/README.md
+++ b/research/maskgan/README.md
@@ -19,7 +19,7 @@ Copy PTB data downloaded from the above tensorflow RNN tutorial to folder "/tmp/
 Make folder /tmp/pretrain-lm and copy checkpoints from above Tensorflow RNN tutorial under this folder.
 
 
-2. Run MaskGAN in MLE pretraining mode. If step 1 was not run, set
+2. Run MaskGAN in MLE pretraining mode. If step 1 was not run*, set
 `language_model_ckpt_dir` to empty.
 
 ```bash
@@ -86,6 +86,20 @@ python generate_samples.py \
  --baseline_method=critic \
  --number_epochs=4
 ```
+
+*  While trying to run Step 2, the following error appears:
+   NotFoundError (see above for traceback): Restoring from checkpoint failed. This is most likely due to a Variable name or other graph    key that is missing from the checkpoint. Please ensure that you have not altered the graph expected based on the checkpoint. Original    error:
+
+   Key critic/rnn/biases not found in checkpoint
+   [[node save/RestoreV2 (defined at train_mask_gan.py:431) ]]
+
+   This is an issue with seq2seq model because it uses the attention mechanism.
+   The issue arises if you saved the model with an earlier version (seq2seq is old) and restore with a recent one (saver.restore got        updated).
+   The naming convention for LSTM parameters changed, e.g. cell_0/basic_lstm_cell/weights became cell_0/basic_lstm_cell/kernel.
+   Which is why you cannot restore them if you try to restore old checkpoints with recent TF.
+   Please edit the original maskGAN readme file and add this information.
+   The below script will help rename the variables and everything will work as expected.
+   https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/tools/checkpoint_convert.py
 
 ## Contact for Issues
 

--- a/research/maskgan/README.md
+++ b/research/maskgan/README.md
@@ -87,6 +87,7 @@ python generate_samples.py \
  --number_epochs=4
 ```
 
+
 *  While trying to run Step 2, the following error appears:
    NotFoundError (see above for traceback): Restoring from checkpoint failed. This is most likely due to a Variable name or other graph    key that is missing from the checkpoint. Please ensure that you have not altered the graph expected based on the checkpoint. Original    error:
 
@@ -94,7 +95,7 @@ python generate_samples.py \
    [[node save/RestoreV2 (defined at train_mask_gan.py:431) ]]
 
    This is an issue with seq2seq model because it uses the attention mechanism.
-   The issue arises if you saved the model with an earlier version (seq2seq is old) and restore with a recent one (saver.restore got        updated).
+   The issue arises if you saved the model with an earlier version (seq2seq is old) and restore with a recent one (saver.restore got updated).
    The naming convention for LSTM parameters changed, e.g. cell_0/basic_lstm_cell/weights became cell_0/basic_lstm_cell/kernel.
    Which is why you cannot restore them if you try to restore old checkpoints with recent TF.
    Please edit the original maskGAN readme file and add this information.


### PR DESCRIPTION
There is an error in step3 of maskGAN.

NotFoundError (see above for traceback): Restoring from checkpoint failed. This is most likely due to a Variable name or other graph key that is missing from the checkpoint. Please ensure that you have not altered the graph expected based on the checkpoint. Original error:

Key critic/rnn/biases not found in checkpoint
[[node save/RestoreV2 (defined at train_mask_gan.py:431) ]]

This is an issue with seq2seq model because it uses the attention mechanism.
The issue arises if you saved the model with an earlier version (seq2seq is old) and restore with a recent one (saver.restore got updated).
The naming convention for LSTM parameters changed, e.g. cell_0/basic_lstm_cell/weights became cell_0/basic_lstm_cell/kernel.
Which is why you cannot restore them if you try to restore old checkpoints with recent TF.
Please edit the original maskGAN readme file and add this information.
The below script will help rename the variables and everything will work as expected.
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/tools/checkpoint_convert.py

I tested and it worked for me, please confirm if it does for you.