### PR TITLE
Update label_map_util.py to avoid unnecessary deprecation warnings.

### DIFF
--- a/research/object_detection/utils/label_map_util.py
+++ b/research/object_detection/utils/label_map_util.py
@@ -135,7 +135,7 @@ def load_labelmap(path):
   Returns:
     a StringIntLabelMapProto
   """
-  with tf.gfile.GFile(path, 'r') as fid:
+  with tf.io.gfile.GFile(path, 'r') as fid:
     label_map_string = fid.read()
     label_map = string_int_label_map_pb2.StringIntLabelMap()
     try:


### PR DESCRIPTION
**The name tf.gfile.GFile is deprecated.  I have replaced it with updated tf.io.gfile.GFile instead. To avoid unnecessary warnings**