### PR TITLE
Update README.md

### DIFF
--- a/research/vid2depth/README.md
+++ b/research/vid2depth/README.md
@@ -50,7 +50,7 @@ git clone --depth 1 https://github.com/tensorflow/models.git
 ```shell
 mkdir -p ~/vid2depth/kitti-raw-uncompressed
 cd ~/vid2depth/kitti-raw-uncompressed
-wget https://github.com/mrharicot/monodepth/blob/master/utils/kitti_archives_to_download.txt
+wget https://raw.githubusercontent.com/mrharicot/monodepth/master/utils/kitti_archives_to_download.txt
 wget -i kitti_archives_to_download.txt
 unzip "*.zip"
 ```


### PR DESCRIPTION
changed the link for kitti_archives_to_download.txt to point to the raw file rather than just the github URL.