### PR TITLE
Reduce transformer fp16 test to 12 iterations.

### DIFF
--- a/official/transformer/v2/transformer_benchmark.py
+++ b/official/transformer/v2/transformer_benchmark.py
@@ -310,7 +310,7 @@ class TransformerBigKerasAccuracy(TransformerBenchmark):
     FLAGS['bleu_ref'].value = self.bleu_ref
     FLAGS.param_set = 'big'
     FLAGS.batch_size = 3072*8
-    FLAGS.train_steps = 400000
+    FLAGS.train_steps = 20000 * 12
     FLAGS.steps_between_evals = 20000
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_fp16')
     self._run_and_report_benchmark(total_batch_size=FLAGS.batch_size,


### PR DESCRIPTION
Early results indicate FP16 trains with the same or maybe less steps than FP32. No need for the 20 epochs which takes "forever" and has no added value.