### PR TITLE
fix official.vision.detection.ops import error

### DIFF
--- a/official/vision/detection/ops/__init__.py
+++ b/official/vision/detection/ops/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================


### PR DESCRIPTION
In pip package `tf-models-nightly`, below import throws a ModuleNotFoundError

```python
>>> import official.vision.detection.ops
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'official.vision.detection.ops'
```
This is because of the fact that the `official.vision.detection.ops` module didn't have an `__init__.py` file.

This is fixed in this PR by adding an empty `__init__.py` file inside official/vision/detection/ops. 