### PR TITLE
Guard the unsafe tf.exp operations to prevent possible INF or NAN values

### DIFF
--- a/research/deep_speech/deep_speech.py
+++ b/research/deep_speech/deep_speech.py
@@ -223,7 +223,7 @@ def run_deep_speech(_):
 
   # Use distribution strategy for multi-gpu training
   num_gpus = flags_core.get_num_gpus(flags_obj)
-  distribution_strategy = distribution_utils.get_distribution_strategy(num_gpus)
+  distribution_strategy = distribution_utils.get_distribution_strategy(num_gpus=num_gpus)
   run_config = tf.estimator.RunConfig(
       train_distribute=distribution_strategy)
 

--- a/research/object_detection/box_coders/faster_rcnn_box_coder.py
+++ b/research/object_detection/box_coders/faster_rcnn_box_coder.py
@@ -107,8 +107,8 @@ class FasterRcnnBoxCoder(box_coder.BoxCoder):
       tx /= self._scale_factors[1]
       th /= self._scale_factors[2]
       tw /= self._scale_factors[3]
-    w = tf.exp(tw) * wa
-    h = tf.exp(th) * ha
+    w = tf.exp(tf.minimum(tw, 80)) * wa
+    h = tf.exp(tf.minimum(th, 80)) * ha
     ycenter = ty * ha + ycenter_a
     xcenter = tx * wa + xcenter_a
     ymin = ycenter - h / 2.


### PR DESCRIPTION
The inputs of `tf.exp` come from a `conv2d`, without any guard. The inputs of `tf.exp` can be large than 88 (`tf.exp(x)` with `x>88` if stored in `tf.float32` will cause INF) during training, which may cause INF values. The INF values will further influence the back propagation to cause NAN values.

Not sure if the latest issues are related. [6825](https://github.com/tensorflow/models/issues/6825) [6536](https://github.com/tensorflow/models/issues/6536)