### PR TITLE
Use round() instead of int() when displaying score

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -818,9 +818,9 @@ def visualize_boxes_and_labels_on_image_array(
             display_str = str(class_name)
         if not skip_scores:
           if not display_str:
-            display_str = '{}%'.format(int(100*scores[i]))
+            display_str = '{}%'.format(round(100*scores[i]))
           else:
-            display_str = '{}: {}%'.format(display_str, int(100*scores[i]))
+            display_str = '{}: {}%'.format(display_str, round(100*scores[i]))
         if not skip_track_ids and track_ids is not None:
           if not display_str:
             display_str = 'ID {}'.format(track_ids[i])


### PR DESCRIPTION
Example of incorrect visualization: actual scores below
```
{'id': 1, 'name': 'person'} - 0.9168785214424133
{'id': 38, 'name': 'kite'} - 0.8294453620910645
{'id': 1, 'name': 'person'} - 0.7785056233406067
{'id': 38, 'name': 'kite'} - 0.7699868083000183
{'id': 38, 'name': 'kite'} - 0.7555397152900696
{'id': 1, 'name': 'person'} - 0.6342337727546692
{'id': 38, 'name': 'kite'} - 0.6074063777923584
{'id': 1, 'name': 'person'} - 0.5891015529632568
{'id': 1, 'name': 'person'} - 0.5123766660690308
{'id': 1, 'name': 'person'} - 0.5014634728431702
```
But on the image person has 91% and kite has 82%.
![screen](https://user-images.githubusercontent.com/37259322/79901104-2709be00-83c4-11ea-9617-6f5e3b8b4d6d.png)