### PR TITLE
Add explicit tensorflow version to deeplab_demo.ipynb

### DIFF
--- a/research/deeplab/deeplab_demo.ipynb
+++ b/research/deeplab/deeplab_demo.ipynb
@@ -61,6 +61,7 @@
         "import numpy as np\n",
         "from PIL import Image\n",
         "\n",
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf"
       ]
     },


### PR DESCRIPTION
Colab will soon update the default version of tensorflow to 2.1.0. In order for this notebook to continue to work, I'm adding a line magic that will ensure this notebook continues to use tensorflow 1.x and execute without errors.