### PR TITLE
Move Keras Hook to use global step to resolve issues across epochs.

### DIFF
--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -22,10 +22,8 @@ import time
 from absl import flags
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 
-from official.resnet import cifar10_main as cifar_main
 from official.resnet.keras import keras_benchmark
 from official.resnet.keras import keras_cifar_main
-from official.resnet.keras import keras_common
 
 MIN_TOP_1_ACCURACY = 0.925
 MAX_TOP_1_ACCURACY = 0.938
@@ -228,6 +226,7 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu')
     FLAGS.batch_size = 128
+    FLAGS.train_epochs = 3
     self._run_and_report_benchmark()
 
   def benchmark_graph_1_gpu(self):

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -226,7 +226,6 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu')
     FLAGS.batch_size = 128
-    FLAGS.train_epochs = 3
     self._run_and_report_benchmark()
 
   def benchmark_graph_1_gpu(self):

--- a/official/utils/misc/keras_utils.py
+++ b/official/utils/misc/keras_utils.py
@@ -66,6 +66,7 @@ class TimeHistory(tf.keras.callbacks.Callback):
                                                self.start_time))
 
   def on_batch_end(self, batch, logs=None):
+    """Records elapse time of the batch and calculates examples per second."""
     if self.global_steps % self.log_steps == 0:
       timestamp = time.time()
       elapsed_time = timestamp - self.start_time

--- a/official/utils/misc/keras_utils.py
+++ b/official/utils/misc/keras_utils.py
@@ -56,33 +56,27 @@ class TimeHistory(tf.keras.callbacks.Callback):
     # Logs start of step 0 then end of each step based on log_steps interval.
     self.timestamp_log = []
 
-  def on_train_begin(self, logs=None):
-    self.record_batch = True
-
   def on_train_end(self, logs=None):
     self.train_finish_time = time.time()
 
   def on_batch_begin(self, batch, logs=None):
-    if self.record_batch:
-      timestamp = time.time()
-      self.start_time = timestamp
-      self.record_batch = False
-      if self.global_steps == 0:
-        self.timestamp_log.append(BatchTimestamp(self.global_steps, timestamp))
     self.global_steps += 1
+    if self.global_steps == 1:
+      self.start_time = time.time()
+      self.timestamp_log.append(BatchTimestamp(self.global_steps,
+                                               self.start_time))
 
   def on_batch_end(self, batch, logs=None):
     if self.global_steps % self.log_steps == 0:
       timestamp = time.time()
       elapsed_time = timestamp - self.start_time
       examples_per_second = (self.batch_size * self.log_steps) / elapsed_time
-      if self.global_steps != 1:
-        self.record_batch = True
-        self.timestamp_log.append(BatchTimestamp(self.global_steps, timestamp))
-        tf.compat.v1.logging.info(
-            "BenchmarkMetric: {'global step':%d, 'time_taken': %f,"
-            "'examples_per_second': %f}" %
-            (self.global_steps, elapsed_time, examples_per_second))
+      self.timestamp_log.append(BatchTimestamp(self.global_steps, timestamp))
+      tf.compat.v1.logging.info(
+          "BenchmarkMetric: {'global step':%d, 'time_taken': %f,"
+          "'examples_per_second': %f}" %
+          (self.global_steps, elapsed_time, examples_per_second))
+      self.start_time = timestamp
 
 
 def get_profiler_callback(model_dir, profile_steps, enable_tensorboard):

--- a/official/utils/misc/keras_utils.py
+++ b/official/utils/misc/keras_utils.py
@@ -46,14 +46,13 @@ class TimeHistory(tf.keras.callbacks.Callback):
     Args:
       batch_size: Total batch size.
       log_steps: Interval of time history logs.
-
     """
     self.batch_size = batch_size
     super(TimeHistory, self).__init__()
     self.log_steps = log_steps
     self.global_steps = 0
 
-    # Logs start of step 0 then end of each step based on log_steps interval.
+    # Logs start of step 1 then end of each step based on log_steps interval.
     self.timestamp_log = []
 
   def on_train_end(self, logs=None):


### PR DESCRIPTION
I did local testing and the results of 5+ runs look to have the same variance as before.  Here is what I believe changed so the reviewer can check my logic:

- PerfZero uses the `self.timestamp_log` and I believe my change is a no-op for that code path  `self.timestamp_log.append(BatchTimestamp(self.global_steps, timestamp))` 
- Examples per second print out might be slightly lower because I no longer allow a gap between `on_batch_end` and `on_batch_begin`.  I made the start_time the end_time, which is how perfzero calculates the examples/second anyway.

Note that I do not think the estimator hook does this.  It looks like it used the step time taken from inside TensorFlow and I very much doubt that included the time between steps.  It should be minor based on the results I saw but I did not attempt to measure it.  

The improvement:

- Global step runs through epochs and does not reset like using `batch`.  Uneven batches resulted in the first log of each epoch after the first being incorrect and making it look like there was some issue at the epoch boundary.  I tested that if you do not do any eval between epochs it just keeps going and prints as expected with zero slow down.  If you do eval between epochs you will see the first measurement as slower as it will include that time.
