### PR TITLE
fix "Unknown command line flag 'export_dir'"

### DIFF
--- a/research/deep_speech/deep_speech.py
+++ b/research/deep_speech/deep_speech.py
@@ -304,7 +304,12 @@ def define_deep_speech_flags():
   """Add flags for run_deep_speech."""
   # Add common flags
   flags_core.define_base(
-      data_dir=False  # we use train_data_dir and eval_data_dir instead
+      data_dir=False,  # we use train_data_dir and eval_data_dir instead
+      export_dir=True,
+      train_epochs=True,
+      hooks=True,
+      num_gpu=True,
+      epochs_between_evals=True
   )
   flags_core.define_performance(
       num_parallel_calls=False,


### PR DESCRIPTION
I met some errors as below:
`
Traceback (most recent call last):
  File "deep_speech.py", line 409, in <module>
    define_deep_speech_flags()
  File "deep_speech.py", line 325, in define_deep_speech_flags
    hooks="")
  File "/home/luke/Download/tmp/models/official/utils/flags/core.py", line 41, in set_defaults
    flags.FLAGS.set_default(name=key, value=value)
  File "/home/luke/miniconda3/lib/python3.7/site-packages/absl/flags/_flagvalues.py", line 580, in set_default
    self._set_unknown_flag(name, value)
  File "/home/luke/miniconda3/lib/python3.7/site-packages/absl/flags/_flagvalues.py", line 375, in _set_unknown_flag
    raise _exceptions.UnrecognizedFlagError(name, value)
absl.flags._exceptions.UnrecognizedFlagError: Unknown command line flag 'export_dir'`

`Traceback (most recent call last):
  File "deep_speech.py", line 415, in <module>
    absl_app.run(main)
  File "/home/luke/miniconda3/lib/python3.7/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/home/luke/miniconda3/lib/python3.7/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "deep_speech.py", line 408, in main
    run_deep_speech(flags_obj)
  File "deep_speech.py", line 272, in run_deep_speech
    flags_obj.epochs_between_evals)
  File "/home/luke/miniconda3/lib/python3.7/site-packages/absl/flags/_flagvalues.py", line 473, in __getattr__
    raise AttributeError(name)
AttributeError: epochs_between_evals`