### PR TITLE
Fix the installation instructions for object detection.

### DIFF
--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -11,7 +11,7 @@ Tensorflow Object Detection API depends on the following libraries:
 *   tf Slim (which is included in the "tensorflow/models/research/" checkout)
 *   Jupyter notebook
 *   Matplotlib
-*   Tensorflow (>=1.12.0)
+*   Tensorflow (>=1.12.0, <=1.15.0)
 *   Cython
 *   contextlib2
 *   cocoapi
@@ -21,10 +21,8 @@ instructions](https://www.tensorflow.org/install/). A typical user can install
 Tensorflow using one of the following commands:
 
 ``` bash
-# For CPU
-pip install tensorflow
-# For GPU
-pip install tensorflow-gpu
+# For CPU and GPU
+pip install tensorflow==1.15
 ```
 
 The remaining libraries can be installed on Ubuntu 16.04 using via apt-get:


### PR DESCRIPTION
Currently Tensorflow 2.0 is not supported in this codebase.

Modified the installation instructions to suggest installing the latest Tensorflow 1.X version that passes the installation verification tests.

This should be changed once the code is migrated to Tensorflow 2.0, but in the meantime this will make for a much better experience for anyone trying to install and use this library.