### PR TITLE
struct2depth model.py does not apply imagenet normalization during inference

### DIFF
--- a/research/struct2depth/model.py
+++ b/research/struct2depth/model.py
@@ -761,6 +761,7 @@ class Model(object):
       input_image = tf.placeholder(
           tf.float32, [self.batch_size, self.img_height, self.img_width, 3],
           name='raw_input')
+      self.input_image = input_image
       if self.imagenet_norm:
         input_image = (input_image - reader.IMAGENET_MEAN) / reader.IMAGENET_SD
       est_disp, _ = nets.disp_net(architecture=self.architecture,
@@ -769,7 +770,6 @@ class Model(object):
                                   weight_reg=self.weight_reg,
                                   is_training=True)
     est_depth = 1.0 / est_disp[0]
-    self.input_image = input_image
     self.est_depth = est_depth
 
   def build_egomotion_test_graph(self):


### PR DESCRIPTION
The original version does not apply normalization to the `input_image` even if `self.imagenet_norm` is `True`.
In the original version when line 772 is reached and `self.imagenet_norm == True` the variable `input_image` holds the tensor `depth_prediction/truediv:0`, i.e. the output of the normalization operation. When a value is fed in [line 840](https://github.com/tensorflow/models/blob/master/research/struct2depth/model.py#L840) the normalization operation is not run on this tensor.
With the change `self.input_image` is the tensor `depth_prediction/raw_input:0` which I think is the intended behavior.

I have opened an issue with more information: https://github.com/tensorflow/models/issues/7343 .

I hope that this is a valid bug and apologize if I made a mistake.
Bests
-Lukas