### PR TITLE
Fix Google colab URL

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -10,7 +10,7 @@
         "# Object Detection API Demo\n",
         "\n",
         "\u003ctable align=\"left\"\u003e\u003ctd\u003e\n",
-        "  \u003ca target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
+        "  \u003ca target=\"_blank\"  href=\"https://colab.research.google.com/github/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb\"\u003e\n",
         "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\n",
         "  \u003c/a\u003e\n",
         "\u003c/td\u003e\u003ctd\u003e\n",


### PR DESCRIPTION
Change the current URL in Google Colab link (https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb) for the correct one URL