### PR TITLE
Support RunConfig overrides on command line

### DIFF
--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -24,6 +24,7 @@ import tensorflow as tf
 
 from object_detection import model_hparams
 from object_detection import model_lib
+from object_detection import model_runconfig
 
 flags.DEFINE_string(
     'model_dir', None, 'Path to output model directory '
@@ -46,6 +47,10 @@ flags.DEFINE_string(
     'represented as a string containing comma-separated '
     'hparam_name=value pairs.')
 flags.DEFINE_string(
+    'runconfig_overrides', None, 'run config overrides, '
+    'represented as a string containing comma-separated '
+    'param_name=value pairs.')
+flags.DEFINE_string(
     'checkpoint_dir', None, 'Path to directory holding a checkpoint.  If '
     '`checkpoint_dir` is provided, this binary operates in eval-only mode, '
     'writing resulting metrics to `model_dir`.')
@@ -59,7 +64,8 @@ FLAGS = flags.FLAGS
 def main(unused_argv):
   flags.mark_flag_as_required('model_dir')
   flags.mark_flag_as_required('pipeline_config_path')
-  config = tf.estimator.RunConfig(model_dir=FLAGS.model_dir)
+  config = model_runconfig.create_runconfig(FLAGS.model_dir,
+                                            FLAGS.runconfig_overrides)
 
   train_and_eval_dict = model_lib.create_estimator_and_inputs(
       run_config=config,

--- a/research/object_detection/model_runconfig.py
+++ b/research/object_detection/model_runconfig.py
@@ -1,0 +1,70 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Estimator's RunConfig for the object detection model.
+
+This file provides functions for creating a RunConfig for the Estimator that is
+used for model training.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+
+def create_runconfig(model_dir, runconfig_overrides=None):
+  """Returns a RunConfig with default overwritten according to given
+  override string.
+
+  Args:
+    runconfig_overrides: Optional overrides, represented as a
+      string containing comma-separated param_name=value pairs.
+  Returns:
+    The run config as tf.estimator.RunConfig object.
+  """
+  def _type_map_from_values(config):
+    """Returns a type-map as expected by tf.contrib.training.parse_values
+    according to the given sample object.
+
+    Args:
+      config: a sample tf.estimator.RunConfig object used to determine
+        valid attributes and their types.
+    Returns:
+      A dict mapping from attribute name to the attribute's type. Attribute
+      names and types are computed from vars(config) but only for attributes
+      of primitive types (int, float, bool, str). A leading _ is stripped
+      from attribute names. For some None-valued attributes default types are
+      provided.
+    """
+    # Note that these default types might need to be adapted if
+    # RunConfig's attributes that are None by default changes.
+    type_map = {
+      'save_checkpoints_steps': int,
+      'tf_random_seed': int,
+      'protocol': str,
+    }
+    valid_types = {int, float, str, bool}
+    type_map.update({k.lstrip('_'): type(v)
+                     for k, v in vars(config).items()
+                     if type(v) in valid_types})
+    return type_map
+
+  config = tf.estimator.RunConfig(model_dir=model_dir)
+  if runconfig_overrides:
+    type_map = _type_map_from_values(config)
+    overrides = tf.contrib.training.parse_values(runconfig_overrides, type_map)
+    config = tf.estimator.RunConfig(model_dir=model_dir, **overrides)
+  return config

--- a/research/object_detection/model_runconfig_test.py
+++ b/research/object_detection/model_runconfig_test.py
@@ -1,0 +1,79 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for object detection model library."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from object_detection import model_runconfig
+
+
+class ModelRunConfigTest(tf.test.TestCase):
+
+  def test_create_runconfig(self):
+    """Tests creation of a plain RunConfig"""
+    model_dir = 'dir'
+
+    config = model_runconfig.create_runconfig(model_dir)
+
+    self.assertEqual(config.model_dir, model_dir)
+
+  def test_create_runconfig_with_valid_overrides(self):
+    """Tests creation of a RunConfig with some valid overrides"""
+    overrides = dict(protocol='grpc+verbs',
+                     tf_random_seed=5,
+                     save_checkpoints_secs=10)
+    override_string = self._to_override_string(overrides)
+
+    config = model_runconfig.create_runconfig('dir', override_string)
+
+    for k, v in overrides.items():
+      self.assertEqual(getattr(config, k), v)
+
+  def test_create_runconfig_with_inconsistent_overrides(self):
+    """Tests that overrides do not allow to create an inconsistent RunConfig"""
+
+    overrides = dict(save_checkpoints_steps=100,
+                     save_checkpoints_secs=10)
+    override_string = self._to_override_string(overrides)
+
+    with self.assertRaises(ValueError):
+      model_runconfig.create_runconfig('dir', override_string)
+
+  def test_create_runconfig_with_inconsistent_types_overrides(self):
+    """Tests that overrides with inconsistent types are not allowed"""
+    overrides = dict(save_summary_steps='str')
+    override_string = self._to_override_string(overrides)
+
+    with self.assertRaises(ValueError):
+      model_runconfig.create_runconfig('dir', override_string)
+
+  def test_create_runconfig_with_empty_override(self):
+    """Tests creation of a RunConfig with empty overrides"""
+    model_dir = 'dir'
+    config = model_runconfig.create_runconfig(model_dir, '')
+
+    self.assertEqual(config.model_dir, model_dir)
+
+  @staticmethod
+  def _to_override_string(overrides):
+    return ','.join(['{}={}'.format(k, v) for k, v in overrides.items()])
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
model_main is extended by a runconfig_overrides command line parameter
that allows to overwrite individual attributes of the default RunConfig
in a similar manner as hparams_overrides allows to overwrite
hyperparameters on command line.

Closes #5246

This is just a proposal. I am not sure if it makes sense to _reuse_ `parse_values` from `contrib.training`. Please advise if the implementation and the feature makes sense to you.