### PR TITLE
ResNet50 and ResNet56 Add stdev to the Dense layer.

### DIFF
--- a/official/resnet/keras/resnet_cifar_model.py
+++ b/official/resnet/keras/resnet_cifar_model.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 import functools
 import tensorflow as tf
 from tensorflow.python.keras import backend
+from tensorflow.python.keras  import initializers
 from tensorflow.python.keras import layers
 from tensorflow.python.keras import regularizers
 
@@ -241,9 +242,11 @@ def resnet(num_blocks, classes=10, training=None):
 
   rm_axes = [1, 2] if backend.image_data_format() == 'channels_last' else [2, 3]
   x = layers.Lambda(lambda x: backend.mean(x, rm_axes), name='reduce_mean')(x)
-  x = layers.Dense(classes, activation='softmax',
-                   # kernel_initializer='he_normal',
+  x = layers.Dense(classes,
+                   activation='softmax',
+                   kernel_initializer=initializers.RandomNormal(stddev=0.01),
                    kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
+                   bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
                    name='fc10')(x)
 
   inputs = img_input

--- a/official/resnet/keras/resnet_model.py
+++ b/official/resnet/keras/resnet_model.py
@@ -27,14 +27,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import warnings
-
 from tensorflow.python.keras import backend
+from tensorflow.python.keras  import initializers
 from tensorflow.python.keras import layers
 from tensorflow.python.keras import models
 from tensorflow.python.keras import regularizers
-from tensorflow.python.keras import utils
 
 
 L2_WEIGHT_DECAY = 1e-4
@@ -45,16 +42,15 @@ BATCH_NORM_EPSILON = 1e-5
 def identity_block(input_tensor, kernel_size, filters, stage, block):
   """The identity block is the block that has no conv layer at shortcut.
 
-  # Arguments
-      input_tensor: input tensor
-      kernel_size: default 3, the kernel size of
-          middle conv layer at main path
-      filters: list of integers, the filters of 3 conv layer at main path
-      stage: integer, current stage label, used for generating layer names
-      block: 'a','b'..., current block label, used for generating layer names
+  Args:
+    input_tensor: input tensor
+    kernel_size: default 3, the kernel size of middle conv layer at main path
+    filters: list of integers, the filters of 3 conv layer at main path
+    stage: integer, current stage label, used for generating layer names
+    block: 'a','b'..., current block label, used for generating layer names
 
-  # Returns
-      Output tensor for the block.
+  Returns:
+    Output tensor for the block.
   """
   filters1, filters2, filters3 = filters
   if backend.image_data_format() == 'channels_last':
@@ -107,21 +103,20 @@ def conv_block(input_tensor,
                strides=(2, 2)):
   """A block that has a conv layer at shortcut.
 
-  # Arguments
-      input_tensor: input tensor
-      kernel_size: default 3, the kernel size of
-          middle conv layer at main path
-      filters: list of integers, the filters of 3 conv layer at main path
-      stage: integer, current stage label, used for generating layer names
-      block: 'a','b'..., current block label, used for generating layer names
-      strides: Strides for the second conv layer in the block.
-
-  # Returns
-      Output tensor for the block.
-
   Note that from stage 3,
   the second conv layer at main path is with strides=(2, 2)
   And the shortcut should have strides=(2, 2) as well
+
+  Args:
+    input_tensor: input tensor
+    kernel_size: default 3, the kernel size of middle conv layer at main path
+    filters: list of integers, the filters of 3 conv layer at main path
+    stage: integer, current stage label, used for generating layer names
+    block: 'a','b'..., current block label, used for generating layer names
+    strides: Strides for the second conv layer in the block.
+
+  Returns:
+    Output tensor for the block.
   """
   filters1, filters2, filters3 = filters
   if backend.image_data_format() == 'channels_last':
@@ -175,11 +170,12 @@ def conv_block(input_tensor,
 
 
 def resnet50(num_classes, dtype='float32', batch_size=None):
-  # TODO(tfboyd): add training argument, just lik resnet56.
   """Instantiates the ResNet50 architecture.
 
   Args:
     num_classes: `int` number of classes for image classification.
+    dtype: dtype to use float32 or float16 are most common.
+    batch_size: Size of the batches for each step.
 
   Returns:
       A Keras model instance.
@@ -234,9 +230,11 @@ def resnet50(num_classes, dtype='float32', batch_size=None):
   x = layers.Lambda(lambda x: backend.mean(x, rm_axes), name='reduce_mean')(x)
   x = layers.Dense(
       num_classes,
+      kernel_initializer=initializers.RandomNormal(stddev=0.01),
       kernel_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
       bias_regularizer=regularizers.l2(L2_WEIGHT_DECAY),
       name='fc1000')(x)
+
   # TODO(reedwm): Remove manual casts once mixed precision can be enabled with a
   # single line of code.
   x = backend.cast(x, 'float32')


### PR DESCRIPTION
**Waiting on final test result to finish: ResNet50 XLA+FP16.**

This changes ResNet50 and ResNet56.  The detailed comments below cover each situation. The change was first made to ResNet50 to aligned with TPUs and was tested on TPU to reduce variance and help push to .764 more often. I decided to apply it to ResNet56 as well as make the dense layers match. 

**ResNet56**
In a 6 run test this has make ResNet56 much more stable and should allow us to reduce the error bars for the test to better detect regressions.  We currently have to accept values as low as .924 as possibly ok.  

**Before:**  Min: .924  Max: .938  Median: .931
**After:**   Min  .929  MAX .934  Median: .932

Raw numbers:
0.9324919581
0.9309895635
0.9342948794
0.9292868376
0.9331930876
0.9320913553

**ResNet50**
I just did one run given the change was minor and I believe I have seen us set this in tf_cnn_benchmarks or maybe not.  Either way I did XLA + FP16 because it runs fast and if that works we should be good to go. 
625/625 - 244s - loss: 1.3501 - sparse_categorical_accuracy: 0.7797 - val_loss: 1.3821 - val_sparse_categorical_accuracy: **0.7638** <-- looks good.

https://sponge.corp.google.com/target?id=c09a85d7-28a1-46e0-a3c4-eebd49dbc6cc&target=tensorflow_models/perfzero/manual/v100_8_gpu/v100_8_gpu&searchFor=&show=ALL&sortBy=STATUS


