### PR TITLE
Added skimage troubleshooting

### DIFF
--- a/research/delf/EXTRACTION_MATCHING.md
+++ b/research/delf/EXTRACTION_MATCHING.md
@@ -75,3 +75,13 @@ $DISPLAY environment variable`. To fix this, one option is add the line
 `backend : Agg` to the file `.config/matplotlib/matplotlibrc`. On this problem,
 see the discussion
 [here](https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable).
+
+
+#### 'skimage'
+
+By default, skimage 0.13.XX or 0.14.1 is installed if you followed the instructions. According to [https://github.com/scikit-image/scikit-image/issues/3649#issuecomment-455273659]
+If you have scikit-image related issues, upgrading to a version above 0.14.1 with 
+```
+pip install -U scikit-image
+```
+should fix the issue


### PR DESCRIPTION
Following exactly the installation instructions and running features matching, we encounter at features_matching.py from the skimage import. This is a known bug as indicated in the troubleshooting steps.

`Traceback (most recent call last):
  File "match_images.py", line 34, in <module>
    from skimage import feature
  File "/nfs/core/python/3.6/lib/python3.6/site-packages/skimage/__init__.py", line 158, in <module>
    from .util.dtype import *
  File "/nfs/core/python/3.6/lib/python3.6/site-packages/skimage/util/__init__.py", line 7, in <module>
    from .arraycrop import crop
  File "/nfs/core/python/3.6/lib/python3.6/site-packages/skimage/util/arraycrop.py", line 8, in <module>
    from numpy.lib.arraypad import _validate_lengths
ImportError: cannot import name '_validate_lengths'
`