### PR TITLE
Fix code batch size is 1

### DIFF
--- a/research/slim/eval_image_classifier.py
+++ b/research/slim/eval_image_classifier.py
@@ -154,7 +154,9 @@ def main(_):
       variables_to_restore = slim.get_variables_to_restore()
 
     predictions = tf.argmax(logits, 1)
-    labels = tf.squeeze(labels)
+
+    if not labels.shape[0] == 1:
+      labels = tf.squeeze(labels)
 
     # Define the metrics:
     names_to_values, names_to_updates = slim.metrics.aggregate_metric_map({


### PR DESCRIPTION
Hi, everyone. 

i wanted to etimate inference time. then, i modify batch size is '1'.

but, i met under the error.
```
Traceback (most recent call last):
  File "/home/yoohj/anaconda3/envs/tensorpack/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 1567, in _create_c_op
    c_op = c_api.TF_FinishOperation(op_desc)
tensorflow.python.framework.errors_impl.InvalidArgumentError: Shape must be rank 1 but is rank 0 for 'in_top_k/InTopKV2' (op: 'InTopKV2') with input shapes: [1,1001], [], [].
```

so, I looked for a problem. And, i find it.because of tf.squeeze().
if you use tf.squeeze() in shape of variables (1,), shape of variables is no shape.

Finally, I solve the problem to add a conditional statement.

Thank you for reading!