### PR TITLE
Set deeplay_demo.ipynb to Python 3

### DIFF
--- a/research/deeplab/deeplab_demo.ipynb
+++ b/research/deeplab/deeplab_demo.ipynb
@@ -360,8 +360,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Python 2 is deprecated. Tested by running the notebook in a Python 3 runtime.