### PR TITLE
Add a high max for MLPerf tests so they are green.

### DIFF
--- a/official/recommendation/ncf_keras_benchmark.py
+++ b/official/recommendation/ncf_keras_benchmark.py
@@ -115,7 +115,7 @@ class NCFKerasAccuracy(NCFKerasBenchmarkBase):
     Note: MLPerf like tests are not tuned to hit a specific hr@10 value, but
     we want it recorded.
     """
-    self._run_and_report_benchmark(hr_at_10_min=0.61)
+    self._run_and_report_benchmark(hr_at_10_min=0.61, hr_at_10_max=0.65)
 
   def _run_and_report_benchmark(self, hr_at_10_min=0.630, hr_at_10_max=0.640):
     """Run test and report results.


### PR DESCRIPTION
MLPerf tests are not for accuracy, but I want to record the number just to have it.  I set the error bars really wide so only something horrible would get caught.  We have the "early stop" tests which are used to watch accuracy.  