### PR TITLE
Update vid2depth/README.md: use raw.githubcontent

### DIFF
--- a/research/vid2depth/README.md
+++ b/research/vid2depth/README.md
@@ -50,7 +50,7 @@ git clone --depth 1 https://github.com/tensorflow/models.git
 ```shell
 mkdir -p ~/vid2depth/kitti-raw-uncompressed
 cd ~/vid2depth/kitti-raw-uncompressed
-wget https://github.com/mrharicot/monodepth/blob/master/utils/kitti_archives_to_download.txt
+wget https://raw.githubusercontent.com/mrharicot/monodepth/master/utils/kitti_archives_to_download.txt
 wget -i kitti_archives_to_download.txt
 unzip "*.zip"
 ```


### PR DESCRIPTION
The wget command for the KITTI dataset in the currently downloads the html for GitHub's fancy display of the text file. This change fixes that so it instead downloads the raw txt file (no more trying to resolve host '<')