### PR TITLE
Merged commit includes the following changes:

### DIFF
--- a/research/lstm_object_detection/builders/graph_rewriter_builder.py
+++ b/research/lstm_object_detection/builders/graph_rewriter_builder.py
@@ -21,7 +21,9 @@ customization of freeze_bn_delay.
 """
 
 import re
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import layers as contrib_layers
+from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib.quantize.python import common
 from tensorflow.contrib.quantize.python import input_to_ops
 from tensorflow.contrib.quantize.python import quant_ops
@@ -72,17 +74,18 @@ def build(graph_rewriter_config,
 
     # Quantize the graph by inserting quantize ops for weights and activations
     if is_training:
-      tf.contrib.quantize.experimental_create_training_graph(
+      contrib_quantize.experimental_create_training_graph(
           input_graph=graph,
           quant_delay=graph_rewriter_config.quantization.delay,
           freeze_bn_delay=graph_rewriter_config.quantization.delay)
     else:
-      tf.contrib.quantize.experimental_create_eval_graph(
+      contrib_quantize.experimental_create_eval_graph(
           input_graph=graph,
           quant_delay=graph_rewriter_config.quantization.delay
           if not is_export else 0)
 
-    tf.contrib.layers.summarize_collection('quant_vars')
+    contrib_layers.summarize_collection('quant_vars')
+
   return graph_rewrite_fn
 
 

--- a/research/lstm_object_detection/builders/graph_rewriter_builder_test.py
+++ b/research/lstm_object_detection/builders/graph_rewriter_builder_test.py
@@ -15,7 +15,9 @@
 
 """Tests for graph_rewriter_builder."""
 import mock
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import layers as contrib_layers
+from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from lstm_object_detection.builders import graph_rewriter_builder
@@ -27,9 +29,9 @@ class QuantizationBuilderTest(tf.test.TestCase):
 
   def testQuantizationBuilderSetsUpCorrectTrainArguments(self):
     with mock.patch.object(
-        tf.contrib.quantize,
+        contrib_quantize,
         'experimental_create_training_graph') as mock_quant_fn:
-      with mock.patch.object(tf.contrib.layers,
+      with mock.patch.object(contrib_layers,
                              'summarize_collection') as mock_summarize_col:
         graph_rewriter_proto = graph_rewriter_pb2.GraphRewriter()
         graph_rewriter_proto.quantization.delay = 10
@@ -44,9 +46,9 @@ class QuantizationBuilderTest(tf.test.TestCase):
         mock_summarize_col.assert_called_with('quant_vars')
 
   def testQuantizationBuilderSetsUpCorrectEvalArguments(self):
-    with mock.patch.object(tf.contrib.quantize,
+    with mock.patch.object(contrib_quantize,
                            'experimental_create_eval_graph') as mock_quant_fn:
-      with mock.patch.object(tf.contrib.layers,
+      with mock.patch.object(contrib_layers,
                              'summarize_collection') as mock_summarize_col:
         graph_rewriter_proto = graph_rewriter_pb2.GraphRewriter()
         graph_rewriter_proto.quantization.delay = 10

--- a/research/lstm_object_detection/eval.py
+++ b/research/lstm_object_detection/eval.py
@@ -25,7 +25,7 @@ This executable is used to evaluate DetectionModels. Example usage:
 
 import functools
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from google.protobuf import text_format
 from lstm_object_detection import evaluator
 from lstm_object_detection import model_builder

--- a/research/lstm_object_detection/evaluator.py
+++ b/research/lstm_object_detection/evaluator.py
@@ -20,7 +20,8 @@ DetectionModel.
 
 """
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import tfprof as contrib_tfprof
 from lstm_object_detection.metrics import coco_evaluation_all_frames
 from object_detection import eval_util
 from object_detection.core import prefetcher
