### PR TITLE
Improve Keras graph performance for ResNet56

### DIFF
--- a/official/resnet/cifar10_main.py
+++ b/official/resnet/cifar10_main.py
@@ -114,7 +114,8 @@ def input_fn(is_training,
              dtype=tf.float32,
              datasets_num_private_threads=None,
              parse_record_fn=parse_record,
-             input_context=None):
+             input_context=None,
+             drop_remainder=False):
   """Input function which provides batches for train or eval.
 
   Args:
@@ -127,6 +128,8 @@ def input_fn(is_training,
     parse_record_fn: Function to use for parsing the records.
     input_context: A `tf.distribute.InputContext` object passed in by
       `tf.distribute.Strategy`.
+    drop_remainder: A boolean indicates whether to drop the remainder of the
+      batches. If True, the batch dimension will be static.
 
   Returns:
     A dataset that can be used for iteration.
@@ -149,7 +152,8 @@ def input_fn(is_training,
       parse_record_fn=parse_record_fn,
       num_epochs=num_epochs,
       dtype=dtype,
-      datasets_num_private_threads=datasets_num_private_threads
+      datasets_num_private_threads=datasets_num_private_threads,
+      drop_remainder=drop_remainder
   )
 
 

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -228,6 +228,18 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_tweaked(self):
+    """Test 1 gpu with manual config tuning."""
+    self._setup()
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = True
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_tweaked')
+    FLAGS.batch_size = 128
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.enable_grappler_layout_optimizer
+    self._run_and_report_benchmark()
+
   def benchmark_graph_1_gpu(self):
     """Test 1 gpu graph."""
     self._setup()
@@ -236,6 +248,18 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu')
     FLAGS.batch_size = 128
+    self._run_and_report_benchmark()
+
+  def benchmark_graph_1_gpu_tweaked(self):
+    """Test 1 gpu graph."""
+    self._setup()
+    FLAGS.num_gpus = 1
+    FLAGS.enable_eager = False
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_tweaked')
+    FLAGS.batch_size = 128
+    FLAGS.tf_gpu_thread_mode = 'gpu_private'
+    FLAGS.enable_grappler_layout_optimizer = False
     self._run_and_report_benchmark()
 
   def benchmark_1_gpu_no_dist_strat(self):

--- a/official/resnet/keras/keras_cifar_benchmark.py
+++ b/official/resnet/keras/keras_cifar_benchmark.py
@@ -228,18 +228,6 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
-  def benchmark_1_gpu_tweaked(self):
-    """Test 1 gpu with manual config tuning."""
-    self._setup()
-    FLAGS.num_gpus = 1
-    FLAGS.enable_eager = True
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_tweaked')
-    FLAGS.batch_size = 128
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.enable_grappler_layout_optimizer
-    self._run_and_report_benchmark()
-
   def benchmark_graph_1_gpu(self):
     """Test 1 gpu graph."""
     self._setup()
@@ -248,18 +236,6 @@ class Resnet56KerasBenchmarkBase(keras_benchmark.KerasBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu')
     FLAGS.batch_size = 128
-    self._run_and_report_benchmark()
-
-  def benchmark_graph_1_gpu_tweaked(self):
-    """Test 1 gpu graph."""
-    self._setup()
-    FLAGS.num_gpus = 1
-    FLAGS.enable_eager = False
-    FLAGS.distribution_strategy = 'default'
-    FLAGS.model_dir = self._get_model_dir('benchmark_graph_1_gpu_tweaked')
-    FLAGS.batch_size = 128
-    FLAGS.tf_gpu_thread_mode = 'gpu_private'
-    FLAGS.enable_grappler_layout_optimizer = False
     self._run_and_report_benchmark()
 
   def benchmark_1_gpu_no_dist_strat(self):

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -128,6 +128,14 @@ def run(flags_obj):
       all_reduce_alg=flags_obj.all_reduce_alg,
       num_packs=flags_obj.num_packs)
 
+  if strategy:
+    # flags_obj.enable_get_next_as_optional controls whether enabling
+    # get_next_as_optional behavior in DistributedIterator. If true, last
+    # partial batch can be supported.
+    strategy.extended.experimental_enable_get_next_as_optional = (
+        flags_obj.enable_get_next_as_optional
+    )
+
   strategy_scope = distribution_utils.get_strategy_scope(strategy)
 
   if flags_obj.use_synthetic_data:
@@ -137,7 +145,8 @@ def run(flags_obj):
         width=cifar_main.WIDTH,
         num_channels=cifar_main.NUM_CHANNELS,
         num_classes=cifar_main.NUM_CLASSES,
-        dtype=flags_core.get_tf_dtype(flags_obj))
+        dtype=flags_core.get_tf_dtype(flags_obj),
+        drop_remainder=True)
   else:
     distribution_utils.undo_set_up_synthetic_data()
     input_fn = cifar_main.input_fn
@@ -149,7 +158,11 @@ def run(flags_obj):
       num_epochs=flags_obj.train_epochs,
       parse_record_fn=parse_record_keras,
       datasets_num_private_threads=flags_obj.datasets_num_private_threads,
-      dtype=dtype)
+      dtype=dtype,
+      # Setting drop_remainder to avoid the partial batch logic in normalization
+      # layer, which triggers tf.where and leads to extra memory copy of input
+      # sizes between host and GPU.
+      drop_remainder=(not flags_obj.enable_get_next_as_optional))
 
   eval_input_dataset = None
   if not flags_obj.skip_eval:

--- a/official/resnet/keras/keras_cifar_main.py
+++ b/official/resnet/keras/keras_cifar_main.py
@@ -99,8 +99,16 @@ def run(flags_obj):
   Returns:
     Dictionary of training and eval stats.
   """
-  keras_utils.set_session_config(enable_eager=flags_obj.enable_eager,
-                                 enable_xla=flags_obj.enable_xla)
+  keras_utils.set_session_config(
+      enable_eager=flags_obj.enable_eager,
+      enable_xla=flags_obj.enable_xla,
+      enable_grappler_layout_optimizer=
+      flags_obj.enable_grappler_layout_optimizer)
+
+  # Execute flag override logic for better model performance
+  if flags_obj.tf_gpu_thread_mode:
+    keras_common.set_gpu_thread_mode_and_count(flags_obj)
+  keras_common.set_cudnn_batchnorm_mode()
 
   dtype = flags_core.get_tf_dtype(flags_obj)
   if dtype == 'fp16':


### PR DESCRIPTION
This change should bring Keras graph performance close to legacy graph. The major problem in current code is a large number of many H2D memory copies, and the main reason for that is in the normalization layer there's a cond op that triggers input_sizes being copied for each BN layer.

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/layers/normalization.py#L471

Setting drop_remainder avoids triggering this logic and thus improves the performance.