### PR TITLE
Fix path to movielens helper file

### DIFF
--- a/official/recommendation/run.sh
+++ b/official/recommendation/run.sh
@@ -37,7 +37,7 @@ else
 fi
 
 DATA_DIR="${ROOT_DIR}/movielens_data"
-python "${SCRIPT_DIR}/../datasets/movielens.py" --data_dir ${DATA_DIR} --dataset ${DATASET}
+python "${SCRIPT_DIR}/movielens.py" --data_dir ${DATA_DIR} --dataset ${DATASET}
 
 if [ "$1" == "keras" ]
 then


### PR DESCRIPTION
Just fixing the path to the helper file to download and process the Movielens dataset in the script `run.sh` after a recent move of this file within the repository