### PR TITLE
Fix for TF-models #7216: CIFAR-10 tutorial for multi-GPU fails becaus…

### DIFF
--- a/tutorials/image/cifar10/cifar10_multi_gpu_train.py
+++ b/tutorials/image/cifar10/cifar10_multi_gpu_train.py
@@ -163,6 +163,8 @@ def train():
 
     # Get images and labels for CIFAR-10.
     images, labels = cifar10.distorted_inputs()
+    images = tf.reshape(images, [cifar10.FLAGS.batch_size, 24, 24, 3])
+    labels = tf.reshape(labels, [cifar10.FLAGS.batch_size])
     batch_queue = tf.contrib.slim.prefetch_queue.prefetch_queue(
           [images, labels], capacity=2 * FLAGS.num_gpus)
     # Calculate the gradients for each model tower.


### PR DESCRIPTION
…e full shape isn't passed to prefetch_queue contributed by mattmann.