### PR TITLE
Rename keyword arg identifier to fix deprecation warning

### DIFF
--- a/research/object_detection/utils/ops.py
+++ b/research/object_detection/utils/ops.py
@@ -836,7 +836,7 @@ def reframe_box_masks_to_image_masks(box_masks, boxes, image_height,
     return tf.image.crop_and_resize(
         image=box_masks_expanded,
         boxes=reverse_boxes,
-        box_ind=tf.range(num_boxes),
+        box_indices=tf.range(num_boxes),
         crop_size=[image_height, image_width],
         extrapolation_value=0.0)
   image_masks = tf.cond(
@@ -1092,5 +1092,3 @@ def gather_with_padding_values(input_tensor, indices, padding_value):
 
 EqualizationLossConfig = collections.namedtuple('EqualizationLossConfig',
                                                 ['weight', 'exclude_prefixes'])
-
-


### PR DESCRIPTION
Change `box_ind` to `box_indices` when calling `tf.image.crop_and_resize`.

https://github.com/tensorflow/tensorflow/blob/11bd314518d39066122f2979b2d138b552f613dc/tensorflow/python/ops/image_ops_impl.py#L3729
