### PR TITLE
Fix typo in object detection export_graph example usage

### DIFF
--- a/research/object_detection/export_inference_graph.py
+++ b/research/object_detection/export_inference_graph.py
@@ -62,7 +62,7 @@ Notes:
 
 Example Usage:
 --------------
-python export_inference_graph \
+python export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path path/to/ssd_inception_v2.config \
     --trained_checkpoint_prefix path/to/model.ckpt \
@@ -87,7 +87,7 @@ eval config.
 Example Usage (in which we change the second stage post-processing score
 threshold to be 0.5):
 
-python export_inference_graph \
+python export_inference_graph.py \
     --input_type image_tensor \
     --pipeline_config_path path/to/ssd_inception_v2.config \
     --trained_checkpoint_prefix path/to/model.ckpt \

--- a/research/object_detection/export_tflite_ssd_graph.py
+++ b/research/object_detection/export_tflite_ssd_graph.py
@@ -55,7 +55,7 @@ else:
 
 Example Usage:
 --------------
-python object_detection/export_tflite_ssd_graph \
+python object_detection/export_tflite_ssd_graph.py \
     --pipeline_config_path path/to/ssd_mobilenet.config \
     --trained_checkpoint_prefix path/to/model.ckpt \
     --output_directory path/to/exported_model_directory
@@ -73,7 +73,7 @@ eval config.
 
 Example Usage (in which we change the NMS iou_threshold to be 0.5 and
 NMS score_threshold to be 0.0):
-python object_detection/export_tflite_ssd_graph \
+python object_detection/export_tflite_ssd_graph.py \
     --pipeline_config_path path/to/ssd_mobilenet.config \
     --trained_checkpoint_prefix path/to/model.ckpt \
     --output_directory path/to/exported_model_directory


### PR DESCRIPTION
There is a simple typo in usage.

```bash
python export_inference_graph
```
can not execute python.

I changed this to

```bash
python export_inference_graph.py
```
