### PR TITLE
Add num_summed_dimensions to get_config() of the DenseEinsum layer

### DIFF
--- a/official/nlp/modeling/layers/dense_einsum.py
+++ b/official/nlp/modeling/layers/dense_einsum.py
@@ -147,6 +147,8 @@ class DenseEinsum(tf.keras.layers.Layer):
     config = {
         "output_shape":
             self._output_shape,
+        "num_summed_dimensions":
+            self._num_summed_dimensions,
         "activation":
             tf.keras.activations.serialize(self._activation),
         "use_bias":


### PR DESCRIPTION
It seems that `num_summed_dimensions` is missing in the config dict for serialization.