### PR TITLE
Add a new sanity check script that is able to only check incremental changes.

### DIFF
--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -1,6 +1,5 @@
 [MESSAGES CONTROL]
-disable=R,W,
-        bad-option-value
+disable=R,W,bad-option-value,trailing-newlines
 
 [REPORTS]
 # Tells whether to display a full report or only the messages

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -60,6 +60,9 @@ no-docstring-rgx=(__.*__|main)
 # Min length in lines of a function that requires a docstring.
 docstring-min-length=10
 
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=apply,input,reduce
+
 # Regular expression matching correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$
 
@@ -89,10 +92,6 @@ method-rgx=^(?:(?P<exempt>__[a-z0-9_]+__|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z
 
 # Regular expression matching correct module names
 module-rgx=^(_?[a-z][a-z0-9_]*)|__init__|PRESUBMIT|PRESUBMIT_unittest$
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=(__.*__|main|.*ArgParser)
 
 # Naming hint for variable names
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -75,6 +75,10 @@ class-rgx=^_?[A-Z][a-zA-Z0-9]*$
 # Regular expression matching correct constant names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
 # Regular expression matching correct function names
 function-rgx=^(?:(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
 

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -1,45 +1,6 @@
-[MASTER]
-
-# Specify a configuration file.
-#rcfile=
-
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-#init-hook=
-
-# Profiled execution.
-profile=no
-
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
-ignore=CVS
-
-# Pickle collected data for later comparisons.
-persistent=yes
-
-# List of plugins (as comma separated values of python modules names) to load,
-# usually to register additional checkers.
-load-plugins=
-
 [MESSAGES CONTROL]
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-enable=indexing-exception,old-raise-syntax
-        
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-disable=design,similarities,no-self-use,attribute-defined-outside-init,locally-disabled,star-args,pointless-except,bad-option-value,global-statement,fixme,suppressed-message,useless-suppression,locally-enabled,no-member,no-name-in-module,import-error,unsubscriptable-object,unbalanced-tuple-unpacking,undefined-variable,not-context-manager
-
-# Set the cache size for astng objects.
-cache-size=500
+disable=R,W,
+        bad-option-value
 
 [REPORTS]
 # Tells whether to display a full report or only the messages
@@ -49,16 +10,6 @@ reports=no
 score=no
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
-
-# Regular expression which should only match the name
-# of functions or classes which do not require a docstring.
-no-docstring-rgx=(__.*__|main)
-
-# Min length in lines of a function that requires a docstring.
-docstring-min-length=10
 
 # Regular expression matching correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -75,10 +75,6 @@ class-rgx=^_?[A-Z][a-zA-Z0-9]*$
 # Regular expression matching correct constant names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=10
-
 # Regular expression matching correct function names
 function-rgx=^(?:(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
 

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -60,9 +60,6 @@ no-docstring-rgx=(__.*__|main)
 # Min length in lines of a function that requires a docstring.
 docstring-min-length=10
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=apply,input,reduce
-
 # Regular expression matching correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$
 
@@ -92,6 +89,10 @@ method-rgx=^(?:(?P<exempt>__[a-z0-9_]+__|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z
 
 # Regular expression matching correct module names
 module-rgx=^(_?[a-z][a-z0-9_]*)|__init__|PRESUBMIT|PRESUBMIT_unittest$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|.*ArgParser)
 
 # Naming hint for variable names
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/official/utils/testing/pylint.rcfile
+++ b/official/utils/testing/pylint.rcfile
@@ -1,6 +1,45 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
 [MESSAGES CONTROL]
-disable=R,W,
-        bad-option-value
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=indexing-exception,old-raise-syntax
+        
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=design,similarities,no-self-use,attribute-defined-outside-init,locally-disabled,star-args,pointless-except,bad-option-value,global-statement,fixme,suppressed-message,useless-suppression,locally-enabled,no-member,no-name-in-module,import-error,unsubscriptable-object,unbalanced-tuple-unpacking,undefined-variable,not-context-manager
+
+# Set the cache size for astng objects.
+cache-size=500
 
 [REPORTS]
 # Tells whether to display a full report or only the messages
@@ -10,6 +49,16 @@ reports=no
 score=no
 
 [BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# Regular expression which should only match the name
+# of functions or classes which do not require a docstring.
+no-docstring-rgx=(__.*__|main)
+
+# Min length in lines of a function that requires a docstring.
+docstring-min-length=10
 
 # Regular expression matching correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$

--- a/official/utils/testing/scripts/builds_common.sh
+++ b/official/utils/testing/scripts/builds_common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Common Bash functions used by build scripts
+
+COLOR_NC='\033[0m'
+COLOR_BOLD='\033[1m'
+COLOR_LIGHT_GRAY='\033[0;37m'
+COLOR_GREEN='\033[0;32m'
+COLOR_RED='\033[0;31m'
+
+die() {
+    # Print a message and exit with code 1.
+    #
+    # Usage: die <error_message>
+    #   e.g., die "Something bad happened."
+
+    echo $@
+    exit 1
+}
+
+num_cpus() {
+    # Get the number of CPUs
+    N_CPUS=$(grep -c ^processor /proc/cpuinfo)
+    if [[ -z ${N_CPUS} ]]; then
+        die "ERROR: Unable to determine the number of CPUs"
+    fi
+
+    echo ${N_CPUS}
+}
+
+# List files changed (i.e., added, or revised) from
+# the common ancestor of HEAD and the latest master branch.
+# Usage: get_changed_files_from_master_branch
+get_changed_files_from_master_branch() {
+    ANCESTOR=$(git merge-base HEAD master origin/master)
+    git diff ${ANCESTOR} --diff-filter=d --name-only "$@"
+}
+
+# List python files changed that still exist,
+# i.e., not removed.
+# Usage: get_py_files_to_check [--incremental]
+get_py_files_to_check() {
+    if [[ "$1" == "--incremental" ]]; then
+        get_changed_files_from_master_branch -- '*.py'
+    elif [[ -z "$1" ]]; then
+        find . -name '*.py'
+    else
+        die "Found unsupported args: $@ for get_py_files_to_check."
+    fi
+}

--- a/official/utils/testing/scripts/builds_common.sh
+++ b/official/utils/testing/scripts/builds_common.sh
@@ -57,7 +57,7 @@ get_py_files_to_check() {
     if [[ "$1" == "--incremental" ]]; then
         get_changed_files_from_master_branch -- '*.py'
     elif [[ -z "$1" ]]; then
-        find . -name '*.py'
+        find official/ -name '*.py'
     else
         die "Found unsupported args: $@ for get_py_files_to_check."
     fi

--- a/official/utils/testing/scripts/ci_sanity.sh
+++ b/official/utils/testing/scripts/ci_sanity.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Sanity check script that runs tests and lint under local environment.
+# Make sure that tensorflow and pylint is installed.
+# usage: models >: ./official/utils/testing/scripts/ci_sanity.sh do_pylint --incremental
+set +x
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/builds_common.sh"
+cd "$SCRIPT_DIR/../../../.."
+MODEL_ROOT="$(pwd)"
+
+export PYTHONPATH="$PYTHONPATH:${MODEL_ROOT}"
+
+# Run pylint
+do_pylint() {
+    # Usage: do_pylint [--incremental]
+    #
+    # Options:
+    #   --incremental  Performs check on only the python files changed in the
+    #                  last non-merge git commit.
+
+    # Use this list to whitelist pylint errors
+    ERROR_WHITELIST=""
+
+    echo "ERROR_WHITELIST=\"${ERROR_WHITELIST}\""
+
+    # if [[ $# != "1" ]] && [[ $# != "2" ]]; then
+    #     echo "Invalid syntax when invoking do_pylint"
+    #     echo "Usage: do_pylint [--incremental]"
+    #     return 1
+    # fi
+
+    PYLINT_BIN="pylint"
+
+    PYTHON_SRC_FILES=$(get_py_files_to_check $1)
+    if [[ -z ${PYTHON_SRC_FILES} ]]; then
+        echo "do_pylint found no Python files to check. Returning."
+        return 0
+    fi
+
+    PYLINTRC_FILE="official/utils/testing/pylint.rcfile"
+
+    if [[ ! -f "${PYLINTRC_FILE}" ]]; then
+        die "ERROR: Cannot find pylint rc file at ${PYLINTRC_FILE}"
+    fi
+
+    NUM_SRC_FILES=$(echo ${PYTHON_SRC_FILES} | wc -w)
+    NUM_CPUS=$(num_cpus)
+
+    echo "Running pylint on ${NUM_SRC_FILES} files with ${NUM_CPUS} "\
+    "parallel jobs..."
+    echo ""
+
+    PYLINT_START_TIME=$(date +'%s')
+    OUTPUT_FILE="$(mktemp)_pylint_output.log"
+    ERRORS_FILE="$(mktemp)_pylint_errors.log"
+    NONWL_ERRORS_FILE="$(mktemp)_pylint_nonwl_errors.log"
+
+    rm -rf ${OUTPUT_FILE}
+    rm -rf ${ERRORS_FILE}
+    rm -rf ${NONWL_ERRORS_FILE}
+    touch ${NONWL_ERRORS_FILE}
+
+    ${PYLINT_BIN} --rcfile="${PYLINTRC_FILE}" --output-format=parseable \
+        --jobs=${NUM_CPUS} ${PYTHON_SRC_FILES} > ${OUTPUT_FILE} 2>&1
+    PYLINT_END_TIME=$(date +'%s')
+
+    echo ""
+    echo "pylint took $((PYLINT_END_TIME - PYLINT_START_TIME)) s"
+    echo ""
+
+    N_ERRORS=0
+    while read -r LINE; do
+        IS_WHITELISTED=0
+        for WL_REGEX in ${ERROR_WHITELIST}; do
+            if echo ${LINE} | grep -q "${WL_REGEX}"; then
+                echo "Found a whitelisted error:"
+                echo "  ${LINE}"
+                IS_WHITELISTED=1
+            fi
+        done
+
+        if [[ ${IS_WHITELISTED} == "0" ]]; then
+            echo "${LINE}" >> ${NONWL_ERRORS_FILE}
+            echo "" >> ${NONWL_ERRORS_FILE}
+            ((N_ERRORS++))
+        fi
+    done <${OUTPUT_FILE}
+
+    echo ""
+    if [[ ${N_ERRORS} != 0 ]]; then
+        echo "FAIL: Found ${N_ERRORS} non-whitelited pylint errors:"
+        cat "${NONWL_ERRORS_FILE}"
+        return 1
+    else
+        echo "PASS: No non-whitelisted pylint errors were found."
+        return 0
+    fi
+}
+
+test_result=0
+
+TESTS="$@"
+
+for t in "${TESTS}"; do
+  ${t} || test_result=$?
+done
+
+exit "${test_result}"

--- a/official/utils/testing/scripts/ci_sanity.sh
+++ b/official/utils/testing/scripts/ci_sanity.sh
@@ -39,12 +39,6 @@ do_pylint() {
 
     echo "ERROR_WHITELIST=\"${ERROR_WHITELIST}\""
 
-    # if [[ $# != "1" ]] && [[ $# != "2" ]]; then
-    #     echo "Invalid syntax when invoking do_pylint"
-    #     echo "Usage: do_pylint [--incremental]"
-    #     return 1
-    # fi
-
     PYLINT_BIN="pylint"
 
     PYTHON_SRC_FILES=$(get_py_files_to_check $1)


### PR DESCRIPTION
This is going to replace current lint presubmit.
After that, we can enforce correct lint rules. Now, in pylint.rcfile, there is a disable=W which disables most warning.