### PR TITLE
Address deprecation warning in tf.while_loop

### DIFF
--- a/official/nlp/transformer/beam_search_v1.py
+++ b/official/nlp/transformer/beam_search_v1.py
@@ -128,9 +128,13 @@ class SequenceBeamSearch(object):
     """Beam search for sequences with highest scores."""
     state, state_shapes = self._create_initial_state(initial_ids, initial_cache)
 
-    finished_state = tf.while_loop(
-        self._continue_search, self._search_step, loop_vars=[state],
-        shape_invariants=[state_shapes], parallel_iterations=1, back_prop=False)
+    finished_state = tf.nest.map_structure(
+      tf.stop_gradient,
+      tf.while_loop(self._continue_search,
+                    self._search_step,
+                    loop_vars=[state],
+                    shape_invariants=[state_shapes],
+                    parallel_iterations=1))
     finished_state = finished_state[0]
 
     alive_seq = finished_state[_StateKeys.ALIVE_SEQ]

--- a/official/transformer/v2/beam_search.py
+++ b/official/transformer/v2/beam_search.py
@@ -30,9 +30,13 @@ class SequenceBeamSearchV2(v1.SequenceBeamSearch):
     """Beam search for sequences with highest scores."""
     state, state_shapes = self._create_initial_state(initial_ids, initial_cache)
 
-    finished_state = tf.while_loop(
-        self._continue_search, self._search_step, loop_vars=[state],
-        shape_invariants=[state_shapes], parallel_iterations=1, back_prop=False)
+    finished_state = tf.nest.map_structure(
+      tf.stop_gradient,
+      tf.while_loop(self._continue_search,
+                    self._search_step,
+                    loop_vars=[state],
+                    shape_invariants=[state_shapes],
+                    parallel_iterations=1))
     finished_state = finished_state[0]
 
     alive_seq = finished_state[_StateKeys.ALIVE_SEQ]


### PR DESCRIPTION
I am updating the code according to the recommendation in the deprecation message.

```python
@tf_export("while_loop", v1=[])
@deprecation.deprecated_arg_values(
    None,
    """back_prop=False is deprecated. Consider using tf.stop_gradient instead.
Instead of:
results = tf.while_loop(c, b, vars, back_prop=False)
Use:
results = tf.nest.map_structure(tf.stop_gradient, tf.while_loop(c, b, vars))""",
```