### PR TITLE
Tensorboard summary writing for few params

### DIFF
--- a/official/transformer/transformer_main.py
+++ b/official/transformer/transformer_main.py
@@ -140,7 +140,7 @@ def model_fn(features, labels, mode, params):
 
 def record_scalars(metric_dict):
   for key, value in metric_dict.items():
-    tf.contrib.summary.scalar(name=key, tensor=value)
+    tf.summary.scalar(name=key, tensor=value)
 
 
 def get_learning_rate(learning_rate, hidden_size, learning_rate_warmup_steps):


### PR DESCRIPTION
Using this code on GPU, was not logging "learning_rate" and "gradient norm" etc, basically items in metric_dict. We need to use simple "tf.summary.scalar" instead of contrib one to log these params when "use_tpu" is False. Function "record_scalars" gets called on in case when "use_tpu" is False. So this change helped tensors in metric dict properly show up in Tensorboard summary. Tested on Tensorflow 1.14.