### PR TITLE
Fix Object Detection API to allow any number of additional channels

### DIFF
--- a/research/object_detection/core/standard_fields.py
+++ b/research/object_detection/core/standard_fields.py
@@ -192,6 +192,7 @@ class TfExampleFields(object):
 
   Attributes:
     image_encoded: JPEG encoded string
+    image_additional_channels_encoded: JPEG encoded string of additional channels
     image_format: image format, e.g. "JPEG"
     filename: filename
     channels: number of channels of image
@@ -228,6 +229,7 @@ class TfExampleFields(object):
     detection_score: detection score for the class label and box.
   """
   image_encoded = 'image/encoded'
+  image_additional_channels = 'image/additional_channels/encoded'
   image_format = 'image/format'  # format is reserved keyword
   filename = 'image/filename'
   channels = 'image/channels'

--- a/research/object_detection/data_decoders/tf_example_decoder.py
+++ b/research/object_detection/data_decoders/tf_example_decoder.py
@@ -233,8 +233,7 @@ class TfExampleDecoder(data_decoder.DataDecoder):
       additional_channel_image = slim_example_decoder.Image(
           image_key='image/additional_channels/encoded',
           format_key='image/format',
-          channels=1,
-          repeated=True,
+          channels=num_additional_channels,
           dct_method=dct_method)
     else:
       image = slim_example_decoder.Image(
@@ -242,8 +241,7 @@ class TfExampleDecoder(data_decoder.DataDecoder):
       additional_channel_image = slim_example_decoder.Image(
           image_key='image/additional_channels/encoded',
           format_key='image/format',
-          channels=1,
-          repeated=True)
+          channels=num_additional_channels)
     self.items_to_handlers = {
         fields.InputDataFields.image:
             image,
@@ -277,7 +275,7 @@ class TfExampleDecoder(data_decoder.DataDecoder):
     if num_additional_channels > 0:
       self.keys_to_features[
           'image/additional_channels/encoded'] = tf.FixedLenFeature(
-              (num_additional_channels,), tf.string)
+              (), tf.string)
       self.items_to_handlers[
           fields.InputDataFields.
           image_additional_channels] = additional_channel_image
@@ -395,8 +393,6 @@ class TfExampleDecoder(data_decoder.DataDecoder):
 
     if fields.InputDataFields.image_additional_channels in tensor_dict:
       channels = tensor_dict[fields.InputDataFields.image_additional_channels]
-      channels = tf.squeeze(channels, axis=3)
-      channels = tf.transpose(channels, perm=[1, 2, 0])
       tensor_dict[fields.InputDataFields.image_additional_channels] = channels
 
     def default_groundtruth_weights():

--- a/research/object_detection/inference/detection_inference.py
+++ b/research/object_detection/inference/detection_inference.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from object_detection.core import standard_fields
 
 
-def build_input(tfrecord_paths):
+def build_input(tfrecord_paths, num_additional_channels=0):
   """Builds the graph's input.
 
   Args:
@@ -36,15 +36,28 @@ def build_input(tfrecord_paths):
 
   tf_record_reader = tf.TFRecordReader()
   _, serialized_example_tensor = tf_record_reader.read(filename_queue)
+
+  features_dict = {
+      standard_fields.TfExampleFields.image_encoded: tf.FixedLenFeature([], tf.string),
+  }
+
+  if num_additional_channels>0:
+      features_dict[standard_fields.TfExampleFields.image_additional_channels] = \
+          tf.FixedLenFeature([], tf.string)
+
   features = tf.parse_single_example(
       serialized_example_tensor,
-      features={
-          standard_fields.TfExampleFields.image_encoded:
-              tf.FixedLenFeature([], tf.string),
-      })
+      features=features_dict)
   encoded_image = features[standard_fields.TfExampleFields.image_encoded]
   image_tensor = tf.image.decode_image(encoded_image, channels=3)
   image_tensor.set_shape([None, None, 3])
+
+  if standard_fields.TfExampleFields.image_additional_channels in features:
+      encoded_additional_channels = features[standard_fields.TfExampleFields.image_additional_channels]
+      additional_channels_tensor = tf.image.decode_image(encoded_additional_channels, channels=num_additional_channels)
+      additional_channels_tensor.set_shape([None, None, num_additional_channels])
+      image_tensor = tf.concat([image_tensor, additional_channels_tensor], axis=2)
+
   image_tensor = tf.expand_dims(image_tensor, 0)
 
   return serialized_example_tensor, image_tensor
@@ -137,5 +150,7 @@ def infer_detections_and_add_to_example(
 
   if discard_image_pixels:
     del feature[standard_fields.TfExampleFields.image_encoded]
+    if standard_fields.TfExampleFields.image_additional_channels in feature:
+        del feature[standard_fields.TfExampleFields.image_additional_channels]
 
   return tf_example

--- a/research/object_detection/inference/infer_detections.py
+++ b/research/object_detection/inference/infer_detections.py
@@ -49,7 +49,7 @@ tf.flags.DEFINE_boolean('discard_image_pixels', False,
                         ' significantly reduces the output size and is useful'
                         ' if the subsequent tools don\'t need access to the'
                         ' images (e.g. when computing evaluation measures).')
-
+tf.flags.DEFINE_integer('num_additional_channels', 0, 'Number of additional channels to use')
 FLAGS = tf.flags.FLAGS
 
 
@@ -67,7 +67,7 @@ def main(_):
         v for v in FLAGS.input_tfrecord_paths.split(',') if v]
     tf.logging.info('Reading input from %d files', len(input_tfrecord_paths))
     serialized_example_tensor, image_tensor = detection_inference.build_input(
-        input_tfrecord_paths)
+        input_tfrecord_paths, num_additional_channels=FLAGS.num_additional_channels)
     tf.logging.info('Reading graph and building model...')
     (detected_boxes_tensor, detected_scores_tensor,
      detected_labels_tensor) = detection_inference.build_inference_graph(


### PR DESCRIPTION
The API was only able to parse 1 additional channel.
I propose some changes to the tf_example_decoder.py and the detection_inference.py to allow for more than one additional channel in the input. This should work for both training and inference