### PR TITLE
[TF2.0] Adding automatic mixed precision training (via graph rewrite) support to Resnet CTL mode

### DIFF
--- a/official/resnet/ctl/ctl_imagenet_benchmark.py
+++ b/official/resnet/ctl/ctl_imagenet_benchmark.py
@@ -139,6 +139,24 @@ class Resnet50CtlAccuracy(CtlBenchmark):
     FLAGS.datasets_num_private_threads = 14
     self._run_and_report_benchmark()
 
+  def benchmark_8_gpu_amp(self):
+    """Test Keras model with eager, dist_strat and 8 GPUs with automatic mixed
+    precision.
+    """
+    self._setup()
+    FLAGS.num_gpus = 8
+    FLAGS.data_dir = self.data_dir
+    FLAGS.batch_size = 128 * 8
+    FLAGS.train_epochs = 90
+    FLAGS.epochs_between_evals = 10
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_amp')
+    FLAGS.dtype = 'fp16'
+    FLAGS.fp16_implementation = 'graph_rewrite'
+    FLAGS.use_tf_function = True 
+    # Add some thread tunings to improve performance.
+    FLAGS.datasets_num_private_threads = 14
+    self._run_and_report_benchmark()
+
   def _run_and_report_benchmark(self):
     start_time_sec = time.time()
     stats = ctl_imagenet_main.run(flags.FLAGS)
@@ -206,6 +224,33 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.batch_size = 128
     self._run_and_report_benchmark()
 
+  def benchmark_1_gpu_amp(self):
+    """Test Keras model with 1 GPU with automatic mixed precision."""
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_1_gpu_amp')
+    FLAGS.batch_size = 128
+    FLAGS.dtype = 'fp16'
+    FLAGS.fp16_implementation = 'graph_rewrite'
+    FLAGS.use_tf_function = True 
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_1_gpu_amp(self):
+    """Test Keras model with XLA and 1 GPU with automatic mixed precision."""
+    self._setup()
+
+    FLAGS.num_gpus = 1
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_1_gpu_amp')
+    FLAGS.batch_size = 128
+    FLAGS.dtype = 'fp16'
+    FLAGS.fp16_implementation = 'graph_rewrite'
+    FLAGS.use_tf_function = True 
+    FLAGS.enable_xla = True
+    self._run_and_report_benchmark()
+
   def benchmark_1_gpu_eager(self):
     """Test Keras model with 1 GPU in pure eager mode."""
     self._setup()
@@ -226,6 +271,33 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.distribution_strategy = 'default'
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu')
     FLAGS.batch_size = 128 * 8  # 8 GPUs
+    self._run_and_report_benchmark()
+
+  def benchmark_8_gpu_amp(self):
+    """Test Keras model with 8 GPUs with automatic mixed precision."""
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_amp')
+    FLAGS.batch_size = 128 * 8  # 8 GPUs
+    FLAGS.dtype = 'fp16'
+    FLAGS.fp16_implementation = 'graph_rewrite'
+    FLAGS.use_tf_function = True 
+    self._run_and_report_benchmark()
+
+  def benchmark_xla_8_gpu_amp(self):
+    """Test Keras model with XLA and 8 GPUs with automatic mixed precision."""
+    self._setup()
+
+    FLAGS.num_gpus = 8
+    FLAGS.distribution_strategy = 'default'
+    FLAGS.model_dir = self._get_model_dir('benchmark_xla_8_gpu_amp')
+    FLAGS.batch_size = 128 * 8  # 8 GPUs
+    FLAGS.dtype = 'fp16'
+    FLAGS.fp16_implementation = 'graph_rewrite'
+    FLAGS.use_tf_function = True 
+    FLAGS.enable_xla = True
     self._run_and_report_benchmark()
 
   def fill_report_object(self, stats):

--- a/official/resnet/ctl/ctl_imagenet_benchmark.py
+++ b/official/resnet/ctl/ctl_imagenet_benchmark.py
@@ -140,9 +140,7 @@ class Resnet50CtlAccuracy(CtlBenchmark):
     self._run_and_report_benchmark()
 
   def benchmark_8_gpu_amp(self):
-    """Test Keras model with eager, dist_strat and 8 GPUs with automatic mixed
-    precision.
-    """
+    """Test Keras model with eager, 8 GPUs with automatic mixed precision."""
     self._setup()
     FLAGS.num_gpus = 8
     FLAGS.data_dir = self.data_dir
@@ -152,7 +150,6 @@ class Resnet50CtlAccuracy(CtlBenchmark):
     FLAGS.model_dir = self._get_model_dir('benchmark_8_gpu_amp')
     FLAGS.dtype = 'fp16'
     FLAGS.fp16_implementation = 'graph_rewrite'
-    FLAGS.use_tf_function = True 
     # Add some thread tunings to improve performance.
     FLAGS.datasets_num_private_threads = 14
     self._run_and_report_benchmark()
@@ -234,7 +231,6 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.batch_size = 128
     FLAGS.dtype = 'fp16'
     FLAGS.fp16_implementation = 'graph_rewrite'
-    FLAGS.use_tf_function = True 
     self._run_and_report_benchmark()
 
   def benchmark_xla_1_gpu_amp(self):
@@ -247,7 +243,6 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.batch_size = 128
     FLAGS.dtype = 'fp16'
     FLAGS.fp16_implementation = 'graph_rewrite'
-    FLAGS.use_tf_function = True 
     FLAGS.enable_xla = True
     self._run_and_report_benchmark()
 
@@ -283,7 +278,6 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     FLAGS.dtype = 'fp16'
     FLAGS.fp16_implementation = 'graph_rewrite'
-    FLAGS.use_tf_function = True 
     self._run_and_report_benchmark()
 
   def benchmark_xla_8_gpu_amp(self):
@@ -296,7 +290,6 @@ class Resnet50CtlBenchmarkBase(CtlBenchmark):
     FLAGS.batch_size = 128 * 8  # 8 GPUs
     FLAGS.dtype = 'fp16'
     FLAGS.fp16_implementation = 'graph_rewrite'
-    FLAGS.use_tf_function = True 
     FLAGS.enable_xla = True
     self._run_and_report_benchmark()
 

--- a/official/resnet/ctl/ctl_imagenet_main.py
+++ b/official/resnet/ctl/ctl_imagenet_main.py
@@ -177,7 +177,7 @@ def run(flags_obj):
                          "--use_tf_function to be true")
       loss_scale = flags_core.get_loss_scale(flags_obj, default_for_fp16=128)
       optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(
-                      optimizer, loss_scale)
+          optimizer, loss_scale)
 
     training_accuracy = tf.keras.metrics.SparseCategoricalAccuracy(
         'training_accuracy', dtype=tf.float32)


### PR DESCRIPTION
This PR adds automatic mixed precision training to Resnet in CTL mode via setting the flag combination of --dtype=fp16 --fp16_implementation=graph_rewrite.

Corresponding benchmarks are added as well.