### PR TITLE
GitHub Action to lint for Python syntax errors

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,31 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    # strategy:
+    #  matrix:
+    #    os: [ubuntu-latest, macos-latest, windows-latest]
+    #    python-version: [3.5, 3.6, 3.7, 3.8]  # , pypy3]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      # with:
+      #   python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest reorder-python-imports
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --show-source --statistics --select=E9,F63,F7  # ,F82
+      # isort and reorder-python-imports are two ways of doing the same thing
+      - run: isort --recursive . || true
+      - run: reorder-python-imports . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true


### PR DESCRIPTION
Now that [`TensorFlow has dropped support for Python 2`](https://github.com/tensorflow/tensorflow/releases), let's look for Python 3 syntax errors.
```
./research/cognitive_planning/train_supervised_active_vision.py:185:9: E999 SyntaxError: invalid syntax
  print inputs
        ^
./research/cognitive_planning/viz_active_vision_dataset_main.py:98:11: E999 SyntaxError: invalid syntax
    print world
          ^
./research/cognitive_planning/envs/active_vision_dataset_env.py:940:13: E999 SyntaxError: invalid syntax
      print 'path not found, image_id = ', self._cur_world, self._cur_image_id
            ^
./research/learning_unsupervised_learning/variable_replace.py:94:11: E999 SyntaxError: invalid syntax
    print "Didn't use all replacements"
          ^
./research/learning_unsupervised_learning/meta_objective/sklearn.py:116:20: E999 SyntaxError: invalid syntax
      def blackbox((trX, trY, teX, teY)):
                   ^
./research/object_detection/core/matcher_test.py:192:16: F632 use ==/!= to compare str, bytes, and int literals
          all([op.name is not 'Gather' for op in sess.graph.get_operations()]))
               ^
./research/lexnet_nc/extract_paths.py:83:18: E999 SyntaxError: invalid syntax
          lambda (head, mod): head)}
                 ^
./research/swivel/prep.py:133:9: F633 use of >> is invalid with print function
        print >> vocab_out, tok
        ^
./research/swivel/prep.py:134:9: F633 use of >> is invalid with print function
        print >> sums_out, cnt
        ^
./research/swivel/text2bin.py:53:3: F633 use of >> is invalid with print function
  print >> sys.stderr, e
  ^
./research/swivel/text2bin.py:74:9: F633 use of >> is invalid with print function
        print >> vocab_out, token
        ^
6     E999 SyntaxError: invalid syntax
1     F632 use ==/!= to compare str, bytes, and int literals
4     F633 use of >> is invalid with print function
11
```