### PR TITLE
Fixes the metrics_set name

### DIFF
--- a/research/object_detection/samples/configs/ssd_mobilenet_v2_oid_v4.config
+++ b/research/object_detection/samples/configs/ssd_mobilenet_v2_oid_v4.config
@@ -175,7 +175,7 @@ train_input_reader: {
 }
 
 eval_config: {
-  metrics_set: "open_images_V2_detection_metrics"
+  metrics_set: "oid_V2_detection_metrics"
 }
 
 eval_input_reader: {


### PR DESCRIPTION
So as to match that of eval_util.py, i.e.

https://github.com/bgalvao/models/blob/6766e6ddfabefbd1003d5275fa5cc32f18196c11/research/object_detection/eval_util.py#L65