### PR TITLE
Removing GAN link (deprecated)

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -33,7 +33,6 @@ request.
 -   [domain_adaptation](domain_adaptation): domain separation networks.
 -   [fivo](fivo): filtering variational objectives for training generative
     sequence models.
--   [gan](gan): generative adversarial networks.
 -   [im2txt](im2txt): image-to-text neural network for image captioning.
 -   [inception](inception): deep convolutional networks for computer vision.
 -   [keypointnet](keypointnet): discovery of latent 3D keypoints via end-to-end


### PR DESCRIPTION
Commit https://github.com/tensorflow/models/commit/4dcd5116adf2b4d657858060396f8ce8a0127fab removed the GAN part of the repo, hence it can be removed from the list in the README file. Thanks.