### PR TITLE
Handle non-login shell case in stdout utility

### DIFF
--- a/official/utils/flags/_conventions.py
+++ b/official/utils/flags/_conventions.py
@@ -40,7 +40,7 @@ def _stdout_utf8():
     codecs.lookup("utf-8")
   except LookupError:
     return False
-  return sys.stdout.encoding == "UTF-8"
+  return getattr(sys.stdout, 'encoding', '') == "UTF-8"
 
 
 if _stdout_utf8():


### PR DESCRIPTION
This fix handles situations when `sys.stdout` doesn't have `encoding` field at all. For me this is the case where I pipe script's stdout into a report generator.