### PR TITLE
Updating documentation for pycocotools

### DIFF
--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -72,6 +72,12 @@ make
 cp -r pycocotools <path_to_tensorflow>/models/research/
 ```
 
+ Alternatively, users can install `pycocotools` using pip:
+
+ ```bash
+pip install --user pycocotools
+ ```
+
 ## Protobuf Compilation
 
 The Tensorflow Object Detection API uses Protobufs to configure model and


### PR DESCRIPTION
Just wanted to add documentation stating that users can pip install pycocotools.