### PR TITLE
Official Module Error

### DIFF
--- a/official/README.md
+++ b/official/README.md
@@ -41,7 +41,7 @@ Please follow the below steps before running models in this repo:
     [nightly binaries](https://github.com/tensorflow/tensorflow#installation)
 
 2.  Add the top-level ***/models*** folder to the Python path with the command:
-    `export PYTHONPATH="$PYTHONPATH:/path/to/models"`
+    `export PYTHONPATH=$PYTHONPATH:/path/to/models`
 
     Using Colab: `import os os.environ['PYTHONPATH'] += ":/path/to/models"`
 


### PR DESCRIPTION
people are commonly having issues configuring paths for running python scripts. The README has a typo in it. 