### PR TITLE
Corrected tensorflow library install instruction

### DIFF
--- a/research/delf/INSTALL_INSTRUCTIONS.md
+++ b/research/delf/INSTALL_INSTRUCTIONS.md
@@ -8,9 +8,9 @@ Tensorflow using one of the following commands:
 
 ```bash
 # For CPU:
-pip install tensorflow
+pip install 'tensorflow==1.14'
 # For GPU:
-pip install tensorflow-gpu
+pip install 'tensorflow-gpu==1.14'
 ```
 
 ### Protobuf


### PR DESCRIPTION
Installing tensorflow1.14 instead of 2.X

python3 -c "import delf" crashed because of call to tf.contrib.slim
contrib module has been deprecated in tf 2.0