### PR TITLE
Don't return anything in main function

### DIFF
--- a/official/resnet/keras/keras_imagenet_main.py
+++ b/official/resnet/keras/keras_imagenet_main.py
@@ -269,7 +269,7 @@ def define_imagenet_keras_flags():
 def main(_):
   model_helpers.apply_clean(flags.FLAGS)
   with logger.benchmark_context(flags.FLAGS):
-    return run(flags.FLAGS)
+    run(flags.FLAGS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Returning an object causes the program to exit with a non-zero code.