### PR TITLE
Added `num_keypoints` arg to TfExampleDecoder call

### DIFF
--- a/research/object_detection/builders/dataset_builder.py
+++ b/research/object_detection/builders/dataset_builder.py
@@ -127,7 +127,8 @@ def build(input_reader_config, batch_size=None, transform_input_data_fn=None):
         instance_mask_type=input_reader_config.mask_type,
         label_map_proto_file=label_map_proto_file,
         use_display_name=input_reader_config.use_display_name,
-        num_additional_channels=input_reader_config.num_additional_channels)
+        num_additional_channels=input_reader_config.num_additional_channels,
+        num_keypoints=input_reader_config.num_keypoints)
 
     def process_fn(value):
       """Sets up tf graph that decodes, transforms and pads input data."""


### PR DESCRIPTION
Added `num_keypoints` arg to `TfExampleDecoder` call in [dataset_builder.py](https://github.com/tensorflow/models/blob/master/research/object_detection/builders/dataset_builder.py)

This arg is already part of the proto spec:
https://github.com/tensorflow/models/blob/b9ef963d1e84da0bb9c0a6039457c39a699ea149/research/object_detection/protos/input_reader.proto#L89-L90

The default value in TfExampleDecoder is correctly mapped.
https://github.com/tensorflow/models/blob/b9ef963d1e84da0bb9c0a6039457c39a699ea149/research/object_detection/data_decoders/tf_example_decoder.py#L136-L147

I believe this may be relevant in #2366 and #4676