### PR TITLE
Enable Persist BatchNorm in CTL ResNet50 

### DIFF
--- a/official/vision/image_classification/resnet_ctl_imagenet_main.py
+++ b/official/vision/image_classification/resnet_ctl_imagenet_main.py
@@ -197,6 +197,8 @@ def run(flags_obj):
         'mixed_bfloat16')
     tf.compat.v2.keras.mixed_precision.experimental.set_policy(policy)
 
+  common.set_cudnn_batchnorm_mode()
+
   # TODO(anj-s): Set data_format without using Keras.
   data_format = flags_obj.data_format
   if data_format is None:

--- a/official/vision/image_classification/resnet_ctl_imagenet_main.py
+++ b/official/vision/image_classification/resnet_ctl_imagenet_main.py
@@ -197,6 +197,7 @@ def run(flags_obj):
         'mixed_bfloat16')
     tf.compat.v2.keras.mixed_precision.experimental.set_policy(policy)
 
+  # This only affects GPU.
   common.set_cudnn_batchnorm_mode()
 
   # TODO(anj-s): Set data_format without using Keras.


### PR DESCRIPTION
As in the Keras compile/fit mode (https://github.com/tensorflow/models/blob/master/official/vision/image_classification/resnet_imagenet_main.py#L62), this PR enables the persistent CUDNN batch norm by default for better performance in CTL ResNet50.

fyi @nluehr 