### PR TITLE
Swap mixed-up URLs

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -10,11 +10,11 @@
         "# Object Detection API Demo\n",
         "\n",
         "\u003ctable align=\"left\"\u003e\u003ctd\u003e\n",
-        "  \u003ca target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
+        "  \u003ca target=\"_blank\"  href=\"https://colab.sandbox.google.com/github/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
         "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\n",
         "  \u003c/a\u003e\n",
         "\u003c/td\u003e\u003ctd\u003e\n",
-        "  \u003ca target=\"_blank\"  href=\"https://colab.sandbox.google.com/github/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
+        "  \u003ca target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
         "    \u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
         "\u003c/td\u003e\u003c/table\u003e"
       ]


### PR DESCRIPTION
The URL for the "Run in Google Colab" link pointed to the code on GitHub and the URL for "View source on GitHub" opened the notebook in Google Colab.

This PR switches the URLs so that they point to the correct resources.