### PR TITLE
Merged commit includes the following changes:

### DIFF
--- a/research/object_detection/README.md
+++ b/research/object_detection/README.md
@@ -101,6 +101,19 @@ reporting an issue.
 
 ## Release information
 
+### Nov 13th, 2019
+We have released MobileNetEdgeTPU SSDLite model.
+
+* SSDLite with MobileNetEdgeTPU backbone, which achieves 10% mAP higher than
+MobileNetV2 SSDLite (24.3 mAP vs 22 mAP) on a Google Pixel4 at comparable
+latency (6.6ms vs 6.8ms).
+
+Along with the model definition, we are also releasing model checkpoints
+trained on the COCO dataset.
+
+<b>Thanks to contributors</b>: Yunyang Xiong, Bo Chen, Suyog Gupta, Hanxiao Liu,
+Gabriel Bender, Mingxing Tan, Berkin Akin, Zhichao Lu, Quoc Le
+
 ### Oct 15th, 2019
 We have released two MobileNet V3 SSDLite models (presented in
 [Searching for MobileNetV3](https://arxiv.org/abs/1905.02244)).

--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -44,6 +44,7 @@ from object_detection.models import ssd_resnet_v1_ppn_feature_extractor as ssd_r
 from object_detection.models.embedded_ssd_mobilenet_v1_feature_extractor import EmbeddedSSDMobileNetV1FeatureExtractor
 from object_detection.models.ssd_inception_v2_feature_extractor import SSDInceptionV2FeatureExtractor
 from object_detection.models.ssd_inception_v3_feature_extractor import SSDInceptionV3FeatureExtractor
+from object_detection.models.ssd_mobilenet_edgetpu_feature_extractor import SSDMobileNetEdgeTPUFeatureExtractor
 from object_detection.models.ssd_mobilenet_v1_feature_extractor import SSDMobileNetV1FeatureExtractor
 from object_detection.models.ssd_mobilenet_v1_fpn_feature_extractor import SSDMobileNetV1FpnFeatureExtractor
 from object_detection.models.ssd_mobilenet_v1_fpn_keras_feature_extractor import SSDMobileNetV1FpnKerasFeatureExtractor
@@ -73,6 +74,7 @@ SSD_FEATURE_EXTRACTOR_CLASS_MAP = {
     'ssd_mobilenet_v2_fpn': SSDMobileNetV2FpnFeatureExtractor,
     'ssd_mobilenet_v3_large': SSDMobileNetV3LargeFeatureExtractor,
     'ssd_mobilenet_v3_small': SSDMobileNetV3SmallFeatureExtractor,
+    'ssd_mobilenet_edgetpu': SSDMobileNetEdgeTPUFeatureExtractor,
     'ssd_resnet50_v1_fpn': ssd_resnet_v1_fpn.SSDResnet50V1FpnFeatureExtractor,
     'ssd_resnet101_v1_fpn': ssd_resnet_v1_fpn.SSDResnet101V1FpnFeatureExtractor,
     'ssd_resnet152_v1_fpn': ssd_resnet_v1_fpn.SSDResnet152V1FpnFeatureExtractor,

--- a/research/object_detection/builders/post_processing_builder.py
+++ b/research/object_detection/builders/post_processing_builder.py
@@ -101,7 +101,9 @@ def _build_non_max_suppressor(nms_config):
       max_classes_per_detection=nms_config.max_classes_per_detection,
       soft_nms_sigma=nms_config.soft_nms_sigma,
       use_partitioned_nms=nms_config.use_partitioned_nms,
-      use_combined_nms=nms_config.use_combined_nms)
+      use_combined_nms=nms_config.use_combined_nms,
+      change_coordinate_frame=True)
+
   return non_max_suppressor_fn
 
 

--- a/research/object_detection/exporter_test.py
+++ b/research/object_detection/exporter_test.py
@@ -246,6 +246,29 @@ class ExportInferenceGraphTest(tf.test.TestCase):
       self.assertTrue(os.path.exists(os.path.join(
           output_directory, 'saved_model', 'saved_model.pb')))
 
+  def test_export_graph_with_fixed_size_tf_example_input(self):
+    input_shape = [1, 320, 320, 3]
+
+    tmp_dir = self.get_temp_dir()
+    trained_checkpoint_prefix = os.path.join(tmp_dir, 'model.ckpt')
+    self._save_checkpoint_from_mock_model(
+        trained_checkpoint_prefix, use_moving_averages=False)
+    with mock.patch.object(
+        model_builder, 'build', autospec=True) as mock_builder:
+      mock_builder.return_value = FakeModel()
+      output_directory = os.path.join(tmp_dir, 'output')
+      pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+      pipeline_config.eval_config.use_moving_averages = False
+      exporter.export_inference_graph(
+          input_type='tf_example',
+          pipeline_config=pipeline_config,
+          trained_checkpoint_prefix=trained_checkpoint_prefix,
+          output_directory=output_directory,
+          input_shape=input_shape)
+      saved_model_path = os.path.join(output_directory, 'saved_model')
+      self.assertTrue(
+          os.path.exists(os.path.join(saved_model_path, 'saved_model.pb')))
+
   def test_export_graph_with_encoded_image_string_input(self):
     tmp_dir = self.get_temp_dir()
     trained_checkpoint_prefix = os.path.join(tmp_dir, 'model.ckpt')
@@ -264,6 +287,29 @@ class ExportInferenceGraphTest(tf.test.TestCase):
           output_directory=output_directory)
       self.assertTrue(os.path.exists(os.path.join(
           output_directory, 'saved_model', 'saved_model.pb')))
+
+  def test_export_graph_with_fixed_size_encoded_image_string_input(self):
+    input_shape = [1, 320, 320, 3]
+
+    tmp_dir = self.get_temp_dir()
+    trained_checkpoint_prefix = os.path.join(tmp_dir, 'model.ckpt')
+    self._save_checkpoint_from_mock_model(
+        trained_checkpoint_prefix, use_moving_averages=False)
+    with mock.patch.object(
+        model_builder, 'build', autospec=True) as mock_builder:
+      mock_builder.return_value = FakeModel()
+      output_directory = os.path.join(tmp_dir, 'output')
+      pipeline_config = pipeline_pb2.TrainEvalPipelineConfig()
+      pipeline_config.eval_config.use_moving_averages = False
+      exporter.export_inference_graph(
+          input_type='encoded_image_string_tensor',
+          pipeline_config=pipeline_config,
+          trained_checkpoint_prefix=trained_checkpoint_prefix,
+          output_directory=output_directory,
+          input_shape=input_shape)
+      saved_model_path = os.path.join(output_directory, 'saved_model')
+      self.assertTrue(
+          os.path.exists(os.path.join(saved_model_path, 'saved_model.pb')))
 
   def _get_variables_in_checkpoint(self, checkpoint_file):
     return set([

--- a/research/object_detection/g3doc/detection_model_zoo.md
+++ b/research/object_detection/g3doc/detection_model_zoo.md
@@ -103,12 +103,18 @@ Note: The asterisk (☆) at the end of model name indicates that this model supp
 
 Note: If you download the tar.gz file of quantized models and un-tar, you will get different set of files - a checkpoint, a config file and tflite frozen graphs (txt/binary).
 
+
 ### Mobile models
 
 Model name                                                                                                                          | Pixel 1 Latency (ms) | COCO mAP | Outputs
 ----------------------------------------------------------------------------------------------------------------------------------- | :------------------: | :------: | :-----:
 [ssd_mobilenet_v3_large_coco](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v3_large_coco_2019_08_14.tar.gz) | 119                  | 22.3     | Boxes
 [ssd_mobilenet_v3_small_coco](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v3_small_coco_2019_08_14.tar.gz) | 43                   | 15.6     | Boxes
+
+### Pixel4 Edge TPU models
+Model name                                                                                                                          | Pixel 4  Edge TPU Latency (ms) | COCO mAP | Outputs
+----------------------------------------------------------------------------------------------------------------------------------- | :------------------: | :------: | :-----:
+[ssd_mobilenet_edgetpu_coco](https://storage.cloud.google.com/mobilenet_edgetpu/checkpoints/ssdlite_mobilenet_edgetpu_coco_quant.tar.gz) | 6.6                  | 24.3     | Boxes
 
 ## Kitti-trained models
 

--- a/research/object_detection/legacy/eval.py
+++ b/research/object_detection/legacy/eval.py
@@ -45,6 +45,7 @@ Example usage:
 import functools
 import os
 import tensorflow as tf
+from tensorflow.contrib import framework as contrib_framework
 
 from object_detection.builders import dataset_builder
 from object_detection.builders import graph_rewriter_builder
@@ -80,7 +81,7 @@ flags.DEFINE_boolean(
 FLAGS = flags.FLAGS
 
 
-@tf.contrib.framework.deprecated(None, 'Use object_detection/model_main.py.')
+@contrib_framework.deprecated(None, 'Use object_detection/model_main.py.')
 def main(unused_argv):
   assert FLAGS.checkpoint_dir, '`checkpoint_dir` is missing.'
   assert FLAGS.eval_dir, '`eval_dir` is missing.'

--- a/research/object_detection/legacy/train.py
+++ b/research/object_detection/legacy/train.py
@@ -45,6 +45,7 @@ import functools
 import json
 import os
 import tensorflow as tf
+from tensorflow.contrib import framework as contrib_framework
 
 from object_detection.builders import dataset_builder
 from object_detection.builders import graph_rewriter_builder
@@ -84,7 +85,7 @@ flags.DEFINE_string('model_config_path', '',
 FLAGS = flags.FLAGS
 
 
-@tf.contrib.framework.deprecated(None, 'Use object_detection/model_main.py.')
+@contrib_framework.deprecated(None, 'Use object_detection/model_main.py.')
 def main(_):
   assert FLAGS.train_dir, '`train_dir` is missing.'
   if FLAGS.task == 0: tf.gfile.MakeDirs(FLAGS.train_dir)

--- a/research/object_detection/legacy/trainer.py
+++ b/research/object_detection/legacy/trainer.py
@@ -22,6 +22,7 @@ DetectionModel.
 import functools
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.builders import optimizer_builder
 from object_detection.builders import preprocessor_builder
@@ -32,7 +33,7 @@ from object_detection.utils import ops as util_ops
 from object_detection.utils import variables_helper
 from deployment import model_deploy
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 def create_input_queue(batch_size_per_clone, create_tensor_dict_fn,

--- a/research/object_detection/legacy/trainer_test.py
+++ b/research/object_detection/legacy/trainer_test.py
@@ -18,6 +18,7 @@
 import tensorflow as tf
 
 from google.protobuf import text_format
+from tensorflow.contrib import layers as contrib_layers
 
 from object_detection.core import losses
 from object_detection.core import model
@@ -89,10 +90,10 @@ class FakeDetectionModel(model.DetectionModel):
       prediction_dict: a dictionary holding prediction tensors to be
         passed to the Loss or Postprocess functions.
     """
-    flattened_inputs = tf.contrib.layers.flatten(preprocessed_inputs)
-    class_prediction = tf.contrib.layers.fully_connected(
-        flattened_inputs, self._num_classes)
-    box_prediction = tf.contrib.layers.fully_connected(flattened_inputs, 4)
+    flattened_inputs = contrib_layers.flatten(preprocessed_inputs)
+    class_prediction = contrib_layers.fully_connected(flattened_inputs,
+                                                      self._num_classes)
+    box_prediction = contrib_layers.fully_connected(flattened_inputs, 4)
 
     return {
         'class_predictions_with_background': tf.reshape(

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
@@ -95,6 +95,8 @@ configured in the meta architecture:
 import abc
 import functools
 import tensorflow as tf
+from tensorflow.contrib import framework as contrib_framework
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.anchor_generators import grid_anchor_generator
 from object_detection.builders import box_predictor_builder
@@ -110,7 +112,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from object_detection.utils import variables_helper
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 _UNINITIALIZED_FEATURE_EXTRACTOR = '__uninitialized__'
 
@@ -2772,7 +2774,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
           self.first_stage_feature_extractor_scope,
           self.second_stage_feature_extractor_scope
       ]
-    feature_extractor_variables = tf.contrib.framework.filter_variables(
+    feature_extractor_variables = contrib_framework.filter_variables(
         variables_to_restore, include_patterns=include_patterns)
     return {var.op.name: var for var in feature_extractor_variables}
 

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -21,6 +21,7 @@ import numpy as np
 import tensorflow as tf
 
 from google.protobuf import text_format
+from tensorflow.contrib import slim as contrib_slim
 from object_detection.anchor_generators import grid_anchor_generator
 from object_detection.builders import box_predictor_builder
 from object_detection.builders import hyperparams_builder
@@ -37,7 +38,7 @@ from object_detection.utils import ops
 from object_detection.utils import test_case
 from object_detection.utils import test_utils
 
-slim = tf.contrib.slim
+slim = contrib_slim
 BOX_CODE_SIZE = 4
 
 

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -19,13 +19,14 @@ from absl.testing import parameterized
 
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.meta_architectures import ssd_meta_arch_test_lib
 from object_detection.protos import model_pb2
 from object_detection.utils import test_utils
 
-slim = tf.contrib.slim
+slim = contrib_slim
 keras = tf.keras.layers
 
 

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test_lib.py
@@ -17,6 +17,7 @@
 import functools
 import tensorflow as tf
 from google.protobuf import text_format
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.builders import post_processing_builder
 from object_detection.core import anchor_generator
@@ -33,7 +34,7 @@ from object_detection.utils import ops
 from object_detection.utils import test_case
 from object_detection.utils import test_utils
 
-slim = tf.contrib.slim
+slim = contrib_slim
 keras = tf.keras.layers
 
 

--- a/research/object_detection/model_lib_v2.py
+++ b/research/object_detection/model_lib_v2.py
@@ -135,7 +135,6 @@ def eager_train_step(detection_model,
                      learning_rate,
                      add_regularization_loss=True,
                      clip_gradients_value=None,
-                     use_tpu=False,
                      global_step=None,
                      num_replicas=1.0):
   """Process a single training batch.
@@ -192,7 +191,6 @@ def eager_train_step(detection_model,
       regularization loss in the losses dictionary.
     clip_gradients_value: If this is present, clip the gradients global norm
       at this value using `tf.clip_by_global_norm`.
-    use_tpu: Whether computation should happen on a TPU.
     global_step: The current training step. Used for TensorBoard logging
       purposes. This step is not updated by this function and must be
       incremented separately.
@@ -223,10 +221,9 @@ def eager_train_step(detection_model,
                                 tf.constant(num_replicas, dtype=tf.float32))
     losses_dict['Loss/normalized_total_loss'] = total_loss
 
-  if not use_tpu:
-    for loss_type in losses_dict:
-      tf.compat.v2.summary.scalar(
-          loss_type, losses_dict[loss_type], step=global_step)
+  for loss_type in losses_dict:
+    tf.compat.v2.summary.scalar(
+        loss_type, losses_dict[loss_type], step=global_step)
 
   trainable_variables = detection_model.trainable_variables
 
@@ -235,10 +232,7 @@ def eager_train_step(detection_model,
   if clip_gradients_value:
     gradients, _ = tf.clip_by_global_norm(gradients, clip_gradients_value)
   optimizer.apply_gradients(zip(gradients, trainable_variables))
-
-  if not use_tpu:
-    tf.compat.v2.summary.scalar('learning_rate', learning_rate,
-                                step=global_step)
+  tf.compat.v2.summary.scalar('learning_rate', learning_rate, step=global_step)
 
   return total_loss
 
@@ -451,11 +445,10 @@ def train_loop(
                                   unpad_groundtruth_tensors)
 
       ckpt = tf.compat.v2.train.Checkpoint(
-          step=global_step, model=detection_model)
+          step=global_step, model=detection_model, optimizer=optimizer)
       manager = tf.compat.v2.train.CheckpointManager(
           ckpt, model_dir, max_to_keep=7)
-      ## Maybe re-enable checkpoint restoration depending on how it works:
-      # ckpt.restore(manager.latest_checkpoint)
+      ckpt.restore(manager.latest_checkpoint)
 
       def train_step_fn(features, labels):
         return eager_train_step(
@@ -467,7 +460,6 @@ def train_loop(
             learning_rate=learning_rate_fn(),
             add_regularization_loss=add_regularization_loss,
             clip_gradients_value=clip_gradients_value,
-            use_tpu=use_tpu,
             global_step=global_step,
             num_replicas=strategy.num_replicas_in_sync)
 
@@ -487,19 +479,22 @@ def train_loop(
         return mean_loss
 
       train_input_iter = iter(train_input)
-      for _ in range(train_steps):
+      for _ in range(train_steps - global_step.value()):
         start_time = time.time()
 
         loss = _dist_train_step(train_input_iter)
         global_step.assign_add(1)
         end_time = time.time()
-        if not use_tpu:
-          tf.compat.v2.summary.scalar(
-              'steps_per_sec', 1.0 / (end_time - start_time), step=global_step)
-        # TODO(kaftan): Remove this print after it is no longer helpful for
-        ## debugging.
-        print('Finished step', global_step, end_time, loss)
-        if int(global_step.value().numpy()) % checkpoint_every_n == 0:
+
+        tf.compat.v2.summary.scalar(
+            'steps_per_sec', 1.0 / (end_time - start_time),
+            step=global_step)
+        if (int(global_step.value()) % 100) == 0:
+          tf.logging.info(
+              'Step {} time taken {:.3f}s loss={:.3f}'.format(
+                  global_step.value(), end_time - start_time, loss))
+
+        if int(global_step.value()) % checkpoint_every_n == 0:
           manager.save()
 
 
@@ -620,14 +615,11 @@ def eager_eval_loop(
 
     return eval_dict, losses_dict, class_agnostic
 
-  i = 0
-  for features, labels in eval_dataset:
+  for i, (features, labels) in enumerate(eval_dataset):
     eval_dict, losses_dict, class_agnostic = compute_eval_dict(features, labels)
-    end_time = time.time()
-    # TODO(kaftan): Remove this print after it is no longer helpful for
-    ## debugging.
-    tf.print('Finished eval dict computation', i, end_time)
-    i += 1
+
+    if i % 100 == 0:
+      tf.logging.info('Finished eval step %d', i)
 
     if evaluators is None:
       if class_agnostic:

--- a/research/object_detection/models/embedded_ssd_mobilenet_v1_feature_extractor.py
+++ b/research/object_detection/models/embedded_ssd_mobilenet_v1_feature_extractor.py
@@ -16,6 +16,7 @@
 """Embedded-friendly SSDFeatureExtractor for MobilenetV1 features."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -23,7 +24,7 @@ from object_detection.utils import context_manager
 from object_detection.utils import ops
 from nets import mobilenet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class EmbeddedSSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/faster_rcnn_inception_resnet_v2_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_inception_resnet_v2_feature_extractor.py
@@ -23,12 +23,13 @@ Huang et al. (https://arxiv.org/abs/1611.10012)
 """
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.utils import variables_helper
 from nets import inception_resnet_v2
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class FasterRCNNInceptionResnetV2FeatureExtractor(
@@ -211,4 +212,3 @@ class FasterRCNNInceptionResnetV2FeatureExtractor(
             second_stage_feature_extractor_scope + '/', '')
         variables_to_restore[var_name] = variable
     return variables_to_restore
-

--- a/research/object_detection/models/faster_rcnn_inception_v2_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_inception_v2_feature_extractor.py
@@ -19,11 +19,12 @@ See "Rethinking the Inception Architecture for Computer Vision"
 https://arxiv.org/abs/1512.00567
 """
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from nets import inception_v2
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 def _batch_norm_arg_scope(list_ops,

--- a/research/object_detection/models/faster_rcnn_mobilenet_v1_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_mobilenet_v1_feature_extractor.py
@@ -17,12 +17,13 @@
 import numpy as np
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.utils import shape_utils
 from nets import mobilenet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 def _get_mobilenet_conv_no_last_stride_defs(conv_depth_ratio_in_percentage):

--- a/research/object_detection/models/faster_rcnn_nas_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_nas_feature_extractor.py
@@ -21,14 +21,16 @@ https://arxiv.org/abs/1707.07012
 """
 
 import tensorflow as tf
+from tensorflow.contrib import framework as contrib_framework
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.utils import variables_helper
 from nets.nasnet import nasnet
 from nets.nasnet import nasnet_utils
 
-arg_scope = tf.contrib.framework.arg_scope
-slim = tf.contrib.slim
+arg_scope = contrib_framework.arg_scope
+slim = contrib_slim
 
 
 def nasnet_large_arg_scope_for_detection(is_batch_norm_training=False):
@@ -322,4 +324,3 @@ class FasterRCNNNASFeatureExtractor(
         var_name += '/ExponentialMovingAverage'
         variables_to_restore[var_name] = variable
     return variables_to_restore
-

--- a/research/object_detection/models/faster_rcnn_pnas_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_pnas_feature_extractor.py
@@ -19,14 +19,16 @@ Based on PNASNet model: https://arxiv.org/abs/1712.00559
 """
 
 import tensorflow as tf
+from tensorflow.contrib import framework as contrib_framework
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from object_detection.utils import variables_helper
 from nets.nasnet import nasnet_utils
 from nets.nasnet import pnasnet
 
-arg_scope = tf.contrib.framework.arg_scope
-slim = tf.contrib.slim
+arg_scope = contrib_framework.arg_scope
+slim = contrib_slim
 
 
 def pnasnet_large_arg_scope_for_detection(is_batch_norm_training=False):

--- a/research/object_detection/models/faster_rcnn_resnet_v1_feature_extractor.py
+++ b/research/object_detection/models/faster_rcnn_resnet_v1_feature_extractor.py
@@ -25,12 +25,13 @@ the MSRA provided checkpoints
 same preprocessing, batch norm scaling, etc.
 """
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import faster_rcnn_meta_arch
 from nets import resnet_utils
 from nets import resnet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class FasterRCNNResnetV1FeatureExtractor(

--- a/research/object_detection/models/feature_map_generators.py
+++ b/research/object_detection/models/feature_map_generators.py
@@ -26,9 +26,10 @@ of final feature maps.
 import collections
 import functools
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 from object_detection.utils import ops
 from object_detection.utils import shape_utils
-slim = tf.contrib.slim
+slim = contrib_slim
 
 # Activation bound used for TPU v1. Activations will be clipped to
 # [-ACTIVATION_BOUND, ACTIVATION_BOUND] when training with

--- a/research/object_detection/models/ssd_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_feature_extractor_test.py
@@ -17,11 +17,12 @@
 
 from abc import abstractmethod
 
-import itertools
 import numpy as np
+from six.moves import zip
 import tensorflow as tf
 
 from google.protobuf import text_format
+from tensorflow.contrib import slim as contrib_slim
 from object_detection.builders import hyperparams_builder
 from object_detection.protos import hyperparams_pb2
 from object_detection.utils import test_case
@@ -53,7 +54,7 @@ class SsdFeatureExtractorTestBase(test_case.TestCase):
     return hyperparams_builder.KerasLayerHyperparams(conv_hyperparams)
 
   def conv_hyperparams_fn(self):
-    with tf.contrib.slim.arg_scope([]) as sc:
+    with contrib_slim.arg_scope([]) as sc:
       return sc
 
   @abstractmethod
@@ -135,7 +136,7 @@ class SsdFeatureExtractorTestBase(test_case.TestCase):
     image_tensor = np.random.rand(batch_size, image_height, image_width,
                                   3).astype(np.float32)
     feature_maps = self.execute(graph_fn, [image_tensor])
-    for feature_map, expected_shape in itertools.izip(
+    for feature_map, expected_shape in zip(
         feature_maps, expected_feature_map_shapes):
       self.assertAllEqual(feature_map.shape, expected_shape)
 
@@ -168,7 +169,7 @@ class SsdFeatureExtractorTestBase(test_case.TestCase):
         np.array(image_height, dtype=np.int32),
         np.array(image_width, dtype=np.int32)
     ])
-    for feature_map, expected_shape in itertools.izip(
+    for feature_map, expected_shape in zip(
         feature_maps, expected_feature_map_shapes):
       self.assertAllEqual(feature_map.shape, expected_shape)
 

--- a/research/object_detection/models/ssd_inception_v2_feature_extractor.py
+++ b/research/object_detection/models/ssd_inception_v2_feature_extractor.py
@@ -15,6 +15,7 @@
 
 """SSDFeatureExtractor for InceptionV2 features."""
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -22,7 +23,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import inception_v2
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDInceptionV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_inception_v3_feature_extractor.py
+++ b/research/object_detection/models/ssd_inception_v3_feature_extractor.py
@@ -15,6 +15,7 @@
 
 """SSDFeatureExtractor for InceptionV3 features."""
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -22,7 +23,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import inception_v3
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDInceptionV3FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor.py
@@ -1,0 +1,53 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""SSDFeatureExtractor for MobileNetEdgeTPU features."""
+
+import tensorflow as tf
+
+from object_detection.models import ssd_mobilenet_v3_feature_extractor
+from nets.mobilenet import mobilenet_v3
+
+slim = tf.contrib.slim
+
+
+class SSDMobileNetEdgeTPUFeatureExtractor(
+    ssd_mobilenet_v3_feature_extractor.SSDMobileNetV3FeatureExtractorBase):
+  """MobileNetEdgeTPU feature extractor."""
+
+  def __init__(self,
+               is_training,
+               depth_multiplier,
+               min_depth,
+               pad_to_multiple,
+               conv_hyperparams_fn,
+               reuse_weights=None,
+               use_explicit_padding=False,
+               use_depthwise=False,
+               override_base_feature_extractor_hyperparams=False,
+               scope_name='MobilenetEdgeTPU'):
+    super(SSDMobileNetEdgeTPUFeatureExtractor, self).__init__(
+        conv_defs=mobilenet_v3.V3_EDGETPU,
+        from_layer=['layer_18/expansion_output', 'layer_23'],
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams_fn=conv_hyperparams_fn,
+        reuse_weights=reuse_weights,
+        use_explicit_padding=use_explicit_padding,
+        use_depthwise=use_depthwise,
+        override_base_feature_extractor_hyperparams=override_base_feature_extractor_hyperparams,
+        scope_name=scope_name
+    )

--- a/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor_test.py
@@ -1,0 +1,66 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for ssd_mobilenet_edgetpu_feature_extractor."""
+
+import tensorflow as tf
+
+from tensorflow.contrib import slim as contrib_slim
+from object_detection.models import ssd_mobilenet_edgetpu_feature_extractor
+from object_detection.models import ssd_mobilenet_edgetpu_feature_extractor_testbase
+
+slim = contrib_slim
+
+
+class SsdMobilenetEdgeTPUFeatureExtractorTest(
+    ssd_mobilenet_edgetpu_feature_extractor_testbase
+    ._SsdMobilenetEdgeTPUFeatureExtractorTestBase):
+
+  def _get_input_sizes(self):
+    """Return first two input feature map sizes."""
+    return [384, 192]
+
+  def _create_feature_extractor(self,
+                                depth_multiplier,
+                                pad_to_multiple,
+                                use_explicit_padding=False,
+                                use_keras=False):
+    """Constructs a new MobileNetEdgeTPU feature extractor.
+
+    Args:
+      depth_multiplier: float depth multiplier for feature extractor
+      pad_to_multiple: the nearest multiple to zero pad the input height and
+        width dimensions to.
+      use_explicit_padding: use 'VALID' padding for convolutions, but prepad
+        inputs so that the output dimensions are the same as if 'SAME' padding
+        were used.
+      use_keras: if True builds a keras-based feature extractor, if False builds
+        a slim-based one.
+
+    Returns:
+      an ssd_meta_arch.SSDFeatureExtractor object.
+    """
+    min_depth = 32
+    return (ssd_mobilenet_edgetpu_feature_extractor
+            .SSDMobileNetEdgeTPUFeatureExtractor(
+                False,
+                depth_multiplier,
+                min_depth,
+                pad_to_multiple,
+                self.conv_hyperparams_fn,
+                use_explicit_padding=use_explicit_padding))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor_testbase.py
+++ b/research/object_detection/models/ssd_mobilenet_edgetpu_feature_extractor_testbase.py
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Base test class for ssd_mobilenet_v3_feature_extractor."""
+"""Base test class for ssd_mobilenet_edgetpu_feature_extractor."""
 
 import abc
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 
 
-slim = contrib_slim
+slim = tf.contrib.slim
 
 
-class _SsdMobilenetV3FeatureExtractorTestBase(
+class _SsdMobilenetEdgeTPUFeatureExtractorTestBase(
     ssd_feature_extractor_test.SsdFeatureExtractorTestBase):
-  """Base class for MobilenetV3 tests."""
+  """Base class for MobilenetEdgeTPU tests."""
 
   @abc.abstractmethod
   def _get_input_sizes(self):
@@ -102,8 +101,8 @@ class _SsdMobilenetV3FeatureExtractorTestBase(
     self.assertTrue(np.all(np.less_equal(np.abs(preprocessed_image), 1.0)))
 
   def test_has_fused_batchnorm(self):
-    image_height = 40
-    image_width = 40
+    image_height = 128
+    image_width = 128
     depth_multiplier = 1
     pad_to_multiple = 1
     image_placeholder = tf.placeholder(tf.float32,

--- a/research/object_detection/models/ssd_mobilenet_v1_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_feature_extractor.py
@@ -16,6 +16,7 @@
 """SSDFeatureExtractor for MobilenetV1 features."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -24,7 +25,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import mobilenet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDMobileNetV1FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_mobilenet_v1_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_feature_extractor_test.py
@@ -21,12 +21,13 @@ from absl.testing import parameterized
 
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_mobilenet_v1_feature_extractor
 from object_detection.models import ssd_mobilenet_v1_keras_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 @parameterized.parameters(

--- a/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor.py
@@ -18,6 +18,7 @@
 import copy
 import functools
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -26,7 +27,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import mobilenet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 # A modified config of mobilenet v1 that makes it more detection friendly,

--- a/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_fpn_feature_extractor_test.py
@@ -21,12 +21,13 @@ Keras-based Mobilenet V1 FPN feature extractors in SSD.
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_mobilenet_v1_fpn_feature_extractor
 from object_detection.models import ssd_mobilenet_v1_fpn_keras_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 @parameterized.parameters(

--- a/research/object_detection/models/ssd_mobilenet_v1_keras_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_keras_feature_extractor.py
@@ -16,6 +16,7 @@
 """SSDFeatureExtractor for Keras MobilenetV1 features."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -23,7 +24,7 @@ from object_detection.models.keras_models import mobilenet_v1
 from object_detection.utils import ops
 from object_detection.utils import shape_utils
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDMobileNetV1KerasFeatureExtractor(

--- a/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor.py
@@ -16,6 +16,7 @@
 """SSDFeatureExtractor for MobilenetV1 PPN features."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -24,7 +25,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import mobilenet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDMobileNetV1PpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v1_ppn_feature_extractor_test.py
@@ -16,11 +16,12 @@
 """Tests for ssd_mobilenet_v1_ppn_feature_extractor."""
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_mobilenet_v1_ppn_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SsdMobilenetV1PpnFeatureExtractorTest(

--- a/research/object_detection/models/ssd_mobilenet_v2_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_feature_extractor.py
@@ -16,6 +16,7 @@
 """SSDFeatureExtractor for MobilenetV2 features."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -25,7 +26,7 @@ from object_detection.utils import shape_utils
 from nets.mobilenet import mobilenet
 from nets.mobilenet import mobilenet_v2
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDMobileNetV2FeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_mobilenet_v2_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_feature_extractor_test.py
@@ -18,12 +18,13 @@ from absl.testing import parameterized
 
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_mobilenet_v2_feature_extractor
 from object_detection.models import ssd_mobilenet_v2_keras_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 @parameterized.parameters(

--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor.py
@@ -18,6 +18,7 @@
 import copy
 import functools
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -27,7 +28,7 @@ from object_detection.utils import shape_utils
 from nets.mobilenet import mobilenet
 from nets.mobilenet import mobilenet_v2
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 # A modified config of mobilenet v2 that makes it more detection friendly.

--- a/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v2_fpn_feature_extractor_test.py
@@ -21,12 +21,13 @@ Keras-based Mobilenet V2 FPN feature extractors in SSD.
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_mobilenet_v2_fpn_feature_extractor
 from object_detection.models import ssd_mobilenet_v2_fpn_keras_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 @parameterized.parameters(

--- a/research/object_detection/models/ssd_mobilenet_v3_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_mobilenet_v3_feature_extractor_test.py
@@ -15,12 +15,13 @@
 """Tests for ssd_mobilenet_v3_feature_extractor."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_mobilenet_v3_feature_extractor
 from object_detection.models import ssd_mobilenet_v3_feature_extractor_testbase
 
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SsdMobilenetV3LargeFeatureExtractorTest(

--- a/research/object_detection/models/ssd_pnasnet_feature_extractor.py
+++ b/research/object_detection/models/ssd_pnasnet_feature_extractor.py
@@ -19,6 +19,7 @@ Based on PNASNet ImageNet model: https://arxiv.org/abs/1712.00559
 """
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -27,7 +28,7 @@ from object_detection.utils import ops
 from object_detection.utils import variables_helper
 from nets.nasnet import pnasnet
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 def pnasnet_large_arg_scope_for_detection(is_batch_norm_training=False):

--- a/research/object_detection/models/ssd_pnasnet_feature_extractor_test.py
+++ b/research/object_detection/models/ssd_pnasnet_feature_extractor_test.py
@@ -16,11 +16,12 @@
 """Tests for ssd_pnas_feature_extractor."""
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.models import ssd_feature_extractor_test
 from object_detection.models import ssd_pnasnet_feature_extractor
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SsdPnasNetFeatureExtractorTest(

--- a/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor.py
+++ b/research/object_detection/models/ssd_resnet_v1_fpn_feature_extractor.py
@@ -18,6 +18,7 @@ See https://arxiv.org/abs/1708.02002 for details.
 """
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -26,7 +27,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import resnet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class SSDResnetV1FpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/models/ssd_resnet_v1_ppn_feature_extractor.py
+++ b/research/object_detection/models/ssd_resnet_v1_ppn_feature_extractor.py
@@ -15,6 +15,7 @@
 """SSD feature extractors based on Resnet v1 and PPN architectures."""
 
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.models import feature_map_generators
@@ -23,7 +24,7 @@ from object_detection.utils import ops
 from object_detection.utils import shape_utils
 from nets import resnet_v1
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class _SSDResnetPpnFeatureExtractor(ssd_meta_arch.SSDFeatureExtractor):

--- a/research/object_detection/predictors/convolutional_box_predictor_test.py
+++ b/research/object_detection/predictors/convolutional_box_predictor_test.py
@@ -198,7 +198,7 @@ class ConvolutionalBoxPredictorTest(test_case.TestCase):
             max_depth=32,
             num_layers_before_predictor=1,
             dropout_keep_prob=0.8,
-            kernel_size=1,
+            kernel_size=3,
             box_code_size=4,
             use_dropout=True,
             use_depthwise=True))
@@ -250,7 +250,7 @@ class ConvolutionalBoxPredictorTest(test_case.TestCase):
             max_depth=32,
             num_layers_before_predictor=1,
             dropout_keep_prob=0.8,
-            kernel_size=1,
+            kernel_size=3,
             box_code_size=4,
             use_dropout=True,
             use_depthwise=True))

--- a/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
+++ b/research/object_detection/predictors/convolutional_keras_box_predictor_test.py
@@ -209,7 +209,7 @@ class ConvolutionalKerasBoxPredictorTest(test_case.TestCase):
             num_layers_before_predictor=1,
             use_dropout=True,
             dropout_keep_prob=0.8,
-            kernel_size=1,
+            kernel_size=3,
             box_code_size=4,
             use_depthwise=True
         ))

--- a/research/object_detection/predictors/heads/box_head.py
+++ b/research/object_detection/predictors/heads/box_head.py
@@ -21,10 +21,11 @@ All the box prediction heads have a predict function that receives the
 """
 import functools
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.predictors.heads import head
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class MaskRCNNBoxHead(head.Head):
@@ -137,7 +138,11 @@ class ConvolutionalBoxHead(head.Head):
 
     Raises:
       ValueError: if min_depth > max_depth.
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(ConvolutionalBoxHead, self).__init__()
     self._is_training = is_training
     self._box_code_size = box_code_size
@@ -221,7 +226,13 @@ class WeightSharedConvolutionalBoxHead(head.Head):
         box_coder]. Otherwise returns the prediction tensor before reshaping,
         whose shape is [batch, height, width, num_predictions_per_location *
         num_class_slots].
+
+    Raises:
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(WeightSharedConvolutionalBoxHead, self).__init__()
     self._box_code_size = box_code_size
     self._kernel_size = kernel_size

--- a/research/object_detection/predictors/heads/class_head.py
+++ b/research/object_detection/predictors/heads/class_head.py
@@ -21,10 +21,11 @@ All the class prediction heads have a predict function that receives the
 """
 import functools
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.predictors.heads import head
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class MaskRCNNClassHead(head.Head):
@@ -143,7 +144,11 @@ class ConvolutionalClassHead(head.Head):
 
     Raises:
       ValueError: if min_depth > max_depth.
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(ConvolutionalClassHead, self).__init__()
     self._is_training = is_training
     self._num_class_slots = num_class_slots
@@ -247,7 +252,13 @@ class WeightSharedConvolutionalClassHead(head.Head):
         whose shape is [batch, height, width, num_predictions_per_location *
         num_class_slots].
       scope: Scope name for the convolution operation.
+
+    Raises:
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(WeightSharedConvolutionalClassHead, self).__init__()
     self._num_class_slots = num_class_slots
     self._kernel_size = kernel_size
@@ -303,4 +314,3 @@ class WeightSharedConvolutionalClassHead(head.Head):
           class_predictions_with_background,
           [batch_size, -1, self._num_class_slots])
     return class_predictions_with_background
-

--- a/research/object_detection/predictors/heads/keras_box_head.py
+++ b/research/object_detection/predictors/heads/keras_box_head.py
@@ -62,7 +62,11 @@ class ConvolutionalBoxHead(head.KerasHead):
 
     Raises:
       ValueError: if min_depth > max_depth.
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(ConvolutionalBoxHead, self).__init__(name=name)
     self._is_training = is_training
     self._box_code_size = box_code_size
@@ -266,7 +270,13 @@ class WeightSharedConvolutionalBoxHead(head.KerasHead):
         num_class_slots].
       name: A string name scope to assign to the model. If `None`, Keras
         will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(WeightSharedConvolutionalBoxHead, self).__init__(name=name)
     self._box_code_size = box_code_size
     self._kernel_size = kernel_size

--- a/research/object_detection/predictors/heads/keras_class_head.py
+++ b/research/object_detection/predictors/heads/keras_class_head.py
@@ -71,7 +71,11 @@ class ConvolutionalClassHead(head.KerasHead):
 
     Raises:
       ValueError: if min_depth > max_depth.
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(ConvolutionalClassHead, self).__init__(name=name)
     self._is_training = is_training
     self._use_dropout = use_dropout
@@ -274,7 +278,13 @@ class WeightSharedConvolutionalClassHead(head.KerasHead):
         num_class_slots].
       name: A string name scope to assign to the model. If `None`, Keras
         will auto-generate one from the class name.
+
+    Raises:
+      ValueError: if use_depthwise is True and kernel_size is 1.
     """
+    if use_depthwise and (kernel_size == 1):
+      raise ValueError('Should not use 1x1 kernel when using depthwise conv')
+
     super(WeightSharedConvolutionalClassHead, self).__init__(name=name)
     self._num_class_slots = num_class_slots
     self._kernel_size = kernel_size

--- a/research/object_detection/predictors/heads/keypoint_head.py
+++ b/research/object_detection/predictors/heads/keypoint_head.py
@@ -23,9 +23,10 @@ Mask RCNN paper. Or they could be used to represent different part locations of
 objects.
 """
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.predictors.heads import head
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class MaskRCNNKeypointHead(head.Head):

--- a/research/object_detection/predictors/heads/mask_head.py
+++ b/research/object_detection/predictors/heads/mask_head.py
@@ -21,11 +21,12 @@ All the mask prediction heads have a predict function that receives the
 """
 import math
 import tensorflow as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.predictors.heads import head
 from object_detection.utils import ops
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class MaskRCNNMaskHead(head.Head):

--- a/research/object_detection/protos/eval.proto
+++ b/research/object_detection/protos/eval.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 package object_detection.protos;
 
 // Message for configuring DetectionModel evaluation jobs (eval.py).
+// Next id - 30
 message EvalConfig {
   optional uint32 batch_size = 25 [default = 1];
   // Number of visualization images to generate.
@@ -85,4 +86,9 @@ message EvalConfig {
   // tensor dictionary, so that they can be displayed in Tensorboard.
   optional bool retain_original_image_additional_channels = 28
       [default = false];
+
+  // When this flag is set, images are not resized during evaluation.
+  // When this flag is not set (default case), image are resized according
+  // to the image_resizer config in the model during evaluation.
+  optional bool force_no_resize = 29 [default=false];
 }

--- a/research/object_detection/protos/ssd.proto
+++ b/research/object_detection/protos/ssd.proto
@@ -194,6 +194,7 @@ message SsdFeatureExtractor {
 
   // The number of SSD layers.
   optional int32 num_layers = 12 [default = 6];
+
 }
 
 // Configuration for Feature Pyramid Networks.
@@ -222,3 +223,4 @@ message FeaturePyramidNetworks {
   optional int32 additional_layer_depth = 3 [default = 256];
 
 }
+

--- a/research/object_detection/samples/configs/ssdlite_mobilenet_edgetpu_320x320_coco.config
+++ b/research/object_detection/samples/configs/ssdlite_mobilenet_edgetpu_320x320_coco.config
@@ -1,0 +1,198 @@
+# SSDLite with MobileNetEdgeTPU feature extractor.
+# Trained on COCO14, initialized from scratch.
+# TPU-compatible.
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  ssd {
+    inplace_batchnorm_update: true
+    freeze_batchnorm: false
+    num_classes: 90
+    box_coder {
+      faster_rcnn_box_coder {
+        y_scale: 10.0
+        x_scale: 10.0
+        height_scale: 5.0
+        width_scale: 5.0
+      }
+    }
+    matcher {
+      argmax_matcher {
+        matched_threshold: 0.5
+        unmatched_threshold: 0.5
+        ignore_thresholds: false
+        negatives_lower_than_unmatched: true
+        force_match_for_each_row: true
+        use_matmul_gather: true
+      }
+    }
+    similarity_calculator {
+      iou_similarity {
+      }
+    }
+    encode_background_as_zeros: true
+    anchor_generator {
+      ssd_anchor_generator {
+        num_layers: 6
+        min_scale: 0.2
+        max_scale: 0.95
+        aspect_ratios: 1.0
+        aspect_ratios: 2.0
+        aspect_ratios: 0.5
+        aspect_ratios: 3.0
+        aspect_ratios: 0.3333
+      }
+    }
+    image_resizer {
+      fixed_shape_resizer {
+        height: 320
+        width: 320
+      }
+    }
+    box_predictor {
+      convolutional_box_predictor {
+        min_depth: 0
+        max_depth: 0
+        num_layers_before_predictor: 0
+        use_dropout: false
+        dropout_keep_probability: 0.8
+        kernel_size: 3
+        use_depthwise: true
+        box_code_size: 4
+        apply_sigmoid_to_scores: false
+        class_prediction_bias_init: -4.6
+        conv_hyperparams {
+          activation: RELU_6,
+          regularizer {
+            l2_regularizer {
+              weight: 0.00004
+            }
+          }
+          initializer {
+            random_normal_initializer {
+              stddev: 0.03
+              mean: 0.0
+            }
+          }
+          batch_norm {
+            train: true,
+            scale: true,
+            center: true,
+            decay: 0.97,
+            epsilon: 0.001,
+          }
+        }
+      }
+    }
+    feature_extractor {
+      type: 'ssd_mobilenet_edgetpu'
+      min_depth: 16
+      depth_multiplier: 1.0
+      use_depthwise: true
+      conv_hyperparams {
+        activation: RELU_6,
+        regularizer {
+          l2_regularizer {
+            weight: 0.00004
+          }
+        }
+        initializer {
+          truncated_normal_initializer {
+            stddev: 0.03
+            mean: 0.0
+          }
+        }
+        batch_norm {
+          train: true,
+          scale: true,
+          center: true,
+          decay: 0.97,
+          epsilon: 0.001,
+        }
+      }
+      override_base_feature_extractor_hyperparams: true
+    }
+    loss {
+      classification_loss {
+        weighted_sigmoid_focal {
+          alpha: 0.75,
+          gamma: 2.0
+        }
+      }
+      localization_loss {
+        weighted_smooth_l1 {
+          delta: 1.0
+        }
+      }
+      classification_weight: 1.0
+      localization_weight: 1.0
+    }
+    normalize_loss_by_num_matches: true
+    normalize_loc_loss_by_codesize: true
+    post_processing {
+      batch_non_max_suppression {
+        score_threshold: 1e-8
+        iou_threshold: 0.6
+        max_detections_per_class: 100
+        max_total_detections: 100
+        use_static_shapes: true
+      }
+      score_converter: SIGMOID
+    }
+  }
+}
+
+train_config: {
+  batch_size: 512
+  sync_replicas: true
+  startup_delay_steps: 0
+  replicas_to_aggregate: 32
+  num_steps: 400000
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+  data_augmentation_options {
+    ssd_random_crop {
+    }
+  }
+  optimizer {
+    momentum_optimizer: {
+      learning_rate: {
+        cosine_decay_learning_rate {
+          learning_rate_base: 0.8
+          total_steps: 400000
+          warmup_learning_rate: 0.13333
+          warmup_steps: 2000
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  max_number_of_boxes: 100
+  unpad_groundtruth_tensors: false
+}
+
+train_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/mscoco_train.record-?????-of-00100"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
+}
+
+eval_config: {
+  num_examples: 8000
+}
+
+eval_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/mscoco_val.record-?????-of-00010"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
+}

--- a/research/object_detection/samples/configs/ssdlite_mobilenet_edgetpu_320x320_coco_quant.config
+++ b/research/object_detection/samples/configs/ssdlite_mobilenet_edgetpu_320x320_coco_quant.config
@@ -1,0 +1,206 @@
+# Quantized Training SSDLite with MobileNetEdgeTPU feature extractor.
+# Trained on COCO14, initialized from scratch.
+# TPU-compatible.
+# Users should configure the fine_tune_checkpoint field in the train config as
+# well as the label_map_path and input_path fields in the train_input_reader and
+# eval_input_reader. Search for "PATH_TO_BE_CONFIGURED" to find the fields that
+# should be configured.
+
+model {
+  ssd {
+    inplace_batchnorm_update: true
+    freeze_batchnorm: false
+    num_classes: 90
+    box_coder {
+      faster_rcnn_box_coder {
+        y_scale: 10.0
+        x_scale: 10.0
+        height_scale: 5.0
+        width_scale: 5.0
+      }
+    }
+    matcher {
+      argmax_matcher {
+        matched_threshold: 0.5
+        unmatched_threshold: 0.5
+        ignore_thresholds: false
+        negatives_lower_than_unmatched: true
+        force_match_for_each_row: true
+        use_matmul_gather: true
+      }
+    }
+    similarity_calculator {
+      iou_similarity {
+      }
+    }
+    encode_background_as_zeros: true
+    anchor_generator {
+      ssd_anchor_generator {
+        num_layers: 6
+        min_scale: 0.2
+        max_scale: 0.95
+        aspect_ratios: 1.0
+        aspect_ratios: 2.0
+        aspect_ratios: 0.5
+        aspect_ratios: 3.0
+        aspect_ratios: 0.3333
+      }
+    }
+    image_resizer {
+      fixed_shape_resizer {
+        height: 320
+        width: 320
+      }
+    }
+    box_predictor {
+      convolutional_box_predictor {
+        min_depth: 0
+        max_depth: 0
+        num_layers_before_predictor: 0
+        use_dropout: false
+        dropout_keep_probability: 0.8
+        kernel_size: 3
+        use_depthwise: true
+        box_code_size: 4
+        apply_sigmoid_to_scores: false
+        class_prediction_bias_init: -4.6
+        conv_hyperparams {
+          activation: RELU_6,
+          regularizer {
+            l2_regularizer {
+              weight: 0.00004
+            }
+          }
+          initializer {
+            random_normal_initializer {
+              stddev: 0.03
+              mean: 0.0
+            }
+          }
+          batch_norm {
+            train: true,
+            scale: true,
+            center: true,
+            decay: 0.97,
+            epsilon: 0.001,
+          }
+        }
+      }
+    }
+    feature_extractor {
+      type: 'ssd_mobilenet_edgetpu'
+      min_depth: 16
+      depth_multiplier: 1.0
+      use_depthwise: true
+      conv_hyperparams {
+        activation: RELU_6,
+        regularizer {
+          l2_regularizer {
+            weight: 0.00004
+          }
+        }
+        initializer {
+          truncated_normal_initializer {
+            stddev: 0.03
+            mean: 0.0
+          }
+        }
+        batch_norm {
+          train: true,
+          scale: true,
+          center: true,
+          decay: 0.97,
+          epsilon: 0.001,
+        }
+      }
+      override_base_feature_extractor_hyperparams: true
+    }
+    loss {
+      classification_loss {
+        weighted_sigmoid_focal {
+          alpha: 0.75,
+          gamma: 2.0
+        }
+      }
+      localization_loss {
+        weighted_smooth_l1 {
+          delta: 1.0
+        }
+      }
+      classification_weight: 1.0
+      localization_weight: 1.0
+    }
+    normalize_loss_by_num_matches: true
+    normalize_loc_loss_by_codesize: true
+    post_processing {
+      batch_non_max_suppression {
+        score_threshold: 1e-8
+        iou_threshold: 0.6
+        max_detections_per_class: 100
+        max_total_detections: 100
+        use_static_shapes: true
+      }
+      score_converter: SIGMOID
+    }
+  }
+}
+
+train_config: {
+  batch_size: 512
+  sync_replicas: true
+  startup_delay_steps: 0
+  replicas_to_aggregate: 32
+  num_steps: 400000
+  data_augmentation_options {
+    random_horizontal_flip {
+    }
+  }
+  data_augmentation_options {
+    ssd_random_crop {
+    }
+  }
+  optimizer {
+    momentum_optimizer: {
+      learning_rate: {
+        cosine_decay_learning_rate {
+          learning_rate_base: 0.8
+          total_steps: 400000
+          warmup_learning_rate: 0.13333
+          warmup_steps: 2000
+        }
+      }
+      momentum_optimizer_value: 0.9
+    }
+    use_moving_average: false
+  }
+  max_number_of_boxes: 100
+  unpad_groundtruth_tensors: false
+}
+
+train_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/mscoco_train.record-?????-of-00100"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
+}
+
+eval_config: {
+  num_examples: 8000
+}
+
+eval_input_reader: {
+  tf_record_input_reader {
+    input_path: "PATH_TO_BE_CONFIGURED/mscoco_val.record-?????-of-00010"
+  }
+  label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
+  shuffle: false
+  num_readers: 1
+}
+
+graph_rewriter {
+  quantization {
+    delay: 30000
+    activation_bits: 8
+    weight_bits: 8
+  }
+}

--- a/research/object_detection/utils/label_map_util.py
+++ b/research/object_detection/utils/label_map_util.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import logging
 
+from six import string_types
 from six.moves import range
 import tensorflow as tf
 from google.protobuf import text_format
@@ -145,13 +146,14 @@ def load_labelmap(path):
   return label_map
 
 
-def get_label_map_dict(label_map_path,
+def get_label_map_dict(label_map_path_or_proto,
                        use_display_name=False,
                        fill_in_gaps_and_background=False):
   """Reads a label map and returns a dictionary of label names to id.
 
   Args:
-    label_map_path: path to StringIntLabelMap proto text file.
+    label_map_path_or_proto: path to StringIntLabelMap proto text file or the
+      proto itself.
     use_display_name: whether to use the label map items' display names as keys.
     fill_in_gaps_and_background: whether to fill in gaps and background with
     respect to the id field in the proto. The id: 0 is reserved for the
@@ -166,7 +168,12 @@ def get_label_map_dict(label_map_path,
     ValueError: if fill_in_gaps_and_background and label_map has non-integer or
     negative values.
   """
-  label_map = load_labelmap(label_map_path)
+  if isinstance(label_map_path_or_proto, string_types):
+    label_map = load_labelmap(label_map_path_or_proto)
+  else:
+    _validate_label_map(label_map_path_or_proto)
+    label_map = label_map_path_or_proto
+
   label_map_dict = {}
   for item in label_map.item:
     if use_display_name:

--- a/research/object_detection/utils/label_map_util_test.py
+++ b/research/object_detection/utils/label_map_util_test.py
@@ -57,6 +57,23 @@ class LabelMapUtilTest(tf.test.TestCase):
     self.assertEqual(label_map_dict['dog'], 1)
     self.assertEqual(label_map_dict['cat'], 2)
 
+  def test_get_label_map_dict_from_proto(self):
+    label_map_string = """
+      item {
+        id:2
+        name:'cat'
+      }
+      item {
+        id:1
+        name:'dog'
+      }
+    """
+    label_map_proto = text_format.Parse(
+        label_map_string, string_int_label_map_pb2.StringIntLabelMap())
+    label_map_dict = label_map_util.get_label_map_dict(label_map_proto)
+    self.assertEqual(label_map_dict['dog'], 1)
+    self.assertEqual(label_map_dict['cat'], 2)
+
   def test_get_label_map_dict_display(self):
     label_map_string = """
       item {


### PR DESCRIPTION
280142968  by Zhichao Lu:

    Opensource MobilenetEdgeTPU + ssdlite into third-party object detection APIs on EdgeTPU.

--
280134001  by Zhichao Lu:

    Adds MobilenetEdgeTpu + ssdlite into internal object detection APIs on EdgeTPU.

--
278941778  by Zhichao Lu:

    Add support for fixed input shapes for 'encoded_image_string_tensor' and 'tf_example' inputs.

--
278933274  by Zhichao Lu:

      Adding fool proof check to avoid using 1x1 depthwise conv op.

--
278762192  by Zhichao Lu:

    Ensure correct number of iterations after training resumes.

--
278746440  by Zhichao Lu:

    Internal change.

--
278006953  by Zhichao Lu:

    Internal changes to tf.contrib symbols

--
278006330  by Zhichao Lu:

    Internal changes to tf.contrib symbols

--
277593959  by Zhichao Lu:

      Make the ssd_feature_extractor_test.py PY3 compatible. The "six.zip" will use "itertools.izip" in Python 2 and "zip" in Python 3.

--
277344551  by Zhichao Lu:

    Internal change.

--
277154953  by Zhichao Lu:

    Conditionally use keras based optimizers so that check-pointing works correctly.
    This change also enables summaries on TPU which were previously not enabled
    due to a bug.

--
277087572  by Zhichao Lu:

    Fix resizing boxes when using keep_aspect_ratio_rezier with padding.

--
275898543  by Zhichao Lu:

    Support label_map_proto as input in label_map_util.

--
275891248  by Zhichao Lu:

    Fix top-k computation logic for boxes to consider all classes per location.

--
275347137  by Zhichao Lu:

    Add force_no_resize flag in eval.proto which replaces
    the resize config with identity resizer. This is useful
    when we want to test at the original image resolution.

--

PiperOrigin-RevId: 280142968