### PR TITLE
Correct usage of max_number_of_boxes for TPU

### DIFF
--- a/research/object_detection/g3doc/tpu_compatibility.md
+++ b/research/object_detection/g3doc/tpu_compatibility.md
@@ -46,26 +46,16 @@ have static shape:
 
 *   **Groundtruth tensors with static shape** - Images in a typical detection
     dataset have variable number of groundtruth boxes and associated classes.
-    Setting `max_number_of_boxes` to a large enough number in the
-    `train_input_reader` and `eval_input_reader` pads the groundtruth tensors
-    with zeros to a static shape. Padded groundtruth tensors are correctly
-    handled internally within the model.
+    Setting `max_number_of_boxes` to a large enough number in `train_config`
+    pads the groundtruth tensors with zeros to a static shape. Padded groundtruth
+    tensors are correctly handled internally within the model.
 
     ```
-    train_input_reader: {
-      tf_record_input_reader {
-        input_path: "PATH_TO_BE_CONFIGURED/mscoco_train.record-?????-of-00100"
-      }
-      label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
+    train_config: {
+      fine_tune_checkpoint: "PATH_TO_BE_CONFIGURED/model.ckpt"
+      batch_size: 64
       max_number_of_boxes: 200
-    }
-
-    eval_input_reader: {
-      tf_record_input_reader {
-        input_path: "PATH_TO_BE_CONFIGURED/mscoco_val.record-?????-of-0010"
-      }
-      label_map_path: "PATH_TO_BE_CONFIGURED/mscoco_label_map.pbtxt"
-      max_number_of_boxes: 200
+      unpad_groundtruth_tensors: false
     }
     ```
 


### PR DESCRIPTION
Update TPU compatibility docs to show correct usage of max_number_of_boxes. Should be in train_config section instead of train_input_reader and eval_input_reader.

Correct usage can be seen in the following example TPU compatible config. This config is already linked to in this document.
https://github.com/tensorflow/models/blob/master/research/object_detection/samples/configs/ssd_resnet50_v1_fpn_shared_box_predictor_640x640_coco14_sync.config