### PR TITLE
Record highest uncased bleu found.

### DIFF
--- a/official/transformer/v2/transformer_benchmark.py
+++ b/official/transformer/v2/transformer_benchmark.py
@@ -90,7 +90,7 @@ class TransformerBenchmark(PerfZeroBenchmark):
                         'value': bleu_uncased_best[1],
                         'min_value': bleu_min,
                         'max_value': bleu_max})
-        metrics.append({'name': 'bleu_recorded_iteration',
+        metrics.append({'name': 'bleu_best_score_iteration',
                         'value': bleu_uncased_best[0]})
         metrics.append({'name': 'bleu_uncased_last',
                         'value': stats['bleu_uncased']})

--- a/official/transformer/v2/transformer_benchmark.py
+++ b/official/transformer/v2/transformer_benchmark.py
@@ -83,10 +83,22 @@ class TransformerBenchmark(PerfZeroBenchmark):
 
     metrics = []
     if 'bleu_uncased' in stats:
-      metrics.append({'name': 'bleu_uncased',
-                      'value': stats['bleu_uncased'],
-                      'min_value': bleu_min,
-                      'max_value': bleu_max})
+      if 'bleu_uncased_history' in stats:
+        bleu_uncased_best = max(stats['bleu_uncased_history'],
+                                key=lambda x: x[1])
+        metrics.append({'name': 'bleu_uncased',
+                        'value': bleu_uncased_best[1],
+                        'min_value': bleu_min,
+                        'max_value': bleu_max})
+        metrics.append({'name': 'bleu_recorded_iteration',
+                        'value': bleu_uncased_best[0]})
+        metrics.append({'name': 'bleu_uncased_last',
+                        'value': stats['bleu_uncased']})
+      else:
+        metrics.append({'name': 'bleu_uncased',
+                        'value': stats['bleu_uncased'],
+                        'min_value': bleu_min,
+                        'max_value': bleu_max})
 
     if (warmup and 'step_timestamp_log' in stats and
         len(stats['step_timestamp_log']) > warmup):
@@ -142,9 +154,9 @@ class TransformerBaseKerasAccuracy(TransformerBenchmark):
     FLAGS['bleu_source'].value = self.bleu_source
     FLAGS['bleu_ref'].value = self.bleu_ref
     FLAGS.param_set = 'base'
-    FLAGS.batch_size = 4096
-    FLAGS.train_steps = 100000
-    FLAGS.steps_between_evals = 5000
+    FLAGS.batch_size = 2048
+    FLAGS.train_steps = 1000
+    FLAGS.steps_between_evals = 500
     FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu')
     # These bleu scores are based on test runs after at this limited
     # number of steps and batch size after verifying SOTA at 8xV100s.

--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -167,6 +167,7 @@ class TransformerTask(object):
     iterations = flags_obj.train_steps // flags_obj.steps_between_evals
 
     cased_score, uncased_score = None, None
+    cased_score_history, uncased_score_history = [], []
     for i in range(1, iterations + 1):
       print("Start train iteration:{}/{}".format(i, iterations))
       history = model.fit(
@@ -187,13 +188,15 @@ class TransformerTask(object):
 
       if (flags_obj.bleu_source and flags_obj.bleu_ref):
         uncased_score, cased_score = self.eval()
-
-      print("BLEU: uncased={}, cased={}".format(uncased_score, cased_score))
+        cased_score_history.append([i, cased_score])
+        uncased_score_history.append([i, uncased_score])
 
     stats = misc.build_stats(history, callbacks)
     if uncased_score and cased_score:
       stats["bleu_uncased"] = uncased_score
       stats["bleu_cased"] = cased_score
+      stats["bleu_uncased_history"] = uncased_score_history
+      stats["bleu_cased_history"] = cased_score_history
     return stats
 
   def eval(self):


### PR DESCRIPTION
This records the highest bleu score found along with which iteration it occurred on.  It is possible the issues with our variance can be resolved; but for now this will give us a better indication as to if we have an issue.  

My knowledge is not complete, but the paper mentioned it took the average of the parameters of the last 5 checkpoints.  This suggest to me the result is not as stable as say ResNet.  Currently running the test and taking a reading at a predefined epoch gives results that are not conclusive or actionable.  

I also record the final bleu uncased in a different field so that is also tracked.  