### PR TITLE
Release Open Image 2019 metrics

### DIFF
--- a/research/object_detection/README.md
+++ b/research/object_detection/README.md
@@ -78,7 +78,7 @@ Extras:
   * <a href='g3doc/instance_segmentation.md'>
       Run an instance segmentation model</a><br>
   * <a href='g3doc/challenge_evaluation.md'>
-      Run the evaluation for the Open Images Challenge 2018</a><br>
+      Run the evaluation for the Open Images Challenge 2018/2019</a><br>
   * <a href='g3doc/tpu_compatibility.md'>
       TPU compatible detection pipelines</a><br>
   * <a href='g3doc/running_on_mobile_tensorflowlite.md'>
@@ -101,9 +101,23 @@ reporting an issue.
 
 ## Release information
 
+### July 1st, 2019
+
+We have released an updated set of utils and an updated
+[tutorial](g3doc/challenge_evaluation.md) for all three tracks of the
+[Open Images Challenge 2019](https://storage.googleapis.com/openimages/web/challenge2019.html)!
+
+The Instance Segmentation metric for
+[Open Images V5](https://storage.googleapis.com/openimages/web/index.html)
+and [Challenge 2019](https://storage.googleapis.com/openimages/web/challenge2019.html)
+is part of this release. Check out [the metric description](https://storage.googleapis.com/openimages/web/evaluation.html#instance_segmentation_eval)
+on the Open Images website.
+
+<b>Thanks to contributors</b>: Alina Kuznetsova, Rodrigo Benenson
+
 ### Feb 11, 2019
 
-We have released detection models trained on the [Open Images Dataset V4](https://storage.googleapis.com/openimages/web/challenge.html)
+We have released detection models trained on the Open Images Dataset V4
 in our detection model zoo, including
 
 * Faster R-CNN detector with Inception Resnet V2 feature extractor

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -206,6 +206,9 @@ def _build_ssd_feature_extractor(feature_extractor_config,
             feature_extractor_config.replace_preprocessor_with_placeholder
     })
 
+  if feature_extractor_config.HasField('num_layers'):
+    kwargs.update({'num_layers': feature_extractor_config.num_layers})
+
   if is_keras_extractor:
     kwargs.update({
         'conv_hyperparams': conv_hyperparams,

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -78,13 +78,16 @@ def _build_non_max_suppressor(nms_config):
 
   Raises:
     ValueError: On incorrect iou_threshold or on incompatible values of
-      max_total_detections and max_detections_per_class.
+      max_total_detections and max_detections_per_class or on negative
+      soft_nms_sigma.
   """
   if nms_config.iou_threshold < 0 or nms_config.iou_threshold > 1.0:
     raise ValueError('iou_threshold not in [0, 1.0].')
   if nms_config.max_detections_per_class > nms_config.max_total_detections:
     raise ValueError('max_detections_per_class should be no greater than '
                      'max_total_detections.')
+  if nms_config.soft_nms_sigma < 0.0:
+    raise ValueError('soft_nms_sigma should be non-negative.')
   non_max_suppressor_fn = functools.partial(
       post_processing.batch_multiclass_non_max_suppression,
       score_thresh=nms_config.score_threshold,
@@ -93,7 +96,8 @@ def _build_non_max_suppressor(nms_config):
       max_total_size=nms_config.max_total_detections,
       use_static_shapes=nms_config.use_static_shapes,
       use_class_agnostic_nms=nms_config.use_class_agnostic_nms,
-      max_classes_per_detection=nms_config.max_classes_per_detection)
+      max_classes_per_detection=nms_config.max_classes_per_detection,
+      soft_nms_sigma=nms_config.soft_nms_sigma)
   return non_max_suppressor_fn
 
 

--- a/research/object_detection/builders/post_processing_builder_test.py
+++ b/research/object_detection/builders/post_processing_builder_test.py
@@ -30,6 +30,7 @@ class PostProcessingBuilderTest(tf.test.TestCase):
         iou_threshold: 0.6
         max_detections_per_class: 100
         max_total_detections: 300
+        soft_nms_sigma: 0.4
       }
     """
     post_processing_config = post_processing_pb2.PostProcessing()
@@ -40,6 +41,7 @@ class PostProcessingBuilderTest(tf.test.TestCase):
     self.assertEqual(non_max_suppressor.keywords['max_total_size'], 300)
     self.assertAlmostEqual(non_max_suppressor.keywords['score_thresh'], 0.7)
     self.assertAlmostEqual(non_max_suppressor.keywords['iou_thresh'], 0.6)
+    self.assertAlmostEqual(non_max_suppressor.keywords['soft_nms_sigma'], 0.4)
 
   def test_build_non_max_suppressor_with_correct_parameters_classagnostic_nms(
       self):

--- a/research/object_detection/builders/preprocessor_builder.py
+++ b/research/object_detection/builders/preprocessor_builder.py
@@ -297,6 +297,26 @@ def build(preprocessor_step_config):
               })
     return (preprocessor.ssd_random_crop, {})
 
+  if step_type == 'autoaugment_image':
+    config = preprocessor_step_config.autoaugment_image
+    return (preprocessor.autoaugment_image, {
+        'policy_name': config.policy_name,
+    })
+
+  if step_type == 'drop_label_probabilistically':
+    config = preprocessor_step_config.drop_label_probabilistically
+    return (preprocessor.drop_label_probabilistically, {
+        'dropped_label': config.label,
+        'drop_probability': config.drop_probability,
+    })
+
+  if step_type == 'remap_labels':
+    config = preprocessor_step_config.remap_labels
+    return (preprocessor.remap_labels, {
+        'original_labels': config.original_labels,
+        'new_label': config.new_label
+    })
+
   if step_type == 'ssd_random_crop_pad':
     config = preprocessor_step_config.ssd_random_crop_pad
     if config.operations:

--- a/research/object_detection/builders/preprocessor_builder_test.py
+++ b/research/object_detection/builders/preprocessor_builder_test.py
@@ -363,6 +363,51 @@ class PreprocessorBuilderTest(tf.test.TestCase):
                                         'probability': 0.95,
                                         'size_to_image_ratio': 0.12})
 
+  def test_auto_augment_image(self):
+    preprocessor_text_proto = """
+    autoaugment_image {
+      policy_name: 'v0'
+    }
+    """
+    preprocessor_proto = preprocessor_pb2.PreprocessingStep()
+    text_format.Merge(preprocessor_text_proto, preprocessor_proto)
+    function, args = preprocessor_builder.build(preprocessor_proto)
+    self.assertEqual(function, preprocessor.autoaugment_image)
+    self.assert_dictionary_close(args, {'policy_name': 'v0'})
+
+  def test_drop_label_probabilistically(self):
+    preprocessor_text_proto = """
+    drop_label_probabilistically{
+      label: 2
+      drop_probability: 0.5
+    }
+    """
+    preprocessor_proto = preprocessor_pb2.PreprocessingStep()
+    text_format.Merge(preprocessor_text_proto, preprocessor_proto)
+    function, args = preprocessor_builder.build(preprocessor_proto)
+    self.assertEqual(function, preprocessor.drop_label_probabilistically)
+    self.assert_dictionary_close(args, {
+        'dropped_label': 2,
+        'drop_probability': 0.5
+    })
+
+  def test_remap_labels(self):
+    preprocessor_text_proto = """
+    remap_labels{
+      original_labels: 1
+      original_labels: 2
+      new_label: 3
+    }
+    """
+    preprocessor_proto = preprocessor_pb2.PreprocessingStep()
+    text_format.Merge(preprocessor_text_proto, preprocessor_proto)
+    function, args = preprocessor_builder.build(preprocessor_proto)
+    self.assertEqual(function, preprocessor.remap_labels)
+    self.assert_dictionary_close(args, {
+        'original_labels': [1, 2],
+        'new_label': 3
+    })
+
   def test_build_random_resize_method(self):
     preprocessor_text_proto = """
     random_resize_method {

--- a/research/object_detection/core/anchor_generator.py
+++ b/research/object_detection/core/anchor_generator.py
@@ -29,15 +29,20 @@ dynamically at generation time.  The number of anchors to place at each location
 is static --- implementations of AnchorGenerator must always be able return
 the number of anchors that it uses per location for each feature map.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from abc import ABCMeta
 from abc import abstractmethod
 
+import six
+from six.moves import zip
 import tensorflow as tf
 
 
-class AnchorGenerator(object):
+class AnchorGenerator(six.with_metaclass(ABCMeta, object)):
   """Abstract base class for anchor generators."""
-  __metaclass__ = ABCMeta
 
   @abstractmethod
   def name_scope(self):
@@ -147,4 +152,3 @@ class AnchorGenerator(object):
                                * feature_map_shape[1])
       actual_num_anchors += anchors.num_boxes()
     return tf.assert_equal(expected_num_anchors, actual_num_anchors)
-

--- a/research/object_detection/core/batcher.py
+++ b/research/object_detection/core/batcher.py
@@ -14,8 +14,13 @@
 # ==============================================================================
 
 """Provides functions to batch a dictionary of input tensors."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import collections
 
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import prefetcher

--- a/research/object_detection/core/batcher_test.py
+++ b/research/object_detection/core/batcher_test.py
@@ -15,7 +15,12 @@
 
 """Tests for object_detection.core.batcher."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import batcher

--- a/research/object_detection/core/box_coder.py
+++ b/research/object_detection/core/box_coder.py
@@ -26,10 +26,15 @@ Users of a BoxCoder can call two methods:
 In both cases, the arguments are assumed to be in 1-1 correspondence already;
 it is not the job of a BoxCoder to perform matching.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
 
+import six
 import tensorflow as tf
 
 from object_detection.utils import shape_utils
@@ -42,9 +47,8 @@ MEAN_STDDEV = 'mean_stddev'
 SQUARE = 'square'
 
 
-class BoxCoder(object):
+class BoxCoder(six.with_metaclass(ABCMeta, object)):
   """Abstract base class for box coder."""
-  __metaclass__ = ABCMeta
 
   @abstractproperty
   def code_size(self):

--- a/research/object_detection/core/box_list_ops.py
+++ b/research/object_detection/core/box_list_ops.py
@@ -23,6 +23,11 @@ Example box operations that are supported:
 Whenever box_list_ops functions output a BoxList, the fields of the incoming
 BoxList are retained unless documented otherwise.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import box_list

--- a/research/object_detection/core/class_agnostic_nms_test.py
+++ b/research/object_detection/core/class_agnostic_nms_test.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for google3.third_party.tensorflow_models.object_detection.core.class_agnostic_nms."""
+from absl.testing import parameterized
 import tensorflow as tf
 from object_detection.core import post_processing
 from object_detection.core import standard_fields as fields
 from object_detection.utils import test_case
 
 
-class ClassAgnosticNonMaxSuppressionTest(test_case.TestCase):
+class ClassAgnosticNonMaxSuppressionTest(test_case.TestCase,
+                                         parameterized.TestCase):
 
   def test_class_agnostic_nms_select_with_shared_boxes(self):
     boxes = tf.constant(
@@ -52,6 +54,7 @@ class ClassAgnosticNonMaxSuppressionTest(test_case.TestCase):
       self.assertAllClose(nms_corners_output, exp_nms_corners)
       self.assertAllClose(nms_scores_output, exp_nms_scores)
       self.assertAllClose(nms_classes_output, exp_nms_classes)
+
 
   def test_class_agnostic_nms_select_with_per_class_boxes(self):
     boxes = tf.constant(
@@ -98,7 +101,14 @@ class ClassAgnosticNonMaxSuppressionTest(test_case.TestCase):
       self.assertAllClose(nms_scores_output, exp_nms_scores)
       self.assertAllClose(nms_classes_output, exp_nms_classes)
 
-  def test_batch_classagnostic_nms_with_batch_size_1(self):
+  # Two cases will be tested here: using / not using static shapes.
+  # Named the two test cases for easier control during testing, with a flag of
+  # '--test_filter=ClassAgnosticNonMaxSuppressionTest.test_batch_classagnostic_nms_with_batch_size_1'
+  # or
+  # '--test_filter=ClassAgnosticNonMaxSuppressionTest.test_batch_classagnostic_nms_with_batch_size_1_use_static_shapes'.
+  @parameterized.named_parameters(('', False), ('_use_static_shapes', True))
+  def test_batch_classagnostic_nms_with_batch_size_1(self,
+                                                     use_static_shapes=False):
     boxes = tf.constant(
         [[[[0, 0, 1, 1]], [[0, 0.1, 1, 1.1]], [[0, -0.1, 1, 0.9]],
           [[0, 10, 1, 11]], [[0, 10.1, 1, 11.1]], [[0, 100, 1, 101]],
@@ -126,6 +136,7 @@ class ClassAgnosticNonMaxSuppressionTest(test_case.TestCase):
          max_size_per_class=max_output_size,
          max_total_size=max_output_size,
          use_class_agnostic_nms=use_class_agnostic_nms,
+         use_static_shapes=use_static_shapes,
          max_classes_per_detection=max_classes_per_detection)
 
     self.assertIsNone(nmsed_masks)

--- a/research/object_detection/core/data_decoder.py
+++ b/research/object_detection/core/data_decoder.py
@@ -18,13 +18,16 @@
 Data decoders decode the input data and return a dictionary of tensors keyed by
 the entries in core.reader.Fields.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from abc import ABCMeta
 from abc import abstractmethod
+import six
 
 
-class DataDecoder(object):
+class DataDecoder(six.with_metaclass(ABCMeta, object)):
   """Interface for data decoders."""
-  __metaclass__ = ABCMeta
 
   @abstractmethod
   def decode(self, data):

--- a/research/object_detection/core/data_parser.py
+++ b/research/object_detection/core/data_parser.py
@@ -20,12 +20,16 @@ to numpy arrays (materialized tensors) directly, it is used to read data for
 evaluation/visualization; to parse the data during training, DataDecoder should
 be used.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from abc import ABCMeta
 from abc import abstractmethod
+import six
 
 
-class DataToNumpyParser(object):
-  __metaclass__ = ABCMeta
+class DataToNumpyParser(six.with_metaclass(ABCMeta, object)):
+  """Abstract interface for data parser that produces numpy arrays."""
 
   @abstractmethod
   def parse(self, input_data):

--- a/research/object_detection/core/freezable_batch_norm_test.py
+++ b/research/object_detection/core/freezable_batch_norm_test.py
@@ -14,7 +14,12 @@
 # ==============================================================================
 
 """Tests for object_detection.core.freezable_batch_norm."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import freezable_batch_norm

--- a/research/object_detection/core/losses.py
+++ b/research/object_detection/core/losses.py
@@ -26,7 +26,12 @@ Classification losses:
  * WeightedSoftmaxClassificationAgainstLogitsLoss
  * BootstrappedSigmoidClassificationLoss
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import abc
+import six
 import tensorflow as tf
 
 from object_detection.core import box_list
@@ -36,9 +41,8 @@ from object_detection.utils import ops
 slim = tf.contrib.slim
 
 
-class Loss(object):
+class Loss(six.with_metaclass(abc.ABCMeta, object)):
   """Abstract base class for loss functions."""
-  __metaclass__ = abc.ABCMeta
 
   def __call__(self,
                prediction_tensor,
@@ -153,6 +157,7 @@ class WeightedSmoothL1LocalizationLoss(Loss):
     Args:
       delta: delta for smooth L1 loss.
     """
+    super(WeightedSmoothL1LocalizationLoss, self).__init__()
     self._delta = delta
 
   def _compute_loss(self, prediction_tensor, target_tensor, weights):
@@ -257,6 +262,7 @@ class SigmoidFocalClassificationLoss(Loss):
       gamma: exponent of the modulating factor (1 - p_t) ^ gamma.
       alpha: optional alpha weighting factor to balance positives vs negatives.
     """
+    super(SigmoidFocalClassificationLoss, self).__init__()
     self._alpha = alpha
     self._gamma = gamma
 
@@ -316,6 +322,7 @@ class WeightedSoftmaxClassificationLoss(Loss):
                    (default 1.0)
 
     """
+    super(WeightedSoftmaxClassificationLoss, self).__init__()
     self._logit_scale = logit_scale
 
   def _compute_loss(self, prediction_tensor, target_tensor, weights):
@@ -360,6 +367,7 @@ class WeightedSoftmaxClassificationAgainstLogitsLoss(Loss):
                    (default 1.0)
 
     """
+    super(WeightedSoftmaxClassificationAgainstLogitsLoss, self).__init__()
     self._logit_scale = logit_scale
 
   def _scale_and_softmax_logits(self, logits):
@@ -423,6 +431,7 @@ class BootstrappedSigmoidClassificationLoss(Loss):
     Raises:
       ValueError: if bootstrap_type is not either 'hard' or 'soft'
     """
+    super(BootstrappedSigmoidClassificationLoss, self).__init__()
     if bootstrap_type != 'hard' and bootstrap_type != 'soft':
       raise ValueError('Unrecognized bootstrap_type: must be one of '
                        '\'hard\' or \'soft.\'')
@@ -673,3 +682,5 @@ class HardExampleMiner(object):
     num_negatives = tf.size(subsampled_selection_indices) - num_positives
     return (tf.reshape(tf.gather(indices, subsampled_selection_indices), [-1]),
             num_positives, num_negatives)
+
+

--- a/research/object_detection/core/losses_test.py
+++ b/research/object_detection/core/losses_test.py
@@ -14,9 +14,14 @@
 # ==============================================================================
 
 """Tests for google3.research.vale.object_detection.losses."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import math
 
 import numpy as np
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import box_list

--- a/research/object_detection/core/matcher.py
+++ b/research/object_detection/core/matcher.py
@@ -31,7 +31,12 @@ consider this box a positive example (match) nor a negative example (no match).
 The Match class is used to store the match results and it provides simple apis
 to query the results.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import abc
+import six
 import tensorflow as tf
 
 from object_detection.utils import ops
@@ -210,10 +215,9 @@ class Match(object):
     return gathered_tensor
 
 
-class Matcher(object):
+class Matcher(six.with_metaclass(abc.ABCMeta, object)):
   """Abstract base class for matcher.
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self, use_matmul_gather=False):
     """Constructs a Matcher.

--- a/research/object_detection/core/minibatch_sampler.py
+++ b/research/object_detection/core/minibatch_sampler.py
@@ -28,17 +28,21 @@ Subclasses should implement the Subsample function and can make use of the
 @staticmethod SubsampleIndicator.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from abc import ABCMeta
 from abc import abstractmethod
 
+import six
 import tensorflow as tf
 
 from object_detection.utils import ops
 
 
-class MinibatchSampler(object):
+class MinibatchSampler(six.with_metaclass(ABCMeta, object)):
   """Abstract base class for subsampling minibatches."""
-  __metaclass__ = ABCMeta
 
   def __init__(self):
     """Constructs a minibatch sampler."""

--- a/research/object_detection/core/model.py
+++ b/research/object_detection/core/model.py
@@ -54,7 +54,12 @@ By default, DetectionModels produce bounding box detections; However, we support
 a handful of auxiliary annotations associated with each bounding box, namely,
 instance masks and keypoints.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import abc
+import six
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields
@@ -68,12 +73,11 @@ except AttributeError:
   _BaseClass = object
 
 
-class DetectionModel(_BaseClass):
+class DetectionModel(six.with_metaclass(abc.ABCMeta, _BaseClass)):
   """Abstract base class for detection models.
 
   Extends tf.Module to guarantee variable tracking.
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self, num_classes):
     """Constructor.

--- a/research/object_detection/core/multiclass_nms_test.py
+++ b/research/object_detection/core/multiclass_nms_test.py
@@ -521,5 +521,6 @@ class MulticlassNonMaxSuppressionTest(test_case.TestCase):
       self.assertAllClose(nms_classes_output, exp_nms_classes)
 
 
+
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/core/prefetcher_test.py
+++ b/research/object_detection/core/prefetcher_test.py
@@ -14,6 +14,11 @@
 # ==============================================================================
 
 """Tests for object_detection.core.prefetcher."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import prefetcher

--- a/research/object_detection/core/region_similarity_calculator.py
+++ b/research/object_detection/core/region_similarity_calculator.py
@@ -18,18 +18,22 @@
 Region Similarity Calculators compare a pairwise measure of similarity
 between the boxes in two BoxLists.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from abc import ABCMeta
 from abc import abstractmethod
 
+import six
 import tensorflow as tf
 
 from object_detection.core import box_list_ops
 from object_detection.core import standard_fields as fields
 
 
-class RegionSimilarityCalculator(object):
+class RegionSimilarityCalculator(six.with_metaclass(ABCMeta, object)):
   """Abstract base class for region similarity calculator."""
-  __metaclass__ = ABCMeta
 
   def compare(self, boxlist1, boxlist2, scope=None):
     """Computes matrix of pairwise similarity between BoxLists.
@@ -131,6 +135,7 @@ class ThresholdedIouSimilarity(RegionSimilarityCalculator):
         then the comparison result will be the foreground probability of
         the first box, otherwise it will be zero.
     """
+    super(ThresholdedIouSimilarity, self).__init__()
     self._iou_threshold = iou_threshold
 
   def _compare(self, boxlist1, boxlist2):

--- a/research/object_detection/core/standard_fields.py
+++ b/research/object_detection/core/standard_fields.py
@@ -119,6 +119,9 @@ class DetectionResultFields(object):
     raw_detection_boxes: contains decoded detection boxes without Non-Max
       suppression.
     raw_detection_scores: contains class score logits for raw detection boxes.
+    detection_anchor_indices: The anchor indices of the detections after NMS.
+    detection_features: contains extracted features for each detected box
+      after NMS.
   """
 
   source_id = 'source_id'
@@ -126,6 +129,7 @@ class DetectionResultFields(object):
   detection_boxes = 'detection_boxes'
   detection_scores = 'detection_scores'
   detection_multiclass_scores = 'detection_multiclass_scores'
+  detection_features = 'detection_features'
   detection_classes = 'detection_classes'
   detection_masks = 'detection_masks'
   detection_boundaries = 'detection_boundaries'
@@ -133,6 +137,7 @@ class DetectionResultFields(object):
   num_detections = 'num_detections'
   raw_detection_boxes = 'raw_detection_boxes'
   raw_detection_scores = 'raw_detection_scores'
+  detection_anchor_indices = 'detection_anchor_indices'
 
 
 class BoxListFields(object):

--- a/research/object_detection/core/target_assigner.py
+++ b/research/object_detection/core/target_assigner.py
@@ -31,6 +31,12 @@ Note that TargetAssigners only operate on detections from a single
 image at a time, so any logic for applying a TargetAssigner to multiple
 images must be handled externally.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.box_coders import faster_rcnn_box_coder

--- a/research/object_detection/data_decoders/tf_example_decoder.py
+++ b/research/object_detection/data_decoders/tf_example_decoder.py
@@ -17,6 +17,11 @@
 A decoder to decode string tensors containing serialized tensorflow.Example
 protos for object detection.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import data_decoder

--- a/research/object_detection/data_decoders/tf_example_decoder_test.py
+++ b/research/object_detection/data_decoders/tf_example_decoder_test.py
@@ -16,6 +16,7 @@
 
 import os
 import numpy as np
+import six
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields
@@ -66,9 +67,9 @@ class TfExampleDecoderTest(tf.test.TestCase):
                     dataset_util.bytes_list_feature(
                         [encoded_additional_channel] * 2),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/source_id':
-                    dataset_util.bytes_feature('image_id'),
+                    dataset_util.bytes_feature(six.b('image_id')),
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder(
@@ -88,9 +89,12 @@ class TfExampleDecoderTest(tf.test.TestCase):
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
-                'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
-                'image/format': dataset_util.bytes_feature('jpeg'),
-                'image/source_id': dataset_util.bytes_feature('image_id'),
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature(six.b('jpeg')),
+                'image/source_id':
+                    dataset_util.bytes_feature(six.b('image_id')),
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
@@ -107,7 +111,8 @@ class TfExampleDecoderTest(tf.test.TestCase):
     self.assertAllEqual(decoded_jpeg, tensor_dict[fields.InputDataFields.image])
     self.assertAllEqual([4, 5], tensor_dict[fields.InputDataFields.
                                             original_image_spatial_shape])
-    self.assertEqual('image_id', tensor_dict[fields.InputDataFields.source_id])
+    self.assertEqual(
+        six.b('image_id'), tensor_dict[fields.InputDataFields.source_id])
 
   def testDecodeImageKeyAndFilename(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
@@ -116,8 +121,8 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
-                'image/key/sha256': dataset_util.bytes_feature('abc'),
-                'image/filename': dataset_util.bytes_feature('filename')
+                'image/key/sha256': dataset_util.bytes_feature(six.b('abc')),
+                'image/filename': dataset_util.bytes_feature(six.b('filename'))
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
@@ -126,8 +131,9 @@ class TfExampleDecoderTest(tf.test.TestCase):
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
 
-    self.assertEqual('abc', tensor_dict[fields.InputDataFields.key])
-    self.assertEqual('filename', tensor_dict[fields.InputDataFields.filename])
+    self.assertEqual(six.b('abc'), tensor_dict[fields.InputDataFields.key])
+    self.assertEqual(
+        six.b('filename'), tensor_dict[fields.InputDataFields.filename])
 
   def testDecodePngImage(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
@@ -137,8 +143,9 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded': dataset_util.bytes_feature(encoded_png),
-                'image/format': dataset_util.bytes_feature('png'),
-                'image/source_id': dataset_util.bytes_feature('image_id')
+                'image/format': dataset_util.bytes_feature(six.b('png')),
+                'image/source_id': dataset_util.bytes_feature(
+                    six.b('image_id'))
             })).SerializeToString()
 
     example_decoder = tf_example_decoder.TfExampleDecoder()
@@ -155,7 +162,8 @@ class TfExampleDecoderTest(tf.test.TestCase):
     self.assertAllEqual(decoded_png, tensor_dict[fields.InputDataFields.image])
     self.assertAllEqual([4, 5], tensor_dict[fields.InputDataFields.
                                             original_image_spatial_shape])
-    self.assertEqual('image_id', tensor_dict[fields.InputDataFields.source_id])
+    self.assertEqual(
+        six.b('image_id'), tensor_dict[fields.InputDataFields.source_id])
 
   def testDecodePngInstanceMasks(self):
     image_tensor = np.random.randint(256, size=(10, 10, 3)).astype(np.uint8)
@@ -174,7 +182,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/mask':
                     dataset_util.bytes_list_feature(encoded_masks)
             })).SerializeToString()
@@ -200,7 +208,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/mask':
                     dataset_util.bytes_list_feature(encoded_masks),
                 'image/height':
@@ -232,7 +240,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/bbox/ymin':
                     dataset_util.float_list_feature(bbox_ymins),
                 'image/object/bbox/xmin':
@@ -271,7 +279,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/bbox/ymin':
                     dataset_util.float_list_feature(bbox_ymins),
                 'image/object/bbox/xmin':
@@ -321,7 +329,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/bbox/ymin':
                     dataset_util.float_list_feature(bbox_ymins),
                 'image/object/bbox/xmin':
@@ -354,7 +362,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/label':
                     dataset_util.int64_list_feature(bbox_classes),
             })).SerializeToString()
@@ -385,7 +393,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/multiclass_scores':
                     dataset_util.float_list_feature(flattened_multiclass_scores
                                                    ),
@@ -404,9 +412,40 @@ class TfExampleDecoderTest(tf.test.TestCase):
     tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
     with self.test_session() as sess:
       tensor_dict = sess.run(tensor_dict)
-
     self.assertAllEqual(flattened_multiclass_scores,
                         tensor_dict[fields.InputDataFields.multiclass_scores])
+
+  def testDecodeEmptyMultiClassScores(self):
+    image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
+    encoded_jpeg = self._EncodeImage(image_tensor)
+    bbox_ymins = [0.0, 4.0]
+    bbox_xmins = [1.0, 5.0]
+    bbox_ymaxs = [2.0, 6.0]
+    bbox_xmaxs = [3.0, 7.0]
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/encoded':
+                    dataset_util.bytes_feature(encoded_jpeg),
+                'image/format':
+                    dataset_util.bytes_feature(six.b('jpeg')),
+                'image/object/bbox/ymin':
+                    dataset_util.float_list_feature(bbox_ymins),
+                'image/object/bbox/xmin':
+                    dataset_util.float_list_feature(bbox_xmins),
+                'image/object/bbox/ymax':
+                    dataset_util.float_list_feature(bbox_ymaxs),
+                'image/object/bbox/xmax':
+                    dataset_util.float_list_feature(bbox_xmaxs),
+            })).SerializeToString()
+
+    example_decoder = tf_example_decoder.TfExampleDecoder(
+        load_multiclass_scores=True)
+    tensor_dict = example_decoder.decode(tf.convert_to_tensor(example))
+    with self.test_session() as sess:
+      tensor_dict = sess.run(tensor_dict)
+    self.assertEqual(0,
+                     tensor_dict[fields.InputDataFields.multiclass_scores].size)
 
   def testDecodeObjectLabelNoText(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
@@ -418,7 +457,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/label':
                     dataset_util.int64_list_feature(bbox_classes),
             })).SerializeToString()
@@ -454,7 +493,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeObjectLabelWithText(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    bbox_classes_text = ['cat', 'dog']
+    bbox_classes_text = [six.b('cat'), six.b('dog')]
     # Annotation label gets overridden by labelmap id.
     annotated_bbox_classes = [3, 4]
     expected_bbox_classes = [1, 2]
@@ -464,7 +503,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/text':
                     dataset_util.bytes_list_feature(bbox_classes_text),
                 'image/object/class/label':
@@ -499,14 +538,14 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeObjectLabelUnrecognizedName(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    bbox_classes_text = ['cat', 'cheetah']
+    bbox_classes_text = [six.b('cat'), six.b('cheetah')]
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/text':
                     dataset_util.bytes_list_feature(bbox_classes_text),
             })).SerializeToString()
@@ -541,14 +580,14 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeObjectLabelWithMappingWithDisplayName(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    bbox_classes_text = ['cat', 'dog']
+    bbox_classes_text = [six.b('cat'), six.b('dog')]
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/text':
                     dataset_util.bytes_list_feature(bbox_classes_text),
             })).SerializeToString()
@@ -583,7 +622,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeObjectLabelUnrecognizedNameWithMappingWithDisplayName(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    bbox_classes_text = ['cat', 'cheetah']
+    bbox_classes_text = [six.b('cat'), six.b('cheetah')]
     bbox_classes_id = [5, 6]
     example = tf.train.Example(
         features=tf.train.Features(
@@ -591,7 +630,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/text':
                     dataset_util.bytes_list_feature(bbox_classes_text),
                 'image/object/class/label':
@@ -627,14 +666,14 @@ class TfExampleDecoderTest(tf.test.TestCase):
   def testDecodeObjectLabelWithMappingWithName(self):
     image_tensor = np.random.randint(256, size=(4, 5, 3)).astype(np.uint8)
     encoded_jpeg = self._EncodeImage(image_tensor)
-    bbox_classes_text = ['cat', 'dog']
+    bbox_classes_text = [six.b('cat'), six.b('dog')]
     example = tf.train.Example(
         features=tf.train.Features(
             feature={
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/class/text':
                     dataset_util.bytes_list_feature(bbox_classes_text),
             })).SerializeToString()
@@ -676,7 +715,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/area':
                     dataset_util.float_list_feature(object_area),
             })).SerializeToString()
@@ -702,7 +741,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/is_crowd':
                     dataset_util.int64_list_feature(object_is_crowd),
             })).SerializeToString()
@@ -730,7 +769,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/difficult':
                     dataset_util.int64_list_feature(object_difficult),
             })).SerializeToString()
@@ -758,7 +797,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/group_of':
                     dataset_util.int64_list_feature(object_group_of),
             })).SerializeToString()
@@ -786,7 +825,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/object/weight':
                     dataset_util.float_list_feature(object_weights),
             })).SerializeToString()
@@ -828,7 +867,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/height':
                     dataset_util.int64_feature(image_height),
                 'image/width':
@@ -883,7 +922,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/height':
                     dataset_util.int64_feature(image_height),
                 'image/width':
@@ -905,7 +944,7 @@ class TfExampleDecoderTest(tf.test.TestCase):
         features=tf.train.Features(
             feature={
                 'image/encoded': dataset_util.bytes_feature(encoded_jpeg),
-                'image/format': dataset_util.bytes_feature('jpeg'),
+                'image/format': dataset_util.bytes_feature(six.b('jpeg')),
                 'image/class/label': dataset_util.int64_list_feature([1, 2]),
             })).SerializeToString()
     example_decoder = tf_example_decoder.TfExampleDecoder()
@@ -923,9 +962,10 @@ class TfExampleDecoderTest(tf.test.TestCase):
                 'image/encoded':
                     dataset_util.bytes_feature(encoded_jpeg),
                 'image/format':
-                    dataset_util.bytes_feature('jpeg'),
+                    dataset_util.bytes_feature(six.b('jpeg')),
                 'image/class/text':
-                    dataset_util.bytes_list_feature(['dog', 'cat']),
+                    dataset_util.bytes_list_feature(
+                        [six.b('dog'), six.b('cat')]),
             })).SerializeToString()
     label_map_string = """
       item {

--- a/research/object_detection/dataset_tools/oid_hierarchical_labels_expansion.py
+++ b/research/object_detection/dataset_tools/oid_hierarchical_labels_expansion.py
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-r"""An executable to expand hierarchically image-level labels and boxes.
+r"""An executable to expand image-level labels, boxes and segments.
+
+The expansion is performed using class hierarchy, provided in JSON file.
+
+The expected file formats are the following:
+- for box and segment files: CSV file is expected to have LabelName field
+- for image-level labels: CSV file is expected to have LabelName and Confidence
+fields
+
+Note, that LabelName is the only field used for expansion.
 
 Example usage:
 python models/research/object_detection/dataset_tools/\
@@ -20,13 +29,30 @@ oid_hierarchical_labels_expansion.py \
 --json_hierarchy_file=<path to JSON hierarchy> \
 --input_annotations=<input csv file> \
 --output_annotations=<output csv file> \
---annotation_type=<1 (for boxes) or 2 (for image-level labels)>
+--annotation_type=<1 (for boxes and segments) or 2 (for image-level labels)>
 """
 
 from __future__ import print_function
 
-import argparse
+import copy
 import json
+from absl import app
+from absl import flags
+
+flags.DEFINE_string(
+    'json_hierarchy_file', None,
+    'Path to the file containing label hierarchy in JSON format.')
+flags.DEFINE_string(
+    'input_annotations', None, 'Path to Open Images annotations file'
+    '(either bounding boxes, segments or image-level labels).')
+flags.DEFINE_string('output_annotations', None, 'Path to the output file.')
+flags.DEFINE_integer(
+    'annotation_type', None,
+    'Type of the input annotations: 1 - boxes or segments,'
+    '2 - image-level labels.'
+)
+
+FLAGS = flags.FLAGS
 
 
 def _update_dict(initial_dict, update):
@@ -37,11 +63,11 @@ def _update_dict(initial_dict, update):
    update: updated dictionary.
   """
 
-  for key, value_list in update.iteritems():
+  for key, value_list in update.items():
     if key in initial_dict:
-      initial_dict[key].extend(value_list)
+      initial_dict[key].update(value_list)
     else:
-      initial_dict[key] = value_list
+      initial_dict[key] = set(value_list)
 
 
 def _build_plain_hierarchy(hierarchy, skip_root=False):
@@ -57,7 +83,7 @@ def _build_plain_hierarchy(hierarchy, skip_root=False):
     keyed_child  - dictionary of children - all its parent nodes
     children - all children of the current node.
   """
-  all_children = []
+  all_children = set([])
   all_keyed_parent = {}
   all_keyed_child = {}
   if 'Subcategory' in hierarchy:
@@ -67,14 +93,14 @@ def _build_plain_hierarchy(hierarchy, skip_root=False):
       # ple parents in the hiearchy.
       _update_dict(all_keyed_parent, keyed_parent)
       _update_dict(all_keyed_child, keyed_child)
-      all_children.extend(children)
+      all_children.update(children)
 
   if not skip_root:
-    all_keyed_parent[hierarchy['LabelName']] = all_children
-    all_children = [hierarchy['LabelName']] + all_children
-    for child, _ in all_keyed_child.iteritems():
-      all_keyed_child[child].append(hierarchy['LabelName'])
-    all_keyed_child[hierarchy['LabelName']] = []
+    all_keyed_parent[hierarchy['LabelName']] = copy.deepcopy(all_children)
+    all_children.add(hierarchy['LabelName'])
+    for child, _ in all_keyed_child.items():
+      all_keyed_child[child].add(hierarchy['LabelName'])
+    all_keyed_child[hierarchy['LabelName']] = set([])
 
   return all_keyed_parent, all_keyed_child, all_children
 
@@ -92,110 +118,112 @@ class OIDHierarchicalLabelsExpansion(object):
     self._hierarchy_keyed_parent, self._hierarchy_keyed_child, _ = (
         _build_plain_hierarchy(hierarchy, skip_root=True))
 
-  def expand_boxes_from_csv(self, csv_row):
-    """Expands a row containing bounding boxes from CSV file.
+  def expand_boxes_or_segments_from_csv(self, csv_row,
+                                        labelname_column_index=1):
+    """Expands a row containing bounding boxes/segments from CSV file.
 
     Args:
       csv_row: a single row of Open Images released groundtruth file.
+      labelname_column_index: 0-based index of LabelName column in CSV file.
 
     Returns:
       a list of strings (including the initial row) corresponding to the ground
       truth expanded to multiple annotation for evaluation with Open Images
-      Challenge 2018 metric.
+      Challenge 2018/2019 metrics.
     """
-    # Row header is expected to be exactly:
-    # ImageID,Source,LabelName,Confidence,XMin,XMax,YMin,YMax,IsOccluded,
-    # IsTruncated,IsGroupOf,IsDepiction,IsInside
-    cvs_row_splitted = csv_row.split(',')
-    assert len(cvs_row_splitted) == 13
+    # Row header is expected to be the following for boxes:
+    # ImageID,LabelName,Confidence,XMin,XMax,YMin,YMax,IsGroupOf
+    # Row header is expected to be the following for segments:
+    # ImageID,LabelName,ImageWidth,ImageHeight,XMin,XMax,YMin,YMax,
+    # IsGroupOf,Mask
+    split_csv_row = csv_row.split(',')
     result = [csv_row]
-    assert cvs_row_splitted[2] in self._hierarchy_keyed_child
-    parent_nodes = self._hierarchy_keyed_child[cvs_row_splitted[2]]
+    assert split_csv_row[
+        labelname_column_index] in self._hierarchy_keyed_child
+    parent_nodes = self._hierarchy_keyed_child[
+        split_csv_row[labelname_column_index]]
     for parent_node in parent_nodes:
-      cvs_row_splitted[2] = parent_node
-      result.append(','.join(cvs_row_splitted))
+      split_csv_row[labelname_column_index] = parent_node
+      result.append(','.join(split_csv_row))
     return result
 
-  def expand_labels_from_csv(self, csv_row):
-    """Expands a row containing bounding boxes from CSV file.
+  def expand_labels_from_csv(self,
+                             csv_row,
+                             labelname_column_index=1,
+                             confidence_column_index=2):
+    """Expands a row containing labels from CSV file.
 
     Args:
       csv_row: a single row of Open Images released groundtruth file.
+      labelname_column_index: 0-based index of LabelName column in CSV file.
+      confidence_column_index: 0-based index of Confidence column in CSV file.
 
     Returns:
       a list of strings (including the initial row) corresponding to the ground
       truth expanded to multiple annotation for evaluation with Open Images
-      Challenge 2018 metric.
+      Challenge 2018/2019 metrics.
     """
     # Row header is expected to be exactly:
     # ImageID,Source,LabelName,Confidence
-    cvs_row_splited = csv_row.split(',')
-    assert len(cvs_row_splited) == 4
+    split_csv_row = csv_row.split(',')
     result = [csv_row]
-    if int(cvs_row_splited[3]) == 1:
-      assert cvs_row_splited[2] in self._hierarchy_keyed_child
-      parent_nodes = self._hierarchy_keyed_child[cvs_row_splited[2]]
+    if int(split_csv_row[confidence_column_index]) == 1:
+      assert split_csv_row[
+          labelname_column_index] in self._hierarchy_keyed_child
+      parent_nodes = self._hierarchy_keyed_child[
+          split_csv_row[labelname_column_index]]
       for parent_node in parent_nodes:
-        cvs_row_splited[2] = parent_node
-        result.append(','.join(cvs_row_splited))
+        split_csv_row[labelname_column_index] = parent_node
+        result.append(','.join(split_csv_row))
     else:
-      assert cvs_row_splited[2] in self._hierarchy_keyed_parent
-      child_nodes = self._hierarchy_keyed_parent[cvs_row_splited[2]]
+      assert split_csv_row[
+          labelname_column_index] in self._hierarchy_keyed_parent
+      child_nodes = self._hierarchy_keyed_parent[
+          split_csv_row[labelname_column_index]]
       for child_node in child_nodes:
-        cvs_row_splited[2] = child_node
-        result.append(','.join(cvs_row_splited))
+        split_csv_row[labelname_column_index] = child_node
+        result.append(','.join(split_csv_row))
     return result
 
 
-def main(parsed_args):
+def main(unused_args):
 
-  with open(parsed_args.json_hierarchy_file) as f:
+  del unused_args
+
+  with open(FLAGS.json_hierarchy_file) as f:
     hierarchy = json.load(f)
   expansion_generator = OIDHierarchicalLabelsExpansion(hierarchy)
   labels_file = False
-  if parsed_args.annotation_type == 2:
+  if FLAGS.annotation_type == 2:
     labels_file = True
-  elif parsed_args.annotation_type != 1:
+  elif FLAGS.annotation_type != 1:
     print('--annotation_type expected value is 1 or 2.')
     return -1
-  with open(parsed_args.input_annotations, 'r') as source:
-    with open(parsed_args.output_annotations, 'w') as target:
-      header = None
+  confidence_column_index = -1
+  labelname_column_index = -1
+  with open(FLAGS.input_annotations, 'r') as source:
+    with open(FLAGS.output_annotations, 'w') as target:
+      header = source.readline()
+      target.writelines([header])
+      column_names = header.strip().split(',')
+      labelname_column_index = column_names.index('LabelName')
+      if labels_file:
+        confidence_column_index = column_names.index('Confidence')
       for line in source:
-        if not header:
-          header = line
-          target.writelines(header)
-          continue
         if labels_file:
-          expanded_lines = expansion_generator.expand_labels_from_csv(line)
+          expanded_lines = expansion_generator.expand_labels_from_csv(
+              line, labelname_column_index, confidence_column_index)
         else:
-          expanded_lines = expansion_generator.expand_boxes_from_csv(line)
+          expanded_lines = (
+              expansion_generator.expand_boxes_or_segments_from_csv(
+                  line, labelname_column_index))
         target.writelines(expanded_lines)
 
 
 if __name__ == '__main__':
+  flags.mark_flag_as_required('json_hierarchy_file')
+  flags.mark_flag_as_required('input_annotations')
+  flags.mark_flag_as_required('output_annotations')
+  flags.mark_flag_as_required('annotation_type')
 
-  parser = argparse.ArgumentParser(
-      description='Hierarchically expand annotations (excluding root node).')
-  parser.add_argument(
-      '--json_hierarchy_file',
-      required=True,
-      help='Path to the file containing label hierarchy in JSON format.')
-  parser.add_argument(
-      '--input_annotations',
-      required=True,
-      help="""Path to Open Images annotations file (either bounding boxes or
-      image-level labels).""")
-  parser.add_argument(
-      '--output_annotations',
-      required=True,
-      help="""Path to the output file.""")
-  parser.add_argument(
-      '--annotation_type',
-      type=int,
-      required=True,
-      help="""Type of the input annotations: 1 - boxes, 2 - image-level
-      labels"""
-  )
-  args = parser.parse_args()
-  main(args)
+  app.run(main)

--- a/research/object_detection/eval_util.py
+++ b/research/object_detection/eval_util.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 """Common utility functions for evaluation."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import collections
 import os
 import re
 import time
 
 import numpy as np
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import box_list

--- a/research/object_detection/eval_util_test.py
+++ b/research/object_detection/eval_util_test.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
+import six
+from six.moves import range
 import tensorflow as tf
 
 from object_detection import eval_util
@@ -113,7 +115,7 @@ class EvalUtilTest(test_case.TestCase, parameterized.TestCase):
 
     with self.test_session() as sess:
       metrics = {}
-      for key, (value_op, _) in metric_ops.iteritems():
+      for key, (value_op, _) in six.iteritems(metric_ops):
         metrics[key] = value_op
       sess.run(update_op)
       metrics = sess.run(metrics)
@@ -142,7 +144,7 @@ class EvalUtilTest(test_case.TestCase, parameterized.TestCase):
 
     with self.test_session() as sess:
       metrics = {}
-      for key, (value_op, _) in metric_ops.iteritems():
+      for key, (value_op, _) in six.iteritems(metric_ops):
         metrics[key] = value_op
       sess.run(update_op_boxes)
       sess.run(update_op_masks)
@@ -173,7 +175,7 @@ class EvalUtilTest(test_case.TestCase, parameterized.TestCase):
 
     with self.test_session() as sess:
       metrics = {}
-      for key, (value_op, _) in metric_ops.iteritems():
+      for key, (value_op, _) in six.iteritems(metric_ops):
         metrics[key] = value_op
       sess.run(update_op_boxes)
       sess.run(update_op_masks)

--- a/research/object_detection/export_inference_graph.py
+++ b/research/object_detection/export_inference_graph.py
@@ -45,10 +45,16 @@ and the following output nodes returned by the model.postprocess(..):
   * `raw_detection_scores`: Outputs float32 tensors of the form
       [batch, raw_num_boxes, num_classes_with_background] containing class score
       logits for raw detection boxes.
-  * `detection_masks`: Outputs float32 tensors of the form
+  * `detection_masks`: (Optional) Outputs float32 tensors of the form
       [batch, num_boxes, mask_height, mask_width] containing predicted instance
       masks for each box if its present in the dictionary of postprocessed
       tensors returned by the model.
+  * detection_multiclass_scores: (Optional) Outputs float32 tensor of shape
+      [batch, num_boxes, num_classes_with_background] for containing class
+      score distribution for detected boxes including background if any.
+  * detection_features: (Optional) float32 tensor of shape
+      [batch, num_boxes, roi_height, roi_width, depth]
+  containing classifier features
 
 Notes:
  * This tool uses `use_moving_averages` from eval_config to decide which

--- a/research/object_detection/exporter_test.py
+++ b/research/object_detection/exporter_test.py
@@ -28,6 +28,7 @@ from object_detection.core import model
 from object_detection.protos import graph_rewriter_pb2
 from object_detection.protos import pipeline_pb2
 from object_detection.utils import ops
+from object_detection.utils import variables_helper
 
 if six.PY2:
   import mock  # pylint: disable=g-import-not-at-top
@@ -39,9 +40,11 @@ slim = tf.contrib.slim
 
 class FakeModel(model.DetectionModel):
 
-  def __init__(self, add_detection_keypoints=False, add_detection_masks=False):
+  def __init__(self, add_detection_keypoints=False, add_detection_masks=False,
+               add_detection_features=False):
     self._add_detection_keypoints = add_detection_keypoints
     self._add_detection_masks = add_detection_masks
+    self._add_detection_features = add_detection_features
 
   def preprocess(self, inputs):
     true_image_shapes = []  # Doesn't matter for the fake model.
@@ -79,6 +82,11 @@ class FakeModel(model.DetectionModel):
       if self._add_detection_masks:
         postprocessed_tensors['detection_masks'] = tf.constant(
             np.arange(64).reshape([2, 2, 4, 4]), tf.float32)
+      if self._add_detection_features:
+        # let fake detection features have shape [4, 4, 10]
+        postprocessed_tensors['detection_features'] = tf.constant(
+            np.ones((2, 2, 4, 4, 10)), tf.float32)
+
     return postprocessed_tensors
 
   def restore_map(self, checkpoint_path, fine_tune_checkpoint_type):
@@ -345,7 +353,7 @@ class ExportInferenceGraphTest(tf.test.TestCase):
           write_inference_graph=True)
     self._load_inference_graph(inference_graph_path, is_binary=False)
     has_quant_nodes = False
-    for v in tf.global_variables():
+    for v in variables_helper.get_global_variables_safely():
       if v.op.name.endswith('act_quant/min'):
         has_quant_nodes = True
         break
@@ -362,7 +370,8 @@ class ExportInferenceGraphTest(tf.test.TestCase):
     with mock.patch.object(
         model_builder, 'build', autospec=True) as mock_builder:
       mock_builder.return_value = FakeModel(
-          add_detection_keypoints=True, add_detection_masks=True)
+          add_detection_keypoints=True, add_detection_masks=True,
+          add_detection_features=True)
       pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
       exporter.export_inference_graph(
           input_type='image_tensor',
@@ -379,6 +388,7 @@ class ExportInferenceGraphTest(tf.test.TestCase):
       inference_graph.get_tensor_by_name('detection_keypoints:0')
       inference_graph.get_tensor_by_name('detection_masks:0')
       inference_graph.get_tensor_by_name('num_detections:0')
+      inference_graph.get_tensor_by_name('detection_features:0')
 
   def test_export_model_with_detection_only_nodes(self):
     tmp_dir = self.get_temp_dir()
@@ -405,6 +415,36 @@ class ExportInferenceGraphTest(tf.test.TestCase):
       inference_graph.get_tensor_by_name('detection_multiclass_scores:0')
       inference_graph.get_tensor_by_name('detection_classes:0')
       inference_graph.get_tensor_by_name('num_detections:0')
+      with self.assertRaises(KeyError):
+        inference_graph.get_tensor_by_name('detection_keypoints:0')
+        inference_graph.get_tensor_by_name('detection_masks:0')
+
+  def test_export_model_with_detection_only_nodes_and_detection_features(self):
+    tmp_dir = self.get_temp_dir()
+    trained_checkpoint_prefix = os.path.join(tmp_dir, 'model.ckpt')
+    self._save_checkpoint_from_mock_model(trained_checkpoint_prefix,
+                                          use_moving_averages=True)
+    output_directory = os.path.join(tmp_dir, 'output')
+    inference_graph_path = os.path.join(output_directory,
+                                        'frozen_inference_graph.pb')
+    with mock.patch.object(
+        model_builder, 'build', autospec=True) as mock_builder:
+      mock_builder.return_value = FakeModel(add_detection_features=True)
+      pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+      exporter.export_inference_graph(
+          input_type='image_tensor',
+          pipeline_config=pipeline_config,
+          trained_checkpoint_prefix=trained_checkpoint_prefix,
+          output_directory=output_directory)
+    inference_graph = self._load_inference_graph(inference_graph_path)
+    with self.test_session(graph=inference_graph):
+      inference_graph.get_tensor_by_name('image_tensor:0')
+      inference_graph.get_tensor_by_name('detection_boxes:0')
+      inference_graph.get_tensor_by_name('detection_scores:0')
+      inference_graph.get_tensor_by_name('detection_multiclass_scores:0')
+      inference_graph.get_tensor_by_name('detection_classes:0')
+      inference_graph.get_tensor_by_name('num_detections:0')
+      inference_graph.get_tensor_by_name('detection_features:0')
       with self.assertRaises(KeyError):
         inference_graph.get_tensor_by_name('detection_keypoints:0')
         inference_graph.get_tensor_by_name('detection_masks:0')
@@ -738,6 +778,8 @@ class ExportInferenceGraphTest(tf.test.TestCase):
             signature.outputs['detection_boxes'].name)
         scores = od_graph.get_tensor_by_name(
             signature.outputs['detection_scores'].name)
+        multiclass_scores = od_graph.get_tensor_by_name(
+            signature.outputs['detection_multiclass_scores'].name)
         classes = od_graph.get_tensor_by_name(
             signature.outputs['detection_classes'].name)
         keypoints = od_graph.get_tensor_by_name(
@@ -747,9 +789,10 @@ class ExportInferenceGraphTest(tf.test.TestCase):
         num_detections = od_graph.get_tensor_by_name(
             signature.outputs['num_detections'].name)
 
-        (boxes_np, scores_np, classes_np, keypoints_np, masks_np,
-         num_detections_np) = sess.run(
-             [boxes, scores, classes, keypoints, masks, num_detections],
+        (boxes_np, scores_np, multiclass_scores_np, classes_np, keypoints_np,
+         masks_np, num_detections_np) = sess.run(
+             [boxes, scores, multiclass_scores, classes, keypoints, masks,
+              num_detections],
              feed_dict={tf_example: tf_example_np})
         self.assertAllClose(boxes_np, [[[0.0, 0.0, 0.5, 0.5],
                                         [0.5, 0.5, 0.8, 0.8]],
@@ -757,6 +800,8 @@ class ExportInferenceGraphTest(tf.test.TestCase):
                                         [0.0, 0.0, 0.0, 0.0]]])
         self.assertAllClose(scores_np, [[0.7, 0.6],
                                         [0.9, 0.0]])
+        self.assertAllClose(multiclass_scores_np, [[[0.3, 0.7], [0.4, 0.6]],
+                                                   [[0.1, 0.9], [0.0, 0.0]]])
         self.assertAllClose(classes_np, [[1, 2],
                                          [2, 1]])
         self.assertAllClose(keypoints_np, np.arange(48).reshape([2, 2, 6, 2]))

--- a/research/object_detection/g3doc/challenge_evaluation.md
+++ b/research/object_detection/g3doc/challenge_evaluation.md
@@ -1,24 +1,38 @@
 # Open Images Challenge Evaluation
 
-The Object Detection API is currently supporting several evaluation metrics used in the [Open Images Challenge 2018](https://storage.googleapis.com/openimages/web/challenge.html).
-In addition, several data processing tools are available. Detailed instructions on using the tools for each track are available below.
+The Object Detection API is currently supporting several evaluation metrics used
+in the
+[Open Images Challenge 2018](https://storage.googleapis.com/openimages/web/challenge.html)
+and
+[Open Images Challenge 2019](https://storage.googleapis.com/openimages/web/challenge2019.html).
+In addition, several data processing tools are available. Detailed instructions
+on using the tools for each track are available below.
 
-**NOTE**: links to the external website in this tutorial may change after the Open Images Challenge 2018 is finished.
+**NOTE:** all data links are updated to the Open Images Challenge 2019.
 
 ## Object Detection Track
 
-The [Object Detection metric](https://storage.googleapis.com/openimages/web/object_detection_metric.html) protocol requires a pre-processing of the released data to ensure correct evaluation. The released data contains only leaf-most bounding box annotations and image-level labels.
-The evaluation metric implementation is available in the class `OpenImagesDetectionChallengeEvaluator`.
+The
+[Object Detection metric](https://storage.googleapis.com/openimages/web/evaluation.html#object_detection_eval)
+protocol requires a pre-processing of the released data to ensure correct
+evaluation. The released data contains only leaf-most bounding box annotations
+and image-level labels. The evaluation metric implementation is available in the
+class `OpenImagesChallengeEvaluator`.
 
-1. Download class hierarchy of Open Images Challenge 2018 in JSON format from [here](https://storage.googleapis.com/openimages/challenge_2018/bbox_labels_500_hierarchy.json).
-2. Download ground-truth [boundling boxes](https://storage.googleapis.com/openimages/challenge_2018/train/challenge-2018-train-annotations-bbox.csv) and [image-level labels](https://storage.googleapis.com/openimages/challenge_2018/train/challenge-2018-train-annotations-human-imagelabels.csv).
-3. Filter the rows corresponding to the validation set images you want to use and store the results in the same CSV format.
-4. Run the following command to create hierarchical expansion of the bounding boxes annotations:
+1.  Download
+    [class hierarchy of Open Images Detection Challenge 2019](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-label500-hierarchy.json)
+    in JSON format.
+2.  Download
+    [ground-truth boundling boxes](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-detection-bbox.csv)
+    and
+    [image-level labels](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-detection-human-imagelabels.csv).
+3.  Run the following command to create hierarchical expansion of the bounding
+    boxes and image-level label annotations:
 
 ```
-HIERARCHY_FILE=/path/to/bbox_labels_500_hierarchy.json
-BOUNDING_BOXES=/path/to/challenge-2018-train-annotations-bbox
-IMAGE_LABELS=/path/to/challenge-2018-train-annotations-human-imagelabels
+HIERARCHY_FILE=/path/to/challenge-2019-label500-hierarchy.json
+BOUNDING_BOXES=/path/to/challenge-2019-validation-detection-bbox
+IMAGE_LABELS=/path/to/challenge-2019-validation-detection-human-imagelabels
 
 python object_detection/dataset_tools/oid_hierarchical_labels_expansion.py \
     --json_hierarchy_file=${HIERARCHY_FILE} \
@@ -33,13 +47,18 @@ python object_detection/dataset_tools/oid_hierarchical_labels_expansion.py \
     --annotation_type=2
 ```
 
-After step 4 you will have produced the ground-truth files suitable for running 'OID Challenge Object Detection Metric 2018' evaluation.
+1.  If you are not using Tensorflow, you can run evaluation directly using your
+    algorithm's output and generated ground-truth files. {value=4}
+
+After step 3 you produced the ground-truth files suitable for running 'OID
+Challenge Object Detection Metric 2019' evaluation. To run the evaluation, use
+the following command:
 
 ```
 INPUT_PREDICTIONS=/path/to/detection_predictions.csv
 OUTPUT_METRICS=/path/to/output/metrics/file
 
-python models/research/object_detection/metrics/oid_od_challenge_evaluation.py \
+python models/research/object_detection/metrics/oid_challenge_evaluation.py \
     --input_annotations_boxes=${BOUNDING_BOXES}_expanded.csv \
     --input_annotations_labels=${IMAGE_LABELS}_expanded.csv \
     --input_class_labelmap=object_detection/data/oid_object_detection_challenge_500_label_map.pbtxt \
@@ -47,66 +66,99 @@ python models/research/object_detection/metrics/oid_od_challenge_evaluation.py \
     --output_metrics=${OUTPUT_METRICS} \
 ```
 
-### Running evaluation on CSV files directly
-
-5. If you are not using Tensorflow, you can run evaluation directly using your algorithm's output and generated ground-truth files. {value=5}
-
-
-### Running evaluation using TF Object Detection API
-
-5. Produce tf.Example files suitable for running inference: {value=5}
-
-```
-RAW_IMAGES_DIR=/path/to/raw_images_location
-OUTPUT_DIR=/path/to/output_tfrecords
-
-python object_detection/dataset_tools/create_oid_tf_record.py \
-    --input_box_annotations_csv ${BOUNDING_BOXES}_expanded.csv \
-    --input_image_label_annotations_csv ${IMAGE_LABELS}_expanded.csv \
-    --input_images_directory ${RAW_IMAGES_DIR} \
-    --input_label_map object_detection/data/oid_object_detection_challenge_500_label_map.pbtxt \
-    --output_tf_record_path_prefix ${OUTPUT_DIR} \
-    --num_shards=100
-```
-
-6. Run inference of your model and fill corresponding fields in tf.Example: see [this tutorial](object_detection/g3doc/oid_inference_and_evaluation.md) on running the inference with Tensorflow Object Detection API models. {value=6}
-
-7. Finally, run the evaluation script to produce the final evaluation result.
-
-```
-INPUT_TFRECORDS_WITH_DETECTIONS=/path/to/tf_records_with_detections
-OUTPUT_CONFIG_DIR=/path/to/configs
-
-echo "
-label_map_path: 'object_detection/data/oid_object_detection_challenge_500_label_map.pbtxt'
-tf_record_input_reader: { input_path: '${INPUT_TFRECORDS_WITH_DETECTIONS}' }
-" > ${OUTPUT_CONFIG_DIR}/input_config.pbtxt
-
-echo "
-metrics_set: 'oid_challenge_detection_metrics'
-" > ${OUTPUT_CONFIG_DIR}/eval_config.pbtxt
-
-OUTPUT_METRICS_DIR=/path/to/metrics_csv
-
-python object_detection/metrics/offline_eval_map_corloc.py \
-    --eval_dir=${OUTPUT_METRICS_DIR} \
-    --eval_config_path=${OUTPUT_CONFIG_DIR}/eval_config.pbtxt \
-    --input_config_path=${OUTPUT_CONFIG_DIR}/input_config.pbtxt
-```
-
-The result of the evaluation will be stored in `${OUTPUT_METRICS_DIR}/metrics.csv`
-
 For the Object Detection Track, the participants will be ranked on:
 
-- "OpenImagesChallenge2018_Precision/mAP@0.5IOU"
+-   "OpenImagesDetectionChallenge_Precision/mAP@0.5IOU"
+
+To use evaluation within Tensorflow training, use metric name
+`oid_challenge_detection_metrics` in the evaluation config.
+
+## Instance Segmentation Track
+
+The
+[Instance Segmentation metric](https://storage.googleapis.com/openimages/web/evaluation.html#instance_segmentation_eval)
+can be directly evaluated using the ground-truth data and model predictions. The
+evaluation metric implementation is available in the class
+`OpenImagesChallengeEvaluator`.
+
+1.  Download
+    [class hierarchy of Open Images Instance Segmentation Challenge 2019](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-label300-segmentable-hierarchy.json)
+    in JSON format.
+2.  Download
+    [ground-truth bounding boxes](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-segmentation-bbox.csv)
+    and
+    [image-level labels](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-segmentation-labels.csv).
+3.  Download instance segmentation files for the validation set (see
+    [Open Images Challenge Downloads page](https://storage.googleapis.com/openimages/web/challenge2019_downloads.html)).
+    The download consists of a set of .zip archives containing binary .png
+    masks.
+    Those should be transformed into a single CSV file in the format:
+
+    ImageID,LabelName,ImageWidth,ImageHeight,XMin,YMin,XMax,YMax,GroupOf,Mask
+    where Mask is MS COCO RLE encoding of a binary mask stored in .png file.
+
+    NOTE: the util to make the transformation will be released soon.
+
+1.  Run the following command to create hierarchical expansion of the instance
+    segmentation, bounding boxes and image-level label annotations: {value=4}
+
+```
+HIERARCHY_FILE=/path/to/challenge-2019-label300-hierarchy.json
+BOUNDING_BOXES=/path/to/challenge-2019-validation-detection-bbox
+IMAGE_LABELS=/path/to/challenge-2019-validation-detection-human-imagelabels
+
+python object_detection/dataset_tools/oid_hierarchical_labels_expansion.py \
+    --json_hierarchy_file=${HIERARCHY_FILE} \
+    --input_annotations=${BOUNDING_BOXES}.csv \
+    --output_annotations=${BOUNDING_BOXES}_expanded.csv \
+    --annotation_type=1
+
+python object_detection/dataset_tools/oid_hierarchical_labels_expansion.py \
+    --json_hierarchy_file=${HIERARCHY_FILE} \
+    --input_annotations=${IMAGE_LABELS}.csv \
+    --output_annotations=${IMAGE_LABELS}_expanded.csv \
+    --annotation_type=2
+
+python object_detection/dataset_tools/oid_hierarchical_labels_expansion.py \
+    --json_hierarchy_file=${HIERARCHY_FILE} \
+    --input_annotations=${INSTANCE_SEGMENTATIONS}.csv \
+    --output_annotations=${INSTANCE_SEGMENTATIONS}_expanded.csv \
+    --annotation_type=1
+```
+
+1.  If you are not using Tensorflow, you can run evaluation directly using your
+    algorithm's output and generated ground-truth files. {value=4}
+
+```
+INPUT_PREDICTIONS=/path/to/instance_segmentation_predictions.csv
+OUTPUT_METRICS=/path/to/output/metrics/file
+
+python models/research/object_detection/metrics/oid_challenge_evaluation.py \
+    --input_annotations_boxes=${BOUNDING_BOXES}_expanded.csv \
+    --input_annotations_labels=${IMAGE_LABELS}_expanded.csv \
+    --input_class_labelmap=object_detection/data/oid_object_detection_challenge_500_label_map.pbtxt \
+    --input_predictions=${INPUT_PREDICTIONS} \
+    --input_annotations_segm=${INSTANCE_SEGMENTATIONS}_expanded.csv
+    --output_metrics=${OUTPUT_METRICS} \
+```
+
+For the Instance Segmentation Track, the participants will be ranked on:
+
+-   "OpenImagesInstanceSegmentationChallenge_Precision/mAP@0.5IOU"
 
 ## Visual Relationships Detection Track
 
-The [Visual Relationships Detection metrics](https://storage.googleapis.com/openimages/web/vrd_detection_metric.html) can be directly evaluated using the ground-truth data and model predictions. The evaluation metric implementation is available in the class `VRDRelationDetectionEvaluator`,`VRDPhraseDetectionEvaluator`.
+The
+[Visual Relationships Detection metrics](https://storage.googleapis.com/openimages/web/evaluation.html#visual_relationships_eval)
+can be directly evaluated using the ground-truth data and model predictions. The
+evaluation metric implementation is available in the class
+`VRDRelationDetectionEvaluator`,`VRDPhraseDetectionEvaluator`.
 
-1. Download the ground-truth [visual relationships annotations](https://storage.googleapis.com/openimages/challenge_2018/train/challenge-2018-train-vrd.csv) and [image-level labels](https://storage.googleapis.com/openimages/challenge_2018/train/challenge-2018-train-vrd-labels.csv).
-2. Filter the rows corresponding to the validation set images you want to use and store the results in the same CSV format.
-3. Run the follwing command to produce final metrics:
+1.  Download the ground-truth
+    [visual relationships annotations](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-vrd.csv)
+    and
+    [image-level labels](https://storage.googleapis.com/openimages/challenge_2019/challenge-2019-validation-vrd-labels.csv).
+2.  Run the follwing command to produce final metrics:
 
 ```
 INPUT_ANNOTATIONS_BOXES=/path/to/challenge-2018-train-vrd.csv

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -138,6 +138,8 @@ Model name                                                                      
 
 
 [^2]: This is PASCAL mAP with a slightly different way of true positives computation: see [Open Images evaluation protocols](evaluation_protocols.md), oid_V2_detection_metrics.
+
 [^3]: Non-face boxes are dropped during training and non-face groundtruth boxes are ignored when evaluating.
+
 [^4]: This is Open Images Challenge metric: see [Open Images evaluation protocols](evaluation_protocols.md), oid_challenge_detection_metrics.
 

--- a/research/object_detection/g3doc/evaluation_protocols.md
+++ b/research/object_detection/g3doc/evaluation_protocols.md
@@ -135,22 +135,29 @@ output bounding-boxes labelled in the same manner.
 The old metric name is DEPRECATED.
 `EvalConfig.metrics_set='open_images_V2_detection_metrics'`
 
-## OID Challenge Object Detection Metric 2018
+## OID Challenge Object Detection Metric
 
 `EvalConfig.metrics_set='oid_challenge_detection_metrics'`
 
-The metric for the OID Challenge Object Detection Metric 2018, Object Detection
-track. The description is provided on the [Open Images Challenge
-website](https://storage.googleapis.com/openimages/web/challenge.html).
+The metric for the OID Challenge Object Detection Metric 2018/2019 Object
+Detection track. The description is provided on the
+[Open Images Challenge website](https://storage.googleapis.com/openimages/web/evaluation.html#object_detection_eval).
 
 The old metric name is DEPRECATED.
 `EvalConfig.metrics_set='oid_challenge_object_detection_metrics'`
 
-## OID Challenge Visual Relationship Detection Metric 2018
+## OID Challenge Visual Relationship Detection Metric
 
-The metric for the OID Challenge Visual Relationship Detection Metric 2018, Visual
-Relationship Detection track. The description is provided on the [Open Images
-Challenge
-website](https://storage.googleapis.com/openimages/web/challenge.html). Note:
-this is currently a stand-alone metric, that can be used only through the
+The metric for the OID Challenge Visual Relationship Detection Metric 2018,2019
+Visual Relationship Detection track. The description is provided on the
+[Open Images Challenge website](https://storage.googleapis.com/openimages/web/evaluation.html#visual_relationships_eval).
+Note: this is currently a stand-alone metric, that can be used only through the
 `metrics/oid_vrd_challenge_evaluation.py` util.
+
+## OID Challenge Instance Segmentation Metric
+
+`EvalConfig.metrics_set='oid_challenge_segmentation_metrics'`
+
+The metric for the OID Challenge Instance Segmentation Metric 2019, Instance
+Segmentation track. The description is provided on the
+[Open Images Challenge website](https://storage.googleapis.com/openimages/web/evaluation.html#instance_segmentation_eval).

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test.py
@@ -383,6 +383,11 @@ class FasterRCNNMetaArchTest(
     class_predictions_with_background_shapes = [(16, 3), (None, 3)]
     proposal_boxes_shapes = [(2, 8, 4), (None, 8, 4)]
     batch_size = 2
+    initial_crop_size = 3
+    maxpool_stride = 1
+    height = initial_crop_size/maxpool_stride
+    width = initial_crop_size/maxpool_stride
+    depth = 3
     image_shape = np.array((2, 36, 48, 3), dtype=np.int32)
     for (num_proposals_shape, refined_box_encoding_shape,
          class_predictions_with_background_shape,
@@ -433,6 +438,7 @@ class FasterRCNNMetaArchTest(
             'detection_scores': tf.zeros([2, 5]),
             'detection_classes': tf.zeros([2, 5]),
             'num_detections': tf.zeros([2]),
+            'detection_features': tf.zeros([2, 5, width, height, depth])
         }, true_image_shapes)
       with self.test_session(graph=tf_graph) as sess:
         detections_out = sess.run(
@@ -453,6 +459,9 @@ class FasterRCNNMetaArchTest(
       self.assertAllClose(detections_out['num_detections'].shape, [2])
       self.assertTrue(np.amax(detections_out['detection_masks'] <= 1.0))
       self.assertTrue(np.amin(detections_out['detection_masks'] >= 0.0))
+      self.assertAllEqual(detections_out['detection_features'].shape,
+                          [2, 5, width, height, depth])
+      self.assertGreaterEqual(np.amax(detections_out['detection_features']), 0)
 
   def _get_box_classifier_features_shape(self,
                                          image_size,

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -188,6 +188,7 @@ class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
                             [0.5, 0., 1., 0.5], [1., 1., 1.5, 1.5]]]
     raw_detection_scores = [[[0, 0], [0, 0], [0, 0], [0, 0]],
                             [[0, 0], [0, 0], [0, 0], [0, 0]]]
+    detection_anchor_indices = [[0, 2, 1, 0, 0], [0, 2, 1, 0, 0]]
 
     for input_shape in input_shapes:
       tf_graph = tf.Graph()
@@ -229,6 +230,8 @@ class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
                           raw_detection_boxes)
       self.assertAllEqual(detections_out['raw_detection_scores'],
                           raw_detection_scores)
+      self.assertAllEqual(detections_out['detection_anchor_indices'],
+                          detection_anchor_indices)
 
   def test_postprocess_results_are_correct_static(self, use_keras):
     with tf.Graph().as_default():

--- a/research/object_detection/metrics/coco_evaluation.py
+++ b/research/object_detection/metrics/coco_evaluation.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 """Class for evaluating object detections with COCO metrics."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import standard_fields

--- a/research/object_detection/metrics/coco_tools.py
+++ b/research/object_detection/metrics/coco_tools.py
@@ -39,6 +39,10 @@ then evaluation (in multi-class mode) can be invoked as follows:
   metrics = evaluator.ComputeMetrics()
 
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from collections import OrderedDict
 import copy
 import time
@@ -48,6 +52,8 @@ from pycocotools import coco
 from pycocotools import cocoeval
 from pycocotools import mask
 
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.utils import json_utils

--- a/research/object_detection/metrics/oid_challenge_evaluation.py
+++ b/research/object_detection/metrics/oid_challenge_evaluation.py
@@ -40,6 +40,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
+
 from absl import app
 from absl import flags
 import pandas as pd
@@ -120,20 +122,22 @@ def main(unused_argv):
       object_detection_evaluation.OpenImagesChallengeEvaluator(
           categories, evaluate_masks=is_instance_segmentation_eval))
 
+  all_predictions = pd.read_csv(FLAGS.input_predictions)
+  images_processed = 0
   for _, groundtruth in enumerate(all_annotations.groupby('ImageID')):
+    logging.info('Processing image %d', images_processed)
     image_id, image_groundtruth = groundtruth
     groundtruth_dictionary = utils.build_groundtruth_dictionary(
         image_groundtruth, class_label_map)
     challenge_evaluator.add_single_ground_truth_image_info(
         image_id, groundtruth_dictionary)
 
-  all_predictions = pd.read_csv(FLAGS.input_predictions)
-  for _, prediction_data in enumerate(all_predictions.groupby('ImageID')):
-    image_id, image_predictions = prediction_data
     prediction_dictionary = utils.build_predictions_dictionary(
-        image_predictions, class_label_map)
+        all_predictions.loc[all_predictions['ImageID'] == image_id],
+        class_label_map)
     challenge_evaluator.add_single_detected_image_info(image_id,
                                                        prediction_dictionary)
+    images_processed += 1
 
   metrics = challenge_evaluator.evaluate()
 

--- a/research/object_detection/model_lib_v2.py
+++ b/research/object_detection/model_lib_v2.py
@@ -1,0 +1,828 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+r"""Constructs model, inputs, and training environment."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import copy
+import time
+
+import tensorflow as tf
+
+from object_detection import eval_util
+from object_detection import inputs
+from object_detection import model_lib
+from object_detection.builders import model_builder
+from object_detection.builders import optimizer_builder
+from object_detection.core import standard_fields as fields
+from object_detection.utils import config_util
+from object_detection.utils import label_map_util
+from object_detection.utils import ops
+from object_detection.utils import variables_helper
+
+MODEL_BUILD_UTIL_MAP = model_lib.MODEL_BUILD_UTIL_MAP
+
+### NOTE: This file is a wip.
+### TODO(kaftan): Explore adding unit tests for individual methods
+### TODO(kaftan): Add unit test that checks training on a single image w/
+#### groundtruth, and verfiy that loss goes to zero.
+#### Possibly have version that takes it as the whole train & eval dataset,
+#### & verify the loss output from the eval_loop method.
+### TODO(kaftan): Make sure the unit tests run in TAP presubmits or Kokoro
+
+
+def _compute_losses_and_predictions_dicts(
+    model, features, labels,
+    add_regularization_loss=True,
+    use_tpu=False,
+    use_bfloat16=False):
+  """Computes the losses dict and predictions dict for a model on inputs.
+
+  Args:
+    model: a DetectionModel (based on Keras).
+    features: Dictionary of feature tensors from the input dataset.
+      Should be in the format output by `inputs.train_input` and
+      `inputs.eval_input`.
+        features[fields.InputDataFields.image] is a [batch_size, H, W, C]
+          float32 tensor with preprocessed images.
+        features[HASH_KEY] is a [batch_size] int32 tensor representing unique
+          identifiers for the images.
+        features[fields.InputDataFields.true_image_shape] is a [batch_size, 3]
+          int32 tensor representing the true image shapes, as preprocessed
+          images could be padded.
+        features[fields.InputDataFields.original_image] (optional) is a
+          [batch_size, H, W, C] float32 tensor with original images.
+    labels: A dictionary of groundtruth tensors post-unstacking. The original
+      labels are of the form returned by `inputs.train_input` and
+      `inputs.eval_input`. The shapes may have been modified by unstacking with
+      `model_lib.unstack_batch`. However, the dictionary includes the following
+      fields.
+        labels[fields.InputDataFields.num_groundtruth_boxes] is a
+          int32 tensor indicating the number of valid groundtruth boxes
+          per image.
+        labels[fields.InputDataFields.groundtruth_boxes] is a float32 tensor
+          containing the corners of the groundtruth boxes.
+        labels[fields.InputDataFields.groundtruth_classes] is a float32
+          one-hot tensor of classes.
+        labels[fields.InputDataFields.groundtruth_weights] is a float32 tensor
+          containing groundtruth weights for the boxes.
+        -- Optional --
+        labels[fields.InputDataFields.groundtruth_instance_masks] is a
+          float32 tensor containing only binary values, which represent
+          instance masks for objects.
+        labels[fields.InputDataFields.groundtruth_keypoints] is a
+          float32 tensor containing keypoints for each box.
+    add_regularization_loss: Whether or not to include the model's
+      regularization loss in the losses dictionary.
+    use_tpu: Whether computation should happen on a TPU.
+    use_bfloat16: Whether computation on a TPU should use bfloat16.
+
+  Returns:
+    A tuple containing the losses dictionary (with the total loss under
+    the key 'Loss/total_loss'), and the predictions dictionary produced by
+    `model.predict`.
+
+  """
+  model_lib.provide_groundtruth(model, labels)
+  preprocessed_images = features[fields.InputDataFields.image]
+
+  # TODO(kaftan): Check how we're supposed to do this mixed precision stuff
+  ## in TF2 TPUStrategy + Keras
+  if use_tpu and use_bfloat16:
+    with tf.contrib.tpu.bfloat16_scope():
+      prediction_dict = model.predict(
+          preprocessed_images,
+          features[fields.InputDataFields.true_image_shape])
+      prediction_dict = ops.bfloat16_to_float32_nested(prediction_dict)
+  else:
+    prediction_dict = model.predict(
+        preprocessed_images,
+        features[fields.InputDataFields.true_image_shape])
+
+  losses_dict = model.loss(
+      prediction_dict, features[fields.InputDataFields.true_image_shape])
+  losses = [loss_tensor for loss_tensor in losses_dict.values()]
+  if add_regularization_loss:
+    # TODO(kaftan): As we figure out mixed precision & bfloat 16, we may
+    ## need to convert these regularization losses from bfloat16 to float32
+    ## as well.
+    regularization_losses = model.regularization_losses()
+    if regularization_losses:
+      regularization_loss = tf.add_n(
+          regularization_losses, name='regularization_loss')
+      losses.append(regularization_loss)
+      losses_dict['Loss/regularization_loss'] = regularization_loss
+
+  total_loss = tf.add_n(losses, name='total_loss')
+  losses_dict['Loss/total_loss'] = total_loss
+
+  return losses_dict, prediction_dict
+
+
+# TODO(kaftan): Explore removing learning_rate from this method & returning
+## The full losses dict instead of just total_loss, then doing all summaries
+## saving in a utility method called by the outer training loop.
+# TODO(kaftan): Explore adding gradient summaries
+def eager_train_step(detection_model,
+                     features,
+                     labels,
+                     unpad_groundtruth_tensors,
+                     optimizer,
+                     learning_rate,
+                     add_regularization_loss=True,
+                     clip_gradients_value=None,
+                     use_tpu=False,
+                     use_bfloat16=False,
+                     global_step=None,
+                     num_replicas=1.0):
+  """Process a single training batch.
+
+  This method computes the loss for the model on a single training batch,
+  while tracking the gradients with a gradient tape. It then updates the
+  model variables with the optimizer, clipping the gradients if
+  clip_gradients_value is present.
+
+  This method can run eagerly or inside a tf.function.
+
+  Args:
+    detection_model: A DetectionModel (based on Keras) to train.
+    features: Dictionary of feature tensors from the input dataset.
+      Should be in the format output by `inputs.train_input.
+        features[fields.InputDataFields.image] is a [batch_size, H, W, C]
+          float32 tensor with preprocessed images.
+        features[HASH_KEY] is a [batch_size] int32 tensor representing unique
+          identifiers for the images.
+        features[fields.InputDataFields.true_image_shape] is a [batch_size, 3]
+          int32 tensor representing the true image shapes, as preprocessed
+          images could be padded.
+        features[fields.InputDataFields.original_image] (optional, not used
+          during training) is a
+          [batch_size, H, W, C] float32 tensor with original images.
+    labels: A dictionary of groundtruth tensors. This method unstacks
+      these labels using model_lib.unstack_batch. The stacked labels are of
+      the form returned by `inputs.train_input` and `inputs.eval_input`.
+        labels[fields.InputDataFields.num_groundtruth_boxes] is a [batch_size]
+          int32 tensor indicating the number of valid groundtruth boxes
+          per image.
+        labels[fields.InputDataFields.groundtruth_boxes] is a
+          [batch_size, num_boxes, 4] float32 tensor containing the corners of
+          the groundtruth boxes.
+        labels[fields.InputDataFields.groundtruth_classes] is a
+          [batch_size, num_boxes, num_classes] float32 one-hot tensor of
+          classes. num_classes includes the background class.
+        labels[fields.InputDataFields.groundtruth_weights] is a
+          [batch_size, num_boxes] float32 tensor containing groundtruth weights
+          for the boxes.
+        -- Optional --
+        labels[fields.InputDataFields.groundtruth_instance_masks] is a
+          [batch_size, num_boxes, H, W] float32 tensor containing only binary
+          values, which represent instance masks for objects.
+        labels[fields.InputDataFields.groundtruth_keypoints] is a
+          [batch_size, num_boxes, num_keypoints, 2] float32 tensor containing
+          keypoints for each box.
+    unpad_groundtruth_tensors: A parameter passed to unstack_batch.
+    optimizer: The training optimizer that will update the variables.
+    learning_rate: The learning rate tensor for the current training step.
+      This is used only for TensorBoard logging purposes, it does not affect
+       model training.
+    add_regularization_loss: Whether or not to include the model's
+      regularization loss in the losses dictionary.
+    clip_gradients_value: If this is present, clip the gradients global norm
+      at this value using `tf.clip_by_global_norm`.
+    use_tpu: Whether computation should happen on a TPU.
+    use_bfloat16: Whether computation on a TPU should use bfloat16.
+    global_step: The current training step. Used for TensorBoard logging
+      purposes. This step is not updated by this function and must be
+      incremented separately.
+    num_replicas: The number of replicas in the current distribution strategy.
+      This is used to scale the total loss so that training in a distribution
+      strategy works correctly.
+
+  Returns:
+    The total loss observed at this training step
+  """
+  # """Execute a single training step in the TF v2 style loop."""
+  is_training = True
+
+  detection_model._is_training = is_training  # pylint: disable=protected-access
+  tf.keras.backend.set_learning_phase(is_training)
+
+  labels = model_lib.unstack_batch(
+      labels, unpad_groundtruth_tensors=unpad_groundtruth_tensors)
+
+  with tf.GradientTape() as tape:
+    losses_dict, _ = _compute_losses_and_predictions_dicts(
+        detection_model, features, labels, add_regularization_loss, use_tpu,
+        use_bfloat16)
+
+    total_loss = losses_dict['Loss/total_loss']
+
+    # Normalize loss for num replicas
+    total_loss = tf.math.divide(total_loss,
+                                tf.constant(num_replicas, dtype=tf.float32))
+    losses_dict['Loss/normalized_total_loss'] = total_loss
+
+  for loss_type in losses_dict:
+    tf.compat.v2.summary.scalar(
+        loss_type, losses_dict[loss_type], step=global_step)
+
+  trainable_variables = detection_model.trainable_variables
+
+  gradients = tape.gradient(total_loss, trainable_variables)
+
+  if clip_gradients_value:
+    gradients, _ = tf.clip_by_global_norm(gradients, clip_gradients_value)
+  optimizer.apply_gradients(zip(gradients, trainable_variables))
+
+  if not use_tpu:
+    tf.compat.v2.summary.scalar('learning_rate', learning_rate,
+                                step=global_step)
+
+  return total_loss
+
+
+def load_fine_tune_checkpoint(
+    model, checkpoint_path, checkpoint_type,
+    load_all_detection_checkpoint_vars, input_dataset,
+    unpad_groundtruth_tensors, use_tpu, use_bfloat16):
+  """Load a fine tuning classification or detection checkpoint.
+
+  To make sure the model variables are all built, this method first executes
+  the model by computing a dummy loss. (Models might not have built their
+  variables before their first execution)
+
+  It then loads a variable-name based classification or detection checkpoint
+  that comes from converted TF 1.x slim model checkpoints.
+
+  This method updates the model in-place and does not return a value.
+
+  Args:
+    model: A DetectionModel (based on Keras) to load a fine-tuning
+      checkpoint for.
+    checkpoint_path: Directory with checkpoints file or path to checkpoint.
+    checkpoint_type: Whether to restore from a full detection
+      checkpoint (with compatible variable names) or to restore from a
+      classification checkpoint for initialization prior to training.
+      Valid values: `detection`, `classification`.
+    load_all_detection_checkpoint_vars: whether to load all variables (when
+      `fine_tune_checkpoint_type` is `detection`). If False, only variables
+      within the feature extractor scopes are included. Default False.
+    input_dataset: The tf.data Dataset the model is being trained on. Needed
+      to get the shapes for the dummy loss computation.
+    unpad_groundtruth_tensors: A parameter passed to unstack_batch.
+    use_tpu: Whether computation should happen on a TPU.
+    use_bfloat16: Whether computation on a TPU should use bfloat16.
+  """
+  features, labels = iter(input_dataset).next()
+
+  def _dummy_computation_fn(features, labels):
+    model._is_training = False  # pylint: disable=protected-access
+    tf.keras.backend.set_learning_phase(False)
+
+    labels = model_lib.unstack_batch(
+        labels, unpad_groundtruth_tensors=unpad_groundtruth_tensors)
+
+    return _compute_losses_and_predictions_dicts(
+        model,
+        features,
+        labels,
+        use_tpu=use_tpu,
+        use_bfloat16=use_bfloat16)
+
+  strategy = tf.compat.v2.distribute.get_strategy()
+  strategy.experimental_run_v2(
+      _dummy_computation_fn, args=(
+          features,
+          labels,
+      ))
+  var_map = model.restore_map(
+      fine_tune_checkpoint_type=checkpoint_type,
+      load_all_detection_checkpoint_vars=(
+          load_all_detection_checkpoint_vars))
+  available_var_map = (
+      variables_helper.get_variables_available_in_checkpoint(
+          var_map,
+          checkpoint_path,
+          include_global_step=False))
+  tf.train.init_from_checkpoint(checkpoint_path,
+                                available_var_map)
+
+
+def train_loop(
+    hparams,
+    pipeline_config_path,
+    model_dir,
+    config_override=None,
+    train_steps=None,
+    use_tpu=False,
+    save_final_config=False,
+    export_to_tpu=None,
+    checkpoint_every_n=1000, **kwargs):
+  """Trains a model using eager + functions.
+
+  This method:
+    1. Processes the pipeline configs
+    2. (Optionally) saves the as-run config
+    3. Builds the model & optimizer
+    4. Gets the training input data
+    5. Loads a fine-tuning detection or classification checkpoint if requested
+    6. Loops over the train data, executing distributed training steps inside
+       tf.functions.
+    7. Checkpoints the model every `checkpoint_every_n` training steps.
+    8. Logs the training metrics as TensorBoard summaries.
+
+  Args:
+    hparams: A `HParams`.
+    pipeline_config_path: A path to a pipeline config file.
+    model_dir:
+      The directory to save checkpoints and summaries to.
+    config_override: A pipeline_pb2.TrainEvalPipelineConfig text proto to
+      override the config from `pipeline_config_path`.
+    train_steps: Number of training steps. If None, the number of training steps
+      is set from the `TrainConfig` proto.
+    use_tpu: Boolean, whether training and evaluation should run on TPU.
+    save_final_config: Whether to save final config (obtained after applying
+      overrides) to `model_dir`.
+    export_to_tpu: When use_tpu and export_to_tpu are true,
+      `export_savedmodel()` exports a metagraph for serving on TPU besides the
+      one on CPU. If export_to_tpu is not provided, we will look for it in
+      hparams too.
+    checkpoint_every_n:
+      Checkpoint every n training steps.
+    **kwargs: Additional keyword arguments for configuration override.
+  """
+  ## Parse the configs
+  get_configs_from_pipeline_file = MODEL_BUILD_UTIL_MAP[
+      'get_configs_from_pipeline_file']
+  merge_external_params_with_configs = MODEL_BUILD_UTIL_MAP[
+      'merge_external_params_with_configs']
+  create_pipeline_proto_from_configs = MODEL_BUILD_UTIL_MAP[
+      'create_pipeline_proto_from_configs']
+
+  configs = get_configs_from_pipeline_file(
+      pipeline_config_path, config_override=config_override)
+  kwargs.update({
+      'train_steps': train_steps,
+      'use_bfloat16': configs['train_config'].use_bfloat16 and use_tpu
+  })
+  configs = merge_external_params_with_configs(
+      configs, hparams, kwargs_dict=kwargs)
+  model_config = configs['model']
+  train_config = configs['train_config']
+  train_input_config = configs['train_input_config']
+
+  unpad_groundtruth_tensors = train_config.unpad_groundtruth_tensors
+  use_bfloat16 = train_config.use_bfloat16
+  add_regularization_loss = train_config.add_regularization_loss
+  clip_gradients_value = None
+  if train_config.gradient_clipping_by_norm > 0:
+    clip_gradients_value = train_config.gradient_clipping_by_norm
+
+  # update train_steps from config but only when non-zero value is provided
+  if train_steps is None and train_config.num_steps != 0:
+    train_steps = train_config.num_steps
+
+  # Read export_to_tpu from hparams if not passed.
+  if export_to_tpu is None:
+    export_to_tpu = hparams.get('export_to_tpu', False)
+  tf.logging.info(
+      'train_loop: use_tpu %s, export_to_tpu %s', use_tpu,
+      export_to_tpu)
+
+  # Parse the checkpoint fine tuning configs
+  if hparams.load_pretrained:
+    fine_tune_checkpoint_path = train_config.fine_tune_checkpoint
+  else:
+    fine_tune_checkpoint_path = None
+  load_all_detection_checkpoint_vars = (
+      train_config.load_all_detection_checkpoint_vars)
+  # TODO(kaftan) (or anyone else): move this piece of config munging to
+  ## utils/config_util.py
+  if not train_config.fine_tune_checkpoint_type:
+    # train_config.from_detection_checkpoint field is deprecated. For
+    # backward compatibility, set train_config.fine_tune_checkpoint_type
+    # based on train_config.from_detection_checkpoint.
+    if train_config.from_detection_checkpoint:
+      train_config.fine_tune_checkpoint_type = 'detection'
+    else:
+      train_config.fine_tune_checkpoint_type = 'classification'
+  fine_tune_checkpoint_type = train_config.fine_tune_checkpoint_type
+
+  # Write the as-run pipeline config to disk.
+  if save_final_config:
+    pipeline_config_final = create_pipeline_proto_from_configs(configs)
+    config_util.save_pipeline_config(pipeline_config_final, model_dir)
+
+  # TODO(kaftan): Either make strategy a parameter of this method, or
+  ## grab it w/  Distribution strategy's get_scope
+  # Build the model, optimizer, and training input
+  strategy = tf.compat.v2.distribute.MirroredStrategy()
+  with strategy.scope():
+    detection_model = model_builder.build(
+        model_config=model_config, is_training=True)
+
+    # Create the inputs.
+    train_input = inputs.train_input(
+        train_config=train_config,
+        train_input_config=train_input_config,
+        model_config=model_config,
+        model=detection_model)
+
+    train_input = strategy.experimental_distribute_dataset(
+        train_input.repeat())
+
+    global_step = tf.compat.v2.Variable(
+        0, trainable=False, dtype=tf.compat.v2.dtypes.int64)
+    optimizer, (learning_rate,) = optimizer_builder.build(
+        train_config.optimizer, global_step=global_step)
+
+    if callable(learning_rate):
+      learning_rate_fn = learning_rate
+    else:
+      learning_rate_fn = lambda: learning_rate
+
+  ## Train the model
+  summary_writer = tf.compat.v2.summary.create_file_writer(model_dir + '/train')
+  with summary_writer.as_default():
+    with strategy.scope():
+      # Load a fine-tuning checkpoint.
+      if fine_tune_checkpoint_path:
+        load_fine_tune_checkpoint(detection_model, fine_tune_checkpoint_path,
+                                  fine_tune_checkpoint_type,
+                                  load_all_detection_checkpoint_vars,
+                                  train_input,
+                                  unpad_groundtruth_tensors, use_tpu,
+                                  use_bfloat16)
+
+      ckpt = tf.compat.v2.train.Checkpoint(
+          step=global_step, model=detection_model)
+      manager = tf.compat.v2.train.CheckpointManager(
+          ckpt, model_dir, max_to_keep=7)
+      ## Maybe re-enable checkpoint restoration depending on how it works:
+      # ckpt.restore(manager.latest_checkpoint)
+
+      def train_step_fn(features, labels):
+        return eager_train_step(
+            detection_model,
+            features,
+            labels,
+            unpad_groundtruth_tensors,
+            optimizer,
+            learning_rate=learning_rate_fn(),
+            use_bfloat16=use_bfloat16,
+            add_regularization_loss=add_regularization_loss,
+            clip_gradients_value=clip_gradients_value,
+            use_tpu=use_tpu,
+            global_step=global_step,
+            num_replicas=strategy.num_replicas_in_sync)
+
+      @tf.function
+      def _dist_train_step(data_iterator):
+        """A distributed train step."""
+        features, labels = data_iterator.next()
+        per_replica_losses = strategy.experimental_run_v2(
+            train_step_fn, args=(
+                features,
+                labels,
+            ))
+        # TODO(anjalisridhar): explore if it is safe to remove the
+        ## num_replicas scaling of the loss and switch this to a ReduceOp.Mean
+        mean_loss = strategy.reduce(
+            tf.distribute.ReduceOp.SUM, per_replica_losses, axis=None)
+        return mean_loss
+
+      train_input_iter = iter(train_input)
+      for _ in range(train_steps):
+        start_time = time.time()
+
+        loss = _dist_train_step(train_input_iter)
+        global_step.assign_add(1)
+        end_time = time.time()
+        tf.compat.v2.summary.scalar(
+            'steps_per_sec', 1.0 / (end_time - start_time), step=global_step)
+        # TODO(kaftan): Remove this print after it is no longer helpful for
+        ## debugging.
+        tf.print('Finished step', global_step, end_time, loss)
+        if int(global_step.value().numpy()) % checkpoint_every_n == 0:
+          manager.save()
+
+
+def eager_eval_loop(
+    detection_model,
+    configs,
+    eval_dataset,
+    use_tpu=False,
+    postprocess_on_cpu=False,
+    global_step=None):
+  """Evaluate the model eagerly on the evaluation dataset.
+
+  This method will compute the evaluation metrics specified in the configs on
+  the entire evaluation dataset, then return the metrics. It will also log
+  the metrics to TensorBoard
+
+  Args:
+    detection_model: A DetectionModel (based on Keras) to evaluate.
+    configs: Object detection configs that specify the evaluators that should
+      be used, as well as whether regularization loss should be included and
+      if bfloat16 should be used on TPUs.
+    eval_dataset: Dataset containing evaluation data.
+    use_tpu: Whether a TPU is being used to execute the model for evaluation.
+    postprocess_on_cpu: Whether model postprocessing should happen on
+      the CPU when using a TPU to execute the model.
+    global_step: A variable containing the training step this model was trained
+      to. Used for logging purposes.
+
+  Returns:
+    A dict of evaluation metrics representing the results of this evaluation.
+  """
+  train_config = configs['train_config']
+  eval_input_config = configs['eval_input_config']
+  eval_config = configs['eval_config']
+  use_bfloat16 = train_config.use_bfloat16
+  add_regularization_loss = train_config.add_regularization_loss
+
+  is_training = False
+  detection_model._is_training = is_training  # pylint: disable=protected-access
+  tf.keras.backend.set_learning_phase(is_training)
+
+  evaluator_options = eval_util.evaluator_options_from_eval_config(
+      eval_config)
+
+  class_agnostic_category_index = (
+      label_map_util.create_class_agnostic_category_index())
+  class_agnostic_evaluators = eval_util.get_evaluators(
+      eval_config,
+      list(class_agnostic_category_index.values()),
+      evaluator_options)
+
+  class_aware_evaluators = None
+  if eval_input_config.label_map_path:
+    class_aware_category_index = (
+        label_map_util.create_category_index_from_labelmap(
+            eval_input_config.label_map_path))
+    class_aware_evaluators = eval_util.get_evaluators(
+        eval_config,
+        list(class_aware_category_index.values()),
+        evaluator_options)
+
+  evaluators = None
+  loss_metrics = {}
+
+  @tf.function
+  def compute_eval_dict(features, labels):
+    """Compute the evaluation result on an image."""
+    # For evaling on train data, it is necessary to check whether groundtruth
+    # must be unpadded.
+    boxes_shape = (
+        labels[fields.InputDataFields.groundtruth_boxes].get_shape().as_list())
+    unpad_groundtruth_tensors = boxes_shape[1] is not None and not use_tpu
+    labels = model_lib.unstack_batch(
+        labels, unpad_groundtruth_tensors=unpad_groundtruth_tensors)
+
+    losses_dict, prediction_dict = _compute_losses_and_predictions_dicts(
+        detection_model, features, labels, add_regularization_loss, use_tpu,
+        use_bfloat16)
+
+    def postprocess_wrapper(args):
+      return detection_model.postprocess(args[0], args[1])
+
+    # TODO(kaftan): Depending on how postprocessing will work for TPUS w/
+    ## TPUStrategy, may be good to move wrapping to a utility method
+    if use_tpu and postprocess_on_cpu:
+      detections = tf.contrib.tpu.outside_compilation(
+          postprocess_wrapper,
+          (prediction_dict, features[fields.InputDataFields.true_image_shape]))
+    else:
+      detections = postprocess_wrapper(
+          (prediction_dict, features[fields.InputDataFields.true_image_shape]))
+
+    class_agnostic = (
+        fields.DetectionResultFields.detection_classes not in detections)
+    # TODO(kaftan) (or anyone): move `_prepare_groundtruth_for_eval to eval_util
+    ## and call this from there.
+    groundtruth = model_lib._prepare_groundtruth_for_eval(  # pylint: disable=protected-access
+        detection_model, class_agnostic, eval_input_config.max_number_of_boxes)
+    use_original_images = fields.InputDataFields.original_image in features
+    if use_original_images:
+      eval_images = features[fields.InputDataFields.original_image]
+      true_image_shapes = tf.slice(
+          features[fields.InputDataFields.true_image_shape], [0, 0], [-1, 3])
+      original_image_spatial_shapes = features[
+          fields.InputDataFields.original_image_spatial_shape]
+    else:
+      eval_images = features[fields.InputDataFields.image]
+      true_image_shapes = None
+      original_image_spatial_shapes = None
+
+    eval_dict = eval_util.result_dict_for_batched_example(
+        eval_images,
+        features[inputs.HASH_KEY],
+        detections,
+        groundtruth,
+        class_agnostic=class_agnostic,
+        scale_to_absolute=True,
+        original_image_spatial_shapes=original_image_spatial_shapes,
+        true_image_shapes=true_image_shapes)
+
+    return eval_dict, losses_dict, class_agnostic
+
+  i = 0
+  for features, labels in eval_dataset:
+    eval_dict, losses_dict, class_agnostic = compute_eval_dict(features, labels)
+    end_time = time.time()
+    # TODO(kaftan): Remove this print after it is no longer helpful for
+    ## debugging.
+    tf.print('Finished eval dict computation', i, end_time)
+    i += 1
+
+    if evaluators is None:
+      if class_agnostic:
+        evaluators = class_agnostic_evaluators
+      else:
+        evaluators = class_aware_evaluators
+
+    for evaluator in evaluators:
+      evaluator.add_eval_dict(eval_dict)
+
+    for loss_key, loss_tensor in iter(losses_dict.items()):
+      if loss_key not in loss_metrics:
+        loss_metrics[loss_key] = tf.keras.metrics.Mean()
+      loss_metrics[loss_key].update_state(loss_tensor)
+
+  eval_metrics = {}
+
+  for evaluator in evaluators:
+    eval_metrics.update(evaluator.evaluate())
+  for loss_key in loss_metrics:
+    eval_metrics[loss_key] = loss_metrics[loss_key].result()
+
+  eval_metrics = {str(k): v for k, v in eval_metrics.items()}
+  for k in eval_metrics:
+    tf.compat.v2.summary.scalar(k, eval_metrics[k], step=global_step)
+
+  return eval_metrics
+
+
+def eval_continuously(
+    hparams,
+    pipeline_config_path,
+    config_override=None,
+    train_steps=None,
+    sample_1_of_n_eval_examples=1,
+    sample_1_of_n_eval_on_train_examples=1,
+    use_tpu=False,
+    override_eval_num_epochs=True,
+    postprocess_on_cpu=False,
+    export_to_tpu=None,
+    model_dir=None,
+    checkpoint_dir=None,
+    wait_interval=180,
+    **kwargs):
+  """Run continuous evaluation of a detection model eagerly.
+
+  This method builds the model, and continously restores it from the most
+  recent training checkpoint in the checkpoint directory & evaluates it
+  on the evaluation data.
+
+  Args:
+    hparams: A `HParams`.
+    pipeline_config_path: A path to a pipeline config file.
+    config_override: A pipeline_pb2.TrainEvalPipelineConfig text proto to
+      override the config from `pipeline_config_path`.
+    train_steps: Number of training steps. If None, the number of training steps
+      is set from the `TrainConfig` proto.
+    sample_1_of_n_eval_examples: Integer representing how often an eval example
+      should be sampled. If 1, will sample all examples.
+    sample_1_of_n_eval_on_train_examples: Similar to
+      `sample_1_of_n_eval_examples`, except controls the sampling of training
+      data for evaluation.
+    use_tpu: Boolean, whether training and evaluation should run on TPU.
+    override_eval_num_epochs: Whether to overwrite the number of epochs to 1 for
+      eval_input.
+    postprocess_on_cpu: When use_tpu and postprocess_on_cpu are true,
+      postprocess is scheduled on the host cpu.
+    export_to_tpu: When use_tpu and export_to_tpu are true,
+      `export_savedmodel()` exports a metagraph for serving on TPU besides the
+      one on CPU. If export_to_tpu is not provided, we will look for it in
+      hparams too.
+    model_dir:
+      Directory to output resulting evaluation summaries to.
+    checkpoint_dir:
+      Directory that contains the training checkpoints.
+    wait_interval:
+      Terminate evaluation in no new checkpoints arrive within this wait
+      interval (in seconds).
+    **kwargs: Additional keyword arguments for configuration override.
+  """
+  get_configs_from_pipeline_file = MODEL_BUILD_UTIL_MAP[
+      'get_configs_from_pipeline_file']
+  merge_external_params_with_configs = MODEL_BUILD_UTIL_MAP[
+      'merge_external_params_with_configs']
+
+  configs = get_configs_from_pipeline_file(
+      pipeline_config_path, config_override=config_override)
+  kwargs.update({
+      'sample_1_of_n_eval_examples': sample_1_of_n_eval_examples,
+      'use_bfloat16': configs['train_config'].use_bfloat16 and use_tpu
+  })
+  if train_steps is not None:
+    kwargs['train_steps'] = train_steps
+  if override_eval_num_epochs:
+    kwargs.update({'eval_num_epochs': 1})
+    tf.logging.warning(
+        'Forced number of epochs for all eval validations to be 1.')
+  configs = merge_external_params_with_configs(
+      configs, hparams, kwargs_dict=kwargs)
+  model_config = configs['model']
+  train_input_config = configs['train_input_config']
+  eval_config = configs['eval_config']
+  eval_input_configs = configs['eval_input_configs']
+  eval_on_train_input_config = copy.deepcopy(train_input_config)
+  eval_on_train_input_config.sample_1_of_n_examples = (
+      sample_1_of_n_eval_on_train_examples)
+  if override_eval_num_epochs and eval_on_train_input_config.num_epochs != 1:
+    tf.logging.warning('Expected number of evaluation epochs is 1, but '
+                       'instead encountered `eval_on_train_input_config'
+                       '.num_epochs` = '
+                       '{}. Overwriting `num_epochs` to 1.'.format(
+                           eval_on_train_input_config.num_epochs))
+    eval_on_train_input_config.num_epochs = 1
+
+  detection_model = model_builder.build(
+      model_config=model_config, is_training=True)
+
+  # Create the inputs.
+  eval_inputs = []
+  for eval_input_config in eval_input_configs:
+    next_eval_input = inputs.eval_input(
+        eval_config=eval_config,
+        eval_input_config=eval_input_config,
+        model_config=model_config,
+        model=detection_model)
+    eval_inputs.append((eval_input_config.name, next_eval_input))
+
+  # Read export_to_tpu from hparams if not passed.
+  if export_to_tpu is None:
+    export_to_tpu = hparams.get('export_to_tpu', False)
+  tf.logging.info('eval_continuously: use_tpu %s, export_to_tpu %s',
+                  use_tpu, export_to_tpu)
+
+  global_step = tf.compat.v2.Variable(
+      0, trainable=False, dtype=tf.compat.v2.dtypes.int64)
+
+  prev_checkpoint = None
+  waiting = False
+  while True:
+    ckpt = tf.compat.v2.train.Checkpoint(
+        step=global_step, model=detection_model)
+    manager = tf.compat.v2.train.CheckpointManager(
+        ckpt, checkpoint_dir, max_to_keep=3)
+
+    latest_checkpoint = manager.latest_checkpoint
+    if prev_checkpoint == latest_checkpoint:
+      if prev_checkpoint is None:
+        tf.logging.info('No checkpoints found yet. Trying again in %s seconds.'
+                        % wait_interval)
+        time.sleep(wait_interval)
+      else:
+        if waiting:
+          tf.logging.info('Terminating eval after %s seconds of no new '
+                          'checkpoints.' % wait_interval)
+          break
+        else:
+          tf.logging.info('No new checkpoint found. Will try again '
+                          'in %s seconds and terminate if no checkpoint '
+                          'appears.' % wait_interval)
+          waiting = True
+          time.sleep(wait_interval)
+    else:
+      tf.logging.info('New checkpoint found. Starting evaluation.')
+      waiting = False
+      prev_checkpoint = latest_checkpoint
+      ckpt.restore(latest_checkpoint)
+
+      for eval_name, eval_input in eval_inputs:
+        summary_writer = tf.compat.v2.summary.create_file_writer(
+            model_dir + '/eval' + eval_name)
+        with summary_writer.as_default():
+          eager_eval_loop(
+              detection_model,
+              configs,
+              eval_input,
+              use_tpu=use_tpu,
+              postprocess_on_cpu=postprocess_on_cpu,
+              global_step=global_step)

--- a/research/object_detection/model_lib_v2_test.py
+++ b/research/object_detection/model_lib_v2_test.py
@@ -1,0 +1,104 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for object detection model library."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import tensorflow as tf
+
+from object_detection import model_hparams
+from object_detection import model_lib_v2
+from object_detection.utils import config_util
+
+
+# Model for test. Current options are:
+# 'ssd_mobilenet_v2_pets_keras'
+MODEL_NAME_FOR_TEST = 'ssd_mobilenet_v2_pets_keras'
+
+
+def _get_data_path():
+  """Returns an absolute path to TFRecord file."""
+  return os.path.join(tf.resource_loader.get_data_files_path(), 'test_data',
+                      'pets_examples.record')
+
+
+def get_pipeline_config_path(model_name):
+  """Returns path to the local pipeline config file."""
+  return os.path.join(tf.resource_loader.get_data_files_path(), 'samples',
+                      'configs', model_name + '.config')
+
+
+def _get_labelmap_path():
+  """Returns an absolute path to label map file."""
+  return os.path.join(tf.resource_loader.get_data_files_path(), 'data',
+                      'pet_label_map.pbtxt')
+
+
+def _get_config_kwarg_overrides():
+  """Returns overrides to the configs that insert the correct local paths."""
+  data_path = _get_data_path()
+  label_map_path = _get_labelmap_path()
+  return {
+      'train_input_path': data_path,
+      'eval_input_path': data_path,
+      'label_map_path': label_map_path
+  }
+
+
+def _get_configs_for_model(model_name):
+  """Returns configurations for model."""
+  filename = get_pipeline_config_path(model_name)
+  configs = config_util.get_configs_from_pipeline_file(filename)
+  configs = config_util.merge_external_params_with_configs(
+      configs, kwargs_dict=_get_config_kwarg_overrides())
+  return configs
+
+
+class ModelLibTest(tf.test.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    tf.keras.backend.clear_session()
+
+  def test_train_loop_then_eval_loop(self):
+    """Tests that Estimator and input function are constructed correctly."""
+    hparams = model_hparams.create_hparams(
+        hparams_overrides='load_pretrained=false')
+    pipeline_config_path = get_pipeline_config_path(MODEL_NAME_FOR_TEST)
+    config_kwarg_overrides = _get_config_kwarg_overrides()
+    model_dir = tf.test.get_temp_dir()
+
+    train_steps = 2
+    model_lib_v2.train_loop(
+        hparams,
+        pipeline_config_path,
+        model_dir=model_dir,
+        train_steps=train_steps,
+        checkpoint_every_n=1,
+        **config_kwarg_overrides)
+
+    model_lib_v2.eval_continuously(
+        hparams,
+        pipeline_config_path,
+        model_dir=model_dir,
+        checkpoint_dir=model_dir,
+        train_steps=train_steps,
+        wait_interval=10,
+        **config_kwarg_overrides)
+

--- a/research/object_detection/models/faster_rcnn_inception_resnet_v2_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_inception_resnet_v2_feature_extractor.py
@@ -25,6 +25,7 @@ Huang et al. (https://arxiv.org/abs/1611.10012)
 import tensorflow as tf
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
+from object_detection.utils import variables_helper
 from nets import inception_resnet_v2
 
 slim = tf.contrib.slim
@@ -195,7 +196,7 @@ class FasterRCNNInceptionResnetV2FeatureExtractor(
     """
 
     variables_to_restore = {}
-    for variable in tf.global_variables():
+    for variable in variables_helper.get_global_variables_safely():
       if variable.op.name.startswith(
           first_stage_feature_extractor_scope):
         var_name = variable.op.name.replace(

--- a/research/object_detection/models/faster_rcnn_inception_resnet_v2_keras_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_inception_resnet_v2_keras_feature_extractor.py
@@ -30,6 +30,7 @@ import tensorflow as tf
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.models.keras_models import inception_resnet_v2
 from object_detection.utils import model_util
+from object_detection.utils import variables_helper
 
 
 class FasterRCNNInceptionResnetV2KerasFeatureExtractor(
@@ -1070,7 +1071,7 @@ class FasterRCNNInceptionResnetV2KerasFeatureExtractor(
     }
 
     variables_to_restore = {}
-    for variable in tf.global_variables():
+    for variable in variables_helper.get_global_variables_safely():
       var_name = keras_to_slim_name_mapping.get(variable.op.name)
       if var_name:
         variables_to_restore[var_name] = variable

--- a/research/object_detection/models/faster_rcnn_nas_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_nas_feature_extractor.py
@@ -23,6 +23,7 @@ https://arxiv.org/abs/1707.07012
 import tensorflow as tf
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
+from object_detection.utils import variables_helper
 from nets.nasnet import nasnet
 from nets.nasnet import nasnet_utils
 
@@ -307,7 +308,7 @@ class FasterRCNNNASFeatureExtractor(
     # Note that the NAS checkpoint only contains the moving average version of
     # the Variables so we need to generate an appropriate dictionary mapping.
     variables_to_restore = {}
-    for variable in tf.global_variables():
+    for variable in variables_helper.get_global_variables_safely():
       if variable.op.name.startswith(
           first_stage_feature_extractor_scope):
         var_name = variable.op.name.replace(

--- a/research/object_detection/models/faster_rcnn_pnas_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_pnas_feature_extractor.py
@@ -21,6 +21,7 @@ Based on PNASNet model: https://arxiv.org/abs/1712.00559
 import tensorflow as tf
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
+from object_detection.utils import variables_helper
 from nets.nasnet import nasnet_utils
 from nets.nasnet import pnasnet
 
@@ -302,7 +303,7 @@ class FasterRCNNPNASFeatureExtractor(
       the model graph.
     """
     variables_to_restore = {}
-    for variable in tf.global_variables():
+    for variable in variables_helper.get_global_variables_safely():
       if variable.op.name.startswith(
           first_stage_feature_extractor_scope):
         var_name = variable.op.name.replace(

--- a/research/object_detection/models/faster_rcnn_resnet_v1_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_resnet_v1_feature_extractor.py
@@ -44,7 +44,8 @@ class FasterRCNNResnetV1FeatureExtractor(
                first_stage_features_stride,
                batch_norm_trainable=False,
                reuse_weights=None,
-               weight_decay=0.0):
+               weight_decay=0.0,
+               activation_fn=tf.nn.relu):
     """Constructor.
 
     Args:
@@ -55,6 +56,7 @@ class FasterRCNNResnetV1FeatureExtractor(
       batch_norm_trainable: See base class.
       reuse_weights: See base class.
       weight_decay: See base class.
+      activation_fn: Activaton functon to use in Resnet V1 model.
 
     Raises:
       ValueError: If `first_stage_features_stride` is not 8 or 16.
@@ -63,9 +65,10 @@ class FasterRCNNResnetV1FeatureExtractor(
       raise ValueError('`first_stage_features_stride` must be 8 or 16.')
     self._architecture = architecture
     self._resnet_model = resnet_model
-    super(FasterRCNNResnetV1FeatureExtractor, self).__init__(
-        is_training, first_stage_features_stride, batch_norm_trainable,
-        reuse_weights, weight_decay)
+    self._activation_fn = activation_fn
+    super(FasterRCNNResnetV1FeatureExtractor,
+          self).__init__(is_training, first_stage_features_stride,
+                         batch_norm_trainable, reuse_weights, weight_decay)
 
   def preprocess(self, resized_inputs):
     """Faster R-CNN Resnet V1 preprocessing.
@@ -125,6 +128,7 @@ class FasterRCNNResnetV1FeatureExtractor(
           resnet_utils.resnet_arg_scope(
               batch_norm_epsilon=1e-5,
               batch_norm_scale=True,
+              activation_fn=self._activation_fn,
               weight_decay=self._weight_decay)):
         with tf.variable_scope(
             self._architecture, reuse=self._reuse_weights) as var_scope:
@@ -159,6 +163,7 @@ class FasterRCNNResnetV1FeatureExtractor(
           resnet_utils.resnet_arg_scope(
               batch_norm_epsilon=1e-5,
               batch_norm_scale=True,
+              activation_fn=self._activation_fn,
               weight_decay=self._weight_decay)):
         with slim.arg_scope([slim.batch_norm],
                             is_training=self._train_batch_norm):
@@ -182,7 +187,8 @@ class FasterRCNNResnet50FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
                first_stage_features_stride,
                batch_norm_trainable=False,
                reuse_weights=None,
-               weight_decay=0.0):
+               weight_decay=0.0,
+               activation_fn=tf.nn.relu):
     """Constructor.
 
     Args:
@@ -191,15 +197,16 @@ class FasterRCNNResnet50FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
       batch_norm_trainable: See base class.
       reuse_weights: See base class.
       weight_decay: See base class.
+      activation_fn: See base class.
 
     Raises:
       ValueError: If `first_stage_features_stride` is not 8 or 16,
         or if `architecture` is not supported.
     """
-    super(FasterRCNNResnet50FeatureExtractor, self).__init__(
-        'resnet_v1_50', resnet_v1.resnet_v1_50, is_training,
-        first_stage_features_stride, batch_norm_trainable,
-        reuse_weights, weight_decay)
+    super(FasterRCNNResnet50FeatureExtractor,
+          self).__init__('resnet_v1_50', resnet_v1.resnet_v1_50, is_training,
+                         first_stage_features_stride, batch_norm_trainable,
+                         reuse_weights, weight_decay, activation_fn)
 
 
 class FasterRCNNResnet101FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
@@ -210,7 +217,8 @@ class FasterRCNNResnet101FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
                first_stage_features_stride,
                batch_norm_trainable=False,
                reuse_weights=None,
-               weight_decay=0.0):
+               weight_decay=0.0,
+               activation_fn=tf.nn.relu):
     """Constructor.
 
     Args:
@@ -219,15 +227,16 @@ class FasterRCNNResnet101FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
       batch_norm_trainable: See base class.
       reuse_weights: See base class.
       weight_decay: See base class.
+      activation_fn: See base class.
 
     Raises:
       ValueError: If `first_stage_features_stride` is not 8 or 16,
         or if `architecture` is not supported.
     """
-    super(FasterRCNNResnet101FeatureExtractor, self).__init__(
-        'resnet_v1_101', resnet_v1.resnet_v1_101, is_training,
-        first_stage_features_stride, batch_norm_trainable,
-        reuse_weights, weight_decay)
+    super(FasterRCNNResnet101FeatureExtractor,
+          self).__init__('resnet_v1_101', resnet_v1.resnet_v1_101, is_training,
+                         first_stage_features_stride, batch_norm_trainable,
+                         reuse_weights, weight_decay, activation_fn)
 
 
 class FasterRCNNResnet152FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
@@ -238,7 +247,8 @@ class FasterRCNNResnet152FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
                first_stage_features_stride,
                batch_norm_trainable=False,
                reuse_weights=None,
-               weight_decay=0.0):
+               weight_decay=0.0,
+               activation_fn=tf.nn.relu):
     """Constructor.
 
     Args:
@@ -247,12 +257,13 @@ class FasterRCNNResnet152FeatureExtractor(FasterRCNNResnetV1FeatureExtractor):
       batch_norm_trainable: See base class.
       reuse_weights: See base class.
       weight_decay: See base class.
+      activation_fn: See base class.
 
     Raises:
       ValueError: If `first_stage_features_stride` is not 8 or 16,
         or if `architecture` is not supported.
     """
-    super(FasterRCNNResnet152FeatureExtractor, self).__init__(
-        'resnet_v1_152', resnet_v1.resnet_v1_152, is_training,
-        first_stage_features_stride, batch_norm_trainable,
-        reuse_weights, weight_decay)
+    super(FasterRCNNResnet152FeatureExtractor,
+          self).__init__('resnet_v1_152', resnet_v1.resnet_v1_152, is_training,
+                         first_stage_features_stride, batch_norm_trainable,
+                         reuse_weights, weight_decay, activation_fn)

--- a/research/object_detection/models/feature_map_generators.py
+++ b/research/object_detection/models/feature_map_generators.py
@@ -79,14 +79,19 @@ def create_conv_block(
   """
   layers = []
   if use_depthwise:
-    layers.append(tf.keras.layers.SeparableConv2D(
-        depth,
-        [kernel_size, kernel_size],
-        depth_multiplier=1,
-        padding=padding,
-        strides=stride,
-        name=layer_name + '_depthwise_conv',
-        **conv_hyperparams.params()))
+    kwargs = conv_hyperparams.params()
+    # Both the regularizer and initializer apply to the depthwise layer,
+    # so we remap the kernel_* to depthwise_* here.
+    kwargs['depthwise_regularizer'] = kwargs['kernel_regularizer']
+    kwargs['depthwise_initializer'] = kwargs['kernel_initializer']
+    layers.append(
+        tf.keras.layers.SeparableConv2D(
+            depth, [kernel_size, kernel_size],
+            depth_multiplier=1,
+            padding=padding,
+            strides=stride,
+            name=layer_name + '_depthwise_conv',
+            **kwargs))
   else:
     layers.append(tf.keras.layers.Conv2D(
         depth,

--- a/research/object_detection/models/keras_models/mobilenet_v2.py
+++ b/research/object_detection/models/keras_models/mobilenet_v2.py
@@ -160,7 +160,12 @@ class _LayersOverride(object):
     """
     if self._conv_hyperparams:
       kwargs = self._conv_hyperparams.params(**kwargs)
+      # Both the regularizer and initializer apply to the depthwise layer in
+      # MobilenetV1, so we remap the kernel_* to depthwise_* here.
+      kwargs['depthwise_regularizer'] = kwargs['kernel_regularizer']
+      kwargs['depthwise_initializer'] = kwargs['kernel_initializer']
     else:
+      kwargs['depthwise_regularizer'] = self.regularizer
       kwargs['depthwise_initializer'] = self.initializer
 
     kwargs['padding'] = 'same'

--- a/research/object_detection/models/keras_models/resnet_v1.py
+++ b/research/object_detection/models/keras_models/resnet_v1.py
@@ -1,0 +1,396 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A wrapper around the Keras Resnet V1 models for object detection."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from object_detection.core import freezable_batch_norm
+
+
+def _fixed_padding(inputs, kernel_size, rate=1):  # pylint: disable=invalid-name
+  """Pads the input along the spatial dimensions independently of input size.
+
+  Pads the input such that if it was used in a convolution with 'VALID' padding,
+  the output would have the same dimensions as if the unpadded input was used
+  in a convolution with 'SAME' padding.
+
+  Args:
+    inputs: A tensor of size [batch, height_in, width_in, channels].
+    kernel_size: The kernel to be used in the conv2d or max_pool2d operation.
+    rate: An integer, rate for atrous convolution.
+
+  Returns:
+    output: A tensor of size [batch, height_out, width_out, channels] with the
+      input, either intact (if kernel_size == 1) or padded (if kernel_size > 1).
+  """
+  kernel_size_effective = kernel_size + (kernel_size - 1) * (rate - 1)
+  pad_total = kernel_size_effective - 1
+  pad_beg = pad_total // 2
+  pad_end = pad_total - pad_beg
+  padded_inputs = tf.pad(
+      inputs, [[0, 0], [pad_beg, pad_end], [pad_beg, pad_end], [0, 0]])
+  return padded_inputs
+
+
+class _LayersOverride(object):
+  """Alternative Keras layers interface for the Keras Resnet V1."""
+
+  def __init__(self,
+               batchnorm_training,
+               batchnorm_scale=True,
+               default_batchnorm_momentum=0.997,
+               default_batchnorm_epsilon=1e-5,
+               weight_decay=0.0001,
+               conv_hyperparams=None,
+               min_depth=8,
+               depth_multiplier=1):
+    """Alternative tf.keras.layers interface, for use by the Keras Resnet V1.
+
+    The class is used by the Keras applications kwargs injection API to
+    modify the Resnet V1 Keras application with changes required by
+    the Object Detection API.
+
+    Args:
+      batchnorm_training: Bool. Assigned to Batch norm layer `training` param
+        when constructing `freezable_batch_norm.FreezableBatchNorm` layers.
+      batchnorm_scale: If True, uses an explicit `gamma` multiplier to scale
+        the activations in the batch normalization layer.
+      default_batchnorm_momentum: Float. When 'conv_hyperparams' is None,
+        batch norm layers will be constructed using this value as the momentum.
+      default_batchnorm_epsilon: Float. When 'conv_hyperparams' is None,
+        batch norm layers will be constructed using this value as the epsilon.
+      weight_decay: The weight decay to use for regularizing the model.
+      conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+        containing hyperparameters for convolution ops. Optionally set to `None`
+        to use default resnet_v1 layer builders.
+      min_depth: Minimum number of filters in the convolutional layers.
+      depth_multiplier: The depth multiplier to modify the number of filters
+        in the convolutional layers.
+    """
+    self._batchnorm_training = batchnorm_training
+    self._batchnorm_scale = batchnorm_scale
+    self._default_batchnorm_momentum = default_batchnorm_momentum
+    self._default_batchnorm_epsilon = default_batchnorm_epsilon
+    self._conv_hyperparams = conv_hyperparams
+    self._min_depth = min_depth
+    self._depth_multiplier = depth_multiplier
+    self.regularizer = tf.keras.regularizers.l2(weight_decay)
+    self.initializer = tf.variance_scaling_initializer()
+
+  def _FixedPaddingLayer(self, kernel_size, rate=1):
+    return tf.keras.layers.Lambda(
+        lambda x: _fixed_padding(x, kernel_size, rate))
+
+  def Conv2D(self, filters, kernel_size, **kwargs):
+    """Builds a Conv2D layer according to the current Object Detection config.
+
+    Overrides the Keras Resnet application's convolutions with ones that
+    follow the spec specified by the Object Detection hyperparameters.
+
+    Args:
+      filters: The number of filters to use for the convolution.
+      kernel_size: The kernel size to specify the height and width of the 2D
+        convolution window.
+      **kwargs: Keyword args specified by the Keras application for
+        constructing the convolution.
+
+    Returns:
+      A one-arg callable that will either directly apply a Keras Conv2D layer to
+      the input argument, or that will first pad the input then apply a Conv2D
+      layer.
+    """
+    # Apply the minimum depth to the convolution layers.
+    filters = max(int(filters * self._depth_multiplier), self._min_depth)
+
+    if self._conv_hyperparams:
+      kwargs = self._conv_hyperparams.params(**kwargs)
+    else:
+      kwargs['kernel_regularizer'] = self.regularizer
+      kwargs['kernel_initializer'] = self.initializer
+
+    # Set use_bias as false to keep it consistent with Slim Resnet model.
+    kwargs['use_bias'] = False
+
+    kwargs['padding'] = 'same'
+    stride = kwargs.get('strides')
+    if stride and kernel_size and stride > 1 and kernel_size > 1:
+      kwargs['padding'] = 'valid'
+      def padded_conv(features):  # pylint: disable=invalid-name
+        padded_features = self._FixedPaddingLayer(kernel_size)(features)
+        return tf.keras.layers.Conv2D(
+            filters, kernel_size, **kwargs)(padded_features)
+      return padded_conv
+    else:
+      return tf.keras.layers.Conv2D(filters, kernel_size, **kwargs)
+
+  def Activation(self, *args, **kwargs):  # pylint: disable=unused-argument
+    """Builds an activation layer.
+
+    Overrides the Keras application Activation layer specified by the
+    Object Detection configuration.
+
+    Args:
+      *args: Ignored,
+        required to match the `tf.keras.layers.Activation` interface.
+      **kwargs: Only the name is used,
+        required to match `tf.keras.layers.Activation` interface.
+
+    Returns:
+      An activation layer specified by the Object Detection hyperparameter
+      configurations.
+    """
+    name = kwargs.get('name')
+    if self._conv_hyperparams:
+      return self._conv_hyperparams.build_activation_layer(name=name)
+    else:
+      return tf.keras.layers.Lambda(tf.nn.relu, name=name)
+
+  def BatchNormalization(self, **kwargs):
+    """Builds a normalization layer.
+
+    Overrides the Keras application batch norm with the norm specified by the
+    Object Detection configuration.
+
+    Args:
+      **kwargs: Only the name is used, all other params ignored.
+        Required for matching `layers.BatchNormalization` calls in the Keras
+        application.
+
+    Returns:
+      A normalization layer specified by the Object Detection hyperparameter
+      configurations.
+    """
+    name = kwargs.get('name')
+    if self._conv_hyperparams:
+      return self._conv_hyperparams.build_batch_norm(
+          training=self._batchnorm_training,
+          name=name)
+    else:
+      kwargs['scale'] = self._batchnorm_scale
+      kwargs['epsilon'] = self._default_batchnorm_epsilon
+      return freezable_batch_norm.FreezableBatchNorm(
+          training=self._batchnorm_training,
+          momentum=self._default_batchnorm_momentum,
+          **kwargs)
+
+  def Input(self, shape):
+    """Builds an Input layer.
+
+    Overrides the Keras application Input layer with one that uses a
+    tf.placeholder_with_default instead of a tf.placeholder. This is necessary
+    to ensure the application works when run on a TPU.
+
+    Args:
+      shape: A tuple of integers representing the shape of the input, which
+        includes both spatial share and channels, but not the batch size.
+        Elements of this tuple can be None; 'None' elements represent dimensions
+        where the shape is not known.
+
+    Returns:
+      An input layer for the specified shape that internally uses a
+      placeholder_with_default.
+    """
+    default_size = 224
+    default_batch_size = 1
+    shape = list(shape)
+    default_shape = [default_size if dim is None else dim for dim in shape]
+
+    input_tensor = tf.constant(0.0, shape=[default_batch_size] + default_shape)
+
+    placeholder_with_default = tf.placeholder_with_default(
+        input=input_tensor, shape=[None] + shape)
+    return tf.keras.layers.Input(tensor=placeholder_with_default)
+
+  def MaxPooling2D(self, pool_size, **kwargs):
+    """Builds a MaxPooling2D layer with default padding as 'SAME'.
+
+    This is specified by the default resnet arg_scope in slim.
+
+    Args:
+      pool_size: The pool size specified by the Keras application.
+      **kwargs: Ignored, required to match the Keras applications usage.
+
+    Returns:
+      A MaxPooling2D layer with default padding as 'SAME'.
+    """
+    kwargs['padding'] = 'same'
+    return tf.keras.layers.MaxPooling2D(pool_size, **kwargs)
+
+  # Add alias as Keras also has it.
+  MaxPool2D = MaxPooling2D  # pylint: disable=invalid-name
+
+  def ZeroPadding2D(self, padding, **kwargs):  # pylint: disable=unused-argument
+    """Replaces explicit padding in the Keras application with a no-op.
+
+    Args:
+      padding: The padding values for image height and width.
+      **kwargs: Ignored, required to match the Keras applications usage.
+
+    Returns:
+      A no-op identity lambda.
+    """
+    return lambda x: x
+
+  # Forward all non-overridden methods to the keras layers
+  def __getattr__(self, item):
+    return getattr(tf.keras.layers, item)
+
+
+# pylint: disable=invalid-name
+def resnet_v1_50(batchnorm_training,
+                 batchnorm_scale=True,
+                 default_batchnorm_momentum=0.997,
+                 default_batchnorm_epsilon=1e-5,
+                 weight_decay=0.0001,
+                 conv_hyperparams=None,
+                 min_depth=8,
+                 depth_multiplier=1,
+                 **kwargs):
+  """Instantiates the Resnet50 architecture, modified for object detection.
+
+  Args:
+    batchnorm_training: Bool. Assigned to Batch norm layer `training` param
+      when constructing `freezable_batch_norm.FreezableBatchNorm` layers.
+    batchnorm_scale: If True, uses an explicit `gamma` multiplier to scale
+      the activations in the batch normalization layer.
+    default_batchnorm_momentum: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the momentum.
+    default_batchnorm_epsilon: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the epsilon.
+    weight_decay: The weight decay to use for regularizing the model.
+    conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+      containing hyperparameters for convolution ops. Optionally set to `None`
+      to use default resnet_v1 layer builders.
+    min_depth: Minimum number of filters in the convolutional layers.
+    depth_multiplier: The depth multiplier to modify the number of filters
+      in the convolutional layers.
+    **kwargs: Keyword arguments forwarded directly to the
+      `tf.keras.applications.Mobilenet` method that constructs the Keras
+      model.
+
+  Returns:
+    A Keras ResnetV1-50 model instance.
+  """
+  layers_override = _LayersOverride(
+      batchnorm_training,
+      batchnorm_scale=batchnorm_scale,
+      default_batchnorm_momentum=default_batchnorm_momentum,
+      default_batchnorm_epsilon=default_batchnorm_epsilon,
+      conv_hyperparams=conv_hyperparams,
+      weight_decay=weight_decay,
+      min_depth=min_depth,
+      depth_multiplier=depth_multiplier)
+  return tf.keras.applications.resnet.ResNet50(
+      layers=layers_override, **kwargs)
+
+
+def resnet_v1_101(batchnorm_training,
+                  batchnorm_scale=True,
+                  default_batchnorm_momentum=0.997,
+                  default_batchnorm_epsilon=1e-5,
+                  weight_decay=0.0001,
+                  conv_hyperparams=None,
+                  min_depth=8,
+                  depth_multiplier=1,
+                  **kwargs):
+  """Instantiates the Resnet50 architecture, modified for object detection.
+
+  Args:
+    batchnorm_training: Bool. Assigned to Batch norm layer `training` param
+      when constructing `freezable_batch_norm.FreezableBatchNorm` layers.
+    batchnorm_scale: If True, uses an explicit `gamma` multiplier to scale
+      the activations in the batch normalization layer.
+    default_batchnorm_momentum: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the momentum.
+    default_batchnorm_epsilon: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the epsilon.
+    weight_decay: The weight decay to use for regularizing the model.
+    conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+      containing hyperparameters for convolution ops. Optionally set to `None`
+      to use default resnet_v1 layer builders.
+    min_depth: Minimum number of filters in the convolutional layers.
+    depth_multiplier: The depth multiplier to modify the number of filters
+      in the convolutional layers.
+    **kwargs: Keyword arguments forwarded directly to the
+      `tf.keras.applications.Mobilenet` method that constructs the Keras
+      model.
+
+  Returns:
+    A Keras ResnetV1-101 model instance.
+  """
+  layers_override = _LayersOverride(
+      batchnorm_training,
+      batchnorm_scale=batchnorm_scale,
+      default_batchnorm_momentum=default_batchnorm_momentum,
+      default_batchnorm_epsilon=default_batchnorm_epsilon,
+      conv_hyperparams=conv_hyperparams,
+      weight_decay=weight_decay,
+      min_depth=min_depth,
+      depth_multiplier=depth_multiplier)
+  return tf.keras.applications.resnet.ResNet101(
+      layers=layers_override, **kwargs)
+
+
+def resnet_v1_152(batchnorm_training,
+                  batchnorm_scale=True,
+                  default_batchnorm_momentum=0.997,
+                  default_batchnorm_epsilon=1e-5,
+                  weight_decay=0.0001,
+                  conv_hyperparams=None,
+                  min_depth=8,
+                  depth_multiplier=1,
+                  **kwargs):
+  """Instantiates the Resnet50 architecture, modified for object detection.
+
+  Args:
+    batchnorm_training: Bool. Assigned to Batch norm layer `training` param
+      when constructing `freezable_batch_norm.FreezableBatchNorm` layers.
+    batchnorm_scale: If True, uses an explicit `gamma` multiplier to scale
+      the activations in the batch normalization layer.
+    default_batchnorm_momentum: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the momentum.
+    default_batchnorm_epsilon: Float. When 'conv_hyperparams' is None,
+      batch norm layers will be constructed using this value as the epsilon.
+    weight_decay: The weight decay to use for regularizing the model.
+    conv_hyperparams: A `hyperparams_builder.KerasLayerHyperparams` object
+      containing hyperparameters for convolution ops. Optionally set to `None`
+      to use default resnet_v1 layer builders.
+    min_depth: Minimum number of filters in the convolutional layers.
+    depth_multiplier: The depth multiplier to modify the number of filters
+      in the convolutional layers.
+    **kwargs: Keyword arguments forwarded directly to the
+      `tf.keras.applications.Mobilenet` method that constructs the Keras
+      model.
+
+  Returns:
+    A Keras ResnetV1-152 model instance.
+  """
+  layers_override = _LayersOverride(
+      batchnorm_training,
+      batchnorm_scale=batchnorm_scale,
+      default_batchnorm_momentum=default_batchnorm_momentum,
+      default_batchnorm_epsilon=default_batchnorm_epsilon,
+      conv_hyperparams=conv_hyperparams,
+      weight_decay=weight_decay,
+      min_depth=min_depth,
+      depth_multiplier=depth_multiplier)
+  return tf.keras.applications.resnet.ResNet152(
+      layers=layers_override, **kwargs)
+# pylint: enable=invalid-name

--- a/research/object_detection/models/keras_models/resnet_v1_test.py
+++ b/research/object_detection/models/keras_models/resnet_v1_test.py
@@ -1,0 +1,183 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for resnet_v1.py.
+
+This test mainly focuses on comparing slim resnet v1 and Keras resnet v1 for
+object detection. To verify the consistency of the two models, we compare:
+  1. Output shape of each layer given different inputs.
+  2. Number of global variables.
+"""
+
+import numpy as np
+from six.moves import zip
+import tensorflow as tf
+
+from google.protobuf import text_format
+
+from object_detection.builders import hyperparams_builder
+from object_detection.models.keras_models import resnet_v1
+from object_detection.protos import hyperparams_pb2
+from object_detection.utils import test_case
+
+_EXPECTED_SHAPES_224_RESNET50 = {
+    'conv2_block3_out': (4, 56, 56, 256),
+    'conv3_block4_out': (4, 28, 28, 512),
+    'conv4_block6_out': (4, 14, 14, 1024),
+    'conv5_block3_out': (4, 7, 7, 2048),
+}
+
+_EXPECTED_SHAPES_224_RESNET101 = {
+    'conv2_block3_out': (4, 56, 56, 256),
+    'conv3_block4_out': (4, 28, 28, 512),
+    'conv4_block23_out': (4, 14, 14, 1024),
+    'conv5_block3_out': (4, 7, 7, 2048),
+}
+
+_EXPECTED_SHAPES_224_RESNET152 = {
+    'conv2_block3_out': (4, 56, 56, 256),
+    'conv3_block8_out': (4, 28, 28, 512),
+    'conv4_block36_out': (4, 14, 14, 1024),
+    'conv5_block3_out': (4, 7, 7, 2048),
+}
+
+_RESNET_NAMES = ['resnet_v1_50', 'resnet_v1_101', 'resnet_v1_152']
+_RESNET_MODELS = [
+    resnet_v1.resnet_v1_50, resnet_v1.resnet_v1_101, resnet_v1.resnet_v1_152
+]
+_RESNET_SHAPES = [
+    _EXPECTED_SHAPES_224_RESNET50, _EXPECTED_SHAPES_224_RESNET101,
+    _EXPECTED_SHAPES_224_RESNET152
+]
+
+_NUM_CHANNELS = 3
+_BATCH_SIZE = 4
+
+
+class ResnetV1Test(test_case.TestCase):
+
+  def _build_conv_hyperparams(self):
+    conv_hyperparams = hyperparams_pb2.Hyperparams()
+    conv_hyperparams_text_proto = """
+      activation: RELU_6,
+      regularizer {
+        l2_regularizer {
+          weight: 0.0004
+        }
+      }
+      initializer {
+        truncated_normal_initializer {
+          stddev: 0.03
+          mean: 0.0
+        }
+      }
+      batch_norm {
+        scale: true,
+        decay: 0.997,
+        epsilon: 0.001,
+      }
+    """
+    text_format.Merge(conv_hyperparams_text_proto, conv_hyperparams)
+    return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
+
+  def _create_application_with_layer_outputs(self,
+                                             model_index,
+                                             batchnorm_training,
+                                             batchnorm_scale=True,
+                                             weight_decay=0.0001,
+                                             default_batchnorm_momentum=0.997,
+                                             default_batchnorm_epsilon=1e-5):
+    """Constructs Keras resnet_v1 that extracts layer outputs."""
+    # Have to clear the Keras backend to ensure isolation in layer naming
+    tf.keras.backend.clear_session()
+    layer_names = _RESNET_SHAPES[model_index].keys()
+    full_model = _RESNET_MODELS[model_index](
+        batchnorm_training=batchnorm_training,
+        weights=None,
+        batchnorm_scale=batchnorm_scale,
+        weight_decay=weight_decay,
+        default_batchnorm_momentum=default_batchnorm_momentum,
+        default_batchnorm_epsilon=default_batchnorm_epsilon,
+        include_top=False)
+
+    layer_outputs = [
+        full_model.get_layer(name=layer).output for layer in layer_names
+    ]
+    return tf.keras.Model(inputs=full_model.inputs, outputs=layer_outputs)
+
+  def _check_returns_correct_shape(self,
+                                   image_height,
+                                   image_width,
+                                   model_index,
+                                   expected_feature_map_shape,
+                                   batchnorm_training=True,
+                                   batchnorm_scale=True,
+                                   weight_decay=0.0001,
+                                   default_batchnorm_momentum=0.997,
+                                   default_batchnorm_epsilon=1e-5):
+    model = self._create_application_with_layer_outputs(
+        model_index=model_index,
+        batchnorm_training=batchnorm_training,
+        batchnorm_scale=batchnorm_scale,
+        weight_decay=weight_decay,
+        default_batchnorm_momentum=default_batchnorm_momentum,
+        default_batchnorm_epsilon=default_batchnorm_epsilon)
+
+    image_tensor = np.random.rand(_BATCH_SIZE, image_height, image_width,
+                                  _NUM_CHANNELS).astype(np.float32)
+    feature_maps = model(image_tensor)
+    layer_names = _RESNET_SHAPES[model_index].keys()
+    for feature_map, layer_name in zip(feature_maps, layer_names):
+      expected_shape = _RESNET_SHAPES[model_index][layer_name]
+      self.assertAllEqual(feature_map.shape, expected_shape)
+
+  def _get_variables(self, model_index):
+    tf.keras.backend.clear_session()
+    model = self._create_application_with_layer_outputs(
+        model_index, batchnorm_training=False)
+    preprocessed_inputs = tf.placeholder(tf.float32,
+                                         (4, None, None, _NUM_CHANNELS))
+    model(preprocessed_inputs)
+    return model.variables
+
+  def test_returns_correct_shapes_224(self):
+    image_height = 224
+    image_width = 224
+    for model_index, _ in enumerate(_RESNET_NAMES):
+      expected_feature_map_shape = _RESNET_SHAPES[model_index]
+      self._check_returns_correct_shape(image_height, image_width, model_index,
+                                        expected_feature_map_shape)
+
+  def test_hyperparam_override(self):
+    for model_name in _RESNET_MODELS:
+      model = model_name(
+          batchnorm_training=True,
+          default_batchnorm_momentum=0.2,
+          default_batchnorm_epsilon=0.1,
+          weights=None,
+          include_top=False)
+      bn_layer = model.get_layer(name='conv1_bn')
+      self.assertAllClose(bn_layer.momentum, 0.2)
+      self.assertAllClose(bn_layer.epsilon, 0.1)
+
+  def test_variable_count(self):
+    # The number of variables from slim resnetv1-* model.
+    variable_nums = [265, 520, 775]
+    for model_index, var_num in enumerate(variable_nums):
+      variables = self._get_variables(model_index)
+      self.assertEqual(len(variables), var_num)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/models/ssd_inception_v2_feature_extractor.py
+++ b/research/object_detection/models/ssd_inception_v2_feature_extractor.py
@@ -37,6 +37,7 @@ class SSDInceptionV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False):
     """InceptionV2 Feature Extractor for SSD Models.
 
@@ -53,6 +54,7 @@ class SSDInceptionV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -69,6 +71,7 @@ class SSDInceptionV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
     if not self._override_base_feature_extractor_hyperparams:
@@ -108,8 +111,9 @@ class SSDInceptionV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         33, preprocessed_inputs)
 
     feature_map_layout = {
-        'from_layer': ['Mixed_4c', 'Mixed_5c', '', '', '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+        'from_layer': ['Mixed_4c', 'Mixed_5c', '', '', '', ''
+                      ][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_explicit_padding': self._use_explicit_padding,
         'use_depthwise': self._use_depthwise,
     }

--- a/research/object_detection/models/ssd_inception_v2_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_inception_v2_feature_extractor_test.py
@@ -24,7 +24,11 @@ from object_detection.models import ssd_inception_v2_feature_extractor
 class SsdInceptionV2FeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                num_layers=6,
                                 is_training=True):
     """Constructs a SsdInceptionV2FeatureExtractor.
 
@@ -32,6 +36,10 @@ class SsdInceptionV2FeatureExtractorTest(
       depth_multiplier: float depth multiplier for feature extractor
       pad_to_multiple: the nearest multiple to zero pad the input height and
         width dimensions to.
+      use_explicit_padding: Use 'VALID' padding for convolutions, but prepad
+        inputs so that the output dimensions are the same as if 'SAME' padding
+        were used.
+      num_layers: number of SSD layers.
       is_training: whether the network is in training mode.
 
     Returns:
@@ -39,8 +47,12 @@ class SsdInceptionV2FeatureExtractorTest(
     """
     min_depth = 32
     return ssd_inception_v2_feature_extractor.SSDInceptionV2FeatureExtractor(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
+        is_training,
+        depth_multiplier,
+        min_depth,
+        pad_to_multiple,
         self.conv_hyperparams_fn,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=True)
 
   def test_extract_features_returns_correct_shapes_128(self):
@@ -128,6 +140,17 @@ class SsdInceptionV2FeatureExtractorTest(
     scope_name = 'InceptionV2'
     self.check_feature_extractor_variables_under_scope(
         depth_multiplier, pad_to_multiple, scope_name)
+
+  def test_extract_features_with_fewer_layers(self):
+    image_height = 128
+    image_width = 128
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 8, 8, 576), (2, 4, 4, 1024),
+                                  (2, 2, 2, 512), (2, 1, 1, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, num_layers=4)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/ssd_inception_v3_feature_extractor.py
+++ b/research/object_detection/models/ssd_inception_v3_feature_extractor.py
@@ -37,6 +37,7 @@ class SSDInceptionV3FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False):
     """InceptionV3 Feature Extractor for SSD Models.
 
@@ -53,6 +54,7 @@ class SSDInceptionV3FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -69,6 +71,7 @@ class SSDInceptionV3FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
 
@@ -109,8 +112,9 @@ class SSDInceptionV3FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         33, preprocessed_inputs)
 
     feature_map_layout = {
-        'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', ''],
-        'layer_depth': [-1, -1, -1, 512, 256, 128],
+        'from_layer': ['Mixed_5d', 'Mixed_6e', 'Mixed_7c', '', '', ''
+                      ][:self._num_layers],
+        'layer_depth': [-1, -1, -1, 512, 256, 128][:self._num_layers],
         'use_explicit_padding': self._use_explicit_padding,
         'use_depthwise': self._use_depthwise,
     }

--- a/research/object_detection/models/ssd_inception_v3_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_inception_v3_feature_extractor_test.py
@@ -24,7 +24,11 @@ from object_detection.models import ssd_inception_v3_feature_extractor
 class SsdInceptionV3FeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                num_layers=6,
                                 is_training=True):
     """Constructs a SsdInceptionV3FeatureExtractor.
 
@@ -32,6 +36,10 @@ class SsdInceptionV3FeatureExtractorTest(
       depth_multiplier: float depth multiplier for feature extractor
       pad_to_multiple: the nearest multiple to zero pad the input height and
         width dimensions to.
+      use_explicit_padding: Use 'VALID' padding for convolutions, but prepad
+        inputs so that the output dimensions are the same as if 'SAME' padding
+        were used.
+      num_layers: number of SSD layers.
       is_training: whether the network is in training mode.
 
     Returns:
@@ -39,8 +47,12 @@ class SsdInceptionV3FeatureExtractorTest(
     """
     min_depth = 32
     return ssd_inception_v3_feature_extractor.SSDInceptionV3FeatureExtractor(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
+        is_training,
+        depth_multiplier,
+        min_depth,
+        pad_to_multiple,
         self.conv_hyperparams_fn,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=True)
 
   def test_extract_features_returns_correct_shapes_128(self):
@@ -128,6 +140,17 @@ class SsdInceptionV3FeatureExtractorTest(
     scope_name = 'InceptionV3'
     self.check_feature_extractor_variables_under_scope(
         depth_multiplier, pad_to_multiple, scope_name)
+
+  def test_extract_features_with_fewer_layers(self):
+    image_height = 128
+    image_width = 128
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 13, 13, 288), (2, 6, 6, 768),
+                                  (2, 2, 2, 2048), (2, 1, 1, 512)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, num_layers=4)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/ssd_mobilenet_v1_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_feature_extractor.py
@@ -39,6 +39,7 @@ class SSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False):
     """MobileNetV1 Feature Extractor for SSD Models.
 
@@ -56,6 +57,7 @@ class SSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -69,6 +71,7 @@ class SSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
 
@@ -103,8 +106,8 @@ class SSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
 
     feature_map_layout = {
         'from_layer': ['Conv2d_11_pointwise', 'Conv2d_13_pointwise', '', '',
-                       '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+                       '', ''][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_explicit_padding': self._use_explicit_padding,
         'use_depthwise': self._use_depthwise,
     }

--- a/research/object_detection/models/ssd_mobilenet_v1_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_feature_extractor_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Tests for SSD Mobilenet V1 feature extractors.
 
 By using parameterized test decorator, this test serves for both Slim-based and
@@ -37,8 +36,12 @@ slim = tf.contrib.slim
 class SsdMobilenetV1FeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                use_explicit_padding=False, is_training=False,
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                num_layers=6,
+                                is_training=False,
                                 use_keras=False):
     """Constructs a new feature extractor.
 
@@ -49,16 +52,18 @@ class SsdMobilenetV1FeatureExtractorTest(
       use_explicit_padding: Use 'VALID' padding for convolutions, but prepad
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
+      num_layers: number of SSD layers.
       is_training: whether the network is in training mode.
       use_keras: if True builds a keras-based feature extractor, if False builds
         a slim-based one.
+
     Returns:
       an ssd_meta_arch.SSDFeatureExtractor object.
     """
     min_depth = 32
     if use_keras:
-      return (ssd_mobilenet_v1_keras_feature_extractor.
-              SSDMobileNetV1KerasFeatureExtractor(
+      return (ssd_mobilenet_v1_keras_feature_extractor
+              .SSDMobileNetV1KerasFeatureExtractor(
                   is_training=is_training,
                   depth_multiplier=depth_multiplier,
                   min_depth=min_depth,
@@ -68,12 +73,17 @@ class SsdMobilenetV1FeatureExtractorTest(
                   freeze_batchnorm=False,
                   inplace_batchnorm_update=False,
                   use_explicit_padding=use_explicit_padding,
+                  num_layers=num_layers,
                   name='MobilenetV1'))
     else:
       return ssd_mobilenet_v1_feature_extractor.SSDMobileNetV1FeatureExtractor(
-          is_training, depth_multiplier, min_depth, pad_to_multiple,
+          is_training,
+          depth_multiplier,
+          min_depth,
+          pad_to_multiple,
           self.conv_hyperparams_fn,
-          use_explicit_padding=use_explicit_padding)
+          use_explicit_padding=use_explicit_padding,
+          num_layers=num_layers)
 
   def test_extract_features_returns_correct_shapes_128(self, use_keras):
     image_height = 128
@@ -84,12 +94,22 @@ class SsdMobilenetV1FeatureExtractorTest(
                                   (2, 2, 2, 512), (2, 1, 1, 256),
                                   (2, 1, 1, 256), (2, 1, 1, 128)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
         use_keras=use_keras)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
         use_keras=use_keras)
 
   def test_extract_features_returns_correct_shapes_299(self, use_keras):
@@ -101,12 +121,22 @@ class SsdMobilenetV1FeatureExtractorTest(
                                   (2, 5, 5, 512), (2, 3, 3, 256),
                                   (2, 2, 2, 256), (2, 1, 1, 128)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
         use_keras=use_keras)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
         use_keras=use_keras)
 
   def test_extract_features_with_dynamic_image_shape(self, use_keras):
@@ -118,12 +148,22 @@ class SsdMobilenetV1FeatureExtractorTest(
                                   (2, 2, 2, 512), (2, 1, 1, 256),
                                   (2, 1, 1, 256), (2, 1, 1, 128)]
     self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
         use_keras=use_keras)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
         use_keras=use_keras)
 
   def test_extract_features_returns_correct_shapes_enforcing_min_depth(
@@ -133,15 +173,25 @@ class SsdMobilenetV1FeatureExtractorTest(
     depth_multiplier = 0.5**12
     pad_to_multiple = 1
     expected_feature_map_shape = [(2, 19, 19, 32), (2, 10, 10, 32),
-                                  (2, 5, 5, 32), (2, 3, 3, 32),
-                                  (2, 2, 2, 32), (2, 1, 1, 32)]
+                                  (2, 5, 5, 32), (2, 3, 3, 32), (2, 2, 2, 32),
+                                  (2, 1, 1, 32)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
         use_keras=use_keras)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
         use_keras=use_keras)
 
   def test_extract_features_returns_correct_shapes_with_pad_to_multiple(
@@ -154,12 +204,22 @@ class SsdMobilenetV1FeatureExtractorTest(
                                   (2, 5, 5, 512), (2, 3, 3, 256),
                                   (2, 2, 2, 256), (2, 1, 1, 128)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
         use_keras=use_keras)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
         use_keras=use_keras)
 
   def test_extract_features_raises_error_with_invalid_image_size(
@@ -169,7 +229,10 @@ class SsdMobilenetV1FeatureExtractorTest(
     depth_multiplier = 1.0
     pad_to_multiple = 1
     self.check_extract_features_raises_error_with_invalid_image_size(
-        image_height, image_width, depth_multiplier, pad_to_multiple,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
         use_keras=use_keras)
 
   def test_preprocess_returns_correct_value_range(self, use_keras):
@@ -178,9 +241,8 @@ class SsdMobilenetV1FeatureExtractorTest(
     depth_multiplier = 1
     pad_to_multiple = 1
     test_image = np.random.rand(2, image_height, image_width, 3)
-    feature_extractor = self._create_feature_extractor(depth_multiplier,
-                                                       pad_to_multiple,
-                                                       use_keras=use_keras)
+    feature_extractor = self._create_feature_extractor(
+        depth_multiplier, pad_to_multiple, use_keras=use_keras)
     preprocessed_image = feature_extractor.preprocess(test_image)
     self.assertTrue(np.all(np.less_equal(np.abs(preprocessed_image), 1.0)))
 
@@ -212,8 +274,22 @@ class SsdMobilenetV1FeatureExtractorTest(
       _ = feature_extractor(preprocessed_image)
     else:
       _ = feature_extractor.extract_features(preprocessed_image)
-    self.assertTrue(any(op.type == 'FusedBatchNorm'
-                        for op in tf.get_default_graph().get_operations()))
+    self.assertTrue(
+        any('FusedBatchNorm' in op.type
+            for op in tf.get_default_graph().get_operations()))
+
+  def test_extract_features_with_fewer_layers(self, use_keras):
+    image_height = 128
+    image_width = 128
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 8, 8, 512), (2, 4, 4, 1024),
+                                  (2, 2, 2, 512), (2, 1, 1, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False, num_layers=4,
+        use_keras=use_keras)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor_test.py
@@ -220,7 +220,7 @@ class SsdMobilenetV1FpnFeatureExtractorTest(
       _ = feature_extractor.extract_features(preprocessed_image)
 
     self.assertTrue(
-        any(op.type == 'FusedBatchNorm'
+        any('FusedBatchNorm' in op.type
             for op in tf.get_default_graph().get_operations()))
 
 

--- a/research/object_detection/models/ssd_mobilenet_v1_keras_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_keras_feature_extractor.py
@@ -40,6 +40,7 @@ class SSDMobileNetV1KerasFeatureExtractor(
                inplace_batchnorm_update,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False,
                name=None):
     """Keras MobileNetV1 Feature Extractor for SSD Models.
@@ -65,6 +66,7 @@ class SSDMobileNetV1KerasFeatureExtractor(
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams`.
@@ -81,13 +83,14 @@ class SSDMobileNetV1KerasFeatureExtractor(
         inplace_batchnorm_update=inplace_batchnorm_update,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams,
         name=name)
     self._feature_map_layout = {
         'from_layer': ['Conv2d_11_pointwise', 'Conv2d_13_pointwise', '', '',
-                       '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+                       '', ''][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_explicit_padding': self._use_explicit_padding,
         'use_depthwise': self._use_depthwise,
     }

--- a/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor_test.py
@@ -178,7 +178,7 @@ class SsdMobilenetV1PpnFeatureExtractorTest(
                                                        pad_to_multiple)
     preprocessed_image = feature_extractor.preprocess(image_placeholder)
     _ = feature_extractor.extract_features(preprocessed_image)
-    self.assertTrue(any(op.type == 'FusedBatchNorm'
+    self.assertTrue(any('FusedBatchNorm' in op.type
                         for op in tf.get_default_graph().get_operations()))
 
 if __name__ == '__main__':

--- a/research/object_detection/models/ssd_mobilenet_v2_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_feature_extractor.py
@@ -40,6 +40,7 @@ class SSDMobileNetV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False):
     """MobileNetV2 Feature Extractor for SSD Models.
 
@@ -59,6 +60,7 @@ class SSDMobileNetV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -72,6 +74,7 @@ class SSDMobileNetV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
 
@@ -105,8 +108,9 @@ class SSDMobileNetV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         33, preprocessed_inputs)
 
     feature_map_layout = {
-        'from_layer': ['layer_15/expansion_output', 'layer_19', '', '', '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+        'from_layer': ['layer_15/expansion_output', 'layer_19', '', '', '', ''
+                      ][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_depthwise': self._use_depthwise,
         'use_explicit_padding': self._use_explicit_padding,
     }

--- a/research/object_detection/models/ssd_mobilenet_v2_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_feature_extractor_test.py
@@ -33,8 +33,12 @@ slim = tf.contrib.slim
 class SsdMobilenetV2FeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                use_explicit_padding=False, use_keras=False):
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                num_layers=6,
+                                use_keras=False):
     """Constructs a new feature extractor.
 
     Args:
@@ -44,6 +48,7 @@ class SsdMobilenetV2FeatureExtractorTest(
       use_explicit_padding: use 'VALID' padding for convolutions, but prepad
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
+      num_layers: number of SSD layers.
       use_keras: if True builds a keras-based feature extractor, if False builds
         a slim-based one.
     Returns:
@@ -61,6 +66,7 @@ class SsdMobilenetV2FeatureExtractorTest(
                   freeze_batchnorm=False,
                   inplace_batchnorm_update=False,
                   use_explicit_padding=use_explicit_padding,
+                  num_layers=num_layers,
                   name='MobilenetV2'))
     else:
       return ssd_mobilenet_v2_feature_extractor.SSDMobileNetV2FeatureExtractor(
@@ -69,7 +75,8 @@ class SsdMobilenetV2FeatureExtractorTest(
           min_depth,
           pad_to_multiple,
           self.conv_hyperparams_fn,
-          use_explicit_padding=use_explicit_padding)
+          use_explicit_padding=use_explicit_padding,
+          num_layers=num_layers)
 
   def test_extract_features_returns_correct_shapes_128(self, use_keras):
     image_height = 128
@@ -199,8 +206,20 @@ class SsdMobilenetV2FeatureExtractorTest(
       _ = feature_extractor(preprocessed_image)
     else:
       _ = feature_extractor.extract_features(preprocessed_image)
-    self.assertTrue(any(op.type == 'FusedBatchNorm'
+    self.assertTrue(any('FusedBatchNorm' in op.type
                         for op in tf.get_default_graph().get_operations()))
+
+  def test_extract_features_with_fewer_layers(self, use_keras):
+    image_height = 128
+    image_width = 128
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 8, 8, 576), (2, 4, 4, 1280),
+                                  (2, 2, 2, 512), (2, 1, 1, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, use_explicit_padding=False, num_layers=4,
+        use_keras=use_keras)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
@@ -30,15 +30,33 @@ slim = tf.contrib.slim
 
 
 @parameterized.parameters(
-    {'use_keras': False},
-    {'use_keras': True},
+    {
+        'use_depthwise': False,
+        'use_keras': True
+    },
+    {
+        'use_depthwise': True,
+        'use_keras': True
+    },
+    {
+        'use_depthwise': False,
+        'use_keras': False
+    },
+    {
+        'use_depthwise': True,
+        'use_keras': False
+    },
 )
 class SsdMobilenetV2FpnFeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                is_training=True, use_explicit_padding=False,
-                                use_keras=False):
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                is_training=True,
+                                use_explicit_padding=False,
+                                use_keras=False,
+                                use_depthwise=False):
     """Constructs a new feature extractor.
 
     Args:
@@ -51,13 +69,14 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
         were used.
       use_keras: if True builds a keras-based feature extractor, if False builds
         a slim-based one.
+      use_depthwise: Whether to use depthwise convolutions.
     Returns:
       an ssd_meta_arch.SSDFeatureExtractor object.
     """
     min_depth = 32
     if use_keras:
-      return (ssd_mobilenet_v2_fpn_keras_feature_extractor.
-              SSDMobileNetV2FpnKerasFeatureExtractor(
+      return (ssd_mobilenet_v2_fpn_keras_feature_extractor
+              .SSDMobileNetV2FpnKerasFeatureExtractor(
                   is_training=is_training,
                   depth_multiplier=depth_multiplier,
                   min_depth=min_depth,
@@ -67,18 +86,21 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                   freeze_batchnorm=False,
                   inplace_batchnorm_update=False,
                   use_explicit_padding=use_explicit_padding,
+                  use_depthwise=use_depthwise,
                   name='MobilenetV2_FPN'))
     else:
-      return (ssd_mobilenet_v2_fpn_feature_extractor.
-              SSDMobileNetV2FpnFeatureExtractor(
+      return (ssd_mobilenet_v2_fpn_feature_extractor
+              .SSDMobileNetV2FpnFeatureExtractor(
                   is_training,
                   depth_multiplier,
                   min_depth,
                   pad_to_multiple,
                   self.conv_hyperparams_fn,
+                  use_depthwise=use_depthwise,
                   use_explicit_padding=use_explicit_padding))
 
-  def test_extract_features_returns_correct_shapes_256(self, use_keras):
+  def test_extract_features_returns_correct_shapes_256(self, use_keras,
+                                                       use_depthwise):
     image_height = 256
     image_width = 256
     depth_multiplier = 1.0
@@ -87,15 +109,28 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                                   (2, 8, 8, 256), (2, 4, 4, 256),
                                   (2, 2, 2, 256)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
-  def test_extract_features_returns_correct_shapes_384(self, use_keras):
+  def test_extract_features_returns_correct_shapes_384(self, use_keras,
+                                                       use_depthwise):
     image_height = 320
     image_width = 320
     depth_multiplier = 1.0
@@ -104,15 +139,28 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                                   (2, 10, 10, 256), (2, 5, 5, 256),
                                   (2, 3, 3, 256)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
-  def test_extract_features_with_dynamic_image_shape(self, use_keras):
+  def test_extract_features_with_dynamic_image_shape(self, use_keras,
+                                                     use_depthwise):
     image_height = 256
     image_width = 256
     depth_multiplier = 1.0
@@ -121,16 +169,28 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                                   (2, 8, 8, 256), (2, 4, 4, 256),
                                   (2, 2, 2, 256)]
     self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
   def test_extract_features_returns_correct_shapes_with_pad_to_multiple(
-      self, use_keras):
+      self, use_keras, use_depthwise):
     image_height = 299
     image_width = 299
     depth_multiplier = 1.0
@@ -139,16 +199,28 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                                   (2, 10, 10, 256), (2, 5, 5, 256),
                                   (2, 3, 3, 256)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
   def test_extract_features_returns_correct_shapes_enforcing_min_depth(
-      self, use_keras):
+      self, use_keras, use_depthwise):
     image_height = 256
     image_width = 256
     depth_multiplier = 0.5**12
@@ -157,70 +229,102 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
                                   (2, 8, 8, 32), (2, 4, 4, 32),
                                   (2, 2, 2, 32)]
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=False,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=False,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     self.check_extract_features_returns_correct_shape(
-        2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape, use_explicit_padding=True,
-        use_keras=use_keras)
+        2,
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        expected_feature_map_shape,
+        use_explicit_padding=True,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
   def test_extract_features_raises_error_with_invalid_image_size(
-      self, use_keras):
+      self, use_keras, use_depthwise):
     image_height = 32
     image_width = 32
     depth_multiplier = 1.0
     pad_to_multiple = 1
     self.check_extract_features_raises_error_with_invalid_image_size(
-        image_height, image_width, depth_multiplier, pad_to_multiple,
-        use_keras=use_keras)
+        image_height,
+        image_width,
+        depth_multiplier,
+        pad_to_multiple,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
-  def test_preprocess_returns_correct_value_range(self, use_keras):
+  def test_preprocess_returns_correct_value_range(self, use_keras,
+                                                  use_depthwise):
     image_height = 256
     image_width = 256
     depth_multiplier = 1
     pad_to_multiple = 1
     test_image = np.random.rand(2, image_height, image_width, 3)
-    feature_extractor = self._create_feature_extractor(depth_multiplier,
-                                                       pad_to_multiple,
-                                                       use_keras=use_keras)
+    feature_extractor = self._create_feature_extractor(
+        depth_multiplier,
+        pad_to_multiple,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     preprocessed_image = feature_extractor.preprocess(test_image)
     self.assertTrue(np.all(np.less_equal(np.abs(preprocessed_image), 1.0)))
 
-  def test_variables_only_created_in_scope(self, use_keras):
+  def test_variables_only_created_in_scope(self, use_keras, use_depthwise):
     depth_multiplier = 1
     pad_to_multiple = 1
     scope_name = 'MobilenetV2'
     self.check_feature_extractor_variables_under_scope(
-        depth_multiplier, pad_to_multiple, scope_name, use_keras=use_keras)
+        depth_multiplier,
+        pad_to_multiple,
+        scope_name,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
 
-  def test_fused_batchnorm(self, use_keras):
+  def test_fused_batchnorm(self, use_keras, use_depthwise):
     image_height = 256
     image_width = 256
     depth_multiplier = 1
     pad_to_multiple = 1
     image_placeholder = tf.placeholder(tf.float32,
                                        [1, image_height, image_width, 3])
-    feature_extractor = self._create_feature_extractor(depth_multiplier,
-                                                       pad_to_multiple,
-                                                       use_keras=use_keras)
+    feature_extractor = self._create_feature_extractor(
+        depth_multiplier,
+        pad_to_multiple,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
     preprocessed_image = feature_extractor.preprocess(image_placeholder)
     if use_keras:
       _ = feature_extractor(preprocessed_image)
     else:
       _ = feature_extractor.extract_features(preprocessed_image)
     self.assertTrue(
-        any(op.type == 'FusedBatchNorm'
+        any('FusedBatchNorm' in op.type
             for op in tf.get_default_graph().get_operations()))
 
-  def test_variable_count(self, use_keras):
+  def test_variable_count(self, use_keras, use_depthwise):
     depth_multiplier = 1
     pad_to_multiple = 1
     variables = self.get_feature_extractor_variables(
-        depth_multiplier, pad_to_multiple, use_keras=use_keras)
-    self.assertEqual(len(variables), 274)
+        depth_multiplier,
+        pad_to_multiple,
+        use_keras=use_keras,
+        use_depthwise=use_depthwise)
+    expected_variables_len = 274
+    if use_depthwise:
+      expected_variables_len = 278
+    self.assertEqual(len(variables), expected_variables_len)
 
-  def test_get_expected_feature_map_variable_names(self, use_keras):
+  def test_get_expected_feature_map_variable_names(self, use_keras,
+                                                   use_depthwise):
     depth_multiplier = 1.0
     pad_to_multiple = 1
 
@@ -235,6 +339,25 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
         'MobilenetV2/fpn/bottom_up_Conv2d_21/weights',
         'MobilenetV2/fpn/smoothing_1/weights',
         'MobilenetV2/fpn/smoothing_2/weights',
+        'MobilenetV2/fpn/projection_1/weights',
+        'MobilenetV2/fpn/projection_2/weights',
+        'MobilenetV2/fpn/projection_3/weights',
+    ])
+    slim_expected_feature_maps_variables_with_depthwise = set([
+        # Slim Mobilenet V2 feature maps
+        'MobilenetV2/expanded_conv_4/depthwise/depthwise_weights',
+        'MobilenetV2/expanded_conv_7/depthwise/depthwise_weights',
+        'MobilenetV2/expanded_conv_14/depthwise/depthwise_weights',
+        'MobilenetV2/Conv_1/weights',
+        # FPN layers
+        'MobilenetV2/fpn/bottom_up_Conv2d_20/pointwise_weights',
+        'MobilenetV2/fpn/bottom_up_Conv2d_20/depthwise_weights',
+        'MobilenetV2/fpn/bottom_up_Conv2d_21/pointwise_weights',
+        'MobilenetV2/fpn/bottom_up_Conv2d_21/depthwise_weights',
+        'MobilenetV2/fpn/smoothing_1/depthwise_weights',
+        'MobilenetV2/fpn/smoothing_1/pointwise_weights',
+        'MobilenetV2/fpn/smoothing_2/depthwise_weights',
+        'MobilenetV2/fpn/smoothing_2/pointwise_weights',
         'MobilenetV2/fpn/projection_1/weights',
         'MobilenetV2/fpn/projection_2/weights',
         'MobilenetV2/fpn/projection_3/weights',
@@ -254,17 +377,50 @@ class SsdMobilenetV2FpnFeatureExtractorTest(
         'MobilenetV2_FPN/FeatureMaps/top_down/projection_2/kernel',
         'MobilenetV2_FPN/FeatureMaps/top_down/projection_3/kernel'
     ])
+    keras_expected_feature_maps_variables_with_depthwise = set([
+        # Keras Mobilenet V2 feature maps
+        'MobilenetV2_FPN/block_4_depthwise/depthwise_kernel',
+        'MobilenetV2_FPN/block_7_depthwise/depthwise_kernel',
+        'MobilenetV2_FPN/block_14_depthwise/depthwise_kernel',
+        'MobilenetV2_FPN/Conv_1/kernel',
+        # FPN layers
+        'MobilenetV2_FPN/bottom_up_Conv2d_20_depthwise_conv/depthwise_kernel',
+        'MobilenetV2_FPN/bottom_up_Conv2d_20_depthwise_conv/pointwise_kernel',
+        'MobilenetV2_FPN/bottom_up_Conv2d_21_depthwise_conv/depthwise_kernel',
+        'MobilenetV2_FPN/bottom_up_Conv2d_21_depthwise_conv/pointwise_kernel',
+        ('MobilenetV2_FPN/FeatureMaps/top_down/smoothing_1_depthwise_conv/'
+         'depthwise_kernel'),
+        ('MobilenetV2_FPN/FeatureMaps/top_down/smoothing_1_depthwise_conv/'
+         'pointwise_kernel'),
+        ('MobilenetV2_FPN/FeatureMaps/top_down/smoothing_2_depthwise_conv/'
+         'depthwise_kernel'),
+        ('MobilenetV2_FPN/FeatureMaps/top_down/smoothing_2_depthwise_conv/'
+         'pointwise_kernel'),
+        'MobilenetV2_FPN/FeatureMaps/top_down/projection_1/kernel',
+        'MobilenetV2_FPN/FeatureMaps/top_down/projection_2/kernel',
+        'MobilenetV2_FPN/FeatureMaps/top_down/projection_3/kernel'
+    ])
+
     g = tf.Graph()
     with g.as_default():
       preprocessed_inputs = tf.placeholder(tf.float32, (4, None, None, 3))
       feature_extractor = self._create_feature_extractor(
-          depth_multiplier, pad_to_multiple, use_keras=use_keras)
+          depth_multiplier,
+          pad_to_multiple,
+          use_keras=use_keras,
+          use_depthwise=use_depthwise)
       if use_keras:
-        feature_extractor(preprocessed_inputs)
+        _ = feature_extractor(preprocessed_inputs)
         expected_feature_maps_variables = keras_expected_feature_maps_variables
+        if use_depthwise:
+          expected_feature_maps_variables = (
+              keras_expected_feature_maps_variables_with_depthwise)
       else:
-        feature_extractor.extract_features(preprocessed_inputs)
+        _ = feature_extractor.extract_features(preprocessed_inputs)
         expected_feature_maps_variables = slim_expected_feature_maps_variables
+        if use_depthwise:
+          expected_feature_maps_variables = (
+              slim_expected_feature_maps_variables_with_depthwise)
       actual_variable_set = set([
           var.op.name for var in g.get_collection(tf.GraphKeys.GLOBAL_VARIABLES)
       ])

--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_keras_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_keras_feature_extractor.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
 from object_detection.models.keras_models import mobilenet_v2
+from object_detection.models.keras_models import model_utils
 from object_detection.utils import ops
 from object_detection.utils import shape_utils
 
@@ -29,7 +30,7 @@ NUM_LAYERS = 19
 
 # A modified config of mobilenet v2 that makes it more detection friendly.
 def _create_modified_mobilenet_config():
-  last_conv = mobilenet_v2.ConvDefs(conv_name='Conv_1', filters=256)
+  last_conv = model_utils.ConvDefs(conv_name='Conv_1', filters=256)
   return [last_conv]
 
 

--- a/research/object_detection/models/ssd_mobilenet_v2_keras_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_keras_feature_extractor.py
@@ -38,6 +38,7 @@ class SSDMobileNetV2KerasFeatureExtractor(
                inplace_batchnorm_update,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False,
                name=None):
     """MobileNetV2 Feature Extractor for SSD Models.
@@ -66,6 +67,7 @@ class SSDMobileNetV2KerasFeatureExtractor(
       use_explicit_padding: Whether to use explicit padding when extracting
         features. Default is False.
       use_depthwise: Whether to use depthwise convolutions. Default is False.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -82,12 +84,14 @@ class SSDMobileNetV2KerasFeatureExtractor(
         inplace_batchnorm_update=inplace_batchnorm_update,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams,
         name=name)
     self._feature_map_layout = {
-        'from_layer': ['layer_15/expansion_output', 'layer_19', '', '', '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+        'from_layer': ['layer_15/expansion_output', 'layer_19', '', '', '', ''
+                      ][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_depthwise': self._use_depthwise,
         'use_explicit_padding': self._use_explicit_padding,
     }

--- a/research/object_detection/models/ssd_pnasnet_feature_extractor.py
+++ b/research/object_detection/models/ssd_pnasnet_feature_extractor.py
@@ -24,6 +24,7 @@ from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
 from object_detection.utils import context_manager
 from object_detection.utils import ops
+from object_detection.utils import variables_helper
 from nets.nasnet import pnasnet
 
 slim = tf.contrib.slim
@@ -60,6 +61,7 @@ class SSDPNASNetFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
                reuse_weights=None,
                use_explicit_padding=False,
                use_depthwise=False,
+               num_layers=6,
                override_base_feature_extractor_hyperparams=False):
     """PNASNet Feature Extractor for SSD Models.
 
@@ -77,6 +79,7 @@ class SSDPNASNetFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
       use_depthwise: Whether to use depthwise convolutions.
+      num_layers: Number of SSD layers.
       override_base_feature_extractor_hyperparams: Whether to override
         hyperparameters of the base feature extractor with the one from
         `conv_hyperparams_fn`.
@@ -90,6 +93,7 @@ class SSDPNASNetFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
         reuse_weights=reuse_weights,
         use_explicit_padding=use_explicit_padding,
         use_depthwise=use_depthwise,
+        num_layers=num_layers,
         override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
 
@@ -121,8 +125,8 @@ class SSDPNASNetFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
     """
 
     feature_map_layout = {
-        'from_layer': ['Cell_7', 'Cell_11', '', '', '', ''],
-        'layer_depth': [-1, -1, 512, 256, 256, 128],
+        'from_layer': ['Cell_7', 'Cell_11', '', '', '', ''][:self._num_layers],
+        'layer_depth': [-1, -1, 512, 256, 256, 128][:self._num_layers],
         'use_explicit_padding': self._use_explicit_padding,
         'use_depthwise': self._use_depthwise,
     }
@@ -167,7 +171,7 @@ class SSDPNASNetFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):
       the model graph.
     """
     variables_to_restore = {}
-    for variable in tf.global_variables():
+    for variable in variables_helper.get_global_variables_safely():
       if variable.op.name.startswith(feature_extractor_scope):
         var_name = variable.op.name.replace(feature_extractor_scope + '/', '')
         var_name += '/ExponentialMovingAverage'

--- a/research/object_detection/models/ssd_pnasnet_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_pnasnet_feature_extractor_test.py
@@ -26,26 +26,35 @@ slim = tf.contrib.slim
 class SsdPnasNetFeatureExtractorTest(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
 
-  def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                is_training=True, use_explicit_padding=False):
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                num_layers=6,
+                                is_training=True):
     """Constructs a new feature extractor.
 
     Args:
       depth_multiplier: float depth multiplier for feature extractor
       pad_to_multiple: the nearest multiple to zero pad the input height and
         width dimensions to.
-      is_training: whether the network is in training mode.
       use_explicit_padding: Use 'VALID' padding for convolutions, but prepad
         inputs so that the output dimensions are the same as if 'SAME' padding
         were used.
+      num_layers: number of SSD layers.
+      is_training: whether the network is in training mode.
     Returns:
       an ssd_meta_arch.SSDFeatureExtractor object.
     """
     min_depth = 32
     return ssd_pnasnet_feature_extractor.SSDPNASNetFeatureExtractor(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
+        is_training,
+        depth_multiplier,
+        min_depth,
+        pad_to_multiple,
         self.conv_hyperparams_fn,
-        use_explicit_padding=use_explicit_padding)
+        use_explicit_padding=use_explicit_padding,
+        num_layers=num_layers)
 
   def test_extract_features_returns_correct_shapes_128(self):
     image_height = 128
@@ -81,6 +90,17 @@ class SsdPnasNetFeatureExtractorTest(
                                                        pad_to_multiple)
     preprocessed_image = feature_extractor.preprocess(test_image)
     self.assertTrue(np.all(np.less_equal(np.abs(preprocessed_image), 1.0)))
+
+  def test_extract_features_with_fewer_layers(self):
+    image_height = 128
+    image_width = 128
+    depth_multiplier = 1.0
+    pad_to_multiple = 1
+    expected_feature_map_shape = [(2, 8, 8, 2160), (2, 4, 4, 4320),
+                                  (2, 2, 2, 512), (2, 1, 1, 256)]
+    self.check_extract_features_returns_correct_shape(
+        2, image_height, image_width, depth_multiplier, pad_to_multiple,
+        expected_feature_map_shape, num_layers=4)
 
 
 if __name__ == '__main__':

--- a/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 
 from object_detection.models import ssd_resnet_v1_fpn_feature_extractor
 from object_detection.models import ssd_resnet_v1_fpn_feature_extractor_testbase
+from object_detection.models import ssd_resnet_v1_fpn_keras_feature_extractor
 
 
 class SSDResnet50V1FeatureExtractorTest(
@@ -25,13 +26,31 @@ class SSDResnet50V1FeatureExtractorTest(
   """SSDResnet50v1Fpn feature extractor test."""
 
   def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                use_explicit_padding=False, min_depth=32):
+                                use_explicit_padding=False, min_depth=32,
+                                use_keras=False):
     is_training = True
-    return ssd_resnet_v1_fpn_feature_extractor.SSDResnet50V1FpnFeatureExtractor(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
-        self.conv_hyperparams_fn, use_explicit_padding=use_explicit_padding)
+    if use_keras:
+      return (ssd_resnet_v1_fpn_keras_feature_extractor.
+              SSDResNet50V1FpnKerasFeatureExtractor(
+                  is_training=is_training,
+                  depth_multiplier=depth_multiplier,
+                  min_depth=min_depth,
+                  pad_to_multiple=pad_to_multiple,
+                  conv_hyperparams=self._build_conv_hyperparams(
+                      add_batch_norm=False),
+                  freeze_batchnorm=False,
+                  inplace_batchnorm_update=False,
+                  name='ResNet50V1_FPN'))
+    else:
+      return (
+          ssd_resnet_v1_fpn_feature_extractor.SSDResnet50V1FpnFeatureExtractor(
+              is_training, depth_multiplier, min_depth, pad_to_multiple,
+              self.conv_hyperparams_fn,
+              use_explicit_padding=use_explicit_padding))
 
-  def _resnet_scope_name(self):
+  def _resnet_scope_name(self, use_keras=False):
+    if use_keras:
+      return 'ResNet50V1_FPN'
     return 'resnet_v1_50'
 
 
@@ -41,18 +60,31 @@ class SSDResnet101V1FeatureExtractorTest(
   """SSDResnet101v1Fpn feature extractor test."""
 
   def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                use_explicit_padding=False, min_depth=32):
+                                use_explicit_padding=False, min_depth=32,
+                                use_keras=False):
     is_training = True
-    return (
-        ssd_resnet_v1_fpn_feature_extractor.SSDResnet101V1FpnFeatureExtractor(
-            is_training,
-            depth_multiplier,
-            min_depth,
-            pad_to_multiple,
-            self.conv_hyperparams_fn,
-            use_explicit_padding=use_explicit_padding))
+    if use_keras:
+      return (ssd_resnet_v1_fpn_keras_feature_extractor.
+              SSDResNet101V1FpnKerasFeatureExtractor(
+                  is_training=is_training,
+                  depth_multiplier=depth_multiplier,
+                  min_depth=min_depth,
+                  pad_to_multiple=pad_to_multiple,
+                  conv_hyperparams=self._build_conv_hyperparams(
+                      add_batch_norm=False),
+                  freeze_batchnorm=False,
+                  inplace_batchnorm_update=False,
+                  name='ResNet101V1_FPN'))
+    else:
+      return (
+          ssd_resnet_v1_fpn_feature_extractor.SSDResnet101V1FpnFeatureExtractor(
+              is_training, depth_multiplier, min_depth, pad_to_multiple,
+              self.conv_hyperparams_fn,
+              use_explicit_padding=use_explicit_padding))
 
-  def _resnet_scope_name(self):
+  def _resnet_scope_name(self, use_keras):
+    if use_keras:
+      return 'ResNet101V1_FPN'
     return 'resnet_v1_101'
 
 
@@ -62,18 +94,31 @@ class SSDResnet152V1FeatureExtractorTest(
   """SSDResnet152v1Fpn feature extractor test."""
 
   def _create_feature_extractor(self, depth_multiplier, pad_to_multiple,
-                                use_explicit_padding=False, min_depth=32):
+                                use_explicit_padding=False, min_depth=32,
+                                use_keras=False):
     is_training = True
-    return (
-        ssd_resnet_v1_fpn_feature_extractor.SSDResnet152V1FpnFeatureExtractor(
-            is_training,
-            depth_multiplier,
-            min_depth,
-            pad_to_multiple,
-            self.conv_hyperparams_fn,
-            use_explicit_padding=use_explicit_padding))
+    if use_keras:
+      return (ssd_resnet_v1_fpn_keras_feature_extractor.
+              SSDResNet152V1FpnKerasFeatureExtractor(
+                  is_training=is_training,
+                  depth_multiplier=depth_multiplier,
+                  min_depth=min_depth,
+                  pad_to_multiple=pad_to_multiple,
+                  conv_hyperparams=self._build_conv_hyperparams(
+                      add_batch_norm=False),
+                  freeze_batchnorm=False,
+                  inplace_batchnorm_update=False,
+                  name='ResNet152V1_FPN'))
+    else:
+      return (
+          ssd_resnet_v1_fpn_feature_extractor.SSDResnet152V1FpnFeatureExtractor(
+              is_training, depth_multiplier, min_depth, pad_to_multiple,
+              self.conv_hyperparams_fn,
+              use_explicit_padding=use_explicit_padding))
 
-  def _resnet_scope_name(self):
+  def _resnet_scope_name(self, use_keras):
+    if use_keras:
+      return 'ResNet152V1_FPN'
     return 'resnet_v1_152'
 
 

--- a/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor_testbase.py
+++ b/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor_testbase.py
@@ -15,18 +15,23 @@
 """Tests for ssd resnet v1 FPN feature extractors."""
 import abc
 import itertools
+from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
 from object_detection.models import ssd_feature_extractor_test
 
 
+@parameterized.parameters(
+    {'use_keras': False},
+    {'use_keras': True},
+)
 class SSDResnetFPNFeatureExtractorTestBase(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
   """Helper test class for SSD Resnet v1 FPN feature extractors."""
 
   @abc.abstractmethod
-  def _resnet_scope_name(self):
+  def _resnet_scope_name(self, use_keras):
     pass
 
   @abc.abstractmethod
@@ -38,10 +43,11 @@ class SSDResnetFPNFeatureExtractorTestBase(
                                 depth_multiplier,
                                 pad_to_multiple,
                                 use_explicit_padding=False,
-                                min_depth=32):
+                                min_depth=32,
+                                use_keras=False):
     pass
 
-  def test_extract_features_returns_correct_shapes_256(self):
+  def test_extract_features_returns_correct_shapes_256(self, use_keras):
     image_height = 256
     image_width = 256
     depth_multiplier = 1.0
@@ -53,7 +59,8 @@ class SSDResnetFPNFeatureExtractorTestBase(
         2, image_height, image_width, depth_multiplier, pad_to_multiple,
         expected_feature_map_shape)
 
-  def test_extract_features_returns_correct_shapes_with_dynamic_inputs(self):
+  def test_extract_features_returns_correct_shapes_with_dynamic_inputs(
+      self, use_keras):
     image_height = 256
     image_width = 256
     depth_multiplier = 1.0
@@ -63,9 +70,10 @@ class SSDResnetFPNFeatureExtractorTestBase(
                                   (2, 2, 2, 256)]
     self.check_extract_features_returns_correct_shapes_with_dynamic_inputs(
         2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape)
+        expected_feature_map_shape, use_keras=use_keras)
 
-  def test_extract_features_returns_correct_shapes_with_depth_multiplier(self):
+  def test_extract_features_returns_correct_shapes_with_depth_multiplier(
+      self, use_keras):
     image_height = 256
     image_width = 256
     depth_multiplier = 0.5
@@ -78,9 +86,10 @@ class SSDResnetFPNFeatureExtractorTestBase(
                                   (2, 2, 2, expected_num_channels)]
     self.check_extract_features_returns_correct_shape(
         2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape)
+        expected_feature_map_shape, use_keras=use_keras)
 
-  def test_extract_features_returns_correct_shapes_with_min_depth(self):
+  def test_extract_features_returns_correct_shapes_with_min_depth(
+      self, use_keras):
     image_height = 256
     image_width = 256
     depth_multiplier = 1.0
@@ -94,7 +103,10 @@ class SSDResnetFPNFeatureExtractorTestBase(
 
     def graph_fn(image_tensor):
       feature_extractor = self._create_feature_extractor(
-          depth_multiplier, pad_to_multiple, min_depth=min_depth)
+          depth_multiplier, pad_to_multiple, min_depth=min_depth,
+          use_keras=use_keras)
+      if use_keras:
+        return feature_extractor(image_tensor)
       return feature_extractor.extract_features(image_tensor)
 
     image_tensor = np.random.rand(2, image_height, image_width,
@@ -104,7 +116,8 @@ class SSDResnetFPNFeatureExtractorTestBase(
         feature_maps, expected_feature_map_shape):
       self.assertAllEqual(feature_map.shape, expected_shape)
 
-  def test_extract_features_returns_correct_shapes_with_pad_to_multiple(self):
+  def test_extract_features_returns_correct_shapes_with_pad_to_multiple(
+      self, use_keras):
     image_height = 254
     image_width = 254
     depth_multiplier = 1.0
@@ -115,24 +128,27 @@ class SSDResnetFPNFeatureExtractorTestBase(
 
     self.check_extract_features_returns_correct_shape(
         2, image_height, image_width, depth_multiplier, pad_to_multiple,
-        expected_feature_map_shape)
+        expected_feature_map_shape, use_keras=use_keras)
 
-  def test_extract_features_raises_error_with_invalid_image_size(self):
+  def test_extract_features_raises_error_with_invalid_image_size(
+      self, use_keras):
     image_height = 32
     image_width = 32
     depth_multiplier = 1.0
     pad_to_multiple = 1
     self.check_extract_features_raises_error_with_invalid_image_size(
-        image_height, image_width, depth_multiplier, pad_to_multiple)
+        image_height, image_width, depth_multiplier, pad_to_multiple,
+        use_keras=use_keras)
 
-  def test_preprocess_returns_correct_value_range(self):
+  def test_preprocess_returns_correct_value_range(self, use_keras):
     image_height = 128
     image_width = 128
     depth_multiplier = 1
     pad_to_multiple = 1
     test_image = tf.constant(np.random.rand(4, image_height, image_width, 3))
     feature_extractor = self._create_feature_extractor(depth_multiplier,
-                                                       pad_to_multiple)
+                                                       pad_to_multiple,
+                                                       use_keras=use_keras)
     preprocessed_image = feature_extractor.preprocess(test_image)
     with self.test_session() as sess:
       test_image_out, preprocessed_image_out = sess.run(
@@ -140,17 +156,29 @@ class SSDResnetFPNFeatureExtractorTestBase(
       self.assertAllClose(preprocessed_image_out,
                           test_image_out - [[123.68, 116.779, 103.939]])
 
-  def test_variables_only_created_in_scope(self):
+  def test_variables_only_created_in_scope(self, use_keras):
     depth_multiplier = 1
     pad_to_multiple = 1
-    g = tf.Graph()
-    with g.as_default():
-      feature_extractor = self._create_feature_extractor(
-          depth_multiplier, pad_to_multiple)
-      preprocessed_inputs = tf.placeholder(tf.float32, (4, None, None, 3))
-      feature_extractor.extract_features(preprocessed_inputs)
-      variables = g.get_collection(tf.GraphKeys.GLOBAL_VARIABLES)
-      for variable in variables:
-        self.assertTrue(
-            variable.name.startswith(self._resnet_scope_name())
-            or variable.name.startswith(self._fpn_scope_name()))
+    scope_name = self._resnet_scope_name(use_keras)
+    self.check_feature_extractor_variables_under_scope(
+        depth_multiplier,
+        pad_to_multiple,
+        scope_name,
+        use_keras=use_keras)
+
+  def test_variable_count(self, use_keras):
+    depth_multiplier = 1
+    pad_to_multiple = 1
+    variables = self.get_feature_extractor_variables(
+        depth_multiplier,
+        pad_to_multiple,
+        use_keras=use_keras)
+    # The number of expected variables in resnet_v1_50, resnet_v1_101,
+    # and resnet_v1_152 is 279, 534, and 789 respectively.
+    expected_variables_len = 279
+    scope_name = self._resnet_scope_name(use_keras)
+    if scope_name in ('ResNet101V1_FPN', 'resnet_v1_101'):
+      expected_variables_len = 534
+    elif scope_name in ('ResNet152V1_FPN', 'resnet_v1_152'):
+      expected_variables_len = 789
+    self.assertEqual(len(variables), expected_variables_len)

--- a/research/object_detection/models/ssd_resnet_v1_fpn_keras_feature_extractor.py
+++ b/research/object_detection/models/ssd_resnet_v1_fpn_keras_feature_extractor.py
@@ -1,0 +1,435 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""SSD Keras-based ResnetV1 FPN Feature Extractor."""
+
+import tensorflow as tf
+
+from object_detection.meta_architectures import ssd_meta_arch
+from object_detection.models import feature_map_generators
+from object_detection.models.keras_models import resnet_v1
+from object_detection.utils import ops
+from object_detection.utils import shape_utils
+
+_RESNET_MODEL_OUTPUT_LAYERS = {
+    'resnet_v1_50': ['conv2_block3_out', 'conv3_block4_out',
+                     'conv4_block6_out', 'conv5_block3_out'],
+    'resnet_v1_101': ['conv2_block3_out', 'conv3_block4_out',
+                      'conv4_block23_out', 'conv5_block3_out'],
+    'resnet_v1_152': ['conv2_block3_out', 'conv3_block8_out',
+                      'conv4_block36_out', 'conv5_block3_out'],
+}
+
+
+class SSDResNetV1FpnKerasFeatureExtractor(
+    ssd_meta_arch.SSDKerasFeatureExtractor):
+  """SSD Feature Extractor using Keras-based ResnetV1 FPN features."""
+
+  def __init__(self,
+               is_training,
+               depth_multiplier,
+               min_depth,
+               pad_to_multiple,
+               conv_hyperparams,
+               freeze_batchnorm,
+               inplace_batchnorm_update,
+               resnet_v1_base_model,
+               resnet_v1_base_model_name,
+               fpn_min_level=3,
+               fpn_max_level=7,
+               additional_layer_depth=256,
+               reuse_weights=None,
+               use_explicit_padding=None,
+               override_base_feature_extractor_hyperparams=False,
+               name=None):
+    """SSD Keras based FPN feature extractor Resnet v1 architecture.
+
+    Args:
+      is_training: whether the network is in training mode.
+      depth_multiplier: float depth multiplier for feature extractor.
+      min_depth: minimum feature extractor depth.
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      conv_hyperparams: a `hyperparams_builder.KerasLayerHyperparams` object
+        containing convolution hyperparameters for the layers added on top of
+        the base feature extractor.
+      freeze_batchnorm: whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      inplace_batchnorm_update: whether to update batch norm moving average
+        values inplace. When this is false train op must add a control
+        dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+        batch norm statistics.
+      resnet_v1_base_model: base resnet v1 network to use. One of
+        the resnet_v1.resnet_v1_{50,101,152} models.
+      resnet_v1_base_model_name: model name under which to construct resnet v1.
+      fpn_min_level: the highest resolution feature map to use in FPN. The valid
+        values are {2, 3, 4, 5} which map to Resnet blocks {1, 2, 3, 4}
+        respectively.
+      fpn_max_level: the smallest resolution feature map to construct or use in
+        FPN. FPN constructions uses features maps starting from fpn_min_level
+        upto the fpn_max_level. In the case that there are not enough feature
+        maps in the backbone network, additional feature maps are created by
+        applying stride 2 convolutions until we get the desired number of fpn
+        levels.
+      additional_layer_depth: additional feature map layer channel depth.
+      reuse_weights: whether to reuse variables. Default is None.
+      use_explicit_padding: whether to use explicit padding when extracting
+        features. Default is None, as it's an invalid option and not implemented
+        in this feature extractor.
+      override_base_feature_extractor_hyperparams: Whether to override
+        hyperparameters of the base feature extractor with the one from
+        `conv_hyperparams`.
+      name: a string name scope to assign to the model. If 'None', Keras
+        will auto-generate one from the class name.
+    """
+    super(SSDResNetV1FpnKerasFeatureExtractor, self).__init__(
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=freeze_batchnorm,
+        inplace_batchnorm_update=inplace_batchnorm_update,
+        use_explicit_padding=None,
+        override_base_feature_extractor_hyperparams=
+        override_base_feature_extractor_hyperparams,
+        name=name)
+    if self._use_explicit_padding:
+      raise ValueError('Explicit padding is not a valid option.')
+    self._fpn_min_level = fpn_min_level
+    self._fpn_max_level = fpn_max_level
+    self._additional_layer_depth = additional_layer_depth
+    self._resnet_v1_base_model = resnet_v1_base_model
+    self._resnet_v1_base_model_name = resnet_v1_base_model_name
+    self._resnet_block_names = ['block1', 'block2', 'block3', 'block4']
+    self._resnet_v1 = None
+    self._fpn_features_generator = None
+    self._coarse_feature_layers = []
+
+  def build(self, input_shape):
+    full_resnet_v1_model = self._resnet_v1_base_model(
+        batchnorm_training=(self._is_training and not self._freeze_batchnorm),
+        conv_hyperparams=(self._conv_hyperparams
+                          if self._override_base_feature_extractor_hyperparams
+                          else None),
+        depth_multiplier=self._depth_multiplier,
+        min_depth=self._min_depth,
+        classes=None,
+        weights=None,
+        include_top=False)
+    output_layers = _RESNET_MODEL_OUTPUT_LAYERS[self._resnet_v1_base_model_name]
+    outputs = [full_resnet_v1_model.get_layer(output_layer_name).output
+               for output_layer_name in output_layers]
+    self._resnet_v1 = tf.keras.Model(
+        inputs=full_resnet_v1_model.inputs,
+        outputs=outputs)
+    # pylint:disable=g-long-lambda
+    self._depth_fn = lambda d: max(
+        int(d * self._depth_multiplier), self._min_depth)
+    self._base_fpn_max_level = min(self._fpn_max_level, 5)
+    self._num_levels = self._base_fpn_max_level + 1 - self._fpn_min_level
+    self._fpn_features_generator = (
+        feature_map_generators.KerasFpnTopDownFeatureMaps(
+            num_levels=self._num_levels,
+            depth=self._depth_fn(self._additional_layer_depth),
+            is_training=self._is_training,
+            conv_hyperparams=self._conv_hyperparams,
+            freeze_batchnorm=self._freeze_batchnorm,
+            name='FeatureMaps'))
+    # Construct coarse feature layers
+    depth = self._depth_fn(self._additional_layer_depth)
+    for i in range(self._base_fpn_max_level, self._fpn_max_level):
+      layers = []
+      layer_name = 'bottom_up_block{}'.format(i)
+      layers.append(
+          tf.keras.layers.Conv2D(
+              depth,
+              [3, 3],
+              padding='SAME',
+              strides=2,
+              name=layer_name + '_conv',
+              **self._conv_hyperparams.params()))
+      layers.append(
+          self._conv_hyperparams.build_batch_norm(
+              training=(self._is_training and not self._freeze_batchnorm),
+              name=layer_name + '_batchnorm'))
+      layers.append(
+          self._conv_hyperparams.build_activation_layer(
+              name=layer_name))
+      self._coarse_feature_layers.append(layers)
+    self.built = True
+
+  def preprocess(self, resized_inputs):
+    """SSD preprocessing.
+
+    VGG style channel mean subtraction as described here:
+    https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-mdnge.
+    Note that if the number of channels is not equal to 3, the mean subtraction
+    will be skipped and the original resized_inputs will be returned.
+
+    Args:
+      resized_inputs: a [batch, height, width, channels] float tensor
+        representing a batch of images.
+
+    Returns:
+      preprocessed_inputs: a [batch, height, width, channels] float tensor
+        representing a batch of images.
+    """
+    if resized_inputs.shape.as_list()[3] == 3:
+      channel_means = [123.68, 116.779, 103.939]
+      return resized_inputs - [[channel_means]]
+    else:
+      return resized_inputs
+
+  def _extract_features(self, preprocessed_inputs):
+    """Extract features from preprocessed inputs.
+
+    Args:
+      preprocessed_inputs: a [batch, height, width, channels] float tensor
+        representing a batch of images.
+
+    Returns:
+      feature_maps: a list of tensors where the ith tensor has shape
+        [batch, height_i, width_i, depth_i]
+    """
+    preprocessed_inputs = shape_utils.check_min_image_dim(
+        129, preprocessed_inputs)
+
+    image_features = self._resnet_v1(
+        ops.pad_to_multiple(preprocessed_inputs, self._pad_to_multiple))
+
+    feature_block_list = []
+    for level in range(self._fpn_min_level, self._base_fpn_max_level + 1):
+      feature_block_list.append('block{}'.format(level - 1))
+    feature_block_map = dict(zip(self._resnet_block_names, image_features))
+    fpn_input_image_features = [
+        (feature_block, feature_block_map[feature_block])
+        for feature_block in feature_block_list]
+    fpn_features = self._fpn_features_generator(fpn_input_image_features)
+
+    feature_maps = []
+    for level in range(self._fpn_min_level, self._base_fpn_max_level + 1):
+      feature_maps.append(fpn_features['top_down_block{}'.format(level-1)])
+    last_feature_map = fpn_features['top_down_block{}'.format(
+        self._base_fpn_max_level - 1)]
+
+    for coarse_feature_layers in self._coarse_feature_layers:
+      for layer in coarse_feature_layers:
+        last_feature_map = layer(last_feature_map)
+      feature_maps.append(last_feature_map)
+    return feature_maps
+
+
+class SSDResNet50V1FpnKerasFeatureExtractor(
+    SSDResNetV1FpnKerasFeatureExtractor):
+  """SSD Feature Extractor using Keras-based ResnetV1-50 FPN features."""
+
+  def __init__(self,
+               is_training,
+               depth_multiplier,
+               min_depth,
+               pad_to_multiple,
+               conv_hyperparams,
+               freeze_batchnorm,
+               inplace_batchnorm_update,
+               fpn_min_level=3,
+               fpn_max_level=7,
+               additional_layer_depth=256,
+               reuse_weights=None,
+               use_explicit_padding=None,
+               override_base_feature_extractor_hyperparams=False,
+               name='ResNet50V1_FPN'):
+    """SSD Keras based FPN feature extractor ResnetV1-50 architecture.
+
+    Args:
+      is_training: whether the network is in training mode.
+      depth_multiplier: float depth multiplier for feature extractor.
+      min_depth: minimum feature extractor depth.
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      conv_hyperparams: a `hyperparams_builder.KerasLayerHyperparams` object
+        containing convolution hyperparameters for the layers added on top of
+        the base feature extractor.
+      freeze_batchnorm: whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      inplace_batchnorm_update: whether to update batch norm moving average
+        values inplace. When this is false train op must add a control
+        dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+        batch norm statistics.
+      fpn_min_level: the minimum level in feature pyramid networks.
+      fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
+      reuse_weights: whether to reuse variables. Default is None.
+      use_explicit_padding: whether to use explicit padding when extracting
+        features. Default is None, as it's an invalid option and not implemented
+        in this feature extractor
+      override_base_feature_extractor_hyperparams: Whether to override
+        hyperparameters of the base feature extractor with the one from
+        `conv_hyperparams`.
+      name: a string name scope to assign to the model. If 'None', Keras
+        will auto-generate one from the class name.
+    """
+    super(SSDResNet50V1FpnKerasFeatureExtractor, self).__init__(
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=freeze_batchnorm,
+        inplace_batchnorm_update=inplace_batchnorm_update,
+        resnet_v1_base_model=resnet_v1.resnet_v1_50,
+        resnet_v1_base_model_name='resnet_v1_50',
+        use_explicit_padding=use_explicit_padding,
+        override_base_feature_extractor_hyperparams=
+        override_base_feature_extractor_hyperparams,
+        name=name)
+
+
+class SSDResNet101V1FpnKerasFeatureExtractor(
+    SSDResNetV1FpnKerasFeatureExtractor):
+  """SSD Feature Extractor using Keras-based ResnetV1-101 FPN features."""
+
+  def __init__(self,
+               is_training,
+               depth_multiplier,
+               min_depth,
+               pad_to_multiple,
+               conv_hyperparams,
+               freeze_batchnorm,
+               inplace_batchnorm_update,
+               fpn_min_level=3,
+               fpn_max_level=7,
+               additional_layer_depth=256,
+               reuse_weights=None,
+               use_explicit_padding=None,
+               override_base_feature_extractor_hyperparams=False,
+               name='ResNet101V1_FPN'):
+    """SSD Keras based FPN feature extractor ResnetV1-101 architecture.
+
+    Args:
+      is_training: whether the network is in training mode.
+      depth_multiplier: float depth multiplier for feature extractor.
+      min_depth: minimum feature extractor depth.
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      conv_hyperparams: a `hyperparams_builder.KerasLayerHyperparams` object
+        containing convolution hyperparameters for the layers added on top of
+        the base feature extractor.
+      freeze_batchnorm: whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      inplace_batchnorm_update: whether to update batch norm moving average
+        values inplace. When this is false train op must add a control
+        dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+        batch norm statistics.
+      fpn_min_level: the minimum level in feature pyramid networks.
+      fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
+      reuse_weights: whether to reuse variables. Default is None.
+      use_explicit_padding: whether to use explicit padding when extracting
+        features. Default is None, as it's an invalid option and not implemented
+        in this feature extractor
+      override_base_feature_extractor_hyperparams: Whether to override
+        hyperparameters of the base feature extractor with the one from
+        `conv_hyperparams`.
+      name: a string name scope to assign to the model. If 'None', Keras
+        will auto-generate one from the class name.
+    """
+    super(SSDResNet101V1FpnKerasFeatureExtractor, self).__init__(
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=freeze_batchnorm,
+        inplace_batchnorm_update=inplace_batchnorm_update,
+        resnet_v1_base_model=resnet_v1.resnet_v1_101,
+        resnet_v1_base_model_name='resnet_v1_101',
+        use_explicit_padding=use_explicit_padding,
+        override_base_feature_extractor_hyperparams=
+        override_base_feature_extractor_hyperparams,
+        name=name)
+
+
+class SSDResNet152V1FpnKerasFeatureExtractor(
+    SSDResNetV1FpnKerasFeatureExtractor):
+  """SSD Feature Extractor using Keras-based ResnetV1-152 FPN features."""
+
+  def __init__(self,
+               is_training,
+               depth_multiplier,
+               min_depth,
+               pad_to_multiple,
+               conv_hyperparams,
+               freeze_batchnorm,
+               inplace_batchnorm_update,
+               fpn_min_level=3,
+               fpn_max_level=7,
+               additional_layer_depth=256,
+               reuse_weights=None,
+               use_explicit_padding=False,
+               override_base_feature_extractor_hyperparams=False,
+               name='ResNet152V1_FPN'):
+    """SSD Keras based FPN feature extractor ResnetV1-152 architecture.
+
+    Args:
+      is_training: whether the network is in training mode.
+      depth_multiplier: float depth multiplier for feature extractor.
+      min_depth: minimum feature extractor depth.
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      conv_hyperparams: a `hyperparams_builder.KerasLayerHyperparams` object
+        containing convolution hyperparameters for the layers added on top of
+        the base feature extractor.
+      freeze_batchnorm: whether to freeze batch norm parameters during
+        training or not. When training with a small batch size (e.g. 1), it is
+        desirable to freeze batch norm update and use pretrained batch norm
+        params.
+      inplace_batchnorm_update: whether to update batch norm moving average
+        values inplace. When this is false train op must add a control
+        dependency on tf.graphkeys.UPDATE_OPS collection in order to update
+        batch norm statistics.
+      fpn_min_level: the minimum level in feature pyramid networks.
+      fpn_max_level: the maximum level in feature pyramid networks.
+      additional_layer_depth: additional feature map layer channel depth.
+      reuse_weights: whether to reuse variables. Default is None.
+      use_explicit_padding: whether to use explicit padding when extracting
+        features. Default is None, as it's an invalid option and not implemented
+        in this feature extractor
+      override_base_feature_extractor_hyperparams: Whether to override
+        hyperparameters of the base feature extractor with the one from
+        `conv_hyperparams`.
+      name: a string name scope to assign to the model. If 'None', Keras
+        will auto-generate one from the class name.
+    """
+    super(SSDResNet152V1FpnKerasFeatureExtractor, self).__init__(
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams=conv_hyperparams,
+        freeze_batchnorm=freeze_batchnorm,
+        inplace_batchnorm_update=inplace_batchnorm_update,
+        resnet_v1_base_model=resnet_v1.resnet_v1_152,
+        resnet_v1_base_model_name='resnet_v1_152',
+        use_explicit_padding=use_explicit_padding,
+        override_base_feature_extractor_hyperparams=
+        override_base_feature_extractor_hyperparams,
+        name=name)

--- a/research/object_detection/predictors/mask_rcnn_keras_box_predictor.py
+++ b/research/object_detection/predictors/mask_rcnn_keras_box_predictor.py
@@ -87,7 +87,8 @@ class MaskRCNNKerasBoxPredictor(box_predictor.KerasBoxPredictor):
 
   def _predict(self,
                image_features,
-               prediction_stage=2):
+               prediction_stage=2,
+               **kwargs):
     """Optionally computes encoded object locations, confidences, and masks.
 
     Predicts the heads belonging to the given prediction stage.
@@ -98,6 +99,7 @@ class MaskRCNNKerasBoxPredictor(box_predictor.KerasBoxPredictor):
         features for each image. The length of the list should be 1 otherwise
         a ValueError will be raised.
       prediction_stage: Prediction stage. Acceptable values are 2 and 3.
+      **kwargs: Unused Keyword args
 
     Returns:
       A dictionary containing the predicted tensors that are listed in

--- a/research/object_detection/predictors/rfcn_keras_box_predictor.py
+++ b/research/object_detection/predictors/rfcn_keras_box_predictor.py
@@ -133,7 +133,7 @@ class RfcnKerasBoxPredictor(box_predictor.KerasBoxPredictor):
   def num_classes(self):
     return self._num_classes
 
-  def _predict(self, image_features, proposal_boxes):
+  def _predict(self, image_features, proposal_boxes, **kwargs):
     """Computes encoded object locations and corresponding confidences.
 
     Args:
@@ -141,6 +141,7 @@ class RfcnKerasBoxPredictor(box_predictor.KerasBoxPredictor):
       width_i, channels_i] containing features for a batch of images.
       proposal_boxes: A float tensor of shape [batch_size, num_proposals,
         box_code_size].
+      **kwargs: Unused Keyword args
 
     Returns:
       box_encodings: A list of float tensors of shape

--- a/research/object_detection/protos/calibration.proto
+++ b/research/object_detection/protos/calibration.proto
@@ -1,64 +1,78 @@
+// These protos contain the calibration parameters necessary for transforming
+// a model's original detection scores or logits. The parameters result from
+// fitting a calibration function on the model's outputs.
+
 syntax = "proto2";
 
 package object_detection.protos;
 
-// Message wrapper for various calibration configurations
+// Message wrapper for various calibration configurations.
 message CalibrationConfig {
   oneof calibrator {
     // Class-agnostic calibration via linear interpolation (usually output from
-    // isotonic regression)
+    // isotonic regression).
     FunctionApproximation function_approximation = 1;
 
-    // Per-class calibration via linear interpolation
-    LabelFunctionApproximations label_function_approximations = 2;
+    // Per-class calibration via linear interpolation.
+    ClassIdFunctionApproximations class_id_function_approximations = 2;
 
-    // Class-agnostic sigmoid calibration
+    // Class-agnostic sigmoid calibration.
     SigmoidCalibration sigmoid_calibration = 3;
 
-    // Per-class sigmoid calibration
-    LabelSigmoidCalibrations label_sigmoid_calibrations = 4;
+    // Per-class sigmoid calibration.
+    ClassIdSigmoidCalibrations class_id_sigmoid_calibrations = 4;
   }
 }
 
 // Message for class-agnostic domain/range mapping for function
-// approximations
+// approximations.
 message FunctionApproximation {
   // Message mapping class labels to indices
   optional XYPairs x_y_pairs = 1;
 }
 
 // Message for class-specific domain/range mapping for function
-// approximations
-message LabelFunctionApproximations {
-  // Message mapping class labels to indices
-  map<string, XYPairs> label_xy_pairs_map = 1;
-  // Label map to map label names from to class ids.
-  optional string label_map_path = 2;
+// approximations.
+message ClassIdFunctionApproximations {
+  // Message mapping class ids to indices.
+  map<int32, XYPairs> class_id_xy_pairs_map = 1;
 }
 
-// Message for class-agnostic Sigmoid Calibration
+// Message for class-agnostic Sigmoid Calibration.
 message SigmoidCalibration {
   // Message mapping class index to Sigmoid Parameters
   optional SigmoidParameters sigmoid_parameters = 1;
 }
 
-// Message for class-specific Sigmoid Calibration
-message LabelSigmoidCalibrations {
-  // Message mapping class index to Sigmoid Parameters
-  map<string, SigmoidParameters> label_sigmoid_parameters_map = 1;
-  // Label map to map label names from to class ids.
-  optional string label_map_path = 2;
+// Message for class-specific Sigmoid Calibration.
+message ClassIdSigmoidCalibrations {
+  // Message mapping class index to Sigmoid Parameters.
+  map<int32, SigmoidParameters> class_id_sigmoid_parameters_map = 1;
 }
 
-// Message to store a domain/range pair for function to be approximated
+// Description of data used to fit the calibration model. CLASS_SPECIFIC
+// indicates that the calibration parameters are derived from detections
+// pertaining to a single class. ALL_CLASSES indicates that parameters were
+// obtained by fitting a model on detections from all classes (including the
+// background class).
+enum TrainingDataType {
+  DATA_TYPE_UNKNOWN = 0;
+  ALL_CLASSES = 1;
+  CLASS_SPECIFIC = 2;
+}
+
+// Message to store a domain/range pair for function to be approximated.
 message XYPairs {
   message XYPair {
     optional float x = 1;
     optional float y = 2;
   }
 
-  // Sequence of x/y pairs for function approximation
+  // Sequence of x/y pairs for function approximation.
   repeated XYPair x_y_pair = 1;
+
+  // Description of data used to fit the calibration model.
+  optional TrainingDataType training_data_type = 2;
 }
 
 // Message defining parameters for sigmoid calibration.

--- a/research/object_detection/protos/graph_rewriter.proto
+++ b/research/object_detection/protos/graph_rewriter.proto
@@ -5,6 +5,7 @@ package object_detection.protos;
 // Message to configure graph rewriter for the tf graph.
 message GraphRewriter {
   optional Quantization quantization = 1;
+  extensions 1000 to max;
 }
 
 // Message for quantization options. See

--- a/research/object_detection/protos/post_processing.proto
+++ b/research/object_detection/protos/post_processing.proto
@@ -36,6 +36,9 @@ message BatchNonMaxSuppression {
   // Number of classes retained per detection in class agnostic NMS.
 
   optional int32 max_classes_per_detection = 8 [default = 1];
+
+  // Soft NMS sigma parameter; Bodla et al, https://arxiv.org/abs/1704.04503)
+  optional float soft_nms_sigma = 9 [default = 0.0];
 }
 
 // Configuration proto for post-processing predicted boxes and

--- a/research/object_detection/protos/preprocessor.proto
+++ b/research/object_detection/protos/preprocessor.proto
@@ -36,6 +36,9 @@ message PreprocessingStep {
     ConvertClassLogitsToSoftmax convert_class_logits_to_softmax = 28;
     RandomAbsolutePadImage random_absolute_pad_image = 29;
     RandomSelfConcatImage random_self_concat_image = 30;
+    AutoAugmentImage autoaugment_image = 31;
+    DropLabelProbabilistically drop_label_probabilistically = 32;
+    RemapLabels remap_labels = 33;
   }
 }
 
@@ -460,4 +463,30 @@ message RandomSelfConcatImage {
   optional float concat_vertical_probability = 1 [default = 0.1];
   // Probability of concatenating the image horizontally.
   optional float concat_horizontal_probability = 2 [default = 0.1];
+}
+
+// Apply an Autoaugment policy to the image and bounding boxes.
+message AutoAugmentImage {
+
+  // What AutoAugment policy to apply to the Image
+  optional string policy_name = 1 [default="v0"];
+}
+
+
+// Randomly drops ground truth boxes for a label with some probability.
+message DropLabelProbabilistically {
+  // The label that should be dropped. This corresponds to one of the entries
+  // in the label map.
+  optional int32 label = 1;
+  // Probability of dropping the label.
+  optional float drop_probability = 2 [default = 1.0];
+}
+
+
+//Remap a set of labels to a new label.
+message RemapLabels {
+   // Labels to be remapped.
+  repeated int32 original_labels = 1;
+  // Label to map to.
+  optional int32 new_label = 2;
 }

--- a/research/object_detection/protos/ssd.proto
+++ b/research/object_detection/protos/ssd.proto
@@ -189,6 +189,9 @@ message SsdFeatureExtractor {
   // placeholder. This should only be used if all the image preprocessing steps
   // happen outside the graph.
   optional bool replace_preprocessor_with_placeholder = 11 [default = false];
+
+  // The number of SSD layers.
+  optional int32 num_layers = 12 [default = 6];
 }
 
 // Configuration for Feature Pyramid Networks.

--- a/research/object_detection/samples/configs/ssd_mobilenet_v2_pets_keras.config
+++ b/research/object_detection/samples/configs/ssd_mobilenet_v2_pets_keras.config
@@ -1,0 +1,190 @@
+# An untested config for Keras SSD with MobileNetV2 configured for Oxford-IIIT Pets Dataset.
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  ssd {
+    num_classes: 37
+    box_coder {
+      faster_rcnn_box_coder {
+        y_scale: 10.0
+        x_scale: 10.0
+        height_scale: 5.0
+        width_scale: 5.0
+      }
+    }
+    matcher {
+      argmax_matcher {
+        matched_threshold: 0.5
+        unmatched_threshold: 0.5
+        ignore_thresholds: false
+        negatives_lower_than_unmatched: true
+        force_match_for_each_row: true
+      }
+    }
+    similarity_calculator {
+      iou_similarity {
+      }
+    }
+    anchor_generator {
+      ssd_anchor_generator {
+        num_layers: 6
+        min_scale: 0.2
+        max_scale: 0.95
+        aspect_ratios: 1.0
+        aspect_ratios: 2.0
+        aspect_ratios: 0.5
+        aspect_ratios: 3.0
+        aspect_ratios: 0.3333
+        reduce_boxes_in_lowest_layer: true
+      }
+    }
+    image_resizer {
+      fixed_shape_resizer {
+        height: 300
+        width: 300
+      }
+    }
+    box_predictor {
+      convolutional_box_predictor {
+        min_depth: 0
+        max_depth: 0
+        num_layers_before_predictor: 0
+        use_dropout: false
+        dropout_keep_probability: 0.8
+        kernel_size: 3
+        box_code_size: 4
+        apply_sigmoid_to_scores: false
+        conv_hyperparams {
+          activation: RELU_6,
+          regularizer {
+            l2_regularizer {
+              weight: 0.00004
+            }
+          }
+          initializer {
+            truncated_normal_initializer {
+              stddev: 0.03
+              mean: 0.0
+            }
+          }
+        }
+      }
+    }
+    feature_extractor {
+      type: 'ssd_mobilenet_v2_keras'
+      min_depth: 16
+      depth_multiplier: 1.0
+      conv_hyperparams {
+        activation: RELU_6,
+        regularizer {
+          l2_regularizer {
+            weight: 0.00004
+          }
+        }
+        initializer {
+          truncated_normal_initializer {
+            stddev: 0.03
+            mean: 0.0
+          }
+        }
+        batch_norm {
+          train: true,
+          scale: true,
+          center: true,
+          decay: 0.9997,
+          epsilon: 0.001,
+        }
+      }
+      override_base_feature_extractor_hyperparams: true
+    }
+    loss {
+      classification_loss {
+        weighted_sigmoid {
+        }
+      }
+      localization_loss {
+        weighted_smooth_l1 {
+        }
+      }
+      hard_example_miner {
+        num_hard_examples: 3000
+        iou_threshold: 0.99
+        loss_type: CLASSIFICATION
+        max_negatives_per_positive: 3
+        min_negatives_per_image: 0
+      }
+      classification_weight: 1.0
+      localization_weight: 1.0
+    }
+    normalize_loss_by_num_matches: true
+    post_processing {
+      batch_non_max_suppression {
+        score_threshold: 1e-8
+        iou_threshold: 0.6
+        max_detections_per_class: 100
+        max_total_detections: 100
+      }
+      score_converter: SIGMOID
+    }
+  }
+}
+
+train_config: {
+  batch_size: 24
+  optimizer {
+    rms_prop_optimizer: {
+      learning_rate: {
+        exponential_decay_learning_rate {
+          initial_learning_rate: 0.004
+          decay_steps: 800720
+          decay_factor: 0.95
+        }
+      }
+      momentum_optimizer_value: 0.9
+      decay: 0.9
+      epsilon: 1.0
+    }
+    use_moving_average: False
+  }
+  fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+  from_detection_checkpoint: true
+  load_all_detection_checkpoint_vars: true
+  # Note: The below line limits the training process to 200K steps, which we
+  # empirically found to be sufficient enough to train the pets dataset. This
+  # effectively bypasses the learning rate schedule (the learning rate will
+  # never decay). Remove the below line to train indefinitely.
+  num_steps: 200000
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+  data_augmentation_options {
+    ssd_random_crop {
+    }
+  }
+  max_number_of_boxes: 50
+}
+
+train_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/pet_faces_train.record-?????-of-00010"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+}
+
+eval_config: {
+  metrics_set: "coco_detection_metrics"
+  num_examples: 1101
+}
+
+eval_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/pet_faces_val.record-?????-of-00010"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/pet_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
+}

--- a/research/object_detection/utils/autoaugment_utils.py
+++ b/research/object_detection/utils/autoaugment_utils.py
@@ -1,0 +1,1639 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""AutoAugment util file."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import inspect
+import math
+import six
+import tensorflow as tf
+
+
+# This signifies the max integer that the controller RNN could predict for the
+# augmentation scheme.
+_MAX_LEVEL = 10.
+
+
+# Represents an invalid bounding box that is used for checking for padding
+# lists of bounding box coordinates for a few augmentation operations
+_INVALID_BOX = [[-1.0, -1.0, -1.0, -1.0]]
+
+
+def policy_v0():
+  """Autoaugment policy that was used in AutoAugment Detection Paper."""
+  # Each tuple is an augmentation operation of the form
+  # (operation, probability, magnitude). Each element in policy is a
+  # sub-policy that will be applied sequentially on the image.
+  policy = [
+      [('TranslateX_BBox', 0.6, 4), ('Equalize', 0.8, 10)],
+      [('TranslateY_Only_BBoxes', 0.2, 2), ('Cutout', 0.8, 8)],
+      [('Sharpness', 0.0, 8), ('ShearX_BBox', 0.4, 0)],
+      [('ShearY_BBox', 1.0, 2), ('TranslateY_Only_BBoxes', 0.6, 6)],
+      [('Rotate_BBox', 0.6, 10), ('Color', 1.0, 6)],
+  ]
+  return policy
+
+
+def policy_v1():
+  """Autoaugment policy that was used in AutoAugment Detection Paper."""
+  # Each tuple is an augmentation operation of the form
+  # (operation, probability, magnitude). Each element in policy is a
+  # sub-policy that will be applied sequentially on the image.
+  policy = [
+      [('TranslateX_BBox', 0.6, 4), ('Equalize', 0.8, 10)],
+      [('TranslateY_Only_BBoxes', 0.2, 2), ('Cutout', 0.8, 8)],
+      [('Sharpness', 0.0, 8), ('ShearX_BBox', 0.4, 0)],
+      [('ShearY_BBox', 1.0, 2), ('TranslateY_Only_BBoxes', 0.6, 6)],
+      [('Rotate_BBox', 0.6, 10), ('Color', 1.0, 6)],
+      [('Color', 0.0, 0), ('ShearX_Only_BBoxes', 0.8, 4)],
+      [('ShearY_Only_BBoxes', 0.8, 2), ('Flip_Only_BBoxes', 0.0, 10)],
+      [('Equalize', 0.6, 10), ('TranslateX_BBox', 0.2, 2)],
+      [('Color', 1.0, 10), ('TranslateY_Only_BBoxes', 0.4, 6)],
+      [('Rotate_BBox', 0.8, 10), ('Contrast', 0.0, 10)],
+      [('Cutout', 0.2, 2), ('Brightness', 0.8, 10)],
+      [('Color', 1.0, 6), ('Equalize', 1.0, 2)],
+      [('Cutout_Only_BBoxes', 0.4, 6), ('TranslateY_Only_BBoxes', 0.8, 2)],
+      [('Color', 0.2, 8), ('Rotate_BBox', 0.8, 10)],
+      [('Sharpness', 0.4, 4), ('TranslateY_Only_BBoxes', 0.0, 4)],
+      [('Sharpness', 1.0, 4), ('SolarizeAdd', 0.4, 4)],
+      [('Rotate_BBox', 1.0, 8), ('Sharpness', 0.2, 8)],
+      [('ShearY_BBox', 0.6, 10), ('Equalize_Only_BBoxes', 0.6, 8)],
+      [('ShearX_BBox', 0.2, 6), ('TranslateY_Only_BBoxes', 0.2, 10)],
+      [('SolarizeAdd', 0.6, 8), ('Brightness', 0.8, 10)],
+  ]
+  return policy
+
+
+def policy_vtest():
+  """Autoaugment test policy for debugging."""
+  # Each tuple is an augmentation operation of the form
+  # (operation, probability, magnitude). Each element in policy is a
+  # sub-policy that will be applied sequentially on the image.
+  policy = [
+      [('TranslateX_BBox', 1.0, 4), ('Equalize', 1.0, 10)],
+  ]
+  return policy
+
+
+def policy_v2():
+  """Additional policy that performs well on object detection."""
+  # Each tuple is an augmentation operation of the form
+  # (operation, probability, magnitude). Each element in policy is a
+  # sub-policy that will be applied sequentially on the image.
+  policy = [
+      [('Color', 0.0, 6), ('Cutout', 0.6, 8), ('Sharpness', 0.4, 8)],
+      [('Rotate_BBox', 0.4, 8), ('Sharpness', 0.4, 2),
+       ('Rotate_BBox', 0.8, 10)],
+      [('TranslateY_BBox', 1.0, 8), ('AutoContrast', 0.8, 2)],
+      [('AutoContrast', 0.4, 6), ('ShearX_BBox', 0.8, 8),
+       ('Brightness', 0.0, 10)],
+      [('SolarizeAdd', 0.2, 6), ('Contrast', 0.0, 10),
+       ('AutoContrast', 0.6, 0)],
+      [('Cutout', 0.2, 0), ('Solarize', 0.8, 8), ('Color', 1.0, 4)],
+      [('TranslateY_BBox', 0.0, 4), ('Equalize', 0.6, 8),
+       ('Solarize', 0.0, 10)],
+      [('TranslateY_BBox', 0.2, 2), ('ShearY_BBox', 0.8, 8),
+       ('Rotate_BBox', 0.8, 8)],
+      [('Cutout', 0.8, 8), ('Brightness', 0.8, 8), ('Cutout', 0.2, 2)],
+      [('Color', 0.8, 4), ('TranslateY_BBox', 1.0, 6), ('Rotate_BBox', 0.6, 6)],
+      [('Rotate_BBox', 0.6, 10), ('BBox_Cutout', 1.0, 4), ('Cutout', 0.2, 8)],
+      [('Rotate_BBox', 0.0, 0), ('Equalize', 0.6, 6), ('ShearY_BBox', 0.6, 8)],
+      [('Brightness', 0.8, 8), ('AutoContrast', 0.4, 2),
+       ('Brightness', 0.2, 2)],
+      [('TranslateY_BBox', 0.4, 8), ('Solarize', 0.4, 6),
+       ('SolarizeAdd', 0.2, 10)],
+      [('Contrast', 1.0, 10), ('SolarizeAdd', 0.2, 8), ('Equalize', 0.2, 4)],
+  ]
+  return policy
+
+
+def policy_v3():
+  """"Additional policy that performs well on object detection."""
+  # Each tuple is an augmentation operation of the form
+  # (operation, probability, magnitude). Each element in policy is a
+  # sub-policy that will be applied sequentially on the image.
+  policy = [
+      [('Posterize', 0.8, 2), ('TranslateX_BBox', 1.0, 8)],
+      [('BBox_Cutout', 0.2, 10), ('Sharpness', 1.0, 8)],
+      [('Rotate_BBox', 0.6, 8), ('Rotate_BBox', 0.8, 10)],
+      [('Equalize', 0.8, 10), ('AutoContrast', 0.2, 10)],
+      [('SolarizeAdd', 0.2, 2), ('TranslateY_BBox', 0.2, 8)],
+      [('Sharpness', 0.0, 2), ('Color', 0.4, 8)],
+      [('Equalize', 1.0, 8), ('TranslateY_BBox', 1.0, 8)],
+      [('Posterize', 0.6, 2), ('Rotate_BBox', 0.0, 10)],
+      [('AutoContrast', 0.6, 0), ('Rotate_BBox', 1.0, 6)],
+      [('Equalize', 0.0, 4), ('Cutout', 0.8, 10)],
+      [('Brightness', 1.0, 2), ('TranslateY_BBox', 1.0, 6)],
+      [('Contrast', 0.0, 2), ('ShearY_BBox', 0.8, 0)],
+      [('AutoContrast', 0.8, 10), ('Contrast', 0.2, 10)],
+      [('Rotate_BBox', 1.0, 10), ('Cutout', 1.0, 10)],
+      [('SolarizeAdd', 0.8, 6), ('Equalize', 0.8, 8)],
+  ]
+  return policy
+
+
+def blend(image1, image2, factor):
+  """Blend image1 and image2 using 'factor'.
+
+  Factor can be above 0.0.  A value of 0.0 means only image1 is used.
+  A value of 1.0 means only image2 is used.  A value between 0.0 and
+  1.0 means we linearly interpolate the pixel values between the two
+  images.  A value greater than 1.0 "extrapolates" the difference
+  between the two pixel values, and we clip the results to values
+  between 0 and 255.
+
+  Args:
+    image1: An image Tensor of type uint8.
+    image2: An image Tensor of type uint8.
+    factor: A floating point value above 0.0.
+
+  Returns:
+    A blended image Tensor of type uint8.
+  """
+  if factor == 0.0:
+    return tf.convert_to_tensor(image1)
+  if factor == 1.0:
+    return tf.convert_to_tensor(image2)
+
+  image1 = tf.to_float(image1)
+  image2 = tf.to_float(image2)
+
+  difference = image2 - image1
+  scaled = factor * difference
+
+  # Do addition in float.
+  temp = tf.to_float(image1) + scaled
+
+  # Interpolate
+  if factor > 0.0 and factor < 1.0:
+    # Interpolation means we always stay within 0 and 255.
+    return tf.cast(temp, tf.uint8)
+
+  # Extrapolate:
+  #
+  # We need to clip and then cast.
+  return tf.cast(tf.clip_by_value(temp, 0.0, 255.0), tf.uint8)
+
+
+def cutout(image, pad_size, replace=0):
+  """Apply cutout (https://arxiv.org/abs/1708.04552) to image.
+
+  This operation applies a (2*pad_size x 2*pad_size) mask of zeros to
+  a random location within `img`. The pixel values filled in will be of the
+  value `replace`. The located where the mask will be applied is randomly
+  chosen uniformly over the whole image.
+
+  Args:
+    image: An image Tensor of type uint8.
+    pad_size: Specifies how big the zero mask that will be generated is that
+      is applied to the image. The mask will be of size
+      (2*pad_size x 2*pad_size).
+    replace: What pixel value to fill in the image in the area that has
+      the cutout mask applied to it.
+
+  Returns:
+    An image Tensor that is of type uint8.
+  """
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
+
+  # Sample the center location in the image where the zero mask will be applied.
+  cutout_center_height = tf.random_uniform(
+      shape=[], minval=0, maxval=image_height,
+      dtype=tf.int32)
+
+  cutout_center_width = tf.random_uniform(
+      shape=[], minval=0, maxval=image_width,
+      dtype=tf.int32)
+
+  lower_pad = tf.maximum(0, cutout_center_height - pad_size)
+  upper_pad = tf.maximum(0, image_height - cutout_center_height - pad_size)
+  left_pad = tf.maximum(0, cutout_center_width - pad_size)
+  right_pad = tf.maximum(0, image_width - cutout_center_width - pad_size)
+
+  cutout_shape = [image_height - (lower_pad + upper_pad),
+                  image_width - (left_pad + right_pad)]
+  padding_dims = [[lower_pad, upper_pad], [left_pad, right_pad]]
+  mask = tf.pad(
+      tf.zeros(cutout_shape, dtype=image.dtype),
+      padding_dims, constant_values=1)
+  mask = tf.expand_dims(mask, -1)
+  mask = tf.tile(mask, [1, 1, 3])
+  image = tf.where(
+      tf.equal(mask, 0),
+      tf.ones_like(image, dtype=image.dtype) * replace,
+      image)
+  return image
+
+
+def solarize(image, threshold=128):
+  # For each pixel in the image, select the pixel
+  # if the value is less than the threshold.
+  # Otherwise, subtract 255 from the pixel.
+  return tf.where(image < threshold, image, 255 - image)
+
+
+def solarize_add(image, addition=0, threshold=128):
+  # For each pixel in the image less than threshold
+  # we add 'addition' amount to it and then clip the
+  # pixel value to be between 0 and 255. The value
+  # of 'addition' is between -128 and 128.
+  added_image = tf.cast(image, tf.int64) + addition
+  added_image = tf.cast(tf.clip_by_value(added_image, 0, 255), tf.uint8)
+  return tf.where(image < threshold, added_image, image)
+
+
+def color(image, factor):
+  """Equivalent of PIL Color."""
+  degenerate = tf.image.grayscale_to_rgb(tf.image.rgb_to_grayscale(image))
+  return blend(degenerate, image, factor)
+
+
+def contrast(image, factor):
+  """Equivalent of PIL Contrast."""
+  degenerate = tf.image.rgb_to_grayscale(image)
+  # Cast before calling tf.histogram.
+  degenerate = tf.cast(degenerate, tf.int32)
+
+  # Compute the grayscale histogram, then compute the mean pixel value,
+  # and create a constant image size of that value.  Use that as the
+  # blending degenerate target of the original image.
+  hist = tf.histogram_fixed_width(degenerate, [0, 255], nbins=256)
+  mean = tf.reduce_sum(tf.cast(hist, tf.float32)) / 256.0
+  degenerate = tf.ones_like(degenerate, dtype=tf.float32) * mean
+  degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
+  degenerate = tf.image.grayscale_to_rgb(tf.cast(degenerate, tf.uint8))
+  return blend(degenerate, image, factor)
+
+
+def brightness(image, factor):
+  """Equivalent of PIL Brightness."""
+  degenerate = tf.zeros_like(image)
+  return blend(degenerate, image, factor)
+
+
+def posterize(image, bits):
+  """Equivalent of PIL Posterize."""
+  shift = 8 - bits
+  return tf.bitwise.left_shift(tf.bitwise.right_shift(image, shift), shift)
+
+
+def rotate(image, degrees, replace):
+  """Rotates the image by degrees either clockwise or counterclockwise.
+
+  Args:
+    image: An image Tensor of type uint8.
+    degrees: Float, a scalar angle in degrees to rotate all images by. If
+      degrees is positive the image will be rotated clockwise otherwise it will
+      be rotated counterclockwise.
+    replace: A one or three value 1D tensor to fill empty pixels caused by
+      the rotate operation.
+
+  Returns:
+    The rotated version of image.
+  """
+  # Convert from degrees to radians.
+  degrees_to_radians = math.pi / 180.0
+  radians = degrees * degrees_to_radians
+
+  # In practice, we should randomize the rotation degrees by flipping
+  # it negatively half the time, but that's done on 'degrees' outside
+  # of the function.
+  image = tf.contrib.image.rotate(wrap(image), radians)
+  return unwrap(image, replace)
+
+
+def random_shift_bbox(image, bbox, pixel_scaling, replace,
+                      new_min_bbox_coords=None):
+  """Move the bbox and the image content to a slightly new random location.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+      The potential values for the new min corner of the bbox will be between
+      [old_min - pixel_scaling * bbox_height/2,
+       old_min - pixel_scaling * bbox_height/2].
+    pixel_scaling: A float between 0 and 1 that specifies the pixel range
+      that the new bbox location will be sampled from.
+    replace: A one or three value 1D tensor to fill empty pixels.
+    new_min_bbox_coords: If not None, then this is a tuple that specifies the
+      (min_y, min_x) coordinates of the new bbox. Normally this is randomly
+      specified, but this allows it to be manually set. The coordinates are
+      the absolute coordinates between 0 and image height/width and are int32.
+
+  Returns:
+    The new image that will have the shifted bbox location in it along with
+    the new bbox that contains the new coordinates.
+  """
+  # Obtains image height and width and create helper clip functions.
+  image_height = tf.to_float(tf.shape(image)[0])
+  image_width = tf.to_float(tf.shape(image)[1])
+  def clip_y(val):
+    return tf.clip_by_value(val, 0, tf.to_int32(image_height) - 1)
+  def clip_x(val):
+    return tf.clip_by_value(val, 0, tf.to_int32(image_width) - 1)
+
+  # Convert bbox to pixel coordinates.
+  min_y = tf.to_int32(image_height * bbox[0])
+  min_x = tf.to_int32(image_width * bbox[1])
+  max_y = clip_y(tf.to_int32(image_height * bbox[2]))
+  max_x = clip_x(tf.to_int32(image_width * bbox[3]))
+  bbox_height, bbox_width = (max_y - min_y + 1, max_x - min_x + 1)
+  image_height = tf.to_int32(image_height)
+  image_width = tf.to_int32(image_width)
+
+  # Select the new min/max bbox ranges that are used for sampling the
+  # new min x/y coordinates of the shifted bbox.
+  minval_y = clip_y(
+      min_y - tf.to_int32(pixel_scaling * tf.to_float(bbox_height) / 2.0))
+  maxval_y = clip_y(
+      min_y + tf.to_int32(pixel_scaling * tf.to_float(bbox_height) / 2.0))
+  minval_x = clip_x(
+      min_x - tf.to_int32(pixel_scaling * tf.to_float(bbox_width) / 2.0))
+  maxval_x = clip_x(
+      min_x + tf.to_int32(pixel_scaling * tf.to_float(bbox_width) / 2.0))
+
+  # Sample and calculate the new unclipped min/max coordinates of the new bbox.
+  if new_min_bbox_coords is None:
+    unclipped_new_min_y = tf.random_uniform(
+        shape=[], minval=minval_y, maxval=maxval_y,
+        dtype=tf.int32)
+    unclipped_new_min_x = tf.random_uniform(
+        shape=[], minval=minval_x, maxval=maxval_x,
+        dtype=tf.int32)
+  else:
+    unclipped_new_min_y, unclipped_new_min_x = (
+        clip_y(new_min_bbox_coords[0]), clip_x(new_min_bbox_coords[1]))
+  unclipped_new_max_y = unclipped_new_min_y + bbox_height - 1
+  unclipped_new_max_x = unclipped_new_min_x + bbox_width - 1
+
+  # Determine if any of the new bbox was shifted outside the current image.
+  # This is used for determining if any of the original bbox content should be
+  # discarded.
+  new_min_y, new_min_x, new_max_y, new_max_x = (
+      clip_y(unclipped_new_min_y), clip_x(unclipped_new_min_x),
+      clip_y(unclipped_new_max_y), clip_x(unclipped_new_max_x))
+  shifted_min_y = (new_min_y - unclipped_new_min_y) + min_y
+  shifted_max_y = max_y - (unclipped_new_max_y - new_max_y)
+  shifted_min_x = (new_min_x - unclipped_new_min_x) + min_x
+  shifted_max_x = max_x - (unclipped_new_max_x - new_max_x)
+
+  # Create the new bbox tensor by converting pixel integer values to floats.
+  new_bbox = tf.stack([
+      tf.to_float(new_min_y) / tf.to_float(image_height),
+      tf.to_float(new_min_x) / tf.to_float(image_width),
+      tf.to_float(new_max_y) / tf.to_float(image_height),
+      tf.to_float(new_max_x) / tf.to_float(image_width)])
+
+  # Copy the contents in the bbox and fill the old bbox location
+  # with gray (128).
+  bbox_content = image[shifted_min_y:shifted_max_y + 1,
+                       shifted_min_x:shifted_max_x + 1, :]
+
+  def mask_and_add_image(
+      min_y_, min_x_, max_y_, max_x_, mask, content_tensor, image_):
+    """Applies mask to bbox region in image then adds content_tensor to it."""
+    mask = tf.pad(mask,
+                  [[min_y_, (image_height - 1) - max_y_],
+                   [min_x_, (image_width - 1) - max_x_],
+                   [0, 0]], constant_values=1)
+    content_tensor = tf.pad(content_tensor,
+                            [[min_y_, (image_height - 1) - max_y_],
+                             [min_x_, (image_width - 1) - max_x_],
+                             [0, 0]], constant_values=0)
+    return image_ * mask + content_tensor
+
+  # Zero out original bbox location.
+  mask = tf.zeros_like(image)[min_y:max_y+1, min_x:max_x+1, :]
+  grey_tensor = tf.zeros_like(mask) + replace[0]
+  image = mask_and_add_image(min_y, min_x, max_y, max_x, mask,
+                             grey_tensor, image)
+
+  # Fill in bbox content to new bbox location.
+  mask = tf.zeros_like(bbox_content)
+  image = mask_and_add_image(new_min_y, new_min_x, new_max_y, new_max_x, mask,
+                             bbox_content, image)
+
+  return image, new_bbox
+
+
+def _clip_bbox(min_y, min_x, max_y, max_x):
+  """Clip bounding box coordinates between 0 and 1.
+
+  Args:
+    min_y: Normalized bbox coordinate of type float between 0 and 1.
+    min_x: Normalized bbox coordinate of type float between 0 and 1.
+    max_y: Normalized bbox coordinate of type float between 0 and 1.
+    max_x: Normalized bbox coordinate of type float between 0 and 1.
+
+  Returns:
+    Clipped coordinate values between 0 and 1.
+  """
+  min_y = tf.clip_by_value(min_y, 0.0, 1.0)
+  min_x = tf.clip_by_value(min_x, 0.0, 1.0)
+  max_y = tf.clip_by_value(max_y, 0.0, 1.0)
+  max_x = tf.clip_by_value(max_x, 0.0, 1.0)
+  return min_y, min_x, max_y, max_x
+
+
+def _check_bbox_area(min_y, min_x, max_y, max_x, delta=0.05):
+  """Adjusts bbox coordinates to make sure the area is > 0.
+
+  Args:
+    min_y: Normalized bbox coordinate of type float between 0 and 1.
+    min_x: Normalized bbox coordinate of type float between 0 and 1.
+    max_y: Normalized bbox coordinate of type float between 0 and 1.
+    max_x: Normalized bbox coordinate of type float between 0 and 1.
+    delta: Float, this is used to create a gap of size 2 * delta between
+      bbox min/max coordinates that are the same on the boundary.
+      This prevents the bbox from having an area of zero.
+
+  Returns:
+    Tuple of new bbox coordinates between 0 and 1 that will now have a
+    guaranteed area > 0.
+  """
+  height = max_y - min_y
+  width = max_x - min_x
+  def _adjust_bbox_boundaries(min_coord, max_coord):
+    # Make sure max is never 0 and min is never 1.
+    max_coord = tf.maximum(max_coord, 0.0 + delta)
+    min_coord = tf.minimum(min_coord, 1.0 - delta)
+    return min_coord, max_coord
+  min_y, max_y = tf.cond(tf.equal(height, 0.0),
+                         lambda: _adjust_bbox_boundaries(min_y, max_y),
+                         lambda: (min_y, max_y))
+  min_x, max_x = tf.cond(tf.equal(width, 0.0),
+                         lambda: _adjust_bbox_boundaries(min_x, max_x),
+                         lambda: (min_x, max_x))
+  return min_y, min_x, max_y, max_x
+
+
+def _scale_bbox_only_op_probability(prob):
+  """Reduce the probability of the bbox-only operation.
+
+  Probability is reduced so that we do not distort the content of too many
+  bounding boxes that are close to each other. The value of 3.0 was a chosen
+  hyper parameter when designing the autoaugment algorithm that we found
+  empirically to work well.
+
+  Args:
+    prob: Float that is the probability of applying the bbox-only operation.
+
+  Returns:
+    Reduced probability.
+  """
+  return prob / 3.0
+
+
+def _apply_bbox_augmentation(image, bbox, augmentation_func, *args):
+  """Applies augmentation_func to the subsection of image indicated by bbox.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    augmentation_func: Augmentation function that will be applied to the
+      subsection of image.
+    *args: Additional parameters that will be passed into augmentation_func
+      when it is called.
+
+  Returns:
+    A modified version of image, where the bbox location in the image will
+    have `ugmentation_func applied to it.
+  """
+  image_height = tf.to_float(tf.shape(image)[0])
+  image_width = tf.to_float(tf.shape(image)[1])
+  min_y = tf.to_int32(image_height * bbox[0])
+  min_x = tf.to_int32(image_width * bbox[1])
+  max_y = tf.to_int32(image_height * bbox[2])
+  max_x = tf.to_int32(image_width * bbox[3])
+  image_height = tf.to_int32(image_height)
+  image_width = tf.to_int32(image_width)
+
+  # Clip to be sure the max values do not fall out of range.
+  max_y = tf.minimum(max_y, image_height - 1)
+  max_x = tf.minimum(max_x, image_width - 1)
+
+  # Get the sub-tensor that is the image within the bounding box region.
+  bbox_content = image[min_y:max_y + 1, min_x:max_x + 1, :]
+
+  # Apply the augmentation function to the bbox portion of the image.
+  augmented_bbox_content = augmentation_func(bbox_content, *args)
+
+  # Pad the augmented_bbox_content and the mask to match the shape of original
+  # image.
+  augmented_bbox_content = tf.pad(augmented_bbox_content,
+                                  [[min_y, (image_height - 1) - max_y],
+                                   [min_x, (image_width - 1) - max_x],
+                                   [0, 0]])
+
+  # Create a mask that will be used to zero out a part of the original image.
+  mask_tensor = tf.zeros_like(bbox_content)
+
+  mask_tensor = tf.pad(mask_tensor,
+                       [[min_y, (image_height - 1) - max_y],
+                        [min_x, (image_width - 1) - max_x],
+                        [0, 0]],
+                       constant_values=1)
+  # Replace the old bbox content with the new augmented content.
+  image = image * mask_tensor + augmented_bbox_content
+  return image
+
+
+def _concat_bbox(bbox, bboxes):
+  """Helper function that concates bbox to bboxes along the first dimension."""
+
+  # Note if all elements in bboxes are -1 (_INVALID_BOX), then this means
+  # we discard bboxes and start the bboxes Tensor with the current bbox.
+  bboxes_sum_check = tf.reduce_sum(bboxes)
+  bbox = tf.expand_dims(bbox, 0)
+  # This check will be true when it is an _INVALID_BOX
+  bboxes = tf.cond(tf.equal(bboxes_sum_check, -4.0),
+                   lambda: bbox,
+                   lambda: tf.concat([bboxes, bbox], 0))
+  return bboxes
+
+
+def _apply_bbox_augmentation_wrapper(image, bbox, new_bboxes, prob,
+                                     augmentation_func, func_changes_bbox,
+                                     *args):
+  """Applies _apply_bbox_augmentation with probability prob.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    new_bboxes: 2D Tensor that is a list of the bboxes in the image after they
+      have been altered by aug_func. These will only be changed when
+      func_changes_bbox is set to true. Each bbox has 4 elements
+      (min_y, min_x, max_y, max_x) of type float that are the normalized
+      bbox coordinates between 0 and 1.
+    prob: Float that is the probability of applying _apply_bbox_augmentation.
+    augmentation_func: Augmentation function that will be applied to the
+      subsection of image.
+    func_changes_bbox: Boolean. Does augmentation_func return bbox in addition
+      to image.
+    *args: Additional parameters that will be passed into augmentation_func
+      when it is called.
+
+  Returns:
+    A tuple. Fist element is a modified version of image, where the bbox
+    location in the image will have augmentation_func applied to it if it is
+    chosen to be called with probability `prob`. The second element is a
+    Tensor of Tensors of length 4 that will contain the altered bbox after
+    applying augmentation_func.
+  """
+  should_apply_op = tf.cast(
+      tf.floor(tf.random_uniform([], dtype=tf.float32) + prob), tf.bool)
+  if func_changes_bbox:
+    augmented_image, bbox = tf.cond(
+        should_apply_op,
+        lambda: augmentation_func(image, bbox, *args),
+        lambda: (image, bbox))
+  else:
+    augmented_image = tf.cond(
+        should_apply_op,
+        lambda: _apply_bbox_augmentation(image, bbox, augmentation_func, *args),
+        lambda: image)
+  new_bboxes = _concat_bbox(bbox, new_bboxes)
+  return augmented_image, new_bboxes
+
+
+def _apply_multi_bbox_augmentation(image, bboxes, prob, aug_func,
+                                   func_changes_bbox, *args):
+  """Applies aug_func to the image for each bbox in bboxes.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bboxes: 2D Tensor that is a list of the bboxes in the image. Each bbox
+      has 4 elements (min_y, min_x, max_y, max_x) of type float.
+    prob: Float that is the probability of applying aug_func to a specific
+      bounding box within the image.
+    aug_func: Augmentation function that will be applied to the
+      subsections of image indicated by the bbox values in bboxes.
+    func_changes_bbox: Boolean. Does augmentation_func return bbox in addition
+      to image.
+    *args: Additional parameters that will be passed into augmentation_func
+      when it is called.
+
+  Returns:
+    A modified version of image, where each bbox location in the image will
+    have augmentation_func applied to it if it is chosen to be called with
+    probability prob independently across all bboxes. Also the final
+    bboxes are returned that will be unchanged if func_changes_bbox is set to
+    false and if true, the new altered ones will be returned.
+  """
+  # Will keep track of the new altered bboxes after aug_func is repeatedly
+  # applied. The -1 values are a dummy value and this first Tensor will be
+  # removed upon appending the first real bbox.
+  new_bboxes = tf.constant(_INVALID_BOX)
+
+  # If the bboxes are empty, then just give it _INVALID_BOX. The result
+  # will be thrown away.
+  bboxes = tf.cond(tf.equal(tf.size(bboxes), 0),
+                   lambda: tf.constant(_INVALID_BOX),
+                   lambda: bboxes)
+
+  bboxes = tf.ensure_shape(bboxes, (None, 4))
+
+  # pylint:disable=g-long-lambda
+  # pylint:disable=line-too-long
+  wrapped_aug_func = lambda _image, bbox, _new_bboxes: _apply_bbox_augmentation_wrapper(
+      _image, bbox, _new_bboxes, prob, aug_func, func_changes_bbox, *args)
+  # pylint:enable=g-long-lambda
+  # pylint:enable=line-too-long
+
+  # Setup the while_loop.
+  num_bboxes = tf.shape(bboxes)[0]  # We loop until we go over all bboxes.
+  idx = tf.constant(0)  # Counter for the while loop.
+
+  # Conditional function when to end the loop once we go over all bboxes
+  # images_and_bboxes contain (_image, _new_bboxes)
+  cond = lambda _idx, _images_and_bboxes: tf.less(_idx, num_bboxes)
+
+  # Shuffle the bboxes so that the augmentation order is not deterministic if
+  # we are not changing the bboxes with aug_func.
+  if not func_changes_bbox:
+    loop_bboxes = tf.random.shuffle(bboxes)
+  else:
+    loop_bboxes = bboxes
+
+  # Main function of while_loop where we repeatedly apply augmentation on the
+  # bboxes in the image.
+  # pylint:disable=g-long-lambda
+  body = lambda _idx, _images_and_bboxes: [
+      _idx + 1, wrapped_aug_func(_images_and_bboxes[0],
+                                 loop_bboxes[_idx],
+                                 _images_and_bboxes[1])]
+  # pylint:enable=g-long-lambda
+
+  _, (image, new_bboxes) = tf.while_loop(
+      cond, body, [idx, (image, new_bboxes)],
+      shape_invariants=[idx.get_shape(),
+                        (image.get_shape(), tf.TensorShape([None, 4]))])
+
+  # Either return the altered bboxes or the original ones depending on if
+  # we altered them in anyway.
+  if func_changes_bbox:
+    final_bboxes = new_bboxes
+  else:
+    final_bboxes = bboxes
+  return image, final_bboxes
+
+
+def _apply_multi_bbox_augmentation_wrapper(image, bboxes, prob, aug_func,
+                                           func_changes_bbox, *args):
+  """Checks to be sure num bboxes > 0 before calling inner function."""
+  num_bboxes = tf.shape(bboxes)[0]
+  image, bboxes = tf.cond(
+      tf.equal(num_bboxes, 0),
+      lambda: (image, bboxes),
+      # pylint:disable=g-long-lambda
+      lambda: _apply_multi_bbox_augmentation(
+          image, bboxes, prob, aug_func, func_changes_bbox, *args))
+  # pylint:enable=g-long-lambda
+  return image, bboxes
+
+
+def rotate_only_bboxes(image, bboxes, prob, degrees, replace):
+  """Apply rotate to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, rotate, func_changes_bbox, degrees, replace)
+
+
+def shear_x_only_bboxes(image, bboxes, prob, level, replace):
+  """Apply shear_x to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, shear_x, func_changes_bbox, level, replace)
+
+
+def shear_y_only_bboxes(image, bboxes, prob, level, replace):
+  """Apply shear_y to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, shear_y, func_changes_bbox, level, replace)
+
+
+def translate_x_only_bboxes(image, bboxes, prob, pixels, replace):
+  """Apply translate_x to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, translate_x, func_changes_bbox, pixels, replace)
+
+
+def translate_y_only_bboxes(image, bboxes, prob, pixels, replace):
+  """Apply translate_y to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, translate_y, func_changes_bbox, pixels, replace)
+
+
+def flip_only_bboxes(image, bboxes, prob):
+  """Apply flip_lr to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, tf.image.flip_left_right, func_changes_bbox)
+
+
+def solarize_only_bboxes(image, bboxes, prob, threshold):
+  """Apply solarize to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, solarize, func_changes_bbox, threshold)
+
+
+def equalize_only_bboxes(image, bboxes, prob):
+  """Apply equalize to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, equalize, func_changes_bbox)
+
+
+def cutout_only_bboxes(image, bboxes, prob, pad_size, replace):
+  """Apply cutout to each bbox in the image with probability prob."""
+  func_changes_bbox = False
+  prob = _scale_bbox_only_op_probability(prob)
+  return _apply_multi_bbox_augmentation_wrapper(
+      image, bboxes, prob, cutout, func_changes_bbox, pad_size, replace)
+
+
+def _rotate_bbox(bbox, image_height, image_width, degrees):
+  """Rotates the bbox coordinated by degrees.
+
+  Args:
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    image_height: Int, height of the image.
+    image_width: Int, height of the image.
+    degrees: Float, a scalar angle in degrees to rotate all images by. If
+      degrees is positive the image will be rotated clockwise otherwise it will
+      be rotated counterclockwise.
+
+  Returns:
+    A tensor of the same shape as bbox, but now with the rotated coordinates.
+  """
+  image_height, image_width = (
+      tf.to_float(image_height), tf.to_float(image_width))
+
+  # Convert from degrees to radians.
+  degrees_to_radians = math.pi / 180.0
+  radians = degrees * degrees_to_radians
+
+  # Translate the bbox to the center of the image and turn the normalized 0-1
+  # coordinates to absolute pixel locations.
+  # Y coordinates are made negative as the y axis of images goes down with
+  # increasing pixel values, so we negate to make sure x axis and y axis points
+  # are in the traditionally positive direction.
+  min_y = -tf.to_int32(image_height * (bbox[0] - 0.5))
+  min_x = tf.to_int32(image_width * (bbox[1] - 0.5))
+  max_y = -tf.to_int32(image_height * (bbox[2] - 0.5))
+  max_x = tf.to_int32(image_width * (bbox[3] - 0.5))
+  coordinates = tf.stack(
+      [[min_y, min_x], [min_y, max_x], [max_y, min_x], [max_y, max_x]])
+  coordinates = tf.cast(coordinates, tf.float32)
+  # Rotate the coordinates according to the rotation matrix clockwise if
+  # radians is positive, else negative
+  rotation_matrix = tf.stack(
+      [[tf.cos(radians), tf.sin(radians)],
+       [-tf.sin(radians), tf.cos(radians)]])
+  new_coords = tf.cast(
+      tf.matmul(rotation_matrix, tf.transpose(coordinates)), tf.int32)
+  # Find min/max values and convert them back to normalized 0-1 floats.
+  min_y = -(tf.to_float(tf.reduce_max(new_coords[0, :])) / image_height - 0.5)
+  min_x = tf.to_float(tf.reduce_min(new_coords[1, :])) / image_width + 0.5
+  max_y = -(tf.to_float(tf.reduce_min(new_coords[0, :])) / image_height - 0.5)
+  max_x = tf.to_float(tf.reduce_max(new_coords[1, :])) / image_width + 0.5
+
+  # Clip the bboxes to be sure the fall between [0, 1].
+  min_y, min_x, max_y, max_x = _clip_bbox(min_y, min_x, max_y, max_x)
+  min_y, min_x, max_y, max_x = _check_bbox_area(min_y, min_x, max_y, max_x)
+  return tf.stack([min_y, min_x, max_y, max_x])
+
+
+def rotate_with_bboxes(image, bboxes, degrees, replace):
+  """Equivalent of PIL Rotate that rotates the image and bbox.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bboxes: 2D Tensor that is a list of the bboxes in the image. Each bbox
+      has 4 elements (min_y, min_x, max_y, max_x) of type float.
+    degrees: Float, a scalar angle in degrees to rotate all images by. If
+      degrees is positive the image will be rotated clockwise otherwise it will
+      be rotated counterclockwise.
+    replace: A one or three value 1D tensor to fill empty pixels.
+
+  Returns:
+    A tuple containing a 3D uint8 Tensor that will be the result of rotating
+    image by degrees. The second element of the tuple is bboxes, where now
+    the coordinates will be shifted to reflect the rotated image.
+  """
+  # Rotate the image.
+  image = rotate(image, degrees, replace)
+
+  # Convert bbox coordinates to pixel values.
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
+  # pylint:disable=g-long-lambda
+  wrapped_rotate_bbox = lambda bbox: _rotate_bbox(
+      bbox, image_height, image_width, degrees)
+  # pylint:enable=g-long-lambda
+  bboxes = tf.map_fn(wrapped_rotate_bbox, bboxes)
+  return image, bboxes
+
+
+def translate_x(image, pixels, replace):
+  """Equivalent of PIL Translate in X dimension."""
+  image = tf.contrib.image.translate(wrap(image), [-pixels, 0])
+  return unwrap(image, replace)
+
+
+def translate_y(image, pixels, replace):
+  """Equivalent of PIL Translate in Y dimension."""
+  image = tf.contrib.image.translate(wrap(image), [0, -pixels])
+  return unwrap(image, replace)
+
+
+def _shift_bbox(bbox, image_height, image_width, pixels, shift_horizontal):
+  """Shifts the bbox coordinates by pixels.
+
+  Args:
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    image_height: Int, height of the image.
+    image_width: Int, width of the image.
+    pixels: An int. How many pixels to shift the bbox.
+    shift_horizontal: Boolean. If true then shift in X dimension else shift in
+      Y dimension.
+
+  Returns:
+    A tensor of the same shape as bbox, but now with the shifted coordinates.
+  """
+  pixels = tf.to_int32(pixels)
+  # Convert bbox to integer pixel locations.
+  min_y = tf.to_int32(tf.to_float(image_height) * bbox[0])
+  min_x = tf.to_int32(tf.to_float(image_width) * bbox[1])
+  max_y = tf.to_int32(tf.to_float(image_height) * bbox[2])
+  max_x = tf.to_int32(tf.to_float(image_width) * bbox[3])
+
+  if shift_horizontal:
+    min_x = tf.maximum(0, min_x - pixels)
+    max_x = tf.minimum(image_width, max_x - pixels)
+  else:
+    min_y = tf.maximum(0, min_y - pixels)
+    max_y = tf.minimum(image_height, max_y - pixels)
+
+  # Convert bbox back to floats.
+  min_y = tf.to_float(min_y) / tf.to_float(image_height)
+  min_x = tf.to_float(min_x) / tf.to_float(image_width)
+  max_y = tf.to_float(max_y) / tf.to_float(image_height)
+  max_x = tf.to_float(max_x) / tf.to_float(image_width)
+
+  # Clip the bboxes to be sure the fall between [0, 1].
+  min_y, min_x, max_y, max_x = _clip_bbox(min_y, min_x, max_y, max_x)
+  min_y, min_x, max_y, max_x = _check_bbox_area(min_y, min_x, max_y, max_x)
+  return tf.stack([min_y, min_x, max_y, max_x])
+
+
+def translate_bbox(image, bboxes, pixels, replace, shift_horizontal):
+  """Equivalent of PIL Translate in X/Y dimension that shifts image and bbox.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bboxes: 2D Tensor that is a list of the bboxes in the image. Each bbox
+      has 4 elements (min_y, min_x, max_y, max_x) of type float with values
+      between [0, 1].
+    pixels: An int. How many pixels to shift the image and bboxes
+    replace: A one or three value 1D tensor to fill empty pixels.
+    shift_horizontal: Boolean. If true then shift in X dimension else shift in
+      Y dimension.
+
+  Returns:
+    A tuple containing a 3D uint8 Tensor that will be the result of translating
+    image by pixels. The second element of the tuple is bboxes, where now
+    the coordinates will be shifted to reflect the shifted image.
+  """
+  if shift_horizontal:
+    image = translate_x(image, pixels, replace)
+  else:
+    image = translate_y(image, pixels, replace)
+
+  # Convert bbox coordinates to pixel values.
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
+  # pylint:disable=g-long-lambda
+  wrapped_shift_bbox = lambda bbox: _shift_bbox(
+      bbox, image_height, image_width, pixels, shift_horizontal)
+  # pylint:enable=g-long-lambda
+  bboxes = tf.map_fn(wrapped_shift_bbox, bboxes)
+  return image, bboxes
+
+
+def shear_x(image, level, replace):
+  """Equivalent of PIL Shearing in X dimension."""
+  # Shear parallel to x axis is a projective transform
+  # with a matrix form of:
+  # [1  level
+  #  0  1].
+  image = tf.contrib.image.transform(
+      wrap(image), [1., level, 0., 0., 1., 0., 0., 0.])
+  return unwrap(image, replace)
+
+
+def shear_y(image, level, replace):
+  """Equivalent of PIL Shearing in Y dimension."""
+  # Shear parallel to y axis is a projective transform
+  # with a matrix form of:
+  # [1  0
+  #  level  1].
+  image = tf.contrib.image.transform(
+      wrap(image), [1., 0., 0., level, 1., 0., 0., 0.])
+  return unwrap(image, replace)
+
+
+def _shear_bbox(bbox, image_height, image_width, level, shear_horizontal):
+  """Shifts the bbox according to how the image was sheared.
+
+  Args:
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    image_height: Int, height of the image.
+    image_width: Int, height of the image.
+    level: Float. How much to shear the image.
+    shear_horizontal: If true then shear in X dimension else shear in
+      the Y dimension.
+
+  Returns:
+    A tensor of the same shape as bbox, but now with the shifted coordinates.
+  """
+  image_height, image_width = (
+      tf.to_float(image_height), tf.to_float(image_width))
+
+  # Change bbox coordinates to be pixels.
+  min_y = tf.to_int32(image_height * bbox[0])
+  min_x = tf.to_int32(image_width * bbox[1])
+  max_y = tf.to_int32(image_height * bbox[2])
+  max_x = tf.to_int32(image_width * bbox[3])
+  coordinates = tf.stack(
+      [[min_y, min_x], [min_y, max_x], [max_y, min_x], [max_y, max_x]])
+  coordinates = tf.cast(coordinates, tf.float32)
+
+  # Shear the coordinates according to the translation matrix.
+  if shear_horizontal:
+    translation_matrix = tf.stack(
+        [[1, 0], [-level, 1]])
+  else:
+    translation_matrix = tf.stack(
+        [[1, -level], [0, 1]])
+  translation_matrix = tf.cast(translation_matrix, tf.float32)
+  new_coords = tf.cast(
+      tf.matmul(translation_matrix, tf.transpose(coordinates)), tf.int32)
+
+  # Find min/max values and convert them back to floats.
+  min_y = tf.to_float(tf.reduce_min(new_coords[0, :])) / image_height
+  min_x = tf.to_float(tf.reduce_min(new_coords[1, :])) / image_width
+  max_y = tf.to_float(tf.reduce_max(new_coords[0, :])) / image_height
+  max_x = tf.to_float(tf.reduce_max(new_coords[1, :])) / image_width
+
+  # Clip the bboxes to be sure the fall between [0, 1].
+  min_y, min_x, max_y, max_x = _clip_bbox(min_y, min_x, max_y, max_x)
+  min_y, min_x, max_y, max_x = _check_bbox_area(min_y, min_x, max_y, max_x)
+  return tf.stack([min_y, min_x, max_y, max_x])
+
+
+def shear_with_bboxes(image, bboxes, level, replace, shear_horizontal):
+  """Applies Shear Transformation to the image and shifts the bboxes.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bboxes: 2D Tensor that is a list of the bboxes in the image. Each bbox
+      has 4 elements (min_y, min_x, max_y, max_x) of type float with values
+      between [0, 1].
+    level: Float. How much to shear the image. This value will be between
+      -0.3 to 0.3.
+    replace: A one or three value 1D tensor to fill empty pixels.
+    shear_horizontal: Boolean. If true then shear in X dimension else shear in
+      the Y dimension.
+
+  Returns:
+    A tuple containing a 3D uint8 Tensor that will be the result of shearing
+    image by level. The second element of the tuple is bboxes, where now
+    the coordinates will be shifted to reflect the sheared image.
+  """
+  if shear_horizontal:
+    image = shear_x(image, level, replace)
+  else:
+    image = shear_y(image, level, replace)
+
+  # Convert bbox coordinates to pixel values.
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
+  # pylint:disable=g-long-lambda
+  wrapped_shear_bbox = lambda bbox: _shear_bbox(
+      bbox, image_height, image_width, level, shear_horizontal)
+  # pylint:enable=g-long-lambda
+  bboxes = tf.map_fn(wrapped_shear_bbox, bboxes)
+  return image, bboxes
+
+
+def autocontrast(image):
+  """Implements Autocontrast function from PIL using TF ops.
+
+  Args:
+    image: A 3D uint8 tensor.
+
+  Returns:
+    The image after it has had autocontrast applied to it and will be of type
+    uint8.
+  """
+
+  def scale_channel(image):
+    """Scale the 2D image using the autocontrast rule."""
+    # A possibly cheaper version can be done using cumsum/unique_with_counts
+    # over the histogram values, rather than iterating over the entire image.
+    # to compute mins and maxes.
+    lo = tf.to_float(tf.reduce_min(image))
+    hi = tf.to_float(tf.reduce_max(image))
+
+    # Scale the image, making the lowest value 0 and the highest value 255.
+    def scale_values(im):
+      scale = 255.0 / (hi - lo)
+      offset = -lo * scale
+      im = tf.to_float(im) * scale + offset
+      im = tf.clip_by_value(im, 0.0, 255.0)
+      return tf.cast(im, tf.uint8)
+
+    result = tf.cond(hi > lo, lambda: scale_values(image), lambda: image)
+    return result
+
+  # Assumes RGB for now.  Scales each channel independently
+  # and then stacks the result.
+  s1 = scale_channel(image[:, :, 0])
+  s2 = scale_channel(image[:, :, 1])
+  s3 = scale_channel(image[:, :, 2])
+  image = tf.stack([s1, s2, s3], 2)
+  return image
+
+
+def sharpness(image, factor):
+  """Implements Sharpness function from PIL using TF ops."""
+  orig_image = image
+  image = tf.cast(image, tf.float32)
+  # Make image 4D for conv operation.
+  image = tf.expand_dims(image, 0)
+  # SMOOTH PIL Kernel.
+  kernel = tf.constant(
+      [[1, 1, 1], [1, 5, 1], [1, 1, 1]], dtype=tf.float32,
+      shape=[3, 3, 1, 1]) / 13.
+  # Tile across channel dimension.
+  kernel = tf.tile(kernel, [1, 1, 3, 1])
+  strides = [1, 1, 1, 1]
+  degenerate = tf.nn.depthwise_conv2d(
+      image, kernel, strides, padding='VALID', rate=[1, 1])
+  degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
+  degenerate = tf.squeeze(tf.cast(degenerate, tf.uint8), [0])
+
+  # For the borders of the resulting image, fill in the values of the
+  # original image.
+  mask = tf.ones_like(degenerate)
+  padded_mask = tf.pad(mask, [[1, 1], [1, 1], [0, 0]])
+  padded_degenerate = tf.pad(degenerate, [[1, 1], [1, 1], [0, 0]])
+  result = tf.where(tf.equal(padded_mask, 1), padded_degenerate, orig_image)
+
+  # Blend the final result.
+  return blend(result, orig_image, factor)
+
+
+def equalize(image):
+  """Implements Equalize function from PIL using TF ops."""
+  def scale_channel(im, c):
+    """Scale the data in the channel to implement equalize."""
+    im = tf.cast(im[:, :, c], tf.int32)
+    # Compute the histogram of the image channel.
+    histo = tf.histogram_fixed_width(im, [0, 255], nbins=256)
+
+    # For the purposes of computing the step, filter out the nonzeros.
+    nonzero = tf.where(tf.not_equal(histo, 0))
+    nonzero_histo = tf.reshape(tf.gather(histo, nonzero), [-1])
+    step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // 255
+
+    def build_lut(histo, step):
+      # Compute the cumulative sum, shifting by step // 2
+      # and then normalization by step.
+      lut = (tf.cumsum(histo) + (step // 2)) // step
+      # Shift lut, prepending with 0.
+      lut = tf.concat([[0], lut[:-1]], 0)
+      # Clip the counts to be in range.  This is done
+      # in the C code for image.point.
+      return tf.clip_by_value(lut, 0, 255)
+
+    # If step is zero, return the original image.  Otherwise, build
+    # lut from the full histogram and step and then index from it.
+    result = tf.cond(tf.equal(step, 0),
+                     lambda: im,
+                     lambda: tf.gather(build_lut(histo, step), im))
+
+    return tf.cast(result, tf.uint8)
+
+  # Assumes RGB for now.  Scales each channel independently
+  # and then stacks the result.
+  s1 = scale_channel(image, 0)
+  s2 = scale_channel(image, 1)
+  s3 = scale_channel(image, 2)
+  image = tf.stack([s1, s2, s3], 2)
+  return image
+
+
+def wrap(image):
+  """Returns 'image' with an extra channel set to all 1s."""
+  shape = tf.shape(image)
+  extended_channel = tf.ones([shape[0], shape[1], 1], image.dtype)
+  extended = tf.concat([image, extended_channel], 2)
+  return extended
+
+
+def unwrap(image, replace):
+  """Unwraps an image produced by wrap.
+
+  Where there is a 0 in the last channel for every spatial position,
+  the rest of the three channels in that spatial dimension are grayed
+  (set to 128).  Operations like translate and shear on a wrapped
+  Tensor will leave 0s in empty locations.  Some transformations look
+  at the intensity of values to do preprocessing, and we want these
+  empty pixels to assume the 'average' value, rather than pure black.
+
+
+  Args:
+    image: A 3D Image Tensor with 4 channels.
+    replace: A one or three value 1D tensor to fill empty pixels.
+
+  Returns:
+    image: A 3D image Tensor with 3 channels.
+  """
+  image_shape = tf.shape(image)
+  # Flatten the spatial dimensions.
+  flattened_image = tf.reshape(image, [-1, image_shape[2]])
+
+  # Find all pixels where the last channel is zero.
+  alpha_channel = flattened_image[:, 3]
+
+  replace = tf.concat([replace, tf.ones([1], image.dtype)], 0)
+
+  # Where they are zero, fill them in with 'replace'.
+  flattened_image = tf.where(
+      tf.equal(alpha_channel, 0),
+      tf.ones_like(flattened_image, dtype=image.dtype) * replace,
+      flattened_image)
+
+  image = tf.reshape(flattened_image, image_shape)
+  image = tf.slice(image, [0, 0, 0], [image_shape[0], image_shape[1], 3])
+  return image
+
+
+def _cutout_inside_bbox(image, bbox, pad_fraction):
+  """Generates cutout mask and the mean pixel value of the bbox.
+
+  First a location is randomly chosen within the image as the center where the
+  cutout mask will be applied. Note this can be towards the boundaries of the
+  image, so the full cutout mask may not be applied.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bbox: 1D Tensor that has 4 elements (min_y, min_x, max_y, max_x)
+      of type float that represents the normalized coordinates between 0 and 1.
+    pad_fraction: Float that specifies how large the cutout mask should be in
+      in reference to the size of the original bbox. If pad_fraction is 0.25,
+      then the cutout mask will be of shape
+      (0.25 * bbox height, 0.25 * bbox width).
+
+  Returns:
+    A tuple. Fist element is a tensor of the same shape as image where each
+    element is either a 1 or 0 that is used to determine where the image
+    will have cutout applied. The second element is the mean of the pixels
+    in the image where the bbox is located.
+  """
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
+  # Transform from shape [1, 4] to [4].
+  bbox = tf.squeeze(bbox)
+
+  min_y = tf.to_int32(tf.to_float(image_height) * bbox[0])
+  min_x = tf.to_int32(tf.to_float(image_width) * bbox[1])
+  max_y = tf.to_int32(tf.to_float(image_height) * bbox[2])
+  max_x = tf.to_int32(tf.to_float(image_width) * bbox[3])
+
+  # Calculate the mean pixel values in the bounding box, which will be used
+  # to fill the cutout region.
+  mean = tf.reduce_mean(image[min_y:max_y + 1, min_x:max_x + 1],
+                        reduction_indices=[0, 1])
+
+  # Cutout mask will be size pad_size_heigh * 2 by pad_size_width * 2 if the
+  # region lies entirely within the bbox.
+  box_height = max_y - min_y + 1
+  box_width = max_x - min_x + 1
+  pad_size_height = tf.to_int32(pad_fraction * (box_height / 2))
+  pad_size_width = tf.to_int32(pad_fraction * (box_width / 2))
+
+  # Sample the center location in the image where the zero mask will be applied.
+  cutout_center_height = tf.random_uniform(
+      shape=[], minval=min_y, maxval=max_y+1,
+      dtype=tf.int32)
+
+  cutout_center_width = tf.random_uniform(
+      shape=[], minval=min_x, maxval=max_x+1,
+      dtype=tf.int32)
+
+  lower_pad = tf.maximum(
+      0, cutout_center_height - pad_size_height)
+  upper_pad = tf.maximum(
+      0, image_height - cutout_center_height - pad_size_height)
+  left_pad = tf.maximum(
+      0, cutout_center_width - pad_size_width)
+  right_pad = tf.maximum(
+      0, image_width - cutout_center_width - pad_size_width)
+
+  cutout_shape = [image_height - (lower_pad + upper_pad),
+                  image_width - (left_pad + right_pad)]
+  padding_dims = [[lower_pad, upper_pad], [left_pad, right_pad]]
+
+  mask = tf.pad(
+      tf.zeros(cutout_shape, dtype=image.dtype),
+      padding_dims, constant_values=1)
+
+  mask = tf.expand_dims(mask, 2)
+  mask = tf.tile(mask, [1, 1, 3])
+
+  return mask, mean
+
+
+def bbox_cutout(image, bboxes, pad_fraction, replace_with_mean):
+  """Applies cutout to the image according to bbox information.
+
+  This is a cutout variant that using bbox information to make more informed
+  decisions on where to place the cutout mask.
+
+  Args:
+    image: 3D uint8 Tensor.
+    bboxes: 2D Tensor that is a list of the bboxes in the image. Each bbox
+      has 4 elements (min_y, min_x, max_y, max_x) of type float with values
+      between [0, 1].
+    pad_fraction: Float that specifies how large the cutout mask should be in
+      in reference to the size of the original bbox. If pad_fraction is 0.25,
+      then the cutout mask will be of shape
+      (0.25 * bbox height, 0.25 * bbox width).
+    replace_with_mean: Boolean that specified what value should be filled in
+      where the cutout mask is applied. Since the incoming image will be of
+      uint8 and will not have had any mean normalization applied, by default
+      we set the value to be 128. If replace_with_mean is True then we find
+      the mean pixel values across the channel dimension and use those to fill
+      in where the cutout mask is applied.
+
+  Returns:
+    A tuple. First element is a tensor of the same shape as image that has
+    cutout applied to it. Second element is the bboxes that were passed in
+    that will be unchanged.
+  """
+  def apply_bbox_cutout(image, bboxes, pad_fraction):
+    """Applies cutout to a single bounding box within image."""
+    # Choose a single bounding box to apply cutout to.
+    random_index = tf.random_uniform(
+        shape=[], maxval=tf.shape(bboxes)[0], dtype=tf.int32)
+    # Select the corresponding bbox and apply cutout.
+    chosen_bbox = tf.gather(bboxes, random_index)
+    mask, mean = _cutout_inside_bbox(image, chosen_bbox, pad_fraction)
+
+    # When applying cutout we either set the pixel value to 128 or to the mean
+    # value inside the bbox.
+    replace = mean if replace_with_mean else 128
+
+    # Apply the cutout mask to the image. Where the mask is 0 we fill it with
+    # `replace`.
+    image = tf.where(
+        tf.equal(mask, 0),
+        tf.cast(tf.ones_like(image, dtype=image.dtype) * replace,
+                dtype=image.dtype),
+        image)
+    return image
+
+  # Check to see if there are boxes, if so then apply boxcutout.
+  image = tf.cond(tf.equal(tf.size(bboxes), 0), lambda: image,
+                  lambda: apply_bbox_cutout(image, bboxes, pad_fraction))
+
+  return image, bboxes
+
+
+NAME_TO_FUNC = {
+    'AutoContrast': autocontrast,
+    'Equalize': equalize,
+    'Posterize': posterize,
+    'Solarize': solarize,
+    'SolarizeAdd': solarize_add,
+    'Color': color,
+    'Contrast': contrast,
+    'Brightness': brightness,
+    'Sharpness': sharpness,
+    'Cutout': cutout,
+    'BBox_Cutout': bbox_cutout,
+    'Rotate_BBox': rotate_with_bboxes,
+    # pylint:disable=g-long-lambda
+    'TranslateX_BBox': lambda image, bboxes, pixels, replace: translate_bbox(
+        image, bboxes, pixels, replace, shift_horizontal=True),
+    'TranslateY_BBox': lambda image, bboxes, pixels, replace: translate_bbox(
+        image, bboxes, pixels, replace, shift_horizontal=False),
+    'ShearX_BBox': lambda image, bboxes, level, replace: shear_with_bboxes(
+        image, bboxes, level, replace, shear_horizontal=True),
+    'ShearY_BBox': lambda image, bboxes, level, replace: shear_with_bboxes(
+        image, bboxes, level, replace, shear_horizontal=False),
+    # pylint:enable=g-long-lambda
+    'Rotate_Only_BBoxes': rotate_only_bboxes,
+    'ShearX_Only_BBoxes': shear_x_only_bboxes,
+    'ShearY_Only_BBoxes': shear_y_only_bboxes,
+    'TranslateX_Only_BBoxes': translate_x_only_bboxes,
+    'TranslateY_Only_BBoxes': translate_y_only_bboxes,
+    'Flip_Only_BBoxes': flip_only_bboxes,
+    'Solarize_Only_BBoxes': solarize_only_bboxes,
+    'Equalize_Only_BBoxes': equalize_only_bboxes,
+    'Cutout_Only_BBoxes': cutout_only_bboxes,
+}
+
+
+def _randomly_negate_tensor(tensor):
+  """With 50% prob turn the tensor negative."""
+  should_flip = tf.cast(tf.floor(tf.random_uniform([]) + 0.5), tf.bool)
+  final_tensor = tf.cond(should_flip, lambda: tensor, lambda: -tensor)
+  return final_tensor
+
+
+def _rotate_level_to_arg(level):
+  level = (level/_MAX_LEVEL) * 30.
+  level = _randomly_negate_tensor(level)
+  return (level,)
+
+
+def _shrink_level_to_arg(level):
+  """Converts level to ratio by which we shrink the image content."""
+  if level == 0:
+    return (1.0,)  # if level is zero, do not shrink the image
+  # Maximum shrinking ratio is 2.9.
+  level = 2. / (_MAX_LEVEL / level) + 0.9
+  return (level,)
+
+
+def _enhance_level_to_arg(level):
+  return ((level/_MAX_LEVEL) * 1.8 + 0.1,)
+
+
+def _shear_level_to_arg(level):
+  level = (level/_MAX_LEVEL) * 0.3
+  # Flip level to negative with 50% chance.
+  level = _randomly_negate_tensor(level)
+  return (level,)
+
+
+def _translate_level_to_arg(level, translate_const):
+  level = (level/_MAX_LEVEL) * float(translate_const)
+  # Flip level to negative with 50% chance.
+  level = _randomly_negate_tensor(level)
+  return (level,)
+
+
+def _bbox_cutout_level_to_arg(level, hparams):
+  cutout_pad_fraction = (level/_MAX_LEVEL) * hparams.cutout_max_pad_fraction
+  return (cutout_pad_fraction,
+          hparams.cutout_bbox_replace_with_mean)
+
+
+def level_to_arg(hparams):
+  return {
+      'AutoContrast': lambda level: (),
+      'Equalize': lambda level: (),
+      'Posterize': lambda level: (int((level/_MAX_LEVEL) * 4),),
+      'Solarize': lambda level: (int((level/_MAX_LEVEL) * 256),),
+      'SolarizeAdd': lambda level: (int((level/_MAX_LEVEL) * 110),),
+      'Color': _enhance_level_to_arg,
+      'Contrast': _enhance_level_to_arg,
+      'Brightness': _enhance_level_to_arg,
+      'Sharpness': _enhance_level_to_arg,
+      'Cutout': lambda level: (int((level/_MAX_LEVEL) * hparams.cutout_const),),
+      # pylint:disable=g-long-lambda
+      'BBox_Cutout': lambda level: _bbox_cutout_level_to_arg(
+          level, hparams),
+      'TranslateX_BBox': lambda level: _translate_level_to_arg(
+          level, hparams.translate_const),
+      'TranslateY_BBox': lambda level: _translate_level_to_arg(
+          level, hparams.translate_const),
+      # pylint:enable=g-long-lambda
+      'ShearX_BBox': _shear_level_to_arg,
+      'ShearY_BBox': _shear_level_to_arg,
+      'Rotate_BBox': _rotate_level_to_arg,
+      'Rotate_Only_BBoxes': _rotate_level_to_arg,
+      'ShearX_Only_BBoxes': _shear_level_to_arg,
+      'ShearY_Only_BBoxes': _shear_level_to_arg,
+      # pylint:disable=g-long-lambda
+      'TranslateX_Only_BBoxes': lambda level: _translate_level_to_arg(
+          level, hparams.translate_bbox_const),
+      'TranslateY_Only_BBoxes': lambda level: _translate_level_to_arg(
+          level, hparams.translate_bbox_const),
+      # pylint:enable=g-long-lambda
+      'Flip_Only_BBoxes': lambda level: (),
+      'Solarize_Only_BBoxes': lambda level: (int((level/_MAX_LEVEL) * 256),),
+      'Equalize_Only_BBoxes': lambda level: (),
+      # pylint:disable=g-long-lambda
+      'Cutout_Only_BBoxes': lambda level: (
+          int((level/_MAX_LEVEL) * hparams.cutout_bbox_const),),
+      # pylint:enable=g-long-lambda
+  }
+
+
+def bbox_wrapper(func):
+  """Adds a bboxes function argument to func and returns unchanged bboxes."""
+  def wrapper(images, bboxes, *args, **kwargs):
+    return (func(images, *args, **kwargs), bboxes)
+  return wrapper
+
+
+def _parse_policy_info(name, prob, level, replace_value, augmentation_hparams):
+  """Return the function that corresponds to `name` and update `level` param."""
+  func = NAME_TO_FUNC[name]
+  args = level_to_arg(augmentation_hparams)[name](level)
+
+  if six.PY2:
+    # pylint: disable=deprecated-method
+    arg_spec = inspect.getargspec(func)
+    # pylint: enable=deprecated-method
+  else:
+    arg_spec = inspect.getfullargspec(func)
+
+  # Check to see if prob is passed into function. This is used for operations
+  # where we alter bboxes independently.
+  # pytype:disable=wrong-arg-types
+  if 'prob' in arg_spec[0]:
+    args = tuple([prob] + list(args))
+  # pytype:enable=wrong-arg-types
+
+  # Add in replace arg if it is required for the function that is being called.
+  if 'replace' in arg_spec[0]:
+    # Make sure replace is the final argument
+    assert 'replace' == arg_spec[0][-1]
+    args = tuple(list(args) + [replace_value])
+
+  # Add bboxes as the second positional argument for the function if it does
+  # not already exist.
+  if 'bboxes' not in arg_spec[0]:
+    func = bbox_wrapper(func)
+  return (func, prob, args)
+
+
+def _apply_func_with_prob(func, image, args, prob, bboxes):
+  """Apply `func` to image w/ `args` as input with probability `prob`."""
+  assert isinstance(args, tuple)
+  if six.PY2:
+    # pylint: disable=deprecated-method
+    arg_spec = inspect.getargspec(func)
+    # pylint: enable=deprecated-method
+  else:
+    arg_spec = inspect.getfullargspec(func)
+  assert 'bboxes' == arg_spec[0][1]
+
+  # If prob is a function argument, then this randomness is being handled
+  # inside the function, so make sure it is always called.
+  if 'prob' in arg_spec[0]:
+    prob = 1.0
+
+  # Apply the function with probability `prob`.
+  should_apply_op = tf.cast(
+      tf.floor(tf.random_uniform([], dtype=tf.float32) + prob), tf.bool)
+  augmented_image, augmented_bboxes = tf.cond(
+      should_apply_op,
+      lambda: func(image, bboxes, *args),
+      lambda: (image, bboxes))
+  return augmented_image, augmented_bboxes
+
+
+def select_and_apply_random_policy(policies, image, bboxes):
+  """Select a random policy from `policies` and apply it to `image`."""
+  policy_to_select = tf.random_uniform([], maxval=len(policies), dtype=tf.int32)
+  # Note that using tf.case instead of tf.conds would result in significantly
+  # larger graphs and would even break export for some larger policies.
+  for (i, policy) in enumerate(policies):
+    image, bboxes = tf.cond(
+        tf.equal(i, policy_to_select),
+        lambda selected_policy=policy: selected_policy(image, bboxes),
+        lambda: (image, bboxes))
+  return (image, bboxes)
+
+
+def build_and_apply_nas_policy(policies, image, bboxes,
+                               augmentation_hparams):
+  """Build a policy from the given policies passed in and apply to image.
+
+  Args:
+    policies: list of lists of tuples in the form `(func, prob, level)`, `func`
+      is a string name of the augmentation function, `prob` is the probability
+      of applying the `func` operation, `level` is the input argument for
+      `func`.
+    image: tf.Tensor that the resulting policy will be applied to.
+    bboxes:
+    augmentation_hparams: Hparams associated with the NAS learned policy.
+
+  Returns:
+    A version of image that now has data augmentation applied to it based on
+    the `policies` pass into the function. Additionally, returns bboxes if
+    a value for them is passed in that is not None
+  """
+  replace_value = [128, 128, 128]
+
+  # func is the string name of the augmentation function, prob is the
+  # probability of applying the operation and level is the parameter associated
+  # with the tf op.
+
+  # tf_policies are functions that take in an image and return an augmented
+  # image.
+  tf_policies = []
+  for policy in policies:
+    tf_policy = []
+    # Link string name to the correct python function and make sure the correct
+    # argument is passed into that function.
+    for policy_info in policy:
+      policy_info = list(policy_info) + [replace_value, augmentation_hparams]
+
+      tf_policy.append(_parse_policy_info(*policy_info))
+    # Now build the tf policy that will apply the augmentation procedue
+    # on image.
+    def make_final_policy(tf_policy_):
+      def final_policy(image_, bboxes_):
+        for func, prob, args in tf_policy_:
+          image_, bboxes_ = _apply_func_with_prob(
+              func, image_, args, prob, bboxes_)
+        return image_, bboxes_
+      return final_policy
+    tf_policies.append(make_final_policy(tf_policy))
+
+  augmented_image, augmented_bbox = select_and_apply_random_policy(
+      tf_policies, image, bboxes)
+  # If no bounding boxes were specified, then just return the images.
+  return (augmented_image, augmented_bbox)
+
+
+# TODO(barretzoph): Add in ArXiv link once paper is out.
+def distort_image_with_autoaugment(image, bboxes, augmentation_name):
+  """Applies the AutoAugment policy to `image` and `bboxes`.
+
+  Args:
+    image: `Tensor` of shape [height, width, 3] representing an image.
+    bboxes: `Tensor` of shape [N, 4] representing ground truth boxes that are
+      normalized between [0, 1].
+    augmentation_name: The name of the AutoAugment policy to use. The available
+      options are `v0`, `v1`, `v2`, `v3` and `test`. `v0` is the policy used for
+      all of the results in the paper and was found to achieve the best results
+      on the COCO dataset. `v1`, `v2` and `v3` are additional good policies
+      found on the COCO dataset that have slight variation in what operations
+      were used during the search procedure along with how many operations are
+      applied in parallel to a single image (2 vs 3).
+
+  Returns:
+    A tuple containing the augmented versions of `image` and `bboxes`.
+  """
+  image = tf.cast(image, tf.uint8)
+  available_policies = {'v0': policy_v0, 'v1': policy_v1, 'v2': policy_v2,
+                        'v3': policy_v3, 'test': policy_vtest}
+  if augmentation_name not in available_policies:
+    raise ValueError('Invalid augmentation_name: {}'.format(augmentation_name))
+
+  policy = available_policies[augmentation_name]()
+  # Hparams that will be used for AutoAugment.
+  augmentation_hparams = tf.contrib.training.HParams(
+      cutout_max_pad_fraction=0.75, cutout_bbox_replace_with_mean=False,
+      cutout_const=100, translate_const=250, cutout_bbox_const=50,
+      translate_bbox_const=120)
+
+  augmented_image, augmented_bbox = (
+      build_and_apply_nas_policy(policy, image, bboxes, augmentation_hparams))
+  augmented_image = tf.cast(augmented_image, tf.float32)
+  return augmented_image, augmented_bbox

--- a/research/object_detection/utils/category_util.py
+++ b/research/object_detection/utils/category_util.py
@@ -14,6 +14,11 @@
 # ==============================================================================
 
 """Functions for importing/exporting Object Detection categories."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import csv
 
 import tensorflow as tf

--- a/research/object_detection/utils/category_util_test.py
+++ b/research/object_detection/utils/category_util_test.py
@@ -14,6 +14,11 @@
 # ==============================================================================
 
 """Tests for object_detection.utils.category_util."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
 import tensorflow as tf

--- a/research/object_detection/utils/config_util.py
+++ b/research/object_detection/utils/config_util.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 """Functions for reading and updating configuration files."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 import tensorflow as tf
 

--- a/research/object_detection/utils/config_util_test.py
+++ b/research/object_detection/utils/config_util_test.py
@@ -14,8 +14,13 @@
 # ==============================================================================
 """Tests for object_detection.utils.config_util."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
+from six.moves import range
 import tensorflow as tf
 
 from google.protobuf import text_format

--- a/research/object_detection/utils/context_manager.py
+++ b/research/object_detection/utils/context_manager.py
@@ -37,4 +37,3 @@ class IdentityContextManager(object):
     del exec_value
     del traceback
     return False
-

--- a/research/object_detection/utils/dataset_util.py
+++ b/research/object_detection/utils/dataset_util.py
@@ -15,6 +15,10 @@
 
 """Utility functions for creating TFRecord data sets."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import tensorflow as tf
 
 
@@ -84,5 +88,3 @@ def recursive_parse_xml_to_dict(xml):
         result[child.tag] = []
       result[child.tag].append(child_result[child.tag])
   return {xml.tag: result}
-
-

--- a/research/object_detection/utils/dataset_util_test.py
+++ b/research/object_detection/utils/dataset_util_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.dataset_util."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 import tensorflow as tf
 

--- a/research/object_detection/utils/label_map_util.py
+++ b/research/object_detection/utils/label_map_util.py
@@ -14,8 +14,13 @@
 # ==============================================================================
 """Label map utility functions."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
 
+from six.moves import range
 import tensorflow as tf
 from google.protobuf import text_format
 from object_detection.protos import string_int_label_map_pb2

--- a/research/object_detection/utils/label_map_util_test.py
+++ b/research/object_detection/utils/label_map_util_test.py
@@ -14,7 +14,12 @@
 # ==============================================================================
 """Tests for object_detection.utils.label_map_util."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
+from six.moves import range
 import tensorflow as tf
 
 from google.protobuf import text_format

--- a/research/object_detection/utils/learning_schedules.py
+++ b/research/object_detection/utils/learning_schedules.py
@@ -14,7 +14,12 @@
 # ==============================================================================
 """Library of common learning rate schedules."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 import numpy as np
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 
@@ -191,7 +196,7 @@ def manual_stepping(global_step, boundaries, rates, warmup=False):
 
   if warmup and boundaries:
     slope = (rates[1] - rates[0]) * 1.0 / boundaries[0]
-    warmup_steps = range(boundaries[0])
+    warmup_steps = list(range(boundaries[0]))
     warmup_rates = [rates[0] + slope * step for step in warmup_steps]
     boundaries = warmup_steps + boundaries
     rates = warmup_rates + rates[1:]

--- a/research/object_detection/utils/learning_schedules_test.py
+++ b/research/object_detection/utils/learning_schedules_test.py
@@ -14,7 +14,12 @@
 # ==============================================================================
 
 """Tests for object_detection.utils.learning_schedules."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.utils import learning_schedules

--- a/research/object_detection/utils/metrics.py
+++ b/research/object_detection/utils/metrics.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 """Functions for computing metrics like precision, recall, CorLoc and etc."""
+from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
 import numpy as np
+from six.moves import range
 
 
 def compute_precision_recall(scores, labels, num_gt):

--- a/research/object_detection/utils/metrics_test.py
+++ b/research/object_detection/utils/metrics_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 """Tests for object_detection.metrics."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/model_util.py
+++ b/research/object_detection/utils/model_util.py
@@ -15,6 +15,10 @@
 
 """Utility functions for manipulating Keras models."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import tensorflow as tf
 
 

--- a/research/object_detection/utils/model_util_test.py
+++ b/research/object_detection/utils/model_util_test.py
@@ -15,6 +15,10 @@
 
 """Test utility functions for manipulating Keras models."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import tensorflow as tf
 
 from object_detection.utils import model_util

--- a/research/object_detection/utils/np_box_list.py
+++ b/research/object_detection/utils/np_box_list.py
@@ -15,7 +15,11 @@
 
 """Numpy BoxList classes and functions."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 import numpy as np
+from six.moves import range
 
 
 class BoxList(object):

--- a/research/object_detection/utils/np_box_list_ops_test.py
+++ b/research/object_detection/utils/np_box_list_ops_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.np_box_list_ops."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/np_box_list_test.py
+++ b/research/object_detection/utils/np_box_list_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.np_box_list_test."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/np_box_mask_list.py
+++ b/research/object_detection/utils/np_box_mask_list.py
@@ -15,6 +15,10 @@
 
 """Numpy BoxMaskList classes and functions."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 from object_detection.utils import np_box_list
 
@@ -60,4 +64,3 @@ class BoxMaskList(np_box_list.BoxList):
       a numpy array of shape [N, height, width] representing masks
     """
     return self.get_field('masks')
-

--- a/research/object_detection/utils/np_box_mask_list_ops.py
+++ b/research/object_detection/utils/np_box_mask_list_ops.py
@@ -19,7 +19,12 @@ Example box operations that are supported:
   * Areas: compute bounding box areas
   * IOU: pairwise intersection-over-union scores
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 
 from object_detection.utils import np_box_list_ops
 from object_detection.utils import np_box_mask_list

--- a/research/object_detection/utils/np_box_mask_list_ops_test.py
+++ b/research/object_detection/utils/np_box_mask_list_ops_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.np_box_mask_list_ops."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/np_box_mask_list_test.py
+++ b/research/object_detection/utils/np_box_mask_list_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.np_box_mask_list_test."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/np_box_ops.py
+++ b/research/object_detection/utils/np_box_ops.py
@@ -19,6 +19,11 @@ Example box operations that are supported:
   * Areas: compute bounding box areas
   * IOU: pairwise intersection-over-union scores
 """
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 
 

--- a/research/object_detection/utils/np_box_ops_test.py
+++ b/research/object_detection/utils/np_box_ops_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.np_box_ops."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/np_mask_ops.py
+++ b/research/object_detection/utils/np_mask_ops.py
@@ -19,6 +19,11 @@ Example mask operations that are supported:
   * Areas: compute mask areas
   * IOU: pairwise intersection-over-union scores
 """
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 
 EPSILON = 1e-7

--- a/research/object_detection/utils/np_mask_ops_test.py
+++ b/research/object_detection/utils/np_mask_ops_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.np_mask_ops."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/object_detection_evaluation_test.py
+++ b/research/object_detection/utils/object_detection_evaluation_test.py
@@ -15,8 +15,13 @@
 
 """Tests for object_detection.utils.object_detection_evaluation."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
+import six
+from six.moves import range
 import tensorflow as tf
 from object_detection import eval_util
 from object_detection.core import standard_fields
@@ -310,17 +315,14 @@ class OpenImagesChallengeEvaluatorTest(tf.test.TestCase):
     expected_metric_name = 'OpenImagesInstanceSegmentationChallenge'
 
     self.assertAlmostEqual(
-        metrics[
-            expected_metric_name + '_PerformanceByCategory/AP@0.5IOU/dog'],
-        0.5)
+        metrics[expected_metric_name + '_PerformanceByCategory/AP@0.5IOU/dog'],
+        1.0)
     self.assertAlmostEqual(
         metrics[
             expected_metric_name + '_PerformanceByCategory/AP@0.5IOU/cat'],
         0)
     self.assertAlmostEqual(
-        metrics[
-            expected_metric_name + '_Precision/mAP@0.5IOU'],
-        0.25)
+        metrics[expected_metric_name + '_Precision/mAP@0.5IOU'], 0.5)
 
     oivchallenge_evaluator.clear()
     self.assertFalse(oivchallenge_evaluator._image_ids)
@@ -925,7 +927,7 @@ class ObjectDetectionEvaluationTest(tf.test.TestCase):
     ]
     expected_average_precision_per_class = np.array([1. / 6., 0, 0],
                                                     dtype=float)
-    expected_corloc_per_class = np.array([0, np.divide(0, 0), 0], dtype=float)
+    expected_corloc_per_class = np.array([0, 0, 0], dtype=float)
     expected_mean_ap = 1. / 18
     expected_mean_corloc = 0.0
     for i in range(self.od_eval.num_class):
@@ -1069,7 +1071,7 @@ class ObjectDetectionEvaluatorTest(tf.test.TestCase, parameterized.TestCase):
 
     with self.test_session() as sess:
       metrics = {}
-      for key, (value_op, _) in metric_ops.iteritems():
+      for key, (value_op, _) in six.iteritems(metric_ops):
         metrics[key] = value_op
       sess.run(update_op)
       metrics = sess.run(metrics)

--- a/research/object_detection/utils/ops.py
+++ b/research/object_detection/utils/ops.py
@@ -14,10 +14,16 @@
 # ==============================================================================
 
 """A module for helper tensorflow ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import collections
 import math
 import six
 
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields

--- a/research/object_detection/utils/ops_test.py
+++ b/research/object_detection/utils/ops_test.py
@@ -14,7 +14,13 @@
 # ==============================================================================
 
 """Tests for object_detection.utils.ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+import six
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields
@@ -436,7 +442,7 @@ class GroundtruthFilterTest(tf.test.TestCase):
         fields.InputDataFields.groundtruth_is_crowd: [False],
         fields.InputDataFields.groundtruth_area: [32],
         fields.InputDataFields.groundtruth_difficult: [True],
-        fields.InputDataFields.groundtruth_label_types: ['APPROPRIATE'],
+        fields.InputDataFields.groundtruth_label_types: [six.b('APPROPRIATE')],
         fields.InputDataFields.groundtruth_confidences: [0.99],
     }
     with self.test_session() as sess:
@@ -610,7 +616,7 @@ class RetainGroundTruthWithPositiveClasses(tf.test.TestCase):
         fields.InputDataFields.groundtruth_is_crowd: [False],
         fields.InputDataFields.groundtruth_area: [32],
         fields.InputDataFields.groundtruth_difficult: [True],
-        fields.InputDataFields.groundtruth_label_types: ['APPROPRIATE'],
+        fields.InputDataFields.groundtruth_label_types: [six.b('APPROPRIATE')],
         fields.InputDataFields.groundtruth_confidences: [0.99],
     }
     with self.test_session() as sess:
@@ -819,8 +825,8 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     image_shape = [3, 2, 6]
 
     # First channel is 1's, second channel is 2's, etc.
-    image = tf.constant(range(1, 3 * 2 + 1) * 6, dtype=tf.float32,
-                        shape=image_shape)
+    image = tf.constant(
+        list(range(1, 3 * 2 + 1)) * 6, dtype=tf.float32, shape=image_shape)
     boxes = tf.random_uniform((2, 4))
 
     # The result for both boxes should be [[1, 2], [3, 4], [5, 6]]
@@ -841,8 +847,8 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     image_shape = [3, 3, 4]
     crop_size = [2, 2]
 
-    image = tf.constant(range(1, 3 * 3 + 1), dtype=tf.float32,
-                        shape=[3, 3, 1])
+    image = tf.constant(
+        list(range(1, 3 * 3 + 1)), dtype=tf.float32, shape=[3, 3, 1])
     tiled_image = tf.tile(image, [1, 1, image_shape[2]])
     boxes = tf.random_uniform((3, 4))
     box_ind = tf.constant([0, 0, 0], dtype=tf.int32)
@@ -908,8 +914,8 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     num_boxes = 2
 
     # First channel is 1's, second channel is 2's, etc.
-    image = tf.constant(range(1, 3 * 2 + 1) * 6, dtype=tf.float32,
-                        shape=image_shape)
+    image = tf.constant(
+        list(range(1, 3 * 2 + 1)) * 6, dtype=tf.float32, shape=image_shape)
     boxes = tf.random_uniform((num_boxes, 4))
 
     expected_output = []
@@ -945,8 +951,8 @@ class OpsTestPositionSensitiveCropRegions(tf.test.TestCase):
     num_boxes = 2
 
     # First channel is 1's, second channel is 2's, etc.
-    image = tf.constant(range(1, 3 * 2 + 1) * 6, dtype=tf.float32,
-                        shape=image_shape)
+    image = tf.constant(
+        list(range(1, 3 * 2 + 1)) * 6, dtype=tf.float32, shape=image_shape)
     boxes = tf.random_uniform((num_boxes, 4))
 
     expected_output = []
@@ -1031,8 +1037,8 @@ class OpsTestBatchPositionSensitiveCropRegions(tf.test.TestCase):
     image_shape = [2, 2, 2, 4]
     crop_size = [2, 2]
 
-    images = tf.constant(range(1, 2 * 2 * 4  + 1) * 2, dtype=tf.float32,
-                         shape=image_shape)
+    images = tf.constant(
+        list(range(1, 2 * 2 * 4 + 1)) * 2, dtype=tf.float32, shape=image_shape)
 
     # First box contains whole image, and second box contains only first row.
     boxes = tf.constant(np.array([[[0., 0., 1., 1.]],

--- a/research/object_detection/utils/per_image_evaluation.py
+++ b/research/object_detection/utils/per_image_evaluation.py
@@ -20,7 +20,12 @@ detection is supported by default.
 Based on the settings, per image evaluation is either performed on boxes or
 on object masks.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 
 from object_detection.utils import np_box_list
 from object_detection.utils import np_box_list_ops

--- a/research/object_detection/utils/per_image_evaluation_test.py
+++ b/research/object_detection/utils/per_image_evaluation_test.py
@@ -15,7 +15,12 @@
 
 """Tests for object_detection.utils.per_image_evaluation."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.utils import per_image_evaluation

--- a/research/object_detection/utils/per_image_vrd_evaluation.py
+++ b/research/object_detection/utils/per_image_vrd_evaluation.py
@@ -19,7 +19,12 @@ a predefined IOU ratio. Multi-class detection is supported by default.
 Based on the settings, per image evaluation is performed either on phrase
 detection subtask or on relation detection subtask.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
 
 from object_detection.utils import np_box_list
 from object_detection.utils import np_box_list_ops

--- a/research/object_detection/utils/per_image_vrd_evaluation_test.py
+++ b/research/object_detection/utils/per_image_vrd_evaluation_test.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for object_detection.utils.per_image_vrd_evaluation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/shape_utils.py
+++ b/research/object_detection/utils/shape_utils.py
@@ -15,6 +15,11 @@
 
 """Utils used to manipulate tensor shapes."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.utils import static_shape

--- a/research/object_detection/utils/shape_utils_test.py
+++ b/research/object_detection/utils/shape_utils_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.shape_utils."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/spatial_transform_ops_test.py
+++ b/research/object_detection/utils/spatial_transform_ops_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.utils import spatial_transform_ops as spatial_ops

--- a/research/object_detection/utils/static_shape.py
+++ b/research/object_detection/utils/static_shape.py
@@ -18,6 +18,10 @@
 The rank 4 tensor_shape must be of the form [batch_size, height, width, depth].
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 
 def get_dim_as_int(dim):
   """Utility to get v1 or v2 TensorShape dim as an int.

--- a/research/object_detection/utils/static_shape_test.py
+++ b/research/object_detection/utils/static_shape_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.static_shape."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import tensorflow as tf
 
 from object_detection.utils import static_shape

--- a/research/object_detection/utils/test_case.py
+++ b/research/object_detection/utils/test_case.py
@@ -14,7 +14,11 @@
 # ==============================================================================
 """A convenience wrapper around tf.test.TestCase to enable TPU tests."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 import os
+from six.moves import zip
 import tensorflow as tf
 from tensorflow.contrib import tpu
 

--- a/research/object_detection/utils/test_utils.py
+++ b/research/object_detection/utils/test_utils.py
@@ -14,7 +14,13 @@
 # ==============================================================================
 
 """Contains functions which are convenient for unit testing."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import anchor_generator

--- a/research/object_detection/utils/test_utils_test.py
+++ b/research/object_detection/utils/test_utils_test.py
@@ -15,6 +15,10 @@
 
 """Tests for object_detection.utils.test_utils."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 

--- a/research/object_detection/utils/variables_helper.py
+++ b/research/object_detection/utils/variables_helper.py
@@ -15,6 +15,11 @@
 
 """Helper functions for manipulating collections of variables during training.
 """
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
 import re
 
@@ -44,7 +49,7 @@ def filter_variables(variables, filter_regex_list, invert=False):
     a list of filtered variables.
   """
   kept_vars = []
-  variables_to_ignore_patterns = list(filter(None, filter_regex_list))
+  variables_to_ignore_patterns = list([fre for fre in filter_regex_list if fre])
   for var in variables:
     add = True
     for pattern in variables_to_ignore_patterns:
@@ -151,5 +156,24 @@ def get_variables_available_in_checkpoint(variables,
       logging.warning('Variable [%s] is not available in checkpoint',
                       variable_name)
   if isinstance(variables, list):
-    return vars_in_ckpt.values()
+    return list(vars_in_ckpt.values())
   return vars_in_ckpt
+
+
+def get_global_variables_safely():
+  """If not executing eagerly, returns tf.global_variables().
+
+  Raises a ValueError if eager execution is enabled,
+  because the variables are not tracked when executing eagerly.
+
+  If executing eagerly, use a Keras model's .variables property instead.
+
+  Returns:
+    The result of tf.global_variables()
+  """
+  with tf.init_scope():
+    if tf.executing_eagerly():
+      raise ValueError("Global variables collection is not tracked when "
+                       "executing eagerly. Use a Keras model's `.variables` "
+                       "attribute instead.")
+  return tf.global_variables()

--- a/research/object_detection/utils/variables_helper_test.py
+++ b/research/object_detection/utils/variables_helper_test.py
@@ -14,6 +14,11 @@
 # ==============================================================================
 
 """Tests for object_detection.utils.variables_helper."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
 import tensorflow as tf
@@ -204,7 +209,7 @@ class GetVariablesAvailableInCheckpointTest(tf.test.TestCase):
           graph2_variables_dict, checkpoint_path)
 
     self.assertTrue(isinstance(out_variables, dict))
-    self.assertItemsEqual(out_variables.keys(), ['ckpt_weights'])
+    self.assertItemsEqual(list(out_variables.keys()), ['ckpt_weights'])
     self.assertTrue(out_variables['ckpt_weights'].op.name == 'weights')
 
   def test_return_variables_with_correct_sizes(self):

--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -19,6 +19,10 @@ These functions often receive an image, perform some visualization on the image.
 The functions do not return a value, instead they modify the image itself.
 
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import abc
 import collections
 # Set headless-friendly backend.
@@ -30,6 +34,8 @@ import PIL.ImageColor as ImageColor
 import PIL.ImageDraw as ImageDraw
 import PIL.ImageFont as ImageFont
 import six
+from six.moves import range
+from six.moves import zip
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields
@@ -771,7 +777,7 @@ def visualize_boxes_and_labels_on_image_array(
         display_str = ''
         if not skip_labels:
           if not agnostic_mode:
-            if classes[i] in category_index.keys():
+            if classes[i] in six.viewkeys(category_index):
               class_name = category_index[classes[i]]['name']
             else:
               class_name = 'N/A'
@@ -894,7 +900,7 @@ def add_hist_image_summary(values, bins, name):
   tf.summary.image(name, hist_plot)
 
 
-class EvalMetricOpsVisualization(object):
+class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
   """Abstract base class responsible for visualizations during evaluation.
 
   Currently, summary images are not run during evaluation. One way to produce
@@ -903,7 +909,6 @@ class EvalMetricOpsVisualization(object):
   responsible for accruing images (with overlaid detections and groundtruth)
   and returning a dictionary that can be passed to `eval_metric_ops`.
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self,
                category_index,

--- a/research/object_detection/utils/visualization_utils_test.py
+++ b/research/object_detection/utils/visualization_utils_test.py
@@ -14,11 +14,17 @@
 # ==============================================================================
 
 """Tests for object_detection.utils.visualization_utils."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
 import os
 
 import numpy as np
 import PIL.Image as Image
+import six
+from six.moves import range
 import tensorflow as tf
 
 from object_detection.core import standard_fields as fields
@@ -387,12 +393,12 @@ class VisualizationUtilsTest(tf.test.TestCase):
             groundtruth_classes
     }
     metric_ops = eval_metric_ops.get_estimator_eval_metric_ops(eval_dict)
-    _, update_op = metric_ops[metric_ops.keys()[0]]
+    _, update_op = metric_ops[next(six.iterkeys(metric_ops))]
 
     with self.test_session() as sess:
       sess.run(tf.global_variables_initializer())
       value_ops = {}
-      for key, (value_op, _) in metric_ops.iteritems():
+      for key, (value_op, _) in six.iteritems(metric_ops):
         value_ops[key] = value_op
 
       # First run enough update steps to surpass `max_examples_to_draw`.
@@ -413,7 +419,7 @@ class VisualizationUtilsTest(tf.test.TestCase):
                                    [6 + i, 7 + i, 3], [6 + i, 7 + i, 3]]
             })
       value_ops_out = sess.run(value_ops)
-      for key, value_op in value_ops_out.iteritems():
+      for key, value_op in six.iteritems(value_ops_out):
         self.assertNotEqual('', value_op)
 
       # Now run fewer update steps than `max_examples_to_draw`. A single value
@@ -437,7 +443,7 @@ class VisualizationUtilsTest(tf.test.TestCase):
             })
       value_ops_out = sess.run(value_ops)
       self.assertEqual(
-          '',
+          six.b(''),
           value_ops_out[metric_op_base + '/' + str(max_examples_to_draw - 1)])
 
 

--- a/research/object_detection/utils/vrd_evaluation.py
+++ b/research/object_detection/utils/vrd_evaluation.py
@@ -27,10 +27,16 @@ Note1: groundtruth should be inserted before evaluation.
 Note2: This module operates on numpy boxes and box lists.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from abc import abstractmethod
 import collections
 import logging
 import numpy as np
+import six
+from six.moves import range
 
 from object_detection.core import standard_fields
 from object_detection.utils import metrics
@@ -179,7 +185,7 @@ class VRDDetectionEvaluator(object_detection_evaluation.DetectionEvaluator):
           datatype label_data_type above).
     """
     if image_id not in self._image_ids:
-      logging.warn('No groundtruth for the image with id %s.', image_id)
+      logging.warning('No groundtruth for the image with id %s.', image_id)
       # Since for the correct work of evaluator it is assumed that groundtruth
       # is inserted first we make sure to break the code if is it not the case.
       self._image_ids.update([image_id])
@@ -252,12 +258,12 @@ class VRDDetectionEvaluator(object_detection_evaluation.DetectionEvaluator):
             recall_100,
     }
     if relationships:
-      for key, average_precision in average_precisions.iteritems():
+      for key, average_precision in six.iteritems(average_precisions):
         vrd_metrics[self._metric_prefix + 'AP@{}IOU/{}'.format(
             self._matching_iou_threshold,
             relationships[key])] = average_precision
     else:
-      for key, average_precision in average_precisions.iteritems():
+      for key, average_precision in six.iteritems(average_precisions):
         vrd_metrics[self._metric_prefix + 'AP@{}IOU/{}'.format(
             self._matching_iou_threshold, key)] = average_precision
 
@@ -352,7 +358,7 @@ class VRDPhraseDetectionEvaluator(VRDDetectionEvaluator):
         where the named bounding box is computed as an enclosing bounding box
         of all bounding boxes of the i-th input structure.
     """
-    first_box_key = groundtruth_box_tuples.dtype.fields.keys()[0]
+    first_box_key = next(six.iterkeys(groundtruth_box_tuples.dtype.fields))
     miny = groundtruth_box_tuples[first_box_key][:, 0]
     minx = groundtruth_box_tuples[first_box_key][:, 1]
     maxy = groundtruth_box_tuples[first_box_key][:, 2]
@@ -388,7 +394,7 @@ class VRDPhraseDetectionEvaluator(VRDDetectionEvaluator):
         where the named bounding box is computed as an enclosing bounding box
         of all bounding boxes of the i-th input structure.
     """
-    first_box_key = detections_box_tuples.dtype.fields.keys()[0]
+    first_box_key = next(six.iterkeys(detections_box_tuples.dtype.fields))
     miny = detections_box_tuples[first_box_key][:, 0]
     minx = detections_box_tuples[first_box_key][:, 1]
     maxy = detections_box_tuples[first_box_key][:, 2]
@@ -459,7 +465,7 @@ class _VRDDetectionEvaluation(object):
           possibly additional classes.
     """
     if image_key in self._groundtruth_box_tuples:
-      logging.warn(
+      logging.warning(
           'image %s has already been added to the ground truth database.',
           image_key)
       return
@@ -536,7 +542,7 @@ class _VRDDetectionEvaluation(object):
         median_rank@100: median rank computed on 100 top-scoring samples.
     """
     if self._num_gt_instances == 0:
-      logging.warn('No ground truth instances')
+      logging.warning('No ground truth instances')
 
     if not self._scores:
       scores = np.array([], dtype=float)
@@ -546,8 +552,8 @@ class _VRDDetectionEvaluation(object):
       tp_fp_labels = np.concatenate(self._tp_fp_labels)
       relation_field_values = np.concatenate(self._relation_field_values)
 
-    for relation_field_value, _ in (
-        self._num_gt_instances_per_relationship.iteritems()):
+    for relation_field_value, _ in (six.iteritems(
+        self._num_gt_instances_per_relationship)):
       precisions, recalls = metrics.compute_precision_recall(
           scores[relation_field_values == relation_field_value],
           tp_fp_labels[relation_field_values == relation_field_value],
@@ -556,7 +562,8 @@ class _VRDDetectionEvaluation(object):
           relation_field_value] = metrics.compute_average_precision(
               precisions, recalls)
 
-    self._mean_average_precision = np.mean(self._average_precisions.values())
+    self._mean_average_precision = np.mean(
+        list(self._average_precisions.values()))
 
     self._precisions, self._recalls = metrics.compute_precision_recall(
         scores, tp_fp_labels, self._num_gt_instances)

--- a/research/object_detection/utils/vrd_evaluation_test.py
+++ b/research/object_detection/utils/vrd_evaluation_test.py
@@ -14,6 +14,10 @@
 # ==============================================================================
 """Tests for tensorflow_models.object_detection.utils.vrd_evaluation."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import numpy as np
 import tensorflow as tf
 


### PR DESCRIPTION
257914648  by lzc:

    Internal changes

--
257525973  by Zhichao Lu:

    Fixes bug that silently prevents checkpoints from loading when training w/ eager + functions. Also sets up scripts to run training.

--
257296614  by Zhichao Lu:

    Adding detection_features to model outputs

--
257234565  by Zhichao Lu:

    Fix wrong order of `classes_with_max_scores` in class-agnostic NMS caused by
    sorting in partitioned-NMS.

--
257232002  by ronnyvotel:

    Supporting `filter_nonoverlapping` option in np_box_list_ops.clip_to_window().

--
257198282  by Zhichao Lu:

    Adding the focal loss and l1 loss from the Objects as Points paper.

--
257089535  by Zhichao Lu:

    Create Keras based ssd + resnetv1 + fpn.

--
257087407  by Zhichao Lu:

    Make object_detection/data_decoders Python3-compatible.

--
257004582  by Zhichao Lu:

    Updates _decode_raw_data_into_masks_and_boxes to the latest binary masks-to-string encoding format.

--
257002124  by Zhichao Lu:

    Make object_detection/utils Python3-compatible, except json_utils.

    The patching trick used in json_utils is not going to work in Python 3.

--
256795056  by lzc:

    Add a detection_anchor_indices field to detection outputs.

--
256477542  by Zhichao Lu:

    Make object_detection/core Python3-compatible.

--
256387593  by Zhichao Lu:

    Edit class_id_function_approximations builder to skip class ids not present in label map.

--
256259039  by Zhichao Lu:

    Move NMS to TPU for FasterRCNN.

--
256071360  by rathodv:

    When multiclass_scores is empty, add one-hot encoding of groundtruth_classes as multiclass scores so that data_augmentation ops that expect the presence of multiclass_scores don't have to individually handle this case.

    Also copy input tensor_dict to out_tensor_dict first to avoid inplace modification.

--
256023645  by Zhichao Lu:

    Adds the first WIP iterations of TensorFlow v2 eager + functions style custom training & evaluation loops.

--
255980623  by Zhichao Lu:

    Adds a new data augmentation operation "remap_labels" which remaps a set of labels to a new label.

--
255753259  by Zhichao Lu:

    Announcement of the released evaluation tutorial for Open Images Challenge
    2019.

--
255698776  by lzc:

    Fix rewrite_nn_resize_op function which was broken by tf forward compatibility movement.

--
255623150  by Zhichao Lu:

    Add Keras-based ResnetV1 models.

--
255504992  by Zhichao Lu:

    Fixing the typo in specifying label expansion for ground truth segmentation
    file.

--
255470768  by Zhichao Lu:

    1. Fixing Python bug with parsed arguments.
    2. Adding capability to parse relevant columns from CSV header.
    3. Fixing bug with duplicated labels expansion.

--
255462432  by Zhichao Lu:

    Adds a new data augmentation operation "drop_label_probabilistically" which drops a given label with the given probability. This supports experiments on training in the presence of label noise.

--
255441632  by rathodv:

    Fallback on groundtruth classes when multiclass_scores tensor is empty.

--
255434899  by Zhichao Lu:

    Ensuring evaluation binary can run even with big files by synchronizing
    processing of ground truth and predictions: in this way, ground truth is not stored but immediatly
    used for evaluation. In case gt of object masks, this allows to run
    evaluations on relatively large sets.

--
255337855  by lzc:

    Internal change.

--
255308908  by Zhichao Lu:

    Add comment to clarify usage of calibration parameters proto.

--
255266371  by Zhichao Lu:

    Ensuring correct processing of the case, when no groundtruth masks are provided
    for an image.

--
255236648  by Zhichao Lu:

    Refactor model_builder in faster_rcnn.py to a util_map, so that it's possible to be overwritten.

--
255093285  by Zhichao Lu:

    Updating capability to subsample data during evaluation

--
255081222  by rathodv:

    Convert groundtruth masks to be of type float32 before its used in the loss function.

    When using mixed precision training, masks are represented using bfloat16 tensors in the input pipeline for performance reasons. We need to convert them to float32 before using it in the loss function.

--
254788436  by Zhichao Lu:

    Add forward_compatible to non_max_suppression_with_scores to make it is
    compatible with older tensorflow version.

--
254442362  by Zhichao Lu:

    Add num_layer field to ssd feature extractor proto.

--
253911582  by jonathanhuang:

    Plumbs Soft-NMS options (using the new tf.image.non_max_suppression_with_scores op) into the TF Object Detection API.  It adds a `soft_nms_sigma` field to the postprocessing proto file and plumbs this through to both the multiclass and class_agnostic versions of NMS. Note that there is no effect on behavior of NMS when soft_nms_sigma=0 (which it is set to by default).

    See also "Soft-NMS -- Improving Object Detection With One Line of Code" by Bodla et al (https://arxiv.org/abs/1704.04503)

--
253703949  by Zhichao Lu:

    Internal test fixes.

--
253151266  by Zhichao Lu:

    Fix the op type check for FusedBatchNorm, given that we introduced
    FusedBatchNormV3 in a previous change.

--
252718956  by Zhichao Lu:

    Customize activation function to enable relu6 instead of relu for saliency
    prediction model seastarization

--
252158593  by Zhichao Lu:

    Make object_detection/core Python3-compatible.

--
252150717  by Zhichao Lu:

    Make object_detection/core Python3-compatible.

--
251967048  by Zhichao Lu:

    Make GraphRewriter proto extensible.

--
251950039  by Zhichao Lu:

    Remove experimental_export_device_assignment from TPUEstimator.export_savedmodel(), so as to remove rewrite_for_inference().

    As a replacement, export_savedmodel() V2 API supports device_assignment where user call tpu.rewrite in model_fn and pass in device_assigment there.

--
251890697  by rathodv:

    Updated docstring to include new output nodes.

--
251662894  by Zhichao Lu:

    Add autoaugment augmentation option to objection detection api codebase. This
    is an available option in preprocessor.py.

    The intended usage of autoaugment is to be done along with random flipping and
    cropping for best results.

--
251532908  by Zhichao Lu:

    Add TrainingDataType enum to track whether class-specific or agnostic data was used to fit the calibration function.

    This is useful, since classes with few observations may require a calibration function fit on all classes.

--
251511339  by Zhichao Lu:

    Add multiclass isotonic regression to the calibration builder.

--
251317769  by pengchong:

    Internal Change.

--
250729989  by Zhichao Lu:

    Fixing bug in gt statistics count in case of mask and box annotations.

--
250729627  by Zhichao Lu:

    Label expansion for segmentation.

--
250724905  by Zhichao Lu:

    Fix use_depthwise in fpn and test it with fpnlite on ssd + mobilenet v2.

--
250670379  by Zhichao Lu:

    Internal change

250630364  by lzc:

    Fix detection_model_zoo footnotes

--
250560654  by Zhichao Lu:

    Fix static shape issue in matmul_crop_and_resize.

--
250534857  by Zhichao Lu:

    Edit class agnostic calibration function docstring to more accurately describe the function's outputs.

--
250533277  by Zhichao Lu:

    Edit the multiclass messages to use class ids instead of labels.

--

PiperOrigin-RevId: 257914648