### PR TITLE
use public app runner and flags

### DIFF
--- a/research/lstm_object_detection/eval.py
+++ b/research/lstm_object_detection/eval.py
@@ -27,8 +27,6 @@ import functools
 import os
 import tensorflow as tf
 from google.protobuf import text_format
-from google3.pyglib import app
-from google3.pyglib import flags
 from lstm_object_detection import evaluator
 from lstm_object_detection import model_builder
 from lstm_object_detection.inputs import seq_dataset_builder
@@ -107,4 +105,4 @@ def main(unused_argv):
                      FLAGS.checkpoint_dir, FLAGS.eval_dir)
 
 if __name__ == '__main__':
-  app.run()
+  tf.app.run()

--- a/research/lstm_object_detection/utils/config_util.py
+++ b/research/lstm_object_detection/utils/config_util.py
@@ -37,7 +37,7 @@ def get_configs_from_pipeline_file(pipeline_config_path):
 
   Returns:
     Dictionary of configuration objects. Keys are `model`, `train_config`,
-      `train_input_config`, `eval_config`, `eval_input_config`, `lstm_confg`.
+      `train_input_config`, `eval_config`, `eval_input_config`, `lstm_model`.
       Value are the corresponding config objects.
   """
   pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()


### PR DESCRIPTION
- uses `tf.app` instead of `google3.pyglib.app`
- uses `absl.flags` (already imported) instead if instead of `google3.pyglib.flags`

This removes the need for the `google3` module for the entire project, and also matches `train.py`'s use.