### PR TITLE
Revert "Change how TF 2 is checked"

### DIFF
--- a/official/utils/misc/keras_utils.py
+++ b/official/utils/misc/keras_utils.py
@@ -204,5 +204,7 @@ def set_config_v2(enable_xla=False,
 
 def is_v2_0():
   """Returns true if using tf 2.0."""
-  from tensorflow.python import tf2
-  return tf2.enabled()
+  if hasattr(tf, 'contrib'):
+    return False
+  else:
+    return True


### PR DESCRIPTION
Reverts tensorflow/models#7254

This broke all of the TF 2.0 tests.  It does not actually return true or does not seem to do so.  We should add a quick unit test since that will run on the presubmit for TF 2.0 and return True and the TF 1.0 False.  Easy unit test and we have the tools now.  