### PR TITLE
Replace deprecated functions  tf.rnn.nn 2 tf.contrib.rnn

### DIFF
--- a/research/deep_speech/deep_speech_model.py
+++ b/research/deep_speech/deep_speech_model.py
@@ -22,9 +22,9 @@ import tensorflow as tf
 
 # Supported rnn cells.
 SUPPORTED_RNNS = {
-    "lstm": tf.nn.rnn_cell.BasicLSTMCell,
-    "rnn": tf.nn.rnn_cell.RNNCell,
-    "gru": tf.nn.rnn_cell.GRUCell,
+    "lstm": tf.contrib.rnn.BasicLSTMCell,
+    "rnn": tf.contrib.rnn.RNNCell,
+    "gru": tf.contrib.rnn.GRUCell,
 }
 
 # Parameters for batch normalization.


### PR DESCRIPTION
Referred #881 and #982
This is a very easy fix for the modern style.
This change following this repositorys' most files that are using `contrib.rnn` instead of `rnn.nn`.