### PR TITLE
Make BERT model more customizable

### DIFF
--- a/official/nlp/bert_modeling.py
+++ b/official/nlp/bert_modeling.py
@@ -151,6 +151,7 @@ class BertModel(tf.keras.layers.Layer):
         BertConfig.from_dict(config)
         if isinstance(config, dict) else copy.deepcopy(config))
     self.float_type = float_type
+    self.build(unused_input_shapes=[])
 
   def build(self, unused_input_shapes):
     """Implements build() for the layer."""
@@ -250,6 +251,7 @@ class EmbeddingLookup(tf.keras.layers.Layer):
     self.vocab_size = vocab_size
     self.embedding_size = embedding_size
     self.initializer_range = initializer_range
+    self.build(unused_input_shapes=[])
 
   def build(self, unused_input_shapes):
     """Implements build() for the layer."""
@@ -407,6 +409,7 @@ class Attention(tf.keras.layers.Layer):
     self.attention_probs_dropout_prob = attention_probs_dropout_prob
     self.initializer_range = initializer_range
     self.backward_compatible = backward_compatible
+    self.build(unused_input_shapes=[])
 
   def build(self, unused_input_shapes):
     """Implements build() for the layer."""
@@ -728,6 +731,7 @@ class TransformerBlock(tf.keras.layers.Layer):
           "The hidden size (%d) is not a multiple of the number of attention "
           "heads (%d)" % (self.hidden_size, self.num_attention_heads))
     self.attention_head_size = int(self.hidden_size / self.num_attention_heads)
+    self.build(unused_input_shapes=[])
 
   def build(self, unused_input_shapes):
     """Implements build() for the layer."""
@@ -844,6 +848,7 @@ class Transformer(tf.keras.layers.Layer):
     self.initializer_range = initializer_range
     self.backward_compatible = backward_compatible
     self.float_type = float_type
+    self.build(unused_input_shapes=[])
 
   def build(self, unused_input_shapes):
     """Implements build() for the layer."""

--- a/official/nlp/bert_models.py
+++ b/official/nlp/bert_models.py
@@ -376,6 +376,7 @@ def squad_model(bert_config, max_seq_length, float_type, initializer=None):
       name='squad_model')
   return squad, core_model
 
+
 def classifier_model(bert_config,
                      float_type,
                      num_labels,


### PR DESCRIPTION
Hi. Let me suggest 2 patches that would make BERT model more customizable:
1. Allows users to pass custom `get_bert_model`.
2. Builds BERT's components as early as possible.

The particular problem I'm trying to solve is following: Currently Keras calls `build`s  from `__call__` which doesn't left any space for model modifications. This PR (the 2nd patch) adds `build()` calls to constructors whenever possible to offer user an opportunity to change some of the model's components before hard-wiring things with `__call__`s. This approach should reduce time/efforts required to prepare model experiments. Please check an example below.

Note that some time ago I started a related topic in TFdev mailing list:  https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/B57l_ygjBPU


```py
from mytweaks import CustomTransformerBlock

def get_custom_bert_model(input_word_ids, input_mask, input_type_ids, config=None, name=None, float_type=tf.float32):
  bert_model_layer = BertModel(config=config, float_type=float_type, name=name)
  
  # Added part: update some (in this case all) layers of encoder. Wouldn't be possible wothout patch
  new_layers = []  
  for i,tb in enumerate(bert_model_layer.encoder.layers):
    self=tb
    new_layers.append(CustomTransformerBlock(
          hidden_size=self.hidden_size,
          num_attention_heads=self.num_attention_heads,
          intermediate_size=self.intermediate_size,
          intermediate_activation=self.intermediate_activation,
          hidden_dropout_prob=self.hidden_dropout_prob,
          attention_probs_dropout_prob=self.attention_probs_dropout_prob,
          initializer_range=self.initializer_range,
          backward_compatible=self.backward_compatible,
          float_type=self.float_type,
          name=("custom_layer_%d" % i)))
  bert_model_layer.encoder.layers = new_layers

  pooled_output, sequence_output = bert_model_layer(input_word_ids, input_mask,
                                                    input_type_ids)
  bert_model = tf.keras.Model(
      inputs=[input_word_ids, input_mask, input_type_ids],
      outputs=[pooled_output, sequence_output])
  return bert_model

def run():
  ...
  model,_ = classifier_model(bert_config, tf.float32, num_labels, max_seq_length,
                                              custom_bert_model=get_custom_bert_model)
  model.compile(...)
  model.fit(...)

```