### PR TITLE
Fixed tf.compat.v1 bug

### DIFF
--- a/official/transformer/data_download.py
+++ b/official/transformer/data_download.py
@@ -331,7 +331,7 @@ def shuffle_records(fname):
   tmp_fname = fname + ".unshuffled"
   tf.gfile.Rename(fname, tmp_fname)
 
-  reader = tf.compat.v1.io.tf_record_iterator(tmp_fname)
+  reader = tf.io.tf_record_iterator(tmp_fname)
   records = []
   for record in reader:
     records.append(record)


### PR DESCRIPTION
Before that, it called __tensorflow.compat.v1.compat.v1.io.tf_record_iterator__ function, which does not exist, instead of __tensorflow.compat.v1.io.tf_record_iterator__.