### PR TITLE
Updating cifar download links

### DIFF
--- a/research/autoaugment/README.md
+++ b/research/autoaugment/README.md
@@ -45,8 +45,8 @@ PyramidNet + ShakeDrop | 0.05          | 5e-5         | 1800        | 64
 2.  Download CIFAR-10/CIFAR-100 dataset.
 
 ```shell
-curl -o cifar-10-binary.tar.gz https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz
-curl -o cifar-100-binary.tar.gz https://www.cs.toronto.edu/~kriz/cifar-100-binary.tar.gz
+curl -o cifar-10-binary.tar.gz https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+curl -o cifar-100-binary.tar.gz https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz
 ```
 
 <b>How to run:</b>


### PR DESCRIPTION
# Description

> :memo: The cifar dataset links are changed to download python version of files. Downloading binary files will throw an error with the current code
```
tensorflow.python.framework.errors_impl.NotFoundError: $DATA_DIR/cifar10/data_batch_1; No such file or directory
```

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Tests
Tested on python2.7 and tensorflow1.15

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] My changes generate no new warnings.

