### PR TITLE
Fixed OID tfrecord shard calculation

### DIFF
--- a/research/object_detection/dataset_tools/create_oid_tf_record.py
+++ b/research/object_detection/dataset_tools/create_oid_tf_record.py
@@ -109,7 +109,7 @@ def main(_):
       tf_example = oid_tfrecord_creation.tf_example_from_annotations_data_frame(
           image_annotations, label_map, encoded_image)
       if tf_example:
-        shard_idx = int(image_id, 16) % FLAGS.num_shards
+        shard_idx = counter % FLAGS.num_shards
         output_tfrecords[shard_idx].write(tf_example.SerializeToString())
 
 


### PR DESCRIPTION
Current shard calculation produces tfrecord files with greatly differing filesizes - 100 shard test produced files ranging form 45% to 0% of the total dataset.

To fix the problem, I copied over the shard calculation logic from create_coco_tf_record.py