### PR TITLE
Fix BERT EmbeddingPostprocessor

### DIFF
--- a/official/nlp/bert_modeling.py
+++ b/official/nlp/bert_modeling.py
@@ -341,11 +341,7 @@ class EmbeddingPostprocessor(tf.keras.layers.Layer):
     output = word_embeddings
     if self.use_type_embeddings:
       flat_token_type_ids = tf.reshape(token_type_ids, [-1])
-      one_hot_ids = tf.one_hot(
-          flat_token_type_ids,
-          depth=self.token_type_vocab_size,
-          dtype=self.dtype)
-      token_type_embeddings = tf.matmul(one_hot_ids, self.type_embeddings)
+      token_type_embeddings = tf.gather(self.type_embeddings, flat_token_type_ids)
       token_type_embeddings = tf.reshape(token_type_embeddings,
                                          [batch_size, seq_length, width])
       output += token_type_embeddings


### PR DESCRIPTION
Change one_hot+matmul on gather. It's important for conversion to tflite because one_hot+matmul seriously change model predictions after conversion in tflite format. Gather does the same operations and doesn't have the same effect.

It is related to problem in tflite. Issue: https://github.com/tensorflow/tensorflow/issues/33613.
My fix allow to convert model to tflite before this problem will be solved