### PR TITLE
Change how TF 2 is checked

### DIFF
--- a/official/utils/misc/keras_utils.py
+++ b/official/utils/misc/keras_utils.py
@@ -204,7 +204,5 @@ def set_config_v2(enable_xla=False,
 
 def is_v2_0():
   """Returns true if using tf 2.0."""
-  if hasattr(tf, 'contrib'):
-    return False
-  else:
-    return True
+  from tensorflow.python import tf2
+  return tf2.enabled()


### PR DESCRIPTION
The current approach checks for presence of contrib. Sometimes this is not sufficient (for e..g when testing TF 1 + enable_v2_behavior=True which is what internal tests currently do)