### PR TITLE
Added .values to series object

### DIFF
--- a/research/deep_contextual_bandits/bandits/data/data_sampler.py
+++ b/research/deep_contextual_bandits/bandits/data/data_sampler.py
@@ -71,7 +71,7 @@ def sample_mushroom_data(file_name,
       size=num_contexts)
   eat_reward = r_eat_safe * df.iloc[ind, 0]
   eat_reward += np.multiply(random_poison, df.iloc[ind, 1])
-  eat_reward = eat_reward.reshape((num_contexts, 1))
+  eat_reward = eat_reward.values.reshape((num_contexts, 1))
 
   # compute optimal expected reward and optimal actions
   exp_eat_poison_reward = r_eat_poison_bad * prob_poison_bad


### PR DESCRIPTION
 to prevent crash when running data_sampler.

Running `example_main.py` would result in:

```
Traceback (most recent call last):
  File "example_main.py", line 453, in <module>
    app.run(main)
  File "/usr/local/anaconda3/envs/tf/lib/python3.6/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/usr/local/anaconda3/envs/tf/lib/python3.6/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "example_main.py", line 237, in main
    sampled_vals = sample_data(data_type, num_contexts)
  File "example_main.py", line 127, in sample_data
    dataset, opt_mushroom = sample_mushroom_data(file_name, num_contexts)
  File "/Users/tmo/Nodes/tf-models/research/deep_contextual_bandits/bandits/data/data_sampler.py", line 74, in sample_mushroom_data
    eat_reward = eat_reward.reshape((num_contexts, 1))
  File "/usr/local/anaconda3/envs/tf/lib/python3.6/site-packages/pandas/core/generic.py", line 5179, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'Series' object has no attribute 'reshape'
```