### PR TITLE
replace untar with extract

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -313,7 +313,7 @@
         "  model_dir = tf.keras.utils.get_file(\n",
         "    fname=model_name, \n",
         "    origin=base_url + model_file,\n",
-        "    untar=True)\n",
+        "    extract=True)\n",
         "\n",
         "  model_dir = pathlib.Path(model_dir)/\"saved_model\"\n",
         "\n",


### PR DESCRIPTION
untar option is deprecated, per https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file