### PR TITLE
Add explicit tensorflow version to 4_Neural_Style_Transfer_with_Eager…

### DIFF
--- a/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
+++ b/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
@@ -168,6 +168,7 @@
       },
       "cell_type": "code",
       "source": [
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "\n",
         "from tensorflow.python.keras.preprocessing import image as kp_image\n",


### PR DESCRIPTION
…_Execution.ipynb

Colab will soon update the default version of tensorflow to 2.1.0. In order for this notebook to continue to work, I'm adding a line magic that will ensure this notebook continues to use tensorflow 1.x and execute without errors.