### PR TITLE
Fix output shape of the position embedding layer

### DIFF
--- a/official/nlp/modeling/layers/position_embedding.py
+++ b/official/nlp/modeling/layers/position_embedding.py
@@ -111,14 +111,9 @@ class PositionEmbedding(tf.keras.layers.Layer):
 
   def call(self, inputs):
     """Implements call() for the layer."""
+    input_shape = tf_utils.get_shape_list(inputs, expected_rank=3)
     if self._use_dynamic_slicing:
-      input_shape = tf_utils.get_shape_list(inputs, expected_rank=3)
-      seq_length = input_shape[1]
-      width = input_shape[2]
-
-      position_embeddings = tf.slice(self._position_embeddings,
-                                     [0, 0],
-                                     [seq_length, width])
+      position_embeddings = self._position_embeddings[:input_shape[1], :]
     else:
       position_embeddings = self._position_embeddings
 

--- a/official/nlp/modeling/layers/position_embedding.py
+++ b/official/nlp/modeling/layers/position_embedding.py
@@ -116,10 +116,10 @@ class PositionEmbedding(tf.keras.layers.Layer):
       seq_length = input_shape[1]
       width = input_shape[2]
 
-      position_embeddings = tf.expand_dims(
-          tf.slice(self._position_embeddings, [0, 0], [seq_length, width]),
-          axis=0)
+      position_embeddings = tf.slice(self._position_embeddings,
+                                     [0, 0],
+                                     [seq_length, width])
     else:
-      position_embeddings = tf.expand_dims(self._position_embeddings, axis=0)
+      position_embeddings = self._position_embeddings
 
-    return position_embeddings
+    return tf.broadcast_to(position_embeddings, input_shape)


### PR DESCRIPTION
The output shape of the position embedding layer should be the same as the word embeddings, which is `[batch_size, sequence_length, hidden_size]`, instead of `[1, sequence_length, hidden_size]`.

This PR explicitly calls `tf.broadcast_to()` to ensure the tf.keras.layers.Add() layer on [L133](https://github.com/tensorflow/models/blob/651677f5645831fe748a7eb7fe59a8b05c921a52/official/nlp/modeling/networks/transformer_encoder.py#L133) won't complain about merging tensors with different batch sizes.