@@ -105,13 +106,13 @@ def _extract_prediction_tensors(model,
   detections = _create_detection_op(model, input_dict, batch)
 
   # Print out anaylsis of the model.
-  tf.contrib.tfprof.model_analyzer.print_model_analysis(
+  contrib_tfprof.model_analyzer.print_model_analysis(
       tf.get_default_graph(),
-      tfprof_options=tf.contrib.tfprof.model_analyzer.
-      TRAINABLE_VARS_PARAMS_STAT_OPTIONS)
-  tf.contrib.tfprof.model_analyzer.print_model_analysis(
+      tfprof_options=contrib_tfprof.model_analyzer
+      .TRAINABLE_VARS_PARAMS_STAT_OPTIONS)
+  contrib_tfprof.model_analyzer.print_model_analysis(
       tf.get_default_graph(),
-      tfprof_options=tf.contrib.tfprof.model_analyzer.FLOAT_OPS_OPTIONS)
+      tfprof_options=contrib_tfprof.model_analyzer.FLOAT_OPS_OPTIONS)
 
   num_frames = len(input_dict[fields.InputDataFields.image])
   ret = []

--- a/research/lstm_object_detection/export_tflite_lstd_graph.py
+++ b/research/lstm_object_detection/export_tflite_lstd_graph.py
@@ -84,7 +84,7 @@ python lstm_object_detection/export_tflite_lstd_graph.py \
        "
 """
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from lstm_object_detection import export_tflite_lstd_graph_lib
 from lstm_object_detection.utils import config_util

--- a/research/lstm_object_detection/export_tflite_lstd_graph_lib.py
+++ b/research/lstm_object_detection/export_tflite_lstd_graph_lib.py
@@ -20,7 +20,7 @@ import os
 import tempfile
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.framework import types_pb2

--- a/research/lstm_object_detection/export_tflite_lstd_model.py
+++ b/research/lstm_object_detection/export_tflite_lstd_model.py
@@ -17,7 +17,7 @@
 
 import os
 from absl import flags
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from lstm_object_detection.utils import config_util
 

--- a/research/lstm_object_detection/inputs/seq_dataset_builder.py
+++ b/research/lstm_object_detection/inputs/seq_dataset_builder.py
@@ -22,7 +22,8 @@ Note: If users wishes to also use their own InputReaders with the Object
 Detection configuration framework, they should define their own builder function
 that wraps the build function.
 """
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import slim as contrib_slim
 from tensorflow.contrib.training.python.training import sequence_queueing_state_saver as sqss
 from lstm_object_detection.inputs import tf_sequence_example_decoder
 from lstm_object_detection.protos import input_reader_google_pb2
@@ -32,7 +33,7 @@ from object_detection.core import standard_fields as fields
 from object_detection.protos import input_reader_pb2
 from object_detection.utils import ops as util_ops
 
-parallel_reader = tf.contrib.slim.parallel_reader
+parallel_reader = contrib_slim.parallel_reader
 # TODO(yinxiao): Make the following variable into configurable proto.
 # Padding size for the labeled objects in each frame. Here we assume each
 # frame has a total number of objects less than _PADDING_SIZE.

--- a/research/lstm_object_detection/inputs/tf_sequence_example_decoder.py
+++ b/research/lstm_object_detection/inputs/tf_sequence_example_decoder.py
@@ -18,11 +18,12 @@
 A decoder to decode string tensors containing serialized
 tensorflow.SequenceExample protos.
 """
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import slim as contrib_slim
 from object_detection.core import data_decoder
 from object_detection.core import standard_fields as fields
 
-tfexample_decoder = tf.contrib.slim.tfexample_decoder
+tfexample_decoder = contrib_slim.tfexample_decoder
 
 
 class BoundingBoxSequence(tfexample_decoder.ItemHandler):

--- a/research/lstm_object_detection/inputs/tf_sequence_example_decoder_test.py
+++ b/research/lstm_object_detection/inputs/tf_sequence_example_decoder_test.py
@@ -16,7 +16,7 @@
 """Tests for lstm_object_detection.tf_sequence_example_decoder."""
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.core.example import example_pb2
 from tensorflow.core.example import feature_pb2
 from tensorflow.python.framework import dtypes

--- a/research/lstm_object_detection/lstm/lstm_cells_test.py
+++ b/research/lstm_object_detection/lstm/lstm_cells_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from lstm_object_detection.lstm import lstm_cells
 

--- a/research/lstm_object_detection/lstm/rnn_decoder.py
+++ b/research/lstm_object_detection/lstm/rnn_decoder.py
@@ -15,7 +15,7 @@
 
 """Custom RNN decoder."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import lstm_object_detection.lstm.utils as lstm_utils
 
 

--- a/research/lstm_object_detection/lstm/rnn_decoder_test.py
+++ b/research/lstm_object_detection/lstm/rnn_decoder_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import rnn as contrib_rnn

--- a/research/lstm_object_detection/lstm/utils_test.py
+++ b/research/lstm_object_detection/lstm/utils_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from lstm_object_detection.lstm import utils
 
 
@@ -73,12 +73,19 @@ class QuantizableUtilsTest(tf.test.TestCase):
     self._check_min_max_ema(tf.get_default_graph())
     self._check_min_max_vars(tf.get_default_graph())
 
-  def test_quantize_op_inferene(self):
+  def test_quantize_op_inference(self):
     inputs = tf.zeros([4, 10, 10, 128], dtype=tf.float32)
     outputs = utils.quantize_op(inputs, is_training=False)
     self.assertAllEqual(inputs.shape.as_list(), outputs.shape.as_list())
     self._check_no_min_max_ema(tf.get_default_graph())
     self._check_min_max_vars(tf.get_default_graph())
+
+  def test_fixed_quantize_op(self):
+    inputs = tf.zeros([4, 10, 10, 128], dtype=tf.float32)
+    outputs = utils.fixed_quantize_op(inputs)
+    self.assertAllEqual(inputs.shape.as_list(), outputs.shape.as_list())
+    self._check_no_min_max_ema(tf.get_default_graph())
+    self._check_no_min_max_vars(tf.get_default_graph())
 
   def _check_min_max_vars(self, graph):
     op_types = [op.type for op in graph.get_operations()]

--- a/research/lstm_object_detection/meta_architectures/lstm_ssd_meta_arch.py
+++ b/research/lstm_object_detection/meta_architectures/lstm_ssd_meta_arch.py
@@ -24,7 +24,8 @@ for details.
 """
 import abc
 import re
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.core import box_list_ops
 from object_detection.core import matcher
@@ -33,7 +34,7 @@ from object_detection.meta_architectures import ssd_meta_arch
 from object_detection.utils import ops
 from object_detection.utils import shape_utils
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 class LSTMSSDMetaArch(ssd_meta_arch.SSDMetaArch):

--- a/research/lstm_object_detection/meta_architectures/lstm_ssd_meta_arch_test.py
+++ b/research/lstm_object_detection/meta_architectures/lstm_ssd_meta_arch_test.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import functools
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from lstm_object_detection.lstm import lstm_cells
 from lstm_object_detection.meta_architectures import lstm_ssd_meta_arch
@@ -38,7 +39,7 @@ from object_detection.utils import test_case
 from object_detection.utils import test_utils
 
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 MAX_TOTAL_NUM_BOXES = 5
 NUM_CLASSES = 1

--- a/research/lstm_object_detection/metrics/coco_evaluation_all_frames.py
+++ b/research/lstm_object_detection/metrics/coco_evaluation_all_frames.py
@@ -15,7 +15,7 @@
 
 """Class for evaluating video object detections with COCO metrics."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from object_detection.core import standard_fields
 from object_detection.metrics import coco_evaluation

--- a/research/lstm_object_detection/metrics/coco_evaluation_all_frames_test.py
+++ b/research/lstm_object_detection/metrics/coco_evaluation_all_frames_test.py
@@ -16,7 +16,7 @@
 """Tests for video_object_detection.metrics.coco_video_evaluation."""
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from lstm_object_detection.metrics import coco_evaluation_all_frames
 from object_detection.core import standard_fields
 

--- a/research/lstm_object_detection/model_builder_test.py
+++ b/research/lstm_object_detection/model_builder_test.py
@@ -15,7 +15,7 @@
 
 """Tests for lstm_object_detection.tensorflow.model_builder."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from google.protobuf import text_format
 from lstm_object_detection import model_builder
 from lstm_object_detection.meta_architectures import lstm_ssd_meta_arch

--- a/research/lstm_object_detection/models/lstm_ssd_interleaved_mobilenet_v2_feature_extractor.py
+++ b/research/lstm_object_detection/models/lstm_ssd_interleaved_mobilenet_v2_feature_extractor.py
@@ -15,7 +15,7 @@
 
 """LSTDInterleavedFeatureExtractor which interleaves multiple MobileNet V2."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim
 
 from tensorflow.python.framework import ops as tf_ops
@@ -64,8 +64,15 @@ class LSTMSSDInterleavedMobilenetV2FeatureExtractor(
         `conv_hyperparams_fn`.
     """
     super(LSTMSSDInterleavedMobilenetV2FeatureExtractor, self).__init__(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
-        conv_hyperparams_fn, reuse_weights, use_explicit_padding, use_depthwise,
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams_fn=conv_hyperparams_fn,
+        reuse_weights=reuse_weights,
+        use_explicit_padding=use_explicit_padding,
+        use_depthwise=use_depthwise,
+        override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
     # RANDOM_SKIP_SMALL means the training policy is random and the small model
     # does not update state during training.

--- a/research/lstm_object_detection/models/lstm_ssd_interleaved_mobilenet_v2_feature_extractor_test.py
+++ b/research/lstm_object_detection/models/lstm_ssd_interleaved_mobilenet_v2_feature_extractor_test.py
@@ -17,7 +17,7 @@
 
 import itertools
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim
 from tensorflow.contrib import training as contrib_training
 
@@ -59,6 +59,47 @@ class LSTMSSDInterleavedMobilenetV2FeatureExtractorTest(
     ]
     feature_extractor.is_quantized = is_quantized
     return feature_extractor
+
+  def test_feature_extractor_construct_with_expected_params(self):
+    def conv_hyperparams_fn():
+      with (slim.arg_scope([slim.conv2d], normalizer_fn=slim.batch_norm) and
+            slim.arg_scope([slim.batch_norm], decay=0.97, epsilon=1e-3)) as sc:
+        return sc
+
+    params = {
+        'is_training': True,
+        'depth_multiplier': .55,
+        'min_depth': 9,
+        'pad_to_multiple': 3,
+        'conv_hyperparams_fn': conv_hyperparams_fn,
+        'reuse_weights': False,
+        'use_explicit_padding': True,
+        'use_depthwise': False,
+        'override_base_feature_extractor_hyperparams': True}
+
+    feature_extractor = (
+        lstm_ssd_interleaved_mobilenet_v2_feature_extractor
+        .LSTMSSDInterleavedMobilenetV2FeatureExtractor(**params))
+
+    self.assertEqual(params['is_training'],
+                     feature_extractor._is_training)
+    self.assertEqual(params['depth_multiplier'],
+                     feature_extractor._depth_multiplier)
+    self.assertEqual(params['min_depth'],
+                     feature_extractor._min_depth)
+    self.assertEqual(params['pad_to_multiple'],
+                     feature_extractor._pad_to_multiple)
+    self.assertEqual(params['conv_hyperparams_fn'],
+                     feature_extractor._conv_hyperparams_fn)
+    self.assertEqual(params['reuse_weights'],
+                     feature_extractor._reuse_weights)
+    self.assertEqual(params['use_explicit_padding'],
+                     feature_extractor._use_explicit_padding)
+    self.assertEqual(params['use_depthwise'],
+                     feature_extractor._use_depthwise)
+    self.assertEqual(params['override_base_feature_extractor_hyperparams'],
+                     (feature_extractor.
+                      _override_base_feature_extractor_hyperparams))
 
   def test_extract_features_returns_correct_shapes_128(self):
     image_height = 128

--- a/research/lstm_object_detection/models/lstm_ssd_mobilenet_v1_feature_extractor.py
+++ b/research/lstm_object_detection/models/lstm_ssd_mobilenet_v1_feature_extractor.py
@@ -15,7 +15,7 @@
 
 """LSTMSSDFeatureExtractor for MobilenetV1 features."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 from tensorflow.python.framework import ops as tf_ops
 from lstm_object_detection.lstm import lstm_cells
@@ -66,8 +66,15 @@ class LSTMSSDMobileNetV1FeatureExtractor(
       lstm_state_depth: An integter of the depth of the lstm state.
     """
     super(LSTMSSDMobileNetV1FeatureExtractor, self).__init__(
-        is_training, depth_multiplier, min_depth, pad_to_multiple,
-        conv_hyperparams_fn, reuse_weights, use_explicit_padding, use_depthwise,
+        is_training=is_training,
+        depth_multiplier=depth_multiplier,
+        min_depth=min_depth,
+        pad_to_multiple=pad_to_multiple,
+        conv_hyperparams_fn=conv_hyperparams_fn,
+        reuse_weights=reuse_weights,
+        use_explicit_padding=use_explicit_padding,
+        use_depthwise=use_depthwise,
+        override_base_feature_extractor_hyperparams=
         override_base_feature_extractor_hyperparams)
     self._feature_map_layout = {
         'from_layer': ['Conv2d_13_pointwise_lstm', '', '', '', ''],

--- a/research/lstm_object_detection/models/mobilenet_defs.py
+++ b/research/lstm_object_detection/models/mobilenet_defs.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Definitions for modified MobileNet models used in LSTD."""
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import mobilenet_v1

--- a/research/lstm_object_detection/models/mobilenet_defs_test.py
+++ b/research/lstm_object_detection/models/mobilenet_defs_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from lstm_object_detection.models import mobilenet_defs
 from nets import mobilenet_v1
 from nets.mobilenet import mobilenet_v2

--- a/research/lstm_object_detection/test_tflite_model.py
+++ b/research/lstm_object_detection/test_tflite_model.py
@@ -18,7 +18,7 @@
 from __future__ import print_function
 from absl import flags
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 flags.DEFINE_string('model_path', None, 'Path to model.')
 FLAGS = flags.FLAGS

--- a/research/lstm_object_detection/tflite/BUILD
+++ b/research/lstm_object_detection/tflite/BUILD
@@ -50,7 +50,9 @@ cc_library(
         "//utils:ssd_utils",
     ] + select({
         "//conditions:default": [],
-        "enable_edgetpu": ["@libedgetpu//libedgetpu:header"],
+        "enable_edgetpu": [
+            "@libedgetpu//libedgetpu:header",
+        ],
     }),
     alwayslink = 1,
 )
@@ -71,7 +73,9 @@ cc_library(
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",
     ] + select({
         "//conditions:default": [],
-        "enable_edgetpu": ["@libedgetpu//libedgetpu:header"],
+        "enable_edgetpu": [
+            "@libedgetpu//libedgetpu:header",
+        ],
     }),
     alwayslink = 1,
 )

--- a/research/lstm_object_detection/tflite/WORKSPACE
+++ b/research/lstm_object_detection/tflite/WORKSPACE
@@ -22,6 +22,12 @@ http_archive(
     strip_prefix = "abseil-cpp-a02f62f456f2c4a7ecf2be3104fe0c6e16fbad9a",
 )
 
+http_archive(
+    name = "rules_cc",
+    strip_prefix = "rules_cc-master",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+)
+
 # GoogleTest/GoogleMock framework. Used by most unit-tests.
 http_archive(
      name = "com_google_googletest",
@@ -90,6 +96,12 @@ http_archive(
     sha256 = "79d102c61e2a479a0b7e5fc167bcfaa4832a0c6aad4a75fa7da0480564931bcc",
 )
 
+#
+# http_archive(
+#     name = "com_google_protobuf",
+#     strip_prefix = "protobuf-master",
+#     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+# )
 
 # Needed by TensorFlow
 http_archive(

--- a/research/lstm_object_detection/train.py
+++ b/research/lstm_object_detection/train.py
@@ -46,7 +46,7 @@ import functools
 import json
 import os
 from absl import flags
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from lstm_object_detection import model_builder
 from lstm_object_detection import trainer
 from lstm_object_detection.inputs import seq_dataset_builder

--- a/research/lstm_object_detection/trainer.py
+++ b/research/lstm_object_detection/trainer.py
@@ -20,7 +20,8 @@ DetectionModel.
 """
 
 import functools
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import slim as contrib_slim
 
 from object_detection.builders import optimizer_builder
 from object_detection.core import standard_fields as fields
@@ -28,7 +29,7 @@ from object_detection.utils import ops as util_ops
 from object_detection.utils import variables_helper
 from deployment import model_deploy
 
-slim = tf.contrib.slim
+slim = contrib_slim
 
 
 def create_input_queue(create_tensor_dict_fn):

--- a/research/lstm_object_detection/utils/config_util.py
+++ b/research/lstm_object_detection/utils/config_util.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from google.protobuf import text_format
 from lstm_object_detection.protos import input_reader_google_pb2  # pylint: disable=unused-import

--- a/research/lstm_object_detection/utils/config_util_test.py
+++ b/research/lstm_object_detection/utils/config_util_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from google.protobuf import text_format
 from lstm_object_detection.protos import pipeline_pb2 as internal_pipeline_pb2


### PR DESCRIPTION
298416930  by lzyuan:

    Explicitly mark base models' state inputs as 'raw_inputs/init_lstm_h_1' and 'raw_inputs_init_lstm_h_2' when pre_bottleneck=True.

--
298380851  by skligys:

    Fix LSTD LSTM cells to use fixed_quantize_op().

--
297662737  by Menglong Zhu:

    Explicitly replace "import tensorflow" with "tensorflow.compat.v1" for TF2.x migration

--
289667197  by lzyuan:

    Internal update.

--
288607438  by lzyuan:

    Enforce feature_extractor construction using arg keys.

--

PiperOrigin-RevId: 298416930