### PR TITLE
[Transformer] enable static loss scaling

### DIFF
--- a/official/transformer/v2/transformer_main.py
+++ b/official/transformer/v2/transformer_main.py
@@ -129,6 +129,11 @@ class TransformerTask(object):
       policy = tf.keras.mixed_precision.experimental.Policy(
           "infer_float32_vars")
       tf.keras.mixed_precision.experimental.set_policy(policy)
+  
+    if flags_obj.loss_scale is None:
+      params["loss_scale"] = "dynamic"
+    else:
+      params["loss_scale"] = flags_obj.loss_scale
 
   def train(self):
     """Trains the model."""
@@ -258,7 +263,7 @@ class TransformerTask(object):
     if params["dtype"] == tf.float16:
       opt = tf.keras.mixed_precision.experimental.LossScaleOptimizer(
           opt, loss_scale=flags_core.get_loss_scale(self.flags_obj,
-                                                    default_for_fp16="dynamic"))
+            default_for_fp16=params["loss_scale"]))
     return opt
 
 


### PR DESCRIPTION
This is a workaround to avoid tf.cond() in LossScaleOptimizer.
For fp16, single GPU step time (3072 static batch) reduces ~5ms and 8 GPU step time (3072 x 8 static batch, without XLA) reduces ~35ms.

set --loss_scale=256 and dynamic batching can yield similar Bleu scores as LossScaleOptimizer, reaching {28.45, 27.95} at 200000 steps for {uncased, cased} Bleu.