### PR TITLE
fix index error, to support non-square kernels

### DIFF
--- a/research/slim/nets/mobilenet_v1.py
+++ b/research/slim/nets/mobilenet_v1.py
@@ -158,7 +158,7 @@ def _fixed_padding(inputs, kernel_size, rate=1):
       input, either intact (if kernel_size == 1) or padded (if kernel_size > 1).
   """
   kernel_size_effective = [kernel_size[0] + (kernel_size[0] - 1) * (rate - 1),
-                           kernel_size[0] + (kernel_size[0] - 1) * (rate - 1)]
+                           kernel_size[1] + (kernel_size[1] - 1) * (rate - 1)]
   pad_total = [kernel_size_effective[0] - 1, kernel_size_effective[1] - 1]
   pad_beg = [pad_total[0] // 2, pad_total[1] // 2]
   pad_end = [pad_total[0] - pad_beg[0], pad_total[1] - pad_beg[1]]


### PR DESCRIPTION
With kernel=[3, 3] in all entries of MOBILENETV1_CONV_DEFS, the latent index error (likely due to copy-paste) did not cause problems.
Fix is needed to ensure proper padding with non-square kernels.