### PR TITLE
Merged commit includes the following changes:

### DIFF
--- a/official/bert/benchmark/bert_squad_benchmark.py
+++ b/official/bert/benchmark/bert_squad_benchmark.py
@@ -218,6 +218,54 @@ class BertSquadBenchmarkReal(BertSquadBenchmarkBase):
 
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_fp16(self):
+    """Tests BERT SQuAD model performance with 1 GPU and FP16."""
+
+    self._setup()
+    self.num_gpus = 1
+    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_squad_fp16')
+    FLAGS.train_batch_size = 4
+    FLAGS.dtype = 'fp16'
+    FLAGS.loss_scale = 'dynamic'
+
+    self._run_and_report_benchmark()
+
+  def benchmark_2_gpu_fp16(self):
+    """Tests BERT SQuAD model performance with 2 GPUs and FP16."""
+
+    self._setup()
+    self.num_gpus = 2
+    FLAGS.model_dir = self._get_model_dir('benchmark_2_gpu_squad_fp16')
+    FLAGS.train_batch_size = 8
+    FLAGS.dtype = 'fp16'
+    FLAGS.loss_scale = 'dynamic'
+
+    self._run_and_report_benchmark()
+
+  def benchmark_4_gpu_fp16(self):
+    """Tests BERT SQuAD model performance with 4 GPUs and FP16."""
+
+    self._setup()
+    self.num_gpus = 4
+    FLAGS.model_dir = self._get_model_dir('benchmark_4_gpu_squad_fp16')
+    FLAGS.train_batch_size = 16
+    FLAGS.dtype = 'fp16'
+    FLAGS.loss_scale = 'dynamic'
+
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_fp16(self):
+    """Tests BERT SQuAD model performance with 8 GPUs."""
+
+    self._setup()
+    self.num_gpus = 8
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_squad_fp16')
+    FLAGS.train_batch_size = 32
+    FLAGS.dtype = 'fp16'
+    FLAGS.loss_scale = 'dynamic'
+
+    self._run_and_report_benchmark()
+
 
 class BertSquadAccuracy(BertSquadBenchmarkBase):
   """Short accuracy test for BERT SQuAD model.
@@ -278,6 +326,18 @@ class BertSquadAccuracy(BertSquadBenchmarkBase):
     self.num_gpus = 8
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_squad')
     FLAGS.train_batch_size = 32
+
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_fp16(self):
+    """Tests BERT SQuAD model accuracy with 8 GPUs and FP16."""
+
+    self._setup()
+    self.num_gpus = 8
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_squad_fp16')
+    FLAGS.train_batch_size = 32
+    FLAGS.dtype = 'fp16'
+    FLAGS.loss_scale = 'dynamic'
 
     self._run_and_report_benchmark()
 

--- a/official/bert/bert_models.py
+++ b/official/bert/bert_models.py
@@ -318,6 +318,8 @@ class BertSquadLogitsLayer(tf.keras.layers.Layer):
     logits = tf.keras.backend.reshape(logits, [-1, sequence_length, 2])
     logits = tf.transpose(logits, [2, 0, 1])
     unstacked_logits = tf.unstack(logits, axis=0)
+    if self.float_type == tf.float16:
+      unstacked_logits = tf.cast(unstacked_logits, tf.float32)
     return unstacked_logits[0], unstacked_logits[1]
 
 

--- a/official/bert/common_flags.py
+++ b/official/bert/common_flags.py
@@ -15,6 +15,9 @@
 """Defining common flags used across all BERT models/applications."""
 
 from absl import flags
+import tensorflow as tf
+
+from official.utils.flags import core as flags_core
 
 
 def define_common_bert_flags():
@@ -42,3 +45,26 @@ def define_common_bert_flags():
       'inside.')
   flags.DEFINE_float('learning_rate', 5e-5,
                      'The initial learning rate for Adam.')
+
+  # add flags for mixed precision training.
+  flags_core.define_performance(
+      num_parallel_calls=False,
+      inter_op=False,
+      intra_op=False,
+      synthetic_data=False,
+      max_train_steps=False,
+      dtype=True,
+      dynamic_loss_scale=True,
+      loss_scale=True,
+      all_reduce_alg=False,
+      num_packs=False,
+      enable_xla=False
+  )
+
+
+def use_float16():
+  return flags_core.get_tf_dtype(flags.FLAGS) == tf.float16
+
+
+def get_loss_scale():
+  return flags_core.get_loss_scale(flags.FLAGS, default_for_fp16='dynamic')


### PR DESCRIPTION
Merged commit includes the following changes:
260060237  by zongweiz<zongweiz@google.com>:
    
    [BERT SQuAD] Enable mixed precision training
    
    Add mixed precision training support for BERT SQuAD model. Using the experimental Keras mixed precision API. For numeric stability, use fp32 for layer normalization, dense layers with GELU activation, etc.
    
--
260052674  by hongkuny<hongkuny@google.com>:
    
    Add expect_partial()
    
--
259889221  by hongkuny<hongkuny@google.com>:
    
    Add no ds / xla / eager perfzero tests
    
--
259790197  by hongkuny<hongkuny@google.com>:
    
    Update pretraining model to match tf1 var names.
    
--
259649972  by hongkuny<hongkuny@google.com>:
    
    Update docs.
    
--
259470074  by hongkuny<hongkuny@google.com>:
    
    Adds a dedup phase for trainable variables.
    
--
259442882  by hongkuny<hongkuny@google.com>:
    
    Internal
    
--
259341546  by mrry<mrry@google.com>:
    
    Remove DEBUG-level logging from the BERT benchmark.
    
    This triggers graph serialization and other verbose logging in the TensorFlow runtime, which inflates the execution time.
    
--
259253185  by hongkuny<hongkuny@google.com>:
    
    Writes a separated checkpoint for the core model in pretraining.
    Clean up export utils to just take a model as argument.
    
--
258893811  by hongkuny<hongkuny@google.com>:
    
    Adds summaries for metrics, allowing metrics inside keras.model.
    
--
258881002  by hongkuny<hongkuny@google.com>:
    
    Fix lint.
    
--
258597234  by rxsang<rxsang@google.com>:
    
    Update all the TPUStrategy examples to use the new v2 APIs, i.e.
    make_dataset_iterator -> experimental_distribute_dataset,
    make_input_fn_iterator -> experimental_distribute_datasets_from_function,
    unwrap -> experimental_local_results,
    experimental_run -> experimental_run_v2
    
--
258581998  by taylorrobie<taylorrobie@google.com>:
    
    
    Update keras v2 optimizers to reuse coefficients which are shared across all updates, which reduces the total number of ops created by between 5% (for simple optimizers such as SGD and Adagrad) and 25% (for complicated optimizers such as Adam and NAdam). Separate copies are made for each device and dtype.
    
    The effect of this change on run time is fairly minimal since Grappler is expected to consolidate most of these ops; however it does improve graph construction time.
    
    
--
258208153  by hongkuny<hongkuny@google.com>:
    
    Adds run_eagerly option for bert.
    
--
257883986  by hongkuny<hongkuny@google.com>:
    
    Adds tf.summary for bert training
    
--
256204636  by hongkuny<hongkuny@google.com>:
    
    Internal
    
--
256079834  by hongkuny<hongkuny@google.com>:
    
    Clean up: move common flags together for further refactoring
    Enable steps_per_loop option for all applications.
    
--
255493073  by hongkuny<hongkuny@google.com>:
    
    BERT initial OSS readme update.
    
--
255470372  by dmchen<dmchen@google.com>:
    
    Slightly expand expected range for F1 score in BERT SQuAD accuracy test
    
--
255109240  by hongkuny<hongkuny@google.com>:
    
    Update eval/predict batch sizes.
    
--
255010016  by hongkuny<hongkuny@google.com>:
    
    Internal
    
--
254874613  by hongkuny<hongkuny@google.com>:
    
    Update glue tasks enum to match directory name
    
--
254866171  by taylorrobie<taylorrobie@google.com>:

    Internal change

254785517  by zongweiz<zongweiz@google.com>:
    
    Use train_single_step for BERT GPU models to temporarily work around some performance bugs in GPU runs
    
--
254497647  by hongkuny<hongkuny@google.com>:
    
    Fix device placement for TPU export model.
    
--
254134531  by yuefengz<yuefengz@google.com>:
    
    Fix a typo in bert_benchmark.py
    
--
254069984  by hongkuny<hongkuny@google.com>:
    Automated rollback of changelist 254060732.

254061429  by hongkuny<hongkuny@google.com>:
    
    Use host while loop for training steps.
    
--
254060732  by yifeif<yifeif@google.com>:
    Automated rollback of changelist 254027750.

254027750  by hongkuny<hongkuny@google.com>:

    Internal change

253850824  by hongkuny<hongkuny@google.com>:
    
    Improve bert training utils.
    
--
253818191  by hongkuny<hongkuny@google.com>:
    
    Update savedmodel export to use new model.save() api.
    
--
253636854  by dmchen<dmchen@google.com>:
    
    Run only training in BERT SQuAD performance test
    
--
253118910  by hongkuny<hongkuny@google.com>:

    Internal change

253113801  by zongweiz<zongweiz@google.com>:

    Internal change

252697519  by dmchen<dmchen@google.com>:
    
    BERT SQuAD accuracy test
    
--
252663512  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Internal change
    
--
252647871  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Enable multi worker TPU training for BERT pretraining.
    
--
252522861  by hongkuny<hongkuny@google.com>:
    
    Remove export using trained model due to implementation error
    
--
252156812  by yuefengz<yuefengz@google.com>:
    
    Fix the callback method name in BERT: replaced on_batch_start with on_batch_begin. Without the fix, it won't work with Keras callbacks.
    
--
251782065  by dmchen<dmchen@google.com>:

    Internal change

251681245  by hongkuny<hongkuny@google.com>:
    
    Update bert to use the new tf.distribute APIs 
    
--
251575972  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Remove `steps_per_run` when instantiating TPUStrategy.
    
--
251325964  by hongkuny<hongkuny@google.com>:
    
    Improve flags
    
--
250942274  by tobyboyd<tobyboyd@google.com>:

    Internal change

250779087  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Reduce BERT Perfzero benchmark test training steps.
    
--
250713045  by hongkuny<hongkuny@google.com>:
    
    TPU util
    
--
250606180  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Fix BERT benchamrk test errors.
    
--
250589623  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Change BERT benchmark test pretrained checkpoint url.
    
--
250587892  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Fix error in BERT custom training loop checkpoint restoration.
    
--
250577163  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Add logic to inject callback that measures performance in BERT custom training
    loop.
    
--
250529526  by hongkuny<hongkuny@google.com>:
    
    Internal clean up
    
--
250428976  by hongkuny<hongkuny@google.com>:

    Internal change

250415383  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Add min/max value to BERT classifier benchmark test.
    
--
250376246  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Add benchmark performance test to run BERT on multiple numbers of GPUs. 
    
--
250347237  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Fix linting errors in BERT benchmark test.
    
--
250326131  by A. Unique TensorFlower<gardener@tensorflow.org>:

    Internal change

250315593  by A. Unique TensorFlower<gardener@tensorflow.org>:

    Internal change

250303528  by haoyuzhang<haoyuzhang@google.com>:
    
    Add method docstring to fix lint error.
    
--
250009207  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Add feature in BERT to write training metrics to a summary file.
    
--
249896208  by hongkuny<hongkuny@google.com>:
    
    Adds __init__.py
    
--
249883771  by hongkuny<hongkuny@google.com>:
    
    Creates a benchmark dir
    
--
249580533  by A. Unique TensorFlower<gardener@tensorflow.org>:

    Internal change

249566870  by A. Unique TensorFlower<gardener@tensorflow.org>:
    
    Set up BERT benchmark test.
    
--
249500988  by hongkuny<hongkuny@google.com>:
    
    Lints
    
--
249377254  by hongkuny<hongkuny@google.com>:

    Internal change

249373328  by hongkuny<hongkuny@google.com>:
    
    Clean up tf import
    
--
249333938  by hongkuny<hongkuny@google.com>:
    
    Fix tf1 import
    
--
249325089  by hongkuny<hongkuny@google.com>:
    
    BERT 2.0
    
--
249173564  by hongkuny<hongkuny@google.com>: