### PR TITLE
Migrating from contrib.slim to tf_slim

### DIFF
--- a/research/slim/BUILD
+++ b/research/slim/BUILD
@@ -37,7 +37,7 @@ sh_binary(
 py_binary(
     name = "build_imagenet_data",
     srcs = ["datasets/build_imagenet_data.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
@@ -105,7 +105,7 @@ py_library(
 py_binary(
     name = "download_and_convert_data",
     srcs = ["download_and_convert_data.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":download_and_convert_cifar10",
         ":download_and_convert_flowers",
@@ -122,7 +122,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -132,7 +132,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -143,7 +143,7 @@ py_library(
         ":dataset_utils",
         "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -153,7 +153,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -163,7 +163,7 @@ py_library(
     deps = [
         ":dataset_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -184,7 +184,7 @@ py_library(
     srcs = ["deployment/model_deploy.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -196,11 +196,8 @@ py_test(  # py2and3_test
         ":model_deploy",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
-        "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -209,7 +206,7 @@ py_library(
     srcs = ["preprocessing/cifarnet_preprocessing.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -227,7 +224,7 @@ py_library(
     srcs = ["preprocessing/lenet_preprocessing.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -236,7 +233,7 @@ py_library(
     srcs = ["preprocessing/vgg_preprocessing.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -248,7 +245,7 @@ py_library(
         ":inception_preprocessing",
         ":lenet_preprocessing",
         ":vgg_preprocessing",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -281,21 +278,20 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "alexnet_test",
     size = "medium",
     srcs = ["nets/alexnet_test.py"],
-    python_version = "PY2",
     srcs_version = "PY2AND3",
     deps = [
         ":alexnet",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -304,7 +300,7 @@ py_library(
     srcs = ["nets/cifarnet.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -315,9 +311,8 @@ py_library(
         # "//numpy",
         "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/util:util_py",
+        "//third_party/py/tf_slim:slim",
+        # "//tensorflow/python:tensor_util",
     ],
 )
 
@@ -339,14 +334,13 @@ py_library(
     deps = [
         "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "dcgan_test",
     srcs = ["nets/dcgan_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
@@ -365,7 +359,7 @@ py_library(
         ":i3d_utils",
         ":s3dg",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -380,6 +374,7 @@ py_test(  # py2and3_test
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         "//third_party/py/six",
         # "//tensorflow",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -390,8 +385,7 @@ py_library(
     deps = [
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -414,7 +408,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -425,7 +419,7 @@ py_library(
     deps = [
         ":inception_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -436,7 +430,7 @@ py_library(
     deps = [
         ":inception_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -447,7 +441,7 @@ py_library(
     deps = [
         ":inception_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -458,7 +452,7 @@ py_library(
     deps = [
         ":inception_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -468,15 +462,14 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "inception_v1_test",
     size = "large",
     srcs = ["nets/inception_v1_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
@@ -484,7 +477,7 @@ py_test(
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -499,7 +492,7 @@ py_test(  # py2and3_test
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -514,7 +507,7 @@ py_test(  # py2and3_test
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -528,7 +521,7 @@ py_test(  # py2and3_test
         ":inception",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -542,7 +535,7 @@ py_test(  # py2and3_test
         ":inception",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -551,7 +544,7 @@ py_library(
     srcs = ["nets/lenet.py"],
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -561,8 +554,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -575,7 +567,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -586,8 +578,7 @@ py_library(
     deps = [
         ":mobilenet_common",
         # "//tensorflow",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -599,8 +590,7 @@ py_library(
         ":mobilenet_common",
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -614,7 +604,7 @@ py_test(  # py2and3_test
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -652,22 +642,22 @@ py_test(  # py2and3_test
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
 py_binary(
     name = "mobilenet_v1_train",
     srcs = ["nets/mobilenet_v1_train.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":dataset_factory",
         ":mobilenet_v1",
         ":preprocessing_factory",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/quantize:quantize_graph",
-        # "//tensorflow/contrib/slim",
     ],
 )
 
@@ -681,10 +671,9 @@ py_binary(
         ":mobilenet_v1",
         ":preprocessing_factory",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
-        "//third_party/py/six",
         # "//tensorflow",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/quantize:quantize_graph",
-        # "//tensorflow/contrib/slim",
     ],
 )
 
@@ -694,8 +683,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -706,9 +694,7 @@ py_library(
     deps = [
         ":nasnet_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/training:training_py",
     ],
 )
@@ -735,7 +721,7 @@ py_test(  # py2and3_test
         ":nasnet",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -747,8 +733,7 @@ py_library(
         ":nasnet",
         ":nasnet_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/training:training_py",
     ],
 )
@@ -763,7 +748,7 @@ py_test(  # py2and3_test
         ":pnasnet",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -773,7 +758,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -786,7 +771,7 @@ py_test(  # py2and3_test
         ":overfeat",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -796,8 +781,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -809,7 +793,7 @@ py_test(  # py2and3_test
         ":pix2pix",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -819,7 +803,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -830,7 +814,7 @@ py_library(
     deps = [
         ":resnet_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -846,9 +830,8 @@ py_test(  # py2and3_test
         ":resnet_v1",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
-        "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -859,7 +842,7 @@ py_library(
     deps = [
         ":resnet_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -874,9 +857,8 @@ py_test(  # py2and3_test
         ":resnet_v2",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
-        "//third_party/py/six",
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -887,8 +869,7 @@ py_library(
     deps = [
         ":i3d_utils",
         # "//tensorflow",
-        # "//tensorflow/contrib/framework:framework_py",
-        # "//tensorflow/contrib/layers:layers_py",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -912,7 +893,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -925,7 +906,7 @@ py_test(  # py2and3_test
         ":vgg",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -934,7 +915,7 @@ py_library(
     srcs = ["nets/nets_factory.py"],
     deps = [
         ":nets",
-        # "//tensorflow/contrib/slim",
+        "//third_party/py/tf_slim:slim",
     ],
 )
 
@@ -976,8 +957,8 @@ py_library(
         ":nets_factory",
         ":preprocessing_factory",
         # "//tensorflow",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/quantize:quantize_graph",
-        # "//tensorflow/contrib/slim",
     ],
 )
 
@@ -986,7 +967,7 @@ py_binary(
     srcs = ["train_image_classifier.py"],
     # WARNING: not supported in bazel; will be commented out by copybara.
     # paropts = ["--compress"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":train_image_classifier_lib",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
@@ -1001,15 +982,15 @@ py_library(
         ":nets_factory",
         ":preprocessing_factory",
         # "//tensorflow",
+        "//third_party/py/tf_slim:slim",
         # "//tensorflow/contrib/quantize:quantize_graph",
-        # "//tensorflow/contrib/slim",
     ],
 )
 
 py_binary(
     name = "eval_image_classifier",
     srcs = ["eval_image_classifier.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":eval_image_classifier_lib",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
@@ -1021,7 +1002,7 @@ py_binary(
     srcs = ["export_inference_graph.py"],
     # WARNING: not supported in bazel; will be commented out by copybara.
     # paropts = ["--compress"],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         ":export_inference_graph_lib",
         "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
@@ -1036,16 +1017,15 @@ py_library(
         ":nets_factory",
         # "//tensorflow",
         # "//tensorflow/contrib/quantize:quantize_graph",
-        # "//tensorflow/contrib/slim",
         # "//tensorflow/python:platform",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "export_inference_graph_test",
     size = "medium",
     srcs = ["export_inference_graph_test.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     tags = [
         "manual",

--- a/research/slim/BUILD
+++ b/research/slim/BUILD
@@ -39,6 +39,7 @@ py_binary(
     srcs = ["datasets/build_imagenet_data.py"],
     python_version = "PY2",
     deps = [
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         "//third_party/py/six",
         # "//tensorflow",
@@ -59,8 +60,10 @@ py_library(
 py_library(
     name = "download_and_convert_flowers",
     srcs = ["datasets/download_and_convert_flowers.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":dataset_utils",
+        "//third_party/py/six",
         # "//tensorflow",
     ],
 )
@@ -79,10 +82,12 @@ py_library(
 py_library(
     name = "download_and_convert_visualwakewords_lib",
     srcs = ["datasets/download_and_convert_visualwakewords_lib.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":dataset_utils",
         "//third_party/py/PIL:pil",
         "//third_party/py/contextlib2",
+        "//third_party/py/six",
         # "//tensorflow",
     ],
 )
@@ -90,6 +95,7 @@ py_library(
 py_library(
     name = "download_and_convert_visualwakewords",
     srcs = ["datasets/download_and_convert_visualwakewords.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":download_and_convert_visualwakewords_lib",
         # "//tensorflow",
@@ -105,6 +111,7 @@ py_binary(
         ":download_and_convert_flowers",
         ":download_and_convert_mnist",
         ":download_and_convert_visualwakewords",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
     ],
 )
@@ -181,14 +188,15 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "model_deploy_test",
     srcs = ["deployment/model_deploy_test.py"],
-    python_version = "PY2",
     srcs_version = "PY2AND3",
     deps = [
         ":model_deploy",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
+        "//third_party/py/six",
         # "//tensorflow",
         # "//tensorflow/contrib/framework:framework_py",
         # "//tensorflow/contrib/layers:layers_py",
@@ -285,6 +293,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":alexnet",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -312,14 +321,14 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "cyclegan_test",
     srcs = ["nets/cyclegan_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":cyclegan",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
     ],
 )
@@ -342,6 +351,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":dcgan",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         "//third_party/py/six",
         # "//tensorflow",
     ],
@@ -359,15 +369,16 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "i3d_test",
     size = "large",
     srcs = ["nets/i3d_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":i3d",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
+        "//third_party/py/six",
         # "//tensorflow",
     ],
 )
@@ -470,6 +481,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
@@ -484,50 +496,51 @@ py_test(  # py2and3_test
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "inception_v3_test",
     size = "large",
     srcs = ["nets/inception_v3_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "inception_v4_test",
     size = "large",
     srcs = ["nets/inception_v4_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "inception_resnet_v2_test",
     size = "large",
     srcs = ["nets/inception_resnet_v2_test.py"],
-    python_version = "PY2",
-    shard_count = 3,
+    shard_count = 4,
     srcs_version = "PY2AND3",
     deps = [
         ":inception",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -586,6 +599,7 @@ py_library(
         ":mobilenet_common",
         # "//numpy",
         # "//tensorflow",
+        # "//tensorflow/contrib/layers:layers_py",
         # "//tensorflow/contrib/slim",
     ],
 )
@@ -597,6 +611,7 @@ py_test(  # py2and3_test
     deps = [
         ":mobilenet",
         ":mobilenet_common",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         "//third_party/py/six",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
@@ -606,9 +621,12 @@ py_test(  # py2and3_test
 py_test(  # py2and3_test
     name = "mobilenet_v3_test",
     srcs = ["nets/mobilenet/mobilenet_v3_test.py"],
+    shard_count = 2,
     srcs_version = "PY2AND3",
     deps = [
         ":mobilenet",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
+        "//testing/pybase:parameterized",
         "//third_party/py/absl/testing:absltest",
         # "//tensorflow",
     ],
@@ -623,15 +641,15 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "mobilenet_v1_test",
     size = "large",
     srcs = ["nets/mobilenet_v1_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":mobilenet_v1",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
@@ -646,6 +664,7 @@ py_binary(
         ":dataset_factory",
         ":mobilenet_v1",
         ":preprocessing_factory",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/quantize:quantize_graph",
         # "//tensorflow/contrib/slim",
@@ -655,11 +674,14 @@ py_binary(
 py_binary(
     name = "mobilenet_v1_eval",
     srcs = ["nets/mobilenet_v1_eval.py"],
-    python_version = "PY2",
+    python_version = "PY3",
+    srcs_version = "PY3",
     deps = [
         ":dataset_factory",
         ":mobilenet_v1",
         ":preprocessing_factory",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
+        "//third_party/py/six",
         # "//tensorflow",
         # "//tensorflow/contrib/quantize:quantize_graph",
         # "//tensorflow/contrib/slim",
@@ -691,27 +713,27 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "nasnet_utils_test",
     size = "medium",
     srcs = ["nets/nasnet/nasnet_utils_test.py"],
-    python_version = "PY2",
     srcs_version = "PY2AND3",
     deps = [
         ":nasnet_utils",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "nasnet_test",
     size = "large",
     srcs = ["nets/nasnet/nasnet_test.py"],
-    python_version = "PY2",
     shard_count = 10,
     srcs_version = "PY2AND3",
     deps = [
         ":nasnet",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -731,15 +753,15 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "pnasnet_test",
     size = "large",
     srcs = ["nets/nasnet/pnasnet_test.py"],
-    python_version = "PY2",
     shard_count = 4,
     srcs_version = "PY2AND3",
     deps = [
         ":pnasnet",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -762,6 +784,7 @@ py_test(  # py2and3_test
     srcs_version = "PY2AND3",
     deps = [
         ":overfeat",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -784,6 +807,7 @@ py_test(  # py2and3_test
     srcs_version = "PY2AND3",
     deps = [
         ":pix2pix",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/framework:framework_py",
     ],
@@ -810,18 +834,19 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "resnet_v1_test",
     size = "medium",
     timeout = "long",
     srcs = ["nets/resnet_v1_test.py"],
-    python_version = "PY2",
     shard_count = 2,
     srcs_version = "PY2AND3",
     deps = [
         ":resnet_utils",
         ":resnet_v1",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
+        "//third_party/py/six",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -838,17 +863,18 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "resnet_v2_test",
     size = "medium",
     srcs = ["nets/resnet_v2_test.py"],
-    python_version = "PY2",
     shard_count = 2,
     srcs_version = "PY2AND3",
     deps = [
         ":resnet_utils",
         ":resnet_v2",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//numpy",
+        "//third_party/py/six",
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -866,15 +892,16 @@ py_library(
     ],
 )
 
-py_test(
+py_test(  # py2and3_test
     name = "s3dg_test",
     size = "large",
     srcs = ["nets/s3dg_test.py"],
-    python_version = "PY2",
     shard_count = 3,
     srcs_version = "PY2AND3",
     deps = [
         ":s3dg",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
+        "//third_party/py/six",
         # "//tensorflow",
     ],
 )
@@ -896,6 +923,7 @@ py_test(  # py2and3_test
     srcs_version = "PY2AND3",
     deps = [
         ":vgg",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/contrib/slim",
     ],
@@ -918,6 +946,7 @@ py_test(  # py2and3_test
     srcs_version = "PY2AND3",
     deps = [
         ":nets_factory",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
     ],
 )
@@ -929,6 +958,7 @@ pytype_strict_binary(
     deps = [
         ":nets_factory",
         ":preprocessing_factory",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         "//third_party/py/absl:app",
         "//third_party/py/absl/flags",
         # "//tensorflow",
@@ -959,6 +989,7 @@ py_binary(
     python_version = "PY2",
     deps = [
         ":train_image_classifier_lib",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
     ],
 )
 
@@ -981,6 +1012,7 @@ py_binary(
     python_version = "PY2",
     deps = [
         ":eval_image_classifier_lib",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
     ],
 )
 
@@ -990,7 +1022,10 @@ py_binary(
     # WARNING: not supported in bazel; will be commented out by copybara.
     # paropts = ["--compress"],
     python_version = "PY2",
-    deps = [":export_inference_graph_lib"],
+    deps = [
+        ":export_inference_graph_lib",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
+    ],
 )
 
 py_library(
@@ -1017,6 +1052,7 @@ py_test(
     ],
     deps = [
         ":export_inference_graph_lib",
+        "//learning/brain/public:disable_tf2",  # build_cleaner: keep; go/disable_tf2
         # "//tensorflow",
         # "//tensorflow/python:platform",
     ],

--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -1,7 +1,7 @@
 # TensorFlow-Slim image classification model library
 
-[TF-slim](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim)
-is a new lightweight high-level API of TensorFlow (`tensorflow.contrib.slim`)
+[TF-slim](https://github.com/google-research/tf-slim/tree/master/tf_slim)
+is a new lightweight high-level API of TensorFlow (`tf_slim`)
 for defining, training and evaluating complex
 models. This directory contains
 code for training and evaluating several widely used Convolutional Neural
@@ -15,7 +15,7 @@ data reading and queueing utilities. You can easily train any model on any of
 these datasets, as we demonstrate below. We've also included a
 [jupyter notebook](https://github.com/tensorflow/models/blob/master/research/slim/slim_walkthrough.ipynb),
 which provides working examples of how to use TF-Slim for image classification.
-For developing or modifying your own models, see also the [main TF-Slim page](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim).
+For developing or modifying your own models, see also the [main TF-Slim page](https://github.com/google-research/tf-slim/tree/master/tf_slim).
 
 ## Contacts
 
@@ -49,12 +49,12 @@ prerequisite packages.
 
 ## Installing latest version of TF-slim
 
-TF-Slim is available as `tf.contrib.slim` via TensorFlow 1.0. To test that your
+TF-Slim is available as `tf_slim` package. To test that your
 installation is working, execute the following command; it should run without
 raising any errors.
 
 ```
-python -c "import tensorflow.contrib.slim as slim; eval = slim.evaluation.evaluate_once"
+python -c "import tf_slim as slim; eval = slim.evaluation.evaluate_once"
 ```
 
 ## Installing the TF-slim image models library
@@ -140,7 +140,7 @@ download can take several hours, and could use up to 500GB.
 ## Creating a TF-Slim Dataset Descriptor.
 
 Once the TFRecord files have been created, you can easily define a Slim
-[Dataset](https://github.com/tensorflow/tensorflow/blob/r0.10/tensorflow/contrib/slim/python/slim/data/dataset.py),
+[Dataset](https://github.com/google-research/tf-slim/master/tf_slim/data/dataset.py),
 which stores pointers to the data file, as well as various other pieces of
 metadata, such as the class labels, the train/test split, and how to parse the
 TFExample protos. We have included the TF-Slim Dataset descriptors
@@ -153,14 +153,15 @@ and
 [VisualWakeWords](https://github.com/tensorflow/models/blob/master/research/slim/datasets/visualwakewords.py),
 An example of how to load data using a TF-Slim dataset descriptor using a
 TF-Slim
-[DatasetDataProvider](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/data/dataset_data_provider.py)
+[DatasetDataProvider](https://github.com/google-research/tf-slim/tree/master/tf_slim/data/dataset_data_provider.py)
 is found below:
 
 ```python
 import tensorflow as tf
+import tf_slim as slim
 from datasets import flowers
 
-slim = tf.contrib.slim
+
 
 # Selects the 'validation' dataset.
 dataset = flowers.get_split('validation', DATA_DIR)
@@ -411,7 +412,7 @@ $ python eval_image_classifier.py \
     --model_name=inception_v3
 ```
 
-See the [evaluation module example](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim#evaluation-loop)
+See the [evaluation module example](https://github.com/google-research/tf-slim#evaluation-loop)
 for an example of how to evaluate a model at multiple checkpoints during or after the training.
 
 # Exporting the Inference Graph

--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -1,9 +1,6 @@
-![TensorFlow Requirement: 1.x](https://img.shields.io/badge/TensorFlow%20Requirement-1.x-brightgreen)
-![TensorFlow 2 Not Supported](https://img.shields.io/badge/TensorFlow%202%20Not%20Supported-%E2%9C%95-red.svg)
-
 # TensorFlow-Slim image classification model library
 
-[TF-slim](https://github.com/tensorflow/models/tree/master/research/slim)
+[TF-slim](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim)
 is a new lightweight high-level API of TensorFlow (`tensorflow.contrib.slim`)
 for defining, training and evaluating complex
 models. This directory contains
@@ -18,15 +15,15 @@ data reading and queueing utilities. You can easily train any model on any of
 these datasets, as we demonstrate below. We've also included a
 [jupyter notebook](https://github.com/tensorflow/models/blob/master/research/slim/slim_walkthrough.ipynb),
 which provides working examples of how to use TF-Slim for image classification.
-For developing or modifying your own models, see also the [main TF-Slim page](https://github.com/tensorflow/models/tree/master/research/slim).
+For developing or modifying your own models, see also the [main TF-Slim page](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim).
 
 ## Contacts
 
 Maintainers of TF-slim:
 
-* Sergio Guadarrama, GitHub: [sguada](https://github.com/sguada)
 * Nathan Silberman,
-  GitHub: [nathansilberman](https://github.com/nathansilberman)
+  github: [nathansilberman](https://github.com/nathansilberman)
+* Sergio Guadarrama, github: [sguada](https://github.com/sguada)
 
 ## Citation
 "TensorFlow-Slim image classification model library"
@@ -182,7 +179,7 @@ format.
 
 The TFRecord format consists of a set of sharded files where each entry is a serialized `tf.Example` proto. Each `tf.Example` proto contains the ImageNet image (JPEG encoded) as well as metadata such as label and bounding box information.
 
-We provide a single [script](datasets/download_and_convert_imagenet.sh) for
+We provide a single [script](datasets/download_and_preprocess_imagenet.sh) for
 downloading and converting ImageNet data to TFRecord format. Downloading and
 preprocessing the data may take several hours (up to half a day) depending on
 your network and computer speed. Please be patient.

--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -1,5 +1,6 @@
 # TensorFlow-Slim image classification model library
-This directory contains code for training and evaluating several widely used Convolutional Neural Network (CNN) image classification models using [tf_slim]((https://github.com/google-research/tf-slim/tree/master/tf_slim).
+This directory contains code for training and evaluating several widely used Convolutional Neural Network (CNN) image classification models using
+[tf_slim](https://github.com/google-research/tf-slim/tree/master/tf_slim).
 It contains scripts that allow
 you to train models from scratch or fine-tune them from pre-trained network
 weights. It also contains code for downloading standard image datasets,

--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -1,12 +1,6 @@
 # TensorFlow-Slim image classification model library
-
-[TF-slim](https://github.com/google-research/tf-slim/tree/master/tf_slim)
-is a new lightweight high-level API of TensorFlow (`tf_slim`)
-for defining, training and evaluating complex
-models. This directory contains
-code for training and evaluating several widely used Convolutional Neural
-Network (CNN) image classification models using TF-slim.
-It contains scripts that will allow
+This directory contains code for training and evaluating several widely used Convolutional Neural Network (CNN) image classification models using [tf_slim]((https://github.com/google-research/tf-slim/tree/master/tf_slim).
+It contains scripts that allow
 you to train models from scratch or fine-tune them from pre-trained network
 weights. It also contains code for downloading standard image datasets,
 converting them
@@ -20,9 +14,6 @@ For developing or modifying your own models, see also the [main TF-Slim page](ht
 ## Contacts
 
 Maintainers of TF-slim:
-
-* Nathan Silberman,
-  github: [nathansilberman](https://github.com/nathansilberman)
 * Sergio Guadarrama, github: [sguada](https://github.com/sguada)
 
 ## Citation
@@ -180,7 +171,7 @@ format.
 
 The TFRecord format consists of a set of sharded files where each entry is a serialized `tf.Example` proto. Each `tf.Example` proto contains the ImageNet image (JPEG encoded) as well as metadata such as label and bounding box information.
 
-We provide a single [script](datasets/download_and_preprocess_imagenet.sh) for
+We provide a single [script](datasets/download_and_convert_imagenet.sh) for
 downloading and converting ImageNet data to TFRecord format. Downloading and
 preprocessing the data may take several hours (up to half a day) depending on
 your network and computer speed. Please be patient.
@@ -203,10 +194,10 @@ you will not need to interact with the script again.
 DATA_DIR=$HOME/imagenet-data
 
 # build the preprocessing script.
-bazel build slim/download_and_preprocess_imagenet
+bazel build slim/download_and_convert_imagenet
 
 # run it
-bazel-bin/slim/download_and_preprocess_imagenet "${DATA_DIR}"
+bazel-bin/slim/download_and_convert_imagenet "${DATA_DIR}"
 ```
 
 The final line of the output script should read:

--- a/research/slim/README.md
+++ b/research/slim/README.md
@@ -1,5 +1,7 @@
 # TensorFlow-Slim image classification model library
-This directory contains code for training and evaluating several widely used Convolutional Neural Network (CNN) image classification models using
+This directory contains code for training and evaluating several
+widely used Convolutional Neural Network (CNN) image classification
+models using
 [tf_slim](https://github.com/google-research/tf-slim/tree/master/tf_slim).
 It contains scripts that allow
 you to train models from scratch or fine-tune them from pre-trained network
@@ -149,7 +151,7 @@ TF-Slim
 is found below:
 
 ```python
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 from datasets import flowers
 

--- a/research/slim/datasets/build_imagenet_data.py
+++ b/research/slim/datasets/build_imagenet_data.py
@@ -94,7 +94,7 @@ import threading
 
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 
 tf.app.flags.DEFINE_string('train_directory', '/tmp/',

--- a/research/slim/datasets/cifar10.py
+++ b/research/slim/datasets/cifar10.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/cifar10.py
+++ b/research/slim/datasets/cifar10.py
@@ -24,11 +24,9 @@ from __future__ import print_function
 
 import os
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from datasets import dataset_utils
-
-slim = contrib_slim
 
 _FILE_PATTERN = 'cifar10_%s.tfrecord'
 

--- a/research/slim/datasets/dataset_utils.py
+++ b/research/slim/datasets/dataset_utils.py
@@ -23,7 +23,7 @@ import tarfile
 import zipfile
 
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 LABELS_FILENAME = 'labels.txt'
 

--- a/research/slim/datasets/download_and_convert_cifar10.py
+++ b/research/slim/datasets/download_and_convert_cifar10.py
@@ -33,7 +33,7 @@ import tarfile
 import numpy as np
 from six.moves import cPickle
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from datasets import dataset_utils
 

--- a/research/slim/datasets/download_and_convert_flowers.py
+++ b/research/slim/datasets/download_and_convert_flowers.py
@@ -32,7 +32,9 @@ import os
 import random
 import sys
 
-import tensorflow as tf
+from six.moves import range
+from six.moves import zip
+import tensorflow.compat.v1 as tf
 
 from datasets import dataset_utils
 
@@ -189,7 +191,8 @@ def run(dataset_dir):
 
   dataset_utils.download_and_uncompress_tarball(_DATA_URL, dataset_dir)
   photo_filenames, class_names = _get_filenames_and_classes(dataset_dir)
-  class_names_to_ids = dict(zip(class_names, range(len(class_names))))
+  class_names_to_ids = dict(
+      list(zip(class_names, list(range(len(class_names))))))
 
   # Divide into train and test:
   random.seed(_RANDOM_SEED)
@@ -204,7 +207,8 @@ def run(dataset_dir):
                    dataset_dir)
 
   # Finally, write the labels file:
-  labels_to_class_names = dict(zip(range(len(class_names)), class_names))
+  labels_to_class_names = dict(
+      list(zip(list(range(len(class_names))), class_names)))
   dataset_utils.write_label_file(labels_to_class_names, dataset_dir)
 
   _clean_up_temporary_files(dataset_dir)

--- a/research/slim/datasets/download_and_convert_mnist.py
+++ b/research/slim/datasets/download_and_convert_mnist.py
@@ -32,7 +32,7 @@ import sys
 
 import numpy as np
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from datasets import dataset_utils
 

--- a/research/slim/datasets/download_and_convert_visualwakewords.py
+++ b/research/slim/datasets/download_and_convert_visualwakewords.py
@@ -77,7 +77,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from datasets import download_and_convert_visualwakewords_lib
 
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)

--- a/research/slim/datasets/download_and_convert_visualwakewords.py
+++ b/research/slim/datasets/download_and_convert_visualwakewords.py
@@ -80,14 +80,14 @@ import os
 import tensorflow.compat.v1 as tf
 from datasets import download_and_convert_visualwakewords_lib
 
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
+tf.logging.set_verbosity(tf.logging.INFO)
 
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'coco_dirname', 'coco_dataset',
     'A subdirectory in visualwakewords dataset directory'
     'containing the coco dataset')
 
-FLAGS = tf.compat.v1.app.flags.FLAGS
+FLAGS = tf.app.flags.FLAGS
 
 
 def run(dataset_dir, small_object_area_threshold, foreground_class_of_interest):

--- a/research/slim/datasets/download_and_convert_visualwakewords_lib.py
+++ b/research/slim/datasets/download_and_convert_visualwakewords_lib.py
@@ -32,7 +32,8 @@ import contextlib2
 
 import PIL.Image
 
-import tensorflow as tf
+import six
+import tensorflow.compat.v1 as tf
 
 from datasets import dataset_utils
 
@@ -201,7 +202,7 @@ def create_tf_record_for_visualwakewords_dataset(annotations_file, image_dir,
     groundtruth_data = json.load(fid)
     images = groundtruth_data['images']
     annotations_index = groundtruth_data['annotations']
-    annotations_index = {int(k): v for k, v in annotations_index.iteritems()}
+    annotations_index = {int(k): v for k, v in six.iteritems(annotations_index)}
     # convert 'unicode' key to 'int' key after we parse the json file
 
     for idx, image in enumerate(images):

--- a/research/slim/datasets/download_and_convert_visualwakewords_lib.py
+++ b/research/slim/datasets/download_and_convert_visualwakewords_lib.py
@@ -37,22 +37,22 @@ import tensorflow.compat.v1 as tf
 
 from datasets import dataset_utils
 
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
+tf.logging.set_verbosity(tf.logging.INFO)
 
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'coco_train_url',
     'http://images.cocodataset.org/zips/train2014.zip',
     'Link to zip file containing coco training data')
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'coco_validation_url',
     'http://images.cocodataset.org/zips/val2014.zip',
     'Link to zip file containing coco validation data')
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'coco_annotations_url',
     'http://images.cocodataset.org/annotations/annotations_trainval2014.zip',
     'Link to zip file containing coco annotation data')
 
-FLAGS = tf.compat.v1.app.flags.FLAGS
+FLAGS = tf.app.flags.FLAGS
 
 
 def download_coco_dataset(dataset_dir):

--- a/research/slim/datasets/flowers.py
+++ b/research/slim/datasets/flowers.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/flowers.py
+++ b/research/slim/datasets/flowers.py
@@ -24,11 +24,9 @@ from __future__ import print_function
 
 import os
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from datasets import dataset_utils
-
-slim = contrib_slim
 
 _FILE_PATTERN = 'flowers_%s_*.tfrecord'
 

--- a/research/slim/datasets/imagenet.py
+++ b/research/slim/datasets/imagenet.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 
 import os
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/imagenet.py
+++ b/research/slim/datasets/imagenet.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 
 import os
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/imagenet.py
+++ b/research/slim/datasets/imagenet.py
@@ -34,12 +34,10 @@ from __future__ import print_function
 
 import os
 from six.moves import urllib
-import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tensorflow as tf
+import tf_slim as slim
 
 from datasets import dataset_utils
-
-slim = contrib_slim
 
 # TODO(nsilberman): Add tfrecord file type once the script is updated.
 _FILE_PATTERN = '%s-*'

--- a/research/slim/datasets/mnist.py
+++ b/research/slim/datasets/mnist.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/mnist.py
+++ b/research/slim/datasets/mnist.py
@@ -23,12 +23,10 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tensorflow as tf
+import tf_slim as slim
 
 from datasets import dataset_utils
-
-slim = contrib_slim
 
 _FILE_PATTERN = 'mnist_%s.tfrecord'
 

--- a/research/slim/datasets/mnist.py
+++ b/research/slim/datasets/mnist.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/visualwakewords.py
+++ b/research/slim/datasets/visualwakewords.py
@@ -28,13 +28,11 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tensorflow as tf
+import tf_slim as slim
 
 from datasets import dataset_utils
 
-
-slim = contrib_slim
 
 _FILE_PATTERN = '%s.record-*'
 

--- a/research/slim/datasets/visualwakewords.py
+++ b/research/slim/datasets/visualwakewords.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_utils

--- a/research/slim/datasets/visualwakewords.py
+++ b/research/slim/datasets/visualwakewords.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 from datasets import dataset_utils

--- a/research/slim/deployment/model_deploy.py
+++ b/research/slim/deployment/model_deploy.py
@@ -102,9 +102,7 @@ from __future__ import print_function
 import collections
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 __all__ = ['create_clones',

--- a/research/slim/deployment/model_deploy.py
+++ b/research/slim/deployment/model_deploy.py
@@ -101,7 +101,7 @@ from __future__ import print_function
 
 import collections
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/deployment/model_deploy_test.py
+++ b/research/slim/deployment/model_deploy_test.py
@@ -19,7 +19,8 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+from six.moves import range
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import slim as contrib_slim

--- a/research/slim/deployment/model_deploy_test.py
+++ b/research/slim/deployment/model_deploy_test.py
@@ -19,15 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from six.moves import range
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import slim as contrib_slim
+
+import tf_slim as slim
 
 from deployment import model_deploy
-
-slim = contrib_slim
 
 
 class DeploymentConfigTest(tf.test.TestCase):
@@ -512,9 +508,8 @@ class DeployTest(tf.test.TestCase):
 
       with tf.Session() as sess:
         sess.run(tf.global_variables_initializer())
-        moving_mean = contrib_framework.get_variables_by_name('moving_mean')[0]
-        moving_variance = contrib_framework.get_variables_by_name(
-            'moving_variance')[0]
+        moving_mean = slim.get_variables_by_name('moving_mean')[0]
+        moving_variance = slim.get_variables_by_name('moving_variance')[0]
         initial_loss = sess.run(model.total_loss)
         initial_mean, initial_variance = sess.run([moving_mean,
                                                    moving_variance])
@@ -540,8 +535,8 @@ class DeployTest(tf.test.TestCase):
       # clone function creates a fully_connected layer with a regularizer loss.
       def ModelFn():
         inputs = tf.constant(1.0, shape=(10, 20), dtype=tf.float32)
-        reg = contrib_layers.l2_regularizer(0.001)
-        contrib_layers.fully_connected(inputs, 30, weights_regularizer=reg)
+        reg = slim.l2_regularizer(0.001)
+        slim.fully_connected(inputs, 30, weights_regularizer=reg)
 
       model = model_deploy.deploy(
           deploy_config, ModelFn,
@@ -559,8 +554,8 @@ class DeployTest(tf.test.TestCase):
       # clone function creates a fully_connected layer with a regularizer loss.
       def ModelFn():
         inputs = tf.constant(1.0, shape=(10, 20), dtype=tf.float32)
-        reg = contrib_layers.l2_regularizer(0.001)
-        contrib_layers.fully_connected(inputs, 30, weights_regularizer=reg)
+        reg = slim.l2_regularizer(0.001)
+        slim.fully_connected(inputs, 30, weights_regularizer=reg)
 
       # No optimizer here, it's an eval.
       model = model_deploy.deploy(deploy_config, ModelFn)

--- a/research/slim/download_and_convert_data.py
+++ b/research/slim/download_and_convert_data.py
@@ -46,15 +46,15 @@ from datasets import download_and_convert_flowers
 from datasets import download_and_convert_mnist
 from datasets import download_and_convert_visualwakewords
 
-FLAGS = tf.compat.v1.app.flags.FLAGS
+FLAGS = tf.app.flags.FLAGS
 
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'dataset_name',
     None,
     'The name of the dataset to convert, one of "flowers", "cifar10", "mnist", "visualwakewords"'
     )
 
-tf.compat.v1.app.flags.DEFINE_string(
+tf.app.flags.DEFINE_string(
     'dataset_dir',
     None,
     'The directory where the output TFRecords and temporary files are saved.')
@@ -91,4 +91,4 @@ def main(_):
         'dataset_name [%s] was not recognized.' % FLAGS.dataset_name)
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  tf.app.run()

--- a/research/slim/download_and_convert_data.py
+++ b/research/slim/download_and_convert_data.py
@@ -39,7 +39,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from datasets import download_and_convert_cifar10
 from datasets import download_and_convert_flowers

--- a/research/slim/eval_image_classifier.py
+++ b/research/slim/eval_image_classifier.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 from tensorflow.contrib import quantize as contrib_quantize

--- a/research/slim/eval_image_classifier.py
+++ b/research/slim/eval_image_classifier.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/eval_image_classifier.py
+++ b/research/slim/eval_image_classifier.py
@@ -19,15 +19,14 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
+import tf_slim as slim
+
 from tensorflow.contrib import quantize as contrib_quantize
-from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_factory
 from nets import nets_factory
 from preprocessing import preprocessing_factory
-
-slim = contrib_slim
 
 tf.app.flags.DEFINE_integer(
     'batch_size', 100, 'The number of samples in each batch.')

--- a/research/slim/export_inference_graph.py
+++ b/research/slim/export_inference_graph.py
@@ -57,7 +57,7 @@ from __future__ import division
 from __future__ import print_function
 import os
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 
 

--- a/research/slim/export_inference_graph.py
+++ b/research/slim/export_inference_graph.py
@@ -57,16 +57,14 @@ from __future__ import division
 from __future__ import print_function
 import os
 
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
 from tensorflow.contrib import quantize as contrib_quantize
-from tensorflow.contrib import slim as contrib_slim
+
 
 from tensorflow.python.platform import gfile
 from datasets import dataset_factory
 from nets import nets_factory
 
-
-slim = contrib_slim
 
 tf.app.flags.DEFINE_string(
     'model_name', 'inception_v3', 'The name of the architecture to save.')

--- a/research/slim/export_inference_graph.py
+++ b/research/slim/export_inference_graph.py
@@ -57,7 +57,7 @@ from __future__ import division
 from __future__ import print_function
 import os
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/export_inference_graph_test.py
+++ b/research/slim/export_inference_graph_test.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import os
 
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from tensorflow.python.platform import gfile
 import export_inference_graph

--- a/research/slim/nets/alexnet.py
+++ b/research/slim/nets/alexnet.py
@@ -40,14 +40,14 @@ import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 
 
 def alexnet_v2_arg_scope(weight_decay=0.0005):
   with slim.arg_scope([slim.conv2d, slim.fully_connected],
                       activation_fn=tf.nn.relu,
-                      biases_initializer=tf.compat.v1.constant_initializer(0.1),
+                      biases_initializer=tf.constant_initializer(0.1),
                       weights_regularizer=slim.l2_regularizer(weight_decay)):
     with slim.arg_scope([slim.conv2d], padding='SAME'):
       with slim.arg_scope([slim.max_pool2d], padding='VALID') as arg_sc:
@@ -95,7 +95,7 @@ def alexnet_v2(inputs,
       or None).
     end_points: a dict of tensors with intermediate activations.
   """
-  with tf.compat.v1.variable_scope(scope, 'alexnet_v2', [inputs]) as sc:
+  with tf.variable_scope(scope, 'alexnet_v2', [inputs]) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     # Collect outputs for conv2d, fully_connected and max_pool2d.
     with slim.arg_scope([slim.conv2d, slim.fully_connected, slim.max_pool2d],
@@ -114,7 +114,7 @@ def alexnet_v2(inputs,
       with slim.arg_scope(
           [slim.conv2d],
           weights_initializer=trunc_normal(0.005),
-          biases_initializer=tf.compat.v1.constant_initializer(0.1)):
+          biases_initializer=tf.constant_initializer(0.1)):
         net = slim.conv2d(net, 4096, [5, 5], padding='VALID',
                           scope='fc6')
         net = slim.dropout(net, dropout_keep_prob, is_training=is_training,
@@ -135,7 +135,7 @@ def alexnet_v2(inputs,
               num_classes, [1, 1],
               activation_fn=None,
               normalizer_fn=None,
-              biases_initializer=tf.compat.v1.zeros_initializer(),
+              biases_initializer=tf.zeros_initializer(),
               scope='fc8')
           if spatial_squeeze:
             net = tf.squeeze(net, [1, 2], name='fc8/squeezed')

--- a/research/slim/nets/alexnet.py
+++ b/research/slim/nets/alexnet.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/alexnet.py
+++ b/research/slim/nets/alexnet.py
@@ -37,9 +37,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/alexnet_test.py
+++ b/research/slim/nets/alexnet_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import alexnet

--- a/research/slim/nets/alexnet_test.py
+++ b/research/slim/nets/alexnet_test.py
@@ -154,7 +154,7 @@ class AlexnetV2Test(tf.test.TestCase):
       logits, _ = alexnet.alexnet_v2(train_inputs)
       self.assertListEqual(logits.get_shape().as_list(),
                            [train_batch_size, num_classes])
-      tf.compat.v1.get_variable_scope().reuse_variables()
+      tf.get_variable_scope().reuse_variables()
       eval_inputs = tf.random.uniform(
           (eval_batch_size, eval_height, eval_width, 3))
       logits, _ = alexnet.alexnet_v2(eval_inputs, is_training=False,
@@ -171,7 +171,7 @@ class AlexnetV2Test(tf.test.TestCase):
     with self.test_session() as sess:
       inputs = tf.random.uniform((batch_size, height, width, 3))
       logits, _ = alexnet.alexnet_v2(inputs)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits)
       self.assertTrue(output.any())
 

--- a/research/slim/nets/alexnet_test.py
+++ b/research/slim/nets/alexnet_test.py
@@ -18,11 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import alexnet
-
-slim = contrib_slim
 
 
 class AlexnetV2Test(tf.test.TestCase):

--- a/research/slim/nets/cifarnet.py
+++ b/research/slim/nets/cifarnet.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/cifarnet.py
+++ b/research/slim/nets/cifarnet.py
@@ -22,7 +22,7 @@ import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     stddev=stddev)
 
 
@@ -61,7 +61,7 @@ def cifarnet(images, num_classes=10, is_training=False,
   """
   end_points = {}
 
-  with tf.compat.v1.variable_scope(scope, 'CifarNet', [images]):
+  with tf.variable_scope(scope, 'CifarNet', [images]):
     net = slim.conv2d(images, 64, [5, 5], scope='conv1')
     end_points['conv1'] = net
     net = slim.max_pool2d(net, [2, 2], 2, scope='pool1')
@@ -85,7 +85,7 @@ def cifarnet(images, num_classes=10, is_training=False,
     logits = slim.fully_connected(
         net,
         num_classes,
-        biases_initializer=tf.compat.v1.zeros_initializer(),
+        biases_initializer=tf.zeros_initializer(),
         weights_initializer=trunc_normal(1 / 192.0),
         weights_regularizer=None,
         activation_fn=None,
@@ -109,12 +109,12 @@ def cifarnet_arg_scope(weight_decay=0.004):
   """
   with slim.arg_scope(
       [slim.conv2d],
-      weights_initializer=tf.compat.v1.truncated_normal_initializer(
+      weights_initializer=tf.truncated_normal_initializer(
           stddev=5e-2),
       activation_fn=tf.nn.relu):
     with slim.arg_scope(
         [slim.fully_connected],
-        biases_initializer=tf.compat.v1.constant_initializer(0.1),
+        biases_initializer=tf.constant_initializer(0.1),
         weights_initializer=trunc_normal(0.04),
         weights_regularizer=slim.l2_regularizer(weight_decay),
         activation_fn=tf.nn.relu) as sc:

--- a/research/slim/nets/cifarnet.py
+++ b/research/slim/nets/cifarnet.py
@@ -19,9 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -20,11 +20,8 @@ from __future__ import print_function
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import util as contrib_util
-
-layers = contrib_layers
+import tf_slim as slim
+from tensorflow.python.framework import tensor_util
 
 
 def cyclegan_arg_scope(instance_norm_center=True,
@@ -55,11 +52,11 @@ def cyclegan_arg_scope(instance_norm_center=True,
 
   weights_regularizer = None
   if weight_decay and weight_decay > 0.0:
-    weights_regularizer = layers.l2_regularizer(weight_decay)
+    weights_regularizer = slim.l2_regularizer(weight_decay)
 
-  with contrib_framework.arg_scope(
-      [layers.conv2d],
-      normalizer_fn=layers.instance_norm,
+  with slim.arg_scope(
+      [slim.conv2d],
+      normalizer_fn=slim.instance_norm,
       normalizer_params=instance_norm_params,
       weights_initializer=tf.compat.v1.random_normal_initializer(
           0, weights_init_stddev),
@@ -106,19 +103,19 @@ def cyclegan_upsample(net, num_outputs, stride, method='conv2d_transpose',
           net, [stride[0] * height, stride[1] * width],
           method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
       net = tf.pad(tensor=net, paddings=spatial_pad_1, mode=pad_mode)
-      net = layers.conv2d(net, num_outputs, kernel_size=[3, 3], padding='valid')
+      net = slim.conv2d(net, num_outputs, kernel_size=[3, 3], padding='valid')
     elif method == 'bilinear_upsample_conv':
       net = tf.compat.v1.image.resize_bilinear(
           net, [stride[0] * height, stride[1] * width],
           align_corners=align_corners)
       net = tf.pad(tensor=net, paddings=spatial_pad_1, mode=pad_mode)
-      net = layers.conv2d(net, num_outputs, kernel_size=[3, 3], padding='valid')
+      net = slim.conv2d(net, num_outputs, kernel_size=[3, 3], padding='valid')
     elif method == 'conv2d_transpose':
       # This corrects 1 pixel offset for images with even width and height.
       # conv2d is left aligned and conv2d_transpose is right aligned for even
       # sized images (while doing 'SAME' padding).
       # Note: This doesn't reflect actual model in paper.
-      net = layers.conv2d_transpose(
+      net = slim.conv2d_transpose(
           net, num_outputs, kernel_size=[3, 3], stride=stride, padding='valid')
       net = net[:, 1:, 1:, :]
     else:
@@ -129,7 +126,7 @@ def cyclegan_upsample(net, num_outputs, stride, method='conv2d_transpose',
 
 def _dynamic_or_static_shape(tensor):
   shape = tf.shape(input=tensor)
-  static_shape = contrib_util.constant_value(shape)
+  static_shape = tensor_util.constant_value(shape)
   return static_shape if static_shape is not None else shape
 
 
@@ -201,7 +198,7 @@ def cyclegan_generator_resnet(images,
       dtype=np.int32)
   spatial_pad_3 = np.array([[0, 0], [3, 3], [3, 3], [0, 0]])
 
-  with contrib_framework.arg_scope(arg_scope_fn()):
+  with slim.arg_scope(arg_scope_fn()):
 
     ###########
     # Encoder #
@@ -209,39 +206,38 @@ def cyclegan_generator_resnet(images,
     with tf.compat.v1.variable_scope('input'):
       # 7x7 input stage
       net = tf.pad(tensor=images, paddings=spatial_pad_3, mode='REFLECT')
-      net = layers.conv2d(net, num_filters, kernel_size=[7, 7], padding='VALID')
+      net = slim.conv2d(net, num_filters, kernel_size=[7, 7], padding='VALID')
       end_points['encoder_0'] = net
 
     with tf.compat.v1.variable_scope('encoder'):
-      with contrib_framework.arg_scope([layers.conv2d],
-                                       kernel_size=kernel_size,
-                                       stride=2,
-                                       activation_fn=tf.nn.relu,
-                                       padding='VALID'):
+      with slim.arg_scope([slim.conv2d],
+                          kernel_size=kernel_size,
+                          stride=2,
+                          activation_fn=tf.nn.relu,
+                          padding='VALID'):
 
         net = tf.pad(tensor=net, paddings=paddings, mode='REFLECT')
-        net = layers.conv2d(net, num_filters * 2)
+        net = slim.conv2d(net, num_filters * 2)
         end_points['encoder_1'] = net
         net = tf.pad(tensor=net, paddings=paddings, mode='REFLECT')
-        net = layers.conv2d(net, num_filters * 4)
+        net = slim.conv2d(net, num_filters * 4)
         end_points['encoder_2'] = net
 
     ###################
     # Residual Blocks #
     ###################
     with tf.compat.v1.variable_scope('residual_blocks'):
-      with contrib_framework.arg_scope([layers.conv2d],
-                                       kernel_size=kernel_size,
-                                       stride=1,
-                                       activation_fn=tf.nn.relu,
-                                       padding='VALID'):
+      with slim.arg_scope([slim.conv2d],
+                          kernel_size=kernel_size,
+                          stride=1,
+                          activation_fn=tf.nn.relu,
+                          padding='VALID'):
         for block_id in xrange(num_resnet_blocks):
           with tf.compat.v1.variable_scope('block_{}'.format(block_id)):
             res_net = tf.pad(tensor=net, paddings=paddings, mode='REFLECT')
-            res_net = layers.conv2d(res_net, num_filters * 4)
+            res_net = slim.conv2d(res_net, num_filters * 4)
             res_net = tf.pad(tensor=res_net, paddings=paddings, mode='REFLECT')
-            res_net = layers.conv2d(res_net, num_filters * 4,
-                                    activation_fn=None)
+            res_net = slim.conv2d(res_net, num_filters * 4, activation_fn=None)
             net += res_net
 
             end_points['resnet_block_%d' % block_id] = net
@@ -251,10 +247,10 @@ def cyclegan_generator_resnet(images,
     ###########
     with tf.compat.v1.variable_scope('decoder'):
 
-      with contrib_framework.arg_scope([layers.conv2d],
-                                       kernel_size=kernel_size,
-                                       stride=1,
-                                       activation_fn=tf.nn.relu):
+      with slim.arg_scope([slim.conv2d],
+                          kernel_size=kernel_size,
+                          stride=1,
+                          activation_fn=tf.nn.relu):
 
         with tf.compat.v1.variable_scope('decoder1'):
           net = upsample_fn(net, num_outputs=num_filters * 2, stride=[2, 2])
@@ -266,7 +262,7 @@ def cyclegan_generator_resnet(images,
 
     with tf.compat.v1.variable_scope('output'):
       net = tf.pad(tensor=net, paddings=spatial_pad_3, mode='REFLECT')
-      logits = layers.conv2d(
+      logits = slim.conv2d(
           net,
           num_outputs, [7, 7],
           activation_fn=None,

--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import util as contrib_util

--- a/research/slim/nets/cyclegan.py
+++ b/research/slim/nets/cyclegan.py
@@ -58,7 +58,7 @@ def cyclegan_arg_scope(instance_norm_center=True,
       [slim.conv2d],
       normalizer_fn=slim.instance_norm,
       normalizer_params=instance_norm_params,
-      weights_initializer=tf.compat.v1.random_normal_initializer(
+      weights_initializer=tf.random_normal_initializer(
           0, weights_init_stddev),
       weights_regularizer=weights_regularizer) as sc:
     return sc
@@ -88,7 +88,7 @@ def cyclegan_upsample(net, num_outputs, stride, method='conv2d_transpose',
   Raises:
     ValueError: if `method` is not recognized.
   """
-  with tf.compat.v1.variable_scope('upconv'):
+  with tf.variable_scope('upconv'):
     net_shape = tf.shape(input=net)
     height = net_shape[1]
     width = net_shape[2]
@@ -105,7 +105,7 @@ def cyclegan_upsample(net, num_outputs, stride, method='conv2d_transpose',
       net = tf.pad(tensor=net, paddings=spatial_pad_1, mode=pad_mode)
       net = slim.conv2d(net, num_outputs, kernel_size=[3, 3], padding='valid')
     elif method == 'bilinear_upsample_conv':
-      net = tf.compat.v1.image.resize_bilinear(
+      net = tf.image.resize_bilinear(
           net, [stride[0] * height, stride[1] * width],
           align_corners=align_corners)
       net = tf.pad(tensor=net, paddings=spatial_pad_1, mode=pad_mode)
@@ -203,13 +203,13 @@ def cyclegan_generator_resnet(images,
     ###########
     # Encoder #
     ###########
-    with tf.compat.v1.variable_scope('input'):
+    with tf.variable_scope('input'):
       # 7x7 input stage
       net = tf.pad(tensor=images, paddings=spatial_pad_3, mode='REFLECT')
       net = slim.conv2d(net, num_filters, kernel_size=[7, 7], padding='VALID')
       end_points['encoder_0'] = net
 
-    with tf.compat.v1.variable_scope('encoder'):
+    with tf.variable_scope('encoder'):
       with slim.arg_scope([slim.conv2d],
                           kernel_size=kernel_size,
                           stride=2,
@@ -226,14 +226,14 @@ def cyclegan_generator_resnet(images,
     ###################
     # Residual Blocks #
     ###################
-    with tf.compat.v1.variable_scope('residual_blocks'):
+    with tf.variable_scope('residual_blocks'):
       with slim.arg_scope([slim.conv2d],
                           kernel_size=kernel_size,
                           stride=1,
                           activation_fn=tf.nn.relu,
                           padding='VALID'):
         for block_id in xrange(num_resnet_blocks):
-          with tf.compat.v1.variable_scope('block_{}'.format(block_id)):
+          with tf.variable_scope('block_{}'.format(block_id)):
             res_net = tf.pad(tensor=net, paddings=paddings, mode='REFLECT')
             res_net = slim.conv2d(res_net, num_filters * 4)
             res_net = tf.pad(tensor=res_net, paddings=paddings, mode='REFLECT')
@@ -245,22 +245,22 @@ def cyclegan_generator_resnet(images,
     ###########
     # Decoder #
     ###########
-    with tf.compat.v1.variable_scope('decoder'):
+    with tf.variable_scope('decoder'):
 
       with slim.arg_scope([slim.conv2d],
                           kernel_size=kernel_size,
                           stride=1,
                           activation_fn=tf.nn.relu):
 
-        with tf.compat.v1.variable_scope('decoder1'):
+        with tf.variable_scope('decoder1'):
           net = upsample_fn(net, num_outputs=num_filters * 2, stride=[2, 2])
         end_points['decoder1'] = net
 
-        with tf.compat.v1.variable_scope('decoder2'):
+        with tf.variable_scope('decoder2'):
           net = upsample_fn(net, num_outputs=num_filters, stride=[2, 2])
         end_points['decoder2'] = net
 
-    with tf.compat.v1.variable_scope('output'):
+    with tf.variable_scope('output'):
       net = tf.pad(tensor=net, paddings=spatial_pad_3, mode='REFLECT')
       logits = slim.conv2d(
           net,

--- a/research/slim/nets/cyclegan_test.py
+++ b/research/slim/nets/cyclegan_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from nets import cyclegan
 

--- a/research/slim/nets/cyclegan_test.py
+++ b/research/slim/nets/cyclegan_test.py
@@ -31,7 +31,7 @@ class CycleganTest(tf.test.TestCase):
     img_batch = tf.zeros([2, 32, 32, 3])
     model_output, _ = cyclegan.cyclegan_generator_resnet(img_batch)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       sess.run(model_output)
 
   def _test_generator_graph_helper(self, shape):
@@ -50,13 +50,13 @@ class CycleganTest(tf.test.TestCase):
 
   def test_generator_unknown_batch_dim(self):
     """Check that generator can take unknown batch dimension inputs."""
-    img = tf.compat.v1.placeholder(tf.float32, shape=[None, 32, None, 3])
+    img = tf.placeholder(tf.float32, shape=[None, 32, None, 3])
     output_imgs, _ = cyclegan.cyclegan_generator_resnet(img)
 
     self.assertAllEqual([None, 32, None, 3], output_imgs.shape.as_list())
 
   def _input_and_output_same_shape_helper(self, kernel_size):
-    img_batch = tf.compat.v1.placeholder(tf.float32, shape=[None, 32, 32, 3])
+    img_batch = tf.placeholder(tf.float32, shape=[None, 32, 32, 3])
     output_img_batch, _ = cyclegan.cyclegan_generator_resnet(
         img_batch, kernel_size=kernel_size)
 
@@ -79,7 +79,7 @@ class CycleganTest(tf.test.TestCase):
     self.assertRaisesRegexp(
         ValueError, 'The input height must be a multiple of 4.',
         cyclegan.cyclegan_generator_resnet,
-        tf.compat.v1.placeholder(tf.float32, shape=[None, height, 32, 3]))
+        tf.placeholder(tf.float32, shape=[None, height, 32, 3]))
 
   def test_error_if_height_not_multiple_of_four_height29(self):
     self._error_if_height_not_multiple_of_four_helper(29)
@@ -94,7 +94,7 @@ class CycleganTest(tf.test.TestCase):
     self.assertRaisesRegexp(
         ValueError, 'The input width must be a multiple of 4.',
         cyclegan.cyclegan_generator_resnet,
-        tf.compat.v1.placeholder(tf.float32, shape=[None, 32, width, 3]))
+        tf.placeholder(tf.float32, shape=[None, 32, width, 3]))
 
   def test_error_if_width_not_multiple_of_four_width29(self):
     self._error_if_width_not_multiple_of_four_helper(29)

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -80,7 +80,7 @@ def discriminator(inputs,
   inp_shape = inputs.get_shape().as_list()[1]
 
   end_points = {}
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, values=[inputs], reuse=reuse) as scope:
     with slim.arg_scope([normalizer_fn], **normalizer_fn_args):
       with slim.arg_scope([slim.conv2d],
@@ -155,7 +155,7 @@ def generator(inputs,
 
   end_points = {}
   num_layers = int(log(final_size, 2)) - 1
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, values=[inputs], reuse=reuse) as scope:
     with slim.arg_scope([normalizer_fn], **normalizer_fn_args):
       with slim.arg_scope([slim.conv2d_transpose],

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from math import log
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/dcgan.py
+++ b/research/slim/nets/dcgan.py
@@ -21,9 +21,7 @@ from math import log
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def _validate_image_inputs(inputs):

--- a/research/slim/nets/dcgan_test.py
+++ b/research/slim/nets/dcgan_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from nets import dcgan
 

--- a/research/slim/nets/dcgan_test.py
+++ b/research/slim/nets/dcgan_test.py
@@ -27,19 +27,19 @@ from nets import dcgan
 class DCGANTest(tf.test.TestCase):
 
   def test_generator_run(self):
-    tf.compat.v1.set_random_seed(1234)
+    tf.set_random_seed(1234)
     noise = tf.random.normal([100, 64])
     image, _ = dcgan.generator(noise)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       image.eval()
 
   def test_generator_graph(self):
-    tf.compat.v1.set_random_seed(1234)
+    tf.set_random_seed(1234)
     # Check graph construction for a number of image size/depths and batch
     # sizes.
     for i, batch_size in zip(xrange(3, 7), xrange(3, 8)):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       final_size = 2 ** i
       noise = tf.random.normal([batch_size, 64])
       image, end_points = dcgan.generator(
@@ -74,14 +74,14 @@ class DCGANTest(tf.test.TestCase):
     image = tf.random.uniform([5, 32, 32, 3], -1, 1)
     output, _ = dcgan.discriminator(image)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output.eval()
 
   def test_discriminator_graph(self):
     # Check graph construction for a number of image size/depths and batch
     # sizes.
     for i, batch_size in zip(xrange(1, 6), xrange(3, 8)):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       img_w = 2 ** i
       image = tf.random.uniform([batch_size, img_w, img_w, 3], -1, 1)
       output, end_points = dcgan.discriminator(
@@ -103,7 +103,7 @@ class DCGANTest(tf.test.TestCase):
     with self.assertRaises(ValueError):
       dcgan.discriminator(wrong_dim_img)
 
-    spatially_undefined_shape = tf.compat.v1.placeholder(
+    spatially_undefined_shape = tf.placeholder(
         tf.float32, [5, 32, None, 3])
     with self.assertRaises(ValueError):
       dcgan.discriminator(spatially_undefined_shape)

--- a/research/slim/nets/i3d.py
+++ b/research/slim/nets/i3d.py
@@ -31,7 +31,7 @@ from nets import i3d_utils
 from nets import s3dg
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 conv3d_spatiotemporal = i3d_utils.conv3d_spatiotemporal
 
@@ -150,12 +150,12 @@ def i3d(inputs,
       activation.
   """
   # Final pooling and prediction
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV1', [inputs, num_classes], reuse=reuse) as scope:
     with slim.arg_scope(
         [slim.batch_norm, slim.dropout], is_training=is_training):
       net, end_points = i3d_base(inputs, scope=scope)
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         kernel_size = i3d_utils.reduced_kernel_size_3d(net, [2, 7, 7])
         net = slim.avg_pool3d(
             net, kernel_size, stride=1, scope='AvgPool_0a_7x7')

--- a/research/slim/nets/i3d.py
+++ b/research/slim/nets/i3d.py
@@ -25,12 +25,10 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import i3d_utils
 from nets import s3dg
-
-slim = contrib_slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/i3d.py
+++ b/research/slim/nets/i3d.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import i3d_utils

--- a/research/slim/nets/i3d_test.py
+++ b/research/slim/nets/i3d_test.py
@@ -18,7 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import six
+import tensorflow.compat.v1 as tf
 
 from nets import i3d
 
@@ -55,7 +56,7 @@ class I3DTest(tf.test.TestCase):
                           'Mixed_3c', 'MaxPool_4a_3x3', 'Mixed_4b', 'Mixed_4c',
                           'Mixed_4d', 'Mixed_4e', 'Mixed_4f', 'MaxPool_5a_2x2',
                           'Mixed_5b', 'Mixed_5c']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -100,8 +101,9 @@ class I3DTest(tf.test.TestCase):
                         'Mixed_5b': [5, 8, 7, 7, 832],
                         'Mixed_5c': [5, 8, 7, 7, 1024]}
 
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
+    for endpoint_name, expected_shape in six.iteritems(endpoints_shapes):
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)

--- a/research/slim/nets/i3d_test.py
+++ b/research/slim/nets/i3d_test.py
@@ -142,7 +142,7 @@ class I3DTest(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 

--- a/research/slim/nets/i3d_utils.py
+++ b/research/slim/nets/i3d_utils.py
@@ -20,14 +20,10 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
+import tf_slim as slim
 
-
-# Orignaly, add_arg_scope = slim.add_arg_scope and layers = slim, now switch to
-# more update-to-date tf.contrib.* API.
-add_arg_scope = contrib_framework.add_arg_scope
-layers = contrib_layers
+add_arg_scope = slim.add_arg_scope
+layers = slim.layers
 
 
 def center_initializer():

--- a/research/slim/nets/i3d_utils.py
+++ b/research/slim/nets/i3d_utils.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 

--- a/research/slim/nets/i3d_utils.py
+++ b/research/slim/nets/i3d_utils.py
@@ -224,13 +224,13 @@ def inception_block_v1_3d(inputs,
   """
   use_gating = self_gating_fn is not None
 
-  with tf.compat.v1.variable_scope(scope):
-    with tf.compat.v1.variable_scope('Branch_0'):
+  with tf.variable_scope(scope):
+    with tf.variable_scope('Branch_0'):
       branch_0 = layers.conv3d(
           inputs, num_outputs_0_0a, [1, 1, 1], scope='Conv2d_0a_1x1')
       if use_gating:
         branch_0 = self_gating_fn(branch_0, scope='Conv2d_0a_1x1')
-    with tf.compat.v1.variable_scope('Branch_1'):
+    with tf.variable_scope('Branch_1'):
       branch_1 = layers.conv3d(
           inputs, num_outputs_1_0a, [1, 1, 1], scope='Conv2d_0a_1x1')
       branch_1 = conv3d_spatiotemporal(
@@ -238,7 +238,7 @@ def inception_block_v1_3d(inputs,
           scope='Conv2d_0b_3x3')
       if use_gating:
         branch_1 = self_gating_fn(branch_1, scope='Conv2d_0b_3x3')
-    with tf.compat.v1.variable_scope('Branch_2'):
+    with tf.variable_scope('Branch_2'):
       branch_2 = layers.conv3d(
           inputs, num_outputs_2_0a, [1, 1, 1], scope='Conv2d_0a_1x1')
       branch_2 = conv3d_spatiotemporal(
@@ -246,7 +246,7 @@ def inception_block_v1_3d(inputs,
           scope='Conv2d_0b_3x3')
       if use_gating:
         branch_2 = self_gating_fn(branch_2, scope='Conv2d_0b_3x3')
-    with tf.compat.v1.variable_scope('Branch_3'):
+    with tf.variable_scope('Branch_3'):
       branch_3 = layers.max_pool3d(inputs, [3, 3, 3], scope='MaxPool_0a_3x3')
       branch_3 = layers.conv3d(
           branch_3, num_outputs_3_0b, [1, 1, 1], scope='Conv2d_0b_1x1')

--- a/research/slim/nets/inception_resnet_v2.py
+++ b/research/slim/nets/inception_resnet_v2.py
@@ -26,9 +26,7 @@ from __future__ import print_function
 
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def block35(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):

--- a/research/slim/nets/inception_resnet_v2.py
+++ b/research/slim/nets/inception_resnet_v2.py
@@ -31,13 +31,13 @@ import tf_slim as slim
 
 def block35(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):
   """Builds the 35x35 resnet block."""
-  with tf.compat.v1.variable_scope(scope, 'Block35', [net], reuse=reuse):
-    with tf.compat.v1.variable_scope('Branch_0'):
+  with tf.variable_scope(scope, 'Block35', [net], reuse=reuse):
+    with tf.variable_scope('Branch_0'):
       tower_conv = slim.conv2d(net, 32, 1, scope='Conv2d_1x1')
-    with tf.compat.v1.variable_scope('Branch_1'):
+    with tf.variable_scope('Branch_1'):
       tower_conv1_0 = slim.conv2d(net, 32, 1, scope='Conv2d_0a_1x1')
       tower_conv1_1 = slim.conv2d(tower_conv1_0, 32, 3, scope='Conv2d_0b_3x3')
-    with tf.compat.v1.variable_scope('Branch_2'):
+    with tf.variable_scope('Branch_2'):
       tower_conv2_0 = slim.conv2d(net, 32, 1, scope='Conv2d_0a_1x1')
       tower_conv2_1 = slim.conv2d(tower_conv2_0, 48, 3, scope='Conv2d_0b_3x3')
       tower_conv2_2 = slim.conv2d(tower_conv2_1, 64, 3, scope='Conv2d_0c_3x3')
@@ -57,10 +57,10 @@ def block35(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):
 
 def block17(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):
   """Builds the 17x17 resnet block."""
-  with tf.compat.v1.variable_scope(scope, 'Block17', [net], reuse=reuse):
-    with tf.compat.v1.variable_scope('Branch_0'):
+  with tf.variable_scope(scope, 'Block17', [net], reuse=reuse):
+    with tf.variable_scope('Branch_0'):
       tower_conv = slim.conv2d(net, 192, 1, scope='Conv2d_1x1')
-    with tf.compat.v1.variable_scope('Branch_1'):
+    with tf.variable_scope('Branch_1'):
       tower_conv1_0 = slim.conv2d(net, 128, 1, scope='Conv2d_0a_1x1')
       tower_conv1_1 = slim.conv2d(tower_conv1_0, 160, [1, 7],
                                   scope='Conv2d_0b_1x7')
@@ -83,10 +83,10 @@ def block17(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):
 
 def block8(net, scale=1.0, activation_fn=tf.nn.relu, scope=None, reuse=None):
   """Builds the 8x8 resnet block."""
-  with tf.compat.v1.variable_scope(scope, 'Block8', [net], reuse=reuse):
-    with tf.compat.v1.variable_scope('Branch_0'):
+  with tf.variable_scope(scope, 'Block8', [net], reuse=reuse):
+    with tf.variable_scope('Branch_0'):
       tower_conv = slim.conv2d(net, 192, 1, scope='Conv2d_1x1')
-    with tf.compat.v1.variable_scope('Branch_1'):
+    with tf.variable_scope('Branch_1'):
       tower_conv1_0 = slim.conv2d(net, 192, 1, scope='Conv2d_0a_1x1')
       tower_conv1_1 = slim.conv2d(tower_conv1_0, 224, [1, 3],
                                   scope='Conv2d_0b_1x3')
@@ -153,7 +153,7 @@ def inception_resnet_v2_base(inputs,
     end_points[name] = net
     return name == final_endpoint
 
-  with tf.compat.v1.variable_scope(scope, 'InceptionResnetV2', [inputs]):
+  with tf.variable_scope(scope, 'InceptionResnetV2', [inputs]):
     with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
                         stride=1, padding='SAME'):
       # 149 x 149 x 32
@@ -186,20 +186,20 @@ def inception_resnet_v2_base(inputs,
       if add_and_check_final('MaxPool_5a_3x3', net): return net, end_points
 
       # 35 x 35 x 320
-      with tf.compat.v1.variable_scope('Mixed_5b'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_5b'):
+        with tf.variable_scope('Branch_0'):
           tower_conv = slim.conv2d(net, 96, 1, scope='Conv2d_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           tower_conv1_0 = slim.conv2d(net, 48, 1, scope='Conv2d_0a_1x1')
           tower_conv1_1 = slim.conv2d(tower_conv1_0, 64, 5,
                                       scope='Conv2d_0b_5x5')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           tower_conv2_0 = slim.conv2d(net, 64, 1, scope='Conv2d_0a_1x1')
           tower_conv2_1 = slim.conv2d(tower_conv2_0, 96, 3,
                                       scope='Conv2d_0b_3x3')
           tower_conv2_2 = slim.conv2d(tower_conv2_1, 96, 3,
                                       scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           tower_pool = slim.avg_pool2d(net, 3, stride=1, padding='SAME',
                                        scope='AvgPool_0a_3x3')
           tower_pool_1 = slim.conv2d(tower_pool, 64, 1,
@@ -216,12 +216,12 @@ def inception_resnet_v2_base(inputs,
       # 33 x 33 x 1088 if output_stride == 16
       use_atrous = output_stride == 8
 
-      with tf.compat.v1.variable_scope('Mixed_6a'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_6a'):
+        with tf.variable_scope('Branch_0'):
           tower_conv = slim.conv2d(net, 384, 3, stride=1 if use_atrous else 2,
                                    padding=padding,
                                    scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           tower_conv1_0 = slim.conv2d(net, 256, 1, scope='Conv2d_0a_1x1')
           tower_conv1_1 = slim.conv2d(tower_conv1_0, 256, 3,
                                       scope='Conv2d_0b_3x3')
@@ -229,7 +229,7 @@ def inception_resnet_v2_base(inputs,
                                       stride=1 if use_atrous else 2,
                                       padding=padding,
                                       scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           tower_pool = slim.max_pool2d(net, 3, stride=1 if use_atrous else 2,
                                        padding=padding,
                                        scope='MaxPool_1a_3x3')
@@ -249,25 +249,25 @@ def inception_resnet_v2_base(inputs,
                          'PreAuxlogits end_point for now.')
 
       # 8 x 8 x 2080
-      with tf.compat.v1.variable_scope('Mixed_7a'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_7a'):
+        with tf.variable_scope('Branch_0'):
           tower_conv = slim.conv2d(net, 256, 1, scope='Conv2d_0a_1x1')
           tower_conv_1 = slim.conv2d(tower_conv, 384, 3, stride=2,
                                      padding=padding,
                                      scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           tower_conv1 = slim.conv2d(net, 256, 1, scope='Conv2d_0a_1x1')
           tower_conv1_1 = slim.conv2d(tower_conv1, 288, 3, stride=2,
                                       padding=padding,
                                       scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           tower_conv2 = slim.conv2d(net, 256, 1, scope='Conv2d_0a_1x1')
           tower_conv2_1 = slim.conv2d(tower_conv2, 288, 3,
                                       scope='Conv2d_0b_3x3')
           tower_conv2_2 = slim.conv2d(tower_conv2_1, 320, 3, stride=2,
                                       padding=padding,
                                       scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           tower_pool = slim.max_pool2d(net, 3, stride=2,
                                        padding=padding,
                                        scope='MaxPool_1a_3x3')
@@ -318,7 +318,7 @@ def inception_resnet_v2(inputs, num_classes=1001, is_training=True,
   """
   end_points = {}
 
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionResnetV2', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
@@ -327,7 +327,7 @@ def inception_resnet_v2(inputs, num_classes=1001, is_training=True,
                                                  activation_fn=activation_fn)
 
       if create_aux_logits and num_classes:
-        with tf.compat.v1.variable_scope('AuxLogits'):
+        with tf.variable_scope('AuxLogits'):
           aux = end_points['PreAuxLogits']
           aux = slim.avg_pool2d(aux, 5, stride=3, padding='VALID',
                                 scope='Conv2d_1a_3x3')
@@ -339,7 +339,7 @@ def inception_resnet_v2(inputs, num_classes=1001, is_training=True,
                                      scope='Logits')
           end_points['AuxLogits'] = aux
 
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         # TODO(sguada,arnoegw): Consider adding a parameter global_pool which
         # can be set to False to disable pooling here (as in resnet_*()).
         kernel_size = net.get_shape()[1:3]
@@ -370,7 +370,7 @@ def inception_resnet_v2_arg_scope(
     batch_norm_decay=0.9997,
     batch_norm_epsilon=0.001,
     activation_fn=tf.nn.relu,
-    batch_norm_updates_collections=tf.compat.v1.GraphKeys.UPDATE_OPS,
+    batch_norm_updates_collections=tf.GraphKeys.UPDATE_OPS,
     batch_norm_scale=False):
   """Returns the scope with the default parameters for inception_resnet_v2.
 

--- a/research/slim/nets/inception_resnet_v2.py
+++ b/research/slim/nets/inception_resnet_v2.py
@@ -25,7 +25,7 @@ from __future__ import division
 from __future__ import print_function
 
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/inception_resnet_v2_test.py
+++ b/research/slim/nets/inception_resnet_v2_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception
@@ -100,7 +100,7 @@ class InceptionTest(tf.test.TestCase):
                           'MaxPool_3a_3x3', 'Conv2d_3b_1x1', 'Conv2d_4a_3x3',
                           'MaxPool_5a_3x3', 'Mixed_5b', 'Mixed_6a',
                           'PreAuxLogits', 'Mixed_7a', 'Conv2d_7b_1x1']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -117,7 +117,7 @@ class InceptionTest(tf.test.TestCase):
         if endpoint != 'PreAuxLogits':
           self.assertTrue(out_tensor.op.name.startswith(
               'InceptionResnetV2/' + endpoint))
-        self.assertItemsEqual(endpoints[:index+1], end_points.keys())
+        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
 
   def testBuildAndCheckAllEndPointsUptoPreAuxLogits(self):
     batch_size = 5
@@ -138,7 +138,8 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 17, 17, 1088]
                        }
 
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -164,7 +165,8 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 19, 19, 1088]
                        }
 
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -190,7 +192,8 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 33, 33, 1088]
                        }
 
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)

--- a/research/slim/nets/inception_resnet_v2_test.py
+++ b/research/slim/nets/inception_resnet_v2_test.py
@@ -204,15 +204,15 @@ class InceptionTest(tf.test.TestCase):
     with self.test_session():
       inputs = tf.random.uniform((batch_size, height, width, 3))
       # Force all Variables to reside on the device.
-      with tf.compat.v1.variable_scope('on_cpu'), tf.device('/cpu:0'):
+      with tf.variable_scope('on_cpu'), tf.device('/cpu:0'):
         inception.inception_resnet_v2(inputs, num_classes)
-      with tf.compat.v1.variable_scope('on_gpu'), tf.device('/gpu:0'):
+      with tf.variable_scope('on_gpu'), tf.device('/gpu:0'):
         inception.inception_resnet_v2(inputs, num_classes)
-      for v in tf.compat.v1.get_collection(
-          tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
+      for v in tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
         self.assertDeviceEqual(v.device, '/cpu:0')
-      for v in tf.compat.v1.get_collection(
-          tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
+      for v in tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
         self.assertDeviceEqual(v.device, '/gpu:0')
 
   def testHalfSizeImages(self):
@@ -248,7 +248,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 330, 400
     num_classes = 1000
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(tf.float32, (batch_size, None, None, 3))
+      inputs = tf.placeholder(tf.float32, (batch_size, None, None, 3))
       logits, end_points = inception.inception_resnet_v2(
           inputs, num_classes, create_aux_logits=False)
       self.assertTrue(logits.op.name.startswith('InceptionResnetV2/Logits'))
@@ -256,7 +256,7 @@ class InceptionTest(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Conv2d_7b_1x1']
       images = tf.random.uniform((batch_size, height, width, 3))
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       logits_out, pre_pool_out = sess.run([logits, pre_pool],
                                           {inputs: images.eval()})
       self.assertTupleEqual(logits_out.shape, (batch_size, num_classes))
@@ -267,13 +267,13 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+      inputs = tf.placeholder(tf.float32, (None, height, width, 3))
       logits, _ = inception.inception_resnet_v2(inputs, num_classes)
       self.assertTrue(logits.op.name.startswith('InceptionResnetV2/Logits'))
       self.assertListEqual(logits.get_shape().as_list(),
                            [None, num_classes])
       images = tf.random.uniform((batch_size, height, width, 3))
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -287,7 +287,7 @@ class InceptionTest(tf.test.TestCase):
                                                 num_classes,
                                                 is_training=False)
       predictions = tf.argmax(input=logits, axis=1)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -305,32 +305,32 @@ class InceptionTest(tf.test.TestCase):
                                                 is_training=False,
                                                 reuse=True)
       predictions = tf.argmax(input=logits, axis=1)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
   def testNoBatchNormScaleByDefault(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(inception.inception_resnet_v2_arg_scope()):
       inception.inception_resnet_v2(inputs, num_classes, is_training=False)
 
-    self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
+    self.assertEqual(tf.global_variables('.*/BatchNorm/gamma:0$'), [])
 
   def testBatchNormScale(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(
         inception.inception_resnet_v2_arg_scope(batch_norm_scale=True)):
       inception.inception_resnet_v2(inputs, num_classes, is_training=False)
 
     gamma_names = set(
         v.op.name
-        for v in tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'))
+        for v in tf.global_variables('.*/BatchNorm/gamma:0$'))
     self.assertGreater(len(gamma_names), 0)
-    for v in tf.compat.v1.global_variables('.*/BatchNorm/moving_mean:0$'):
+    for v in tf.global_variables('.*/BatchNorm/moving_mean:0$'):
       self.assertIn(v.op.name[:-len('moving_mean')] + 'gamma', gamma_names)
 
 

--- a/research/slim/nets/inception_resnet_v2_test.py
+++ b/research/slim/nets/inception_resnet_v2_test.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception
 
@@ -100,7 +100,7 @@ class InceptionTest(tf.test.TestCase):
                           'MaxPool_3a_3x3', 'Conv2d_3b_1x1', 'Conv2d_4a_3x3',
                           'MaxPool_5a_3x3', 'Mixed_5b', 'Mixed_6a',
                           'PreAuxLogits', 'Mixed_7a', 'Conv2d_7b_1x1']
-    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
+    self.assertItemsEqual(end_points.keys(), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -117,7 +117,7 @@ class InceptionTest(tf.test.TestCase):
         if endpoint != 'PreAuxLogits':
           self.assertTrue(out_tensor.op.name.startswith(
               'InceptionResnetV2/' + endpoint))
-        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
+        self.assertItemsEqual(endpoints[:index + 1], end_points.keys())
 
   def testBuildAndCheckAllEndPointsUptoPreAuxLogits(self):
     batch_size = 5
@@ -138,8 +138,7 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 17, 17, 1088]
                        }
 
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -165,8 +164,7 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 19, 19, 1088]
                        }
 
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -192,8 +190,7 @@ class InceptionTest(tf.test.TestCase):
                         'PreAuxLogits': [5, 33, 33, 1088]
                        }
 
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -316,7 +313,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
-    with contrib_slim.arg_scope(inception.inception_resnet_v2_arg_scope()):
+    with slim.arg_scope(inception.inception_resnet_v2_arg_scope()):
       inception.inception_resnet_v2(inputs, num_classes, is_training=False)
 
     self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
@@ -325,7 +322,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
-    with contrib_slim.arg_scope(
+    with slim.arg_scope(
         inception.inception_resnet_v2_arg_scope(batch_norm_scale=True)):
       inception.inception_resnet_v2(inputs, num_classes, is_training=False)
 

--- a/research/slim/nets/inception_utils.py
+++ b/research/slim/nets/inception_utils.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/inception_utils.py
+++ b/research/slim/nets/inception_utils.py
@@ -25,9 +25,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def inception_arg_scope(

--- a/research/slim/nets/inception_utils.py
+++ b/research/slim/nets/inception_utils.py
@@ -34,7 +34,7 @@ def inception_arg_scope(
     batch_norm_decay=0.9997,
     batch_norm_epsilon=0.001,
     activation_fn=tf.nn.relu,
-    batch_norm_updates_collections=tf.compat.v1.GraphKeys.UPDATE_OPS,
+    batch_norm_updates_collections=tf.GraphKeys.UPDATE_OPS,
     batch_norm_scale=False):
   """Defines the default arg scope for inception models.
 

--- a/research/slim/nets/inception_v1.py
+++ b/research/slim/nets/inception_v1.py
@@ -24,7 +24,7 @@ import tf_slim as slim
 from nets import inception_utils
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 
 
@@ -60,7 +60,7 @@ def inception_v1_base(inputs,
     ValueError: if final_endpoint is not set to one of the predefined values.
   """
   end_points = {}
-  with tf.compat.v1.variable_scope(scope, 'InceptionV1', [inputs]):
+  with tf.variable_scope(scope, 'InceptionV1', [inputs]):
     with slim.arg_scope(
         [slim.conv2d, slim.fully_connected],
         weights_initializer=trunc_normal(0.01)):
@@ -95,16 +95,16 @@ def inception_v1_base(inputs,
             return net, end_points
 
         end_point = 'Mixed_3b'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 64, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 96, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 128, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 16, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 32, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 32, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -113,16 +113,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_3c'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 128, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 128, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 192, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 96, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -136,16 +136,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_4b'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 192, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 96, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 208, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 16, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 48, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -154,16 +154,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_4c'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 160, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 112, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 224, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 24, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -172,16 +172,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_4d'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 128, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 128, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 256, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 24, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -190,16 +190,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_4e'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 112, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 144, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 288, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 64, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 64, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -208,16 +208,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_4f'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 256, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 160, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 320, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -231,16 +231,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_5b'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 256, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 160, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 320, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 32, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0a_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -249,16 +249,16 @@ def inception_v1_base(inputs,
         if final_endpoint == end_point: return net, end_points
 
         end_point = 'Mixed_5c'
-        with tf.compat.v1.variable_scope(end_point):
-          with tf.compat.v1.variable_scope('Branch_0'):
+        with tf.variable_scope(end_point):
+          with tf.variable_scope('Branch_0'):
             branch_0 = slim.conv2d(net, 384, [1, 1], scope='Conv2d_0a_1x1')
-          with tf.compat.v1.variable_scope('Branch_1'):
+          with tf.variable_scope('Branch_1'):
             branch_1 = slim.conv2d(net, 192, [1, 1], scope='Conv2d_0a_1x1')
             branch_1 = slim.conv2d(branch_1, 384, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_2'):
+          with tf.variable_scope('Branch_2'):
             branch_2 = slim.conv2d(net, 48, [1, 1], scope='Conv2d_0a_1x1')
             branch_2 = slim.conv2d(branch_2, 128, [3, 3], scope='Conv2d_0b_3x3')
-          with tf.compat.v1.variable_scope('Branch_3'):
+          with tf.variable_scope('Branch_3'):
             branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
             branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
           net = tf.concat(
@@ -314,12 +314,12 @@ def inception_v1(inputs,
       activation.
   """
   # Final pooling and prediction
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV1', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
       net, end_points = inception_v1_base(inputs, scope=scope)
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         if global_pool:
           # Global average pooling.
           net = tf.reduce_mean(

--- a/research/slim/nets/inception_v1.py
+++ b/research/slim/nets/inception_v1.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception_utils

--- a/research/slim/nets/inception_v1.py
+++ b/research/slim/nets/inception_v1.py
@@ -19,11 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception_utils
-
-slim = contrib_slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/inception_v1_test.py
+++ b/research/slim/nets/inception_v1_test.py
@@ -170,13 +170,13 @@ class InceptionV1Test(tf.test.TestCase):
                            expected_shape)
 
   def testUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 2
     height, width = 224, 224
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v1(inputs, num_classes)
       self.assertTrue(logits.op.name.startswith('InceptionV1/Logits'))
@@ -184,18 +184,18 @@ class InceptionV1Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_5c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 7, 7, 1024])
 
   def testGlobalPoolUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 1
     height, width = 250, 300
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v1(inputs, num_classes,
                                                   global_pool=True)
@@ -204,7 +204,7 @@ class InceptionV1Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_5c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 8, 10, 1024])
 
@@ -213,7 +213,7 @@ class InceptionV1Test(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
 
-    inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (None, height, width, 3))
     logits, _ = inception.inception_v1(inputs, num_classes)
     self.assertTrue(logits.op.name.startswith('InceptionV1/Logits'))
     self.assertListEqual(logits.get_shape().as_list(),
@@ -221,7 +221,7 @@ class InceptionV1Test(tf.test.TestCase):
     images = tf.random.uniform((batch_size, height, width, 3))
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -236,7 +236,7 @@ class InceptionV1Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -253,7 +253,7 @@ class InceptionV1Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
@@ -265,32 +265,32 @@ class InceptionV1Test(tf.test.TestCase):
                                        spatial_squeeze=False)
 
     with self.test_session() as sess:
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       logits_out = sess.run(logits)
       self.assertListEqual(list(logits_out.shape), [1, 1, 1, num_classes])
 
   def testNoBatchNormScaleByDefault(self):
     height, width = 224, 224
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(inception.inception_v1_arg_scope()):
       inception.inception_v1(inputs, num_classes, is_training=False)
 
-    self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
+    self.assertEqual(tf.global_variables('.*/BatchNorm/gamma:0$'), [])
 
   def testBatchNormScale(self):
     height, width = 224, 224
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(
         inception.inception_v1_arg_scope(batch_norm_scale=True)):
       inception.inception_v1(inputs, num_classes, is_training=False)
 
     gamma_names = set(
         v.op.name
-        for v in tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'))
+        for v in tf.global_variables('.*/BatchNorm/gamma:0$'))
     self.assertGreater(len(gamma_names), 0)
-    for v in tf.compat.v1.global_variables('.*/BatchNorm/moving_mean:0$'):
+    for v in tf.global_variables('.*/BatchNorm/moving_mean:0$'):
       self.assertIn(v.op.name[:-len('moving_mean')] + 'gamma', gamma_names)
 
 

--- a/research/slim/nets/inception_v1_test.py
+++ b/research/slim/nets/inception_v1_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception

--- a/research/slim/nets/inception_v1_test.py
+++ b/research/slim/nets/inception_v1_test.py
@@ -20,11 +20,9 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception
-
-slim = contrib_slim
 
 
 class InceptionV1Test(tf.test.TestCase):

--- a/research/slim/nets/inception_v2.py
+++ b/research/slim/nets/inception_v2.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception_utils

--- a/research/slim/nets/inception_v2.py
+++ b/research/slim/nets/inception_v2.py
@@ -24,7 +24,7 @@ import tf_slim as slim
 from nets import inception_utils
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 
 
@@ -93,7 +93,7 @@ def inception_v2_base(inputs,
     )
 
   concat_dim = 3 if data_format == 'NHWC' else 1
-  with tf.compat.v1.variable_scope(scope, 'InceptionV2', [inputs]):
+  with tf.variable_scope(scope, 'InceptionV2', [inputs]):
     with slim.arg_scope(
         [slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
         stride=1,
@@ -168,17 +168,17 @@ def inception_v2_base(inputs,
       # 28 x 28 x 192
       # Inception module.
       end_point = 'Mixed_3b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(64), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -187,7 +187,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(32), [1, 1],
@@ -199,17 +199,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 28 x 28 x 256
       end_point = 'Mixed_3c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(96), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -218,7 +218,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(64), [1, 1],
@@ -230,15 +230,15 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 28 x 28 x 320
       end_point = 'Mixed_4a'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(
               net, depth(128), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_0 = slim.conv2d(branch_0, depth(160), [3, 3], stride=2,
                                  scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -247,7 +247,7 @@ def inception_v2_base(inputs,
               branch_1, depth(96), [3, 3], scope='Conv2d_0b_3x3')
           branch_1 = slim.conv2d(
               branch_1, depth(96), [3, 3], stride=2, scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.max_pool2d(
               net, [3, 3], stride=2, scope='MaxPool_1a_3x3')
         net = tf.concat(axis=concat_dim, values=[branch_0, branch_1, branch_2])
@@ -255,17 +255,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 14 x 14 x 576
       end_point = 'Mixed_4b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(224), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(64), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(
               branch_1, depth(96), [3, 3], scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(96), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -274,7 +274,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(128), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(128), [1, 1],
@@ -286,17 +286,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 14 x 14 x 576
       end_point = 'Mixed_4c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(96), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(128), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(96), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -305,7 +305,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(128), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(128), [1, 1],
@@ -317,17 +317,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 14 x 14 x 576
       end_point = 'Mixed_4d'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(128), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(160), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(128), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -336,7 +336,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(160), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(96), [1, 1],
@@ -348,17 +348,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 14 x 14 x 576
       end_point = 'Mixed_4e'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(96), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(128), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(192), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(160), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -367,7 +367,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(192), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(96), [1, 1],
@@ -379,15 +379,15 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 14 x 14 x 576
       end_point = 'Mixed_5a'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(
               net, depth(128), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_0 = slim.conv2d(branch_0, depth(192), [3, 3], stride=2,
                                  scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(192), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -396,7 +396,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_1 = slim.conv2d(branch_1, depth(256), [3, 3], stride=2,
                                  scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.max_pool2d(net, [3, 3], stride=2,
                                      scope='MaxPool_1a_3x3')
         net = tf.concat(
@@ -405,17 +405,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 7 x 7 x 1024
       end_point = 'Mixed_5b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(352), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(192), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(320), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(160), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -424,7 +424,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(224), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(128), [1, 1],
@@ -436,17 +436,17 @@ def inception_v2_base(inputs,
         if end_point == final_endpoint: return net, end_points
       # 7 x 7 x 1024
       end_point = 'Mixed_5c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(352), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(
               net, depth(192), [1, 1],
               weights_initializer=trunc_normal(0.09),
               scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(320), [3, 3],
                                  scope='Conv2d_0b_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(
               net, depth(192), [1, 1],
               weights_initializer=trunc_normal(0.09),
@@ -455,7 +455,7 @@ def inception_v2_base(inputs,
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(224), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.max_pool2d(net, [3, 3], scope='MaxPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(128), [1, 1],
@@ -526,14 +526,14 @@ def inception_v2(inputs,
     raise ValueError('depth_multiplier is not greater than zero.')
 
   # Final pooling and prediction
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV2', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
       net, end_points = inception_v2_base(
           inputs, scope=scope, min_depth=min_depth,
           depth_multiplier=depth_multiplier)
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         if global_pool:
           # Global average pooling.
           net = tf.reduce_mean(

--- a/research/slim/nets/inception_v2.py
+++ b/research/slim/nets/inception_v2.py
@@ -19,11 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception_utils
-
-slim = contrib_slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/inception_v2_test.py
+++ b/research/slim/nets/inception_v2_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception

--- a/research/slim/nets/inception_v2_test.py
+++ b/research/slim/nets/inception_v2_test.py
@@ -20,11 +20,9 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception
-
-slim = contrib_slim
 
 
 class InceptionV2Test(tf.test.TestCase):

--- a/research/slim/nets/inception_v2_test.py
+++ b/research/slim/nets/inception_v2_test.py
@@ -282,13 +282,13 @@ class InceptionV2Test(tf.test.TestCase):
                            expected_shape)
 
   def testUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 2
     height, width = 224, 224
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v2(inputs, num_classes)
       self.assertTrue(logits.op.name.startswith('InceptionV2/Logits'))
@@ -296,18 +296,18 @@ class InceptionV2Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_5c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 7, 7, 1024])
 
   def testGlobalPoolUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 1
     height, width = 250, 300
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v2(inputs, num_classes,
                                                   global_pool=True)
@@ -316,7 +316,7 @@ class InceptionV2Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_5c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 8, 10, 1024])
 
@@ -325,7 +325,7 @@ class InceptionV2Test(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
 
-    inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (None, height, width, 3))
     logits, _ = inception.inception_v2(inputs, num_classes)
     self.assertTrue(logits.op.name.startswith('InceptionV2/Logits'))
     self.assertListEqual(logits.get_shape().as_list(),
@@ -333,7 +333,7 @@ class InceptionV2Test(tf.test.TestCase):
     images = tf.random.uniform((batch_size, height, width, 3))
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -348,7 +348,7 @@ class InceptionV2Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -365,7 +365,7 @@ class InceptionV2Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
@@ -377,32 +377,32 @@ class InceptionV2Test(tf.test.TestCase):
                                        spatial_squeeze=False)
 
     with self.test_session() as sess:
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       logits_out = sess.run(logits)
       self.assertListEqual(list(logits_out.shape), [1, 1, 1, num_classes])
 
   def testNoBatchNormScaleByDefault(self):
     height, width = 224, 224
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(inception.inception_v2_arg_scope()):
       inception.inception_v2(inputs, num_classes, is_training=False)
 
-    self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
+    self.assertEqual(tf.global_variables('.*/BatchNorm/gamma:0$'), [])
 
   def testBatchNormScale(self):
     height, width = 224, 224
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(
         inception.inception_v2_arg_scope(batch_norm_scale=True)):
       inception.inception_v2(inputs, num_classes, is_training=False)
 
     gamma_names = set(
         v.op.name
-        for v in tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'))
+        for v in tf.global_variables('.*/BatchNorm/gamma:0$'))
     self.assertGreater(len(gamma_names), 0)
-    for v in tf.compat.v1.global_variables('.*/BatchNorm/moving_mean:0$'):
+    for v in tf.global_variables('.*/BatchNorm/moving_mean:0$'):
       self.assertIn(v.op.name[:-len('moving_mean')] + 'gamma', gamma_names)
 
 

--- a/research/slim/nets/inception_v3.py
+++ b/research/slim/nets/inception_v3.py
@@ -24,7 +24,7 @@ import tf_slim as slim
 from nets import inception_utils
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 
 
@@ -98,7 +98,7 @@ def inception_v3_base(inputs,
     raise ValueError('depth_multiplier is not greater than zero.')
   depth = lambda d: max(int(d * depth_multiplier), min_depth)
 
-  with tf.compat.v1.variable_scope(scope, 'InceptionV3', [inputs]):
+  with tf.variable_scope(scope, 'InceptionV3', [inputs]):
     with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
                         stride=1, padding='VALID'):
       # 299 x 299 x 3
@@ -143,20 +143,20 @@ def inception_v3_base(inputs,
                         stride=1, padding='SAME'):
       # mixed: 35 x 35 x 256.
       end_point = 'Mixed_5b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
                                  scope='Conv2d_0b_5x5')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(32), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -166,21 +166,21 @@ def inception_v3_base(inputs,
 
       # mixed_1: 35 x 35 x 288.
       end_point = 'Mixed_5c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0b_1x1')
           branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
                                  scope='Conv_1_0c_5x5')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(64), [1, 1],
                                  scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(64), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -190,20 +190,20 @@ def inception_v3_base(inputs,
 
       # mixed_2: 35 x 35 x 288.
       end_point = 'Mixed_5d'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
                                  scope='Conv2d_0b_5x5')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0b_3x3')
           branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
                                  scope='Conv2d_0c_3x3')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(64), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -213,17 +213,17 @@ def inception_v3_base(inputs,
 
       # mixed_3: 17 x 17 x 768.
       end_point = 'Mixed_6a'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(384), [3, 3], stride=2,
                                  padding='VALID', scope='Conv2d_1a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(96), [3, 3],
                                  scope='Conv2d_0b_3x3')
           branch_1 = slim.conv2d(branch_1, depth(96), [3, 3], stride=2,
                                  padding='VALID', scope='Conv2d_1a_1x1')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
                                      scope='MaxPool_1a_3x3')
         net = tf.concat(axis=3, values=[branch_0, branch_1, branch_2])
@@ -232,16 +232,16 @@ def inception_v3_base(inputs,
 
       # mixed4: 17 x 17 x 768.
       end_point = 'Mixed_6b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(128), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(128), [1, 7],
                                  scope='Conv2d_0b_1x7')
           branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
                                  scope='Conv2d_0c_7x1')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(128), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(128), [7, 1],
                                  scope='Conv2d_0b_7x1')
@@ -251,7 +251,7 @@ def inception_v3_base(inputs,
                                  scope='Conv2d_0d_7x1')
           branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
                                  scope='Conv2d_0e_1x7')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -261,16 +261,16 @@ def inception_v3_base(inputs,
 
       # mixed_5: 17 x 17 x 768.
       end_point = 'Mixed_6c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(160), [1, 7],
                                  scope='Conv2d_0b_1x7')
           branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
                                  scope='Conv2d_0c_7x1')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
                                  scope='Conv2d_0b_7x1')
@@ -280,7 +280,7 @@ def inception_v3_base(inputs,
                                  scope='Conv2d_0d_7x1')
           branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
                                  scope='Conv2d_0e_1x7')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -289,16 +289,16 @@ def inception_v3_base(inputs,
       if end_point == final_endpoint: return net, end_points
       # mixed_6: 17 x 17 x 768.
       end_point = 'Mixed_6d'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(160), [1, 7],
                                  scope='Conv2d_0b_1x7')
           branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
                                  scope='Conv2d_0c_7x1')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
                                  scope='Conv2d_0b_7x1')
@@ -308,7 +308,7 @@ def inception_v3_base(inputs,
                                  scope='Conv2d_0d_7x1')
           branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
                                  scope='Conv2d_0e_1x7')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -318,16 +318,16 @@ def inception_v3_base(inputs,
 
       # mixed_7: 17 x 17 x 768.
       end_point = 'Mixed_6e'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(192), [1, 7],
                                  scope='Conv2d_0b_1x7')
           branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
                                  scope='Conv2d_0c_7x1')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(branch_2, depth(192), [7, 1],
                                  scope='Conv2d_0b_7x1')
@@ -337,7 +337,7 @@ def inception_v3_base(inputs,
                                  scope='Conv2d_0d_7x1')
           branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
                                  scope='Conv2d_0e_1x7')
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
                                  scope='Conv2d_0b_1x1')
@@ -347,12 +347,12 @@ def inception_v3_base(inputs,
 
       # mixed_8: 8 x 8 x 1280.
       end_point = 'Mixed_7a'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
           branch_0 = slim.conv2d(branch_0, depth(320), [3, 3], stride=2,
                                  padding='VALID', scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, depth(192), [1, 7],
                                  scope='Conv2d_0b_1x7')
@@ -360,7 +360,7 @@ def inception_v3_base(inputs,
                                  scope='Conv2d_0c_7x1')
           branch_1 = slim.conv2d(branch_1, depth(192), [3, 3], stride=2,
                                  padding='VALID', scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
                                      scope='MaxPool_1a_3x3')
         net = tf.concat(axis=3, values=[branch_0, branch_1, branch_2])
@@ -368,22 +368,22 @@ def inception_v3_base(inputs,
       if end_point == final_endpoint: return net, end_points
       # mixed_9: 8 x 8 x 2048.
       end_point = 'Mixed_7b'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(320), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(384), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = tf.concat(axis=3, values=[
               slim.conv2d(branch_1, depth(384), [1, 3], scope='Conv2d_0b_1x3'),
               slim.conv2d(branch_1, depth(384), [3, 1], scope='Conv2d_0b_3x1')])
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(448), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(
               branch_2, depth(384), [3, 3], scope='Conv2d_0b_3x3')
           branch_2 = tf.concat(axis=3, values=[
               slim.conv2d(branch_2, depth(384), [1, 3], scope='Conv2d_0c_1x3'),
               slim.conv2d(branch_2, depth(384), [3, 1], scope='Conv2d_0d_3x1')])
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(192), [1, 1], scope='Conv2d_0b_1x1')
@@ -393,22 +393,22 @@ def inception_v3_base(inputs,
 
       # mixed_10: 8 x 8 x 2048.
       end_point = 'Mixed_7c'
-      with tf.compat.v1.variable_scope(end_point):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, depth(320), [1, 1], scope='Conv2d_0a_1x1')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, depth(384), [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = tf.concat(axis=3, values=[
               slim.conv2d(branch_1, depth(384), [1, 3], scope='Conv2d_0b_1x3'),
               slim.conv2d(branch_1, depth(384), [3, 1], scope='Conv2d_0c_3x1')])
-        with tf.compat.v1.variable_scope('Branch_2'):
+        with tf.variable_scope('Branch_2'):
           branch_2 = slim.conv2d(net, depth(448), [1, 1], scope='Conv2d_0a_1x1')
           branch_2 = slim.conv2d(
               branch_2, depth(384), [3, 3], scope='Conv2d_0b_3x3')
           branch_2 = tf.concat(axis=3, values=[
               slim.conv2d(branch_2, depth(384), [1, 3], scope='Conv2d_0c_1x3'),
               slim.conv2d(branch_2, depth(384), [3, 1], scope='Conv2d_0d_3x1')])
-        with tf.compat.v1.variable_scope('Branch_3'):
+        with tf.variable_scope('Branch_3'):
           branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
           branch_3 = slim.conv2d(
               branch_3, depth(192), [1, 1], scope='Conv2d_0b_1x1')
@@ -484,7 +484,7 @@ def inception_v3(inputs,
     raise ValueError('depth_multiplier is not greater than zero.')
   depth = lambda d: max(int(d * depth_multiplier), min_depth)
 
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV3', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
@@ -497,7 +497,7 @@ def inception_v3(inputs,
         with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
                             stride=1, padding='SAME'):
           aux_logits = end_points['Mixed_6e']
-          with tf.compat.v1.variable_scope('AuxLogits'):
+          with tf.variable_scope('AuxLogits'):
             aux_logits = slim.avg_pool2d(
                 aux_logits, [5, 5], stride=3, padding='VALID',
                 scope='AvgPool_1a_5x5')
@@ -520,7 +520,7 @@ def inception_v3(inputs,
             end_points['AuxLogits'] = aux_logits
 
       # Final pooling and prediction
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         if global_pool:
           # Global average pooling.
           net = tf.reduce_mean(

--- a/research/slim/nets/inception_v3.py
+++ b/research/slim/nets/inception_v3.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception_utils

--- a/research/slim/nets/inception_v3.py
+++ b/research/slim/nets/inception_v3.py
@@ -19,11 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception_utils
-
-slim = contrib_slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/inception_v3_test.py
+++ b/research/slim/nets/inception_v3_test.py
@@ -20,11 +20,9 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception
-
-slim = contrib_slim
 
 
 class InceptionV3Test(tf.test.TestCase):
@@ -71,7 +69,7 @@ class InceptionV3Test(tf.test.TestCase):
                           'MaxPool_5a_3x3', 'Mixed_5b', 'Mixed_5c', 'Mixed_5d',
                           'Mixed_6a', 'Mixed_6b', 'Mixed_6c', 'Mixed_6d',
                           'Mixed_6e', 'Mixed_7a', 'Mixed_7b', 'Mixed_7c']
-    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
+    self.assertItemsEqual(end_points.keys(), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -89,7 +87,7 @@ class InceptionV3Test(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'InceptionV3/' + endpoint))
-        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
+        self.assertItemsEqual(endpoints[:index + 1], end_points.keys())
 
   def testBuildAndCheckAllEndPointsUptoMixed7c(self):
     batch_size = 5
@@ -116,8 +114,7 @@ class InceptionV3Test(tf.test.TestCase):
                         'Mixed_7a': [batch_size, 8, 8, 1280],
                         'Mixed_7b': [batch_size, 8, 8, 2048],
                         'Mixed_7c': [batch_size, 8, 8, 2048]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)

--- a/research/slim/nets/inception_v3_test.py
+++ b/research/slim/nets/inception_v3_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception
@@ -71,7 +71,7 @@ class InceptionV3Test(tf.test.TestCase):
                           'MaxPool_5a_3x3', 'Mixed_5b', 'Mixed_5c', 'Mixed_5d',
                           'Mixed_6a', 'Mixed_6b', 'Mixed_6c', 'Mixed_6d',
                           'Mixed_6e', 'Mixed_7a', 'Mixed_7b', 'Mixed_7c']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -89,7 +89,7 @@ class InceptionV3Test(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'InceptionV3/' + endpoint))
-        self.assertItemsEqual(endpoints[:index+1], end_points.keys())
+        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
 
   def testBuildAndCheckAllEndPointsUptoMixed7c(self):
     batch_size = 5
@@ -116,7 +116,8 @@ class InceptionV3Test(tf.test.TestCase):
                         'Mixed_7a': [batch_size, 8, 8, 1280],
                         'Mixed_7b': [batch_size, 8, 8, 2048],
                         'Mixed_7c': [batch_size, 8, 8, 2048]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)

--- a/research/slim/nets/inception_v3_test.py
+++ b/research/slim/nets/inception_v3_test.py
@@ -221,31 +221,31 @@ class InceptionV3Test(tf.test.TestCase):
                          [batch_size, 3, 3, 2048])
 
   def testUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 2
     height, width = 299, 299
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v3(inputs, num_classes)
       self.assertListEqual(logits.get_shape().as_list(),
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_7c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 8, 8, 2048])
 
   def testGlobalPoolUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 1
     height, width = 330, 400
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = inception.inception_v3(inputs, num_classes,
                                                   global_pool=True)
@@ -253,7 +253,7 @@ class InceptionV3Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_7c']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 8, 11, 2048])
 
@@ -262,7 +262,7 @@ class InceptionV3Test(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
 
-    inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (None, height, width, 3))
     logits, _ = inception.inception_v3(inputs, num_classes)
     self.assertTrue(logits.op.name.startswith('InceptionV3/Logits'))
     self.assertListEqual(logits.get_shape().as_list(),
@@ -270,7 +270,7 @@ class InceptionV3Test(tf.test.TestCase):
     images = tf.random.uniform((batch_size, height, width, 3))
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -285,7 +285,7 @@ class InceptionV3Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -303,7 +303,7 @@ class InceptionV3Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
@@ -315,32 +315,32 @@ class InceptionV3Test(tf.test.TestCase):
                                        spatial_squeeze=False)
 
     with self.test_session() as sess:
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       logits_out = sess.run(logits)
       self.assertListEqual(list(logits_out.shape), [1, 1, 1, num_classes])
 
   def testNoBatchNormScaleByDefault(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(inception.inception_v3_arg_scope()):
       inception.inception_v3(inputs, num_classes, is_training=False)
 
-    self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
+    self.assertEqual(tf.global_variables('.*/BatchNorm/gamma:0$'), [])
 
   def testBatchNormScale(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(
         inception.inception_v3_arg_scope(batch_norm_scale=True)):
       inception.inception_v3(inputs, num_classes, is_training=False)
 
     gamma_names = set(
         v.op.name
-        for v in tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'))
+        for v in tf.global_variables('.*/BatchNorm/gamma:0$'))
     self.assertGreater(len(gamma_names), 0)
-    for v in tf.compat.v1.global_variables('.*/BatchNorm/moving_mean:0$'):
+    for v in tf.global_variables('.*/BatchNorm/moving_mean:0$'):
       self.assertIn(v.op.name[:-len('moving_mean')] + 'gamma', gamma_names)
 
 

--- a/research/slim/nets/inception_v4.py
+++ b/research/slim/nets/inception_v4.py
@@ -25,11 +25,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception_utils
-
-slim = contrib_slim
 
 
 def block_inception_a(inputs, scope=None, reuse=None):

--- a/research/slim/nets/inception_v4.py
+++ b/research/slim/nets/inception_v4.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception_utils

--- a/research/slim/nets/inception_v4.py
+++ b/research/slim/nets/inception_v4.py
@@ -35,18 +35,18 @@ def block_inception_a(inputs, scope=None, reuse=None):
   # By default use stride=1 and SAME padding
   with slim.arg_scope([slim.conv2d, slim.avg_pool2d, slim.max_pool2d],
                       stride=1, padding='SAME'):
-    with tf.compat.v1.variable_scope(
+    with tf.variable_scope(
         scope, 'BlockInceptionA', [inputs], reuse=reuse):
-      with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Branch_0'):
         branch_0 = slim.conv2d(inputs, 96, [1, 1], scope='Conv2d_0a_1x1')
-      with tf.compat.v1.variable_scope('Branch_1'):
+      with tf.variable_scope('Branch_1'):
         branch_1 = slim.conv2d(inputs, 64, [1, 1], scope='Conv2d_0a_1x1')
         branch_1 = slim.conv2d(branch_1, 96, [3, 3], scope='Conv2d_0b_3x3')
-      with tf.compat.v1.variable_scope('Branch_2'):
+      with tf.variable_scope('Branch_2'):
         branch_2 = slim.conv2d(inputs, 64, [1, 1], scope='Conv2d_0a_1x1')
         branch_2 = slim.conv2d(branch_2, 96, [3, 3], scope='Conv2d_0b_3x3')
         branch_2 = slim.conv2d(branch_2, 96, [3, 3], scope='Conv2d_0c_3x3')
-      with tf.compat.v1.variable_scope('Branch_3'):
+      with tf.variable_scope('Branch_3'):
         branch_3 = slim.avg_pool2d(inputs, [3, 3], scope='AvgPool_0a_3x3')
         branch_3 = slim.conv2d(branch_3, 96, [1, 1], scope='Conv2d_0b_1x1')
       return tf.concat(axis=3, values=[branch_0, branch_1, branch_2, branch_3])
@@ -57,17 +57,17 @@ def block_reduction_a(inputs, scope=None, reuse=None):
   # By default use stride=1 and SAME padding
   with slim.arg_scope([slim.conv2d, slim.avg_pool2d, slim.max_pool2d],
                       stride=1, padding='SAME'):
-    with tf.compat.v1.variable_scope(
+    with tf.variable_scope(
         scope, 'BlockReductionA', [inputs], reuse=reuse):
-      with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Branch_0'):
         branch_0 = slim.conv2d(inputs, 384, [3, 3], stride=2, padding='VALID',
                                scope='Conv2d_1a_3x3')
-      with tf.compat.v1.variable_scope('Branch_1'):
+      with tf.variable_scope('Branch_1'):
         branch_1 = slim.conv2d(inputs, 192, [1, 1], scope='Conv2d_0a_1x1')
         branch_1 = slim.conv2d(branch_1, 224, [3, 3], scope='Conv2d_0b_3x3')
         branch_1 = slim.conv2d(branch_1, 256, [3, 3], stride=2,
                                padding='VALID', scope='Conv2d_1a_3x3')
-      with tf.compat.v1.variable_scope('Branch_2'):
+      with tf.variable_scope('Branch_2'):
         branch_2 = slim.max_pool2d(inputs, [3, 3], stride=2, padding='VALID',
                                    scope='MaxPool_1a_3x3')
       return tf.concat(axis=3, values=[branch_0, branch_1, branch_2])
@@ -78,21 +78,21 @@ def block_inception_b(inputs, scope=None, reuse=None):
   # By default use stride=1 and SAME padding
   with slim.arg_scope([slim.conv2d, slim.avg_pool2d, slim.max_pool2d],
                       stride=1, padding='SAME'):
-    with tf.compat.v1.variable_scope(
+    with tf.variable_scope(
         scope, 'BlockInceptionB', [inputs], reuse=reuse):
-      with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Branch_0'):
         branch_0 = slim.conv2d(inputs, 384, [1, 1], scope='Conv2d_0a_1x1')
-      with tf.compat.v1.variable_scope('Branch_1'):
+      with tf.variable_scope('Branch_1'):
         branch_1 = slim.conv2d(inputs, 192, [1, 1], scope='Conv2d_0a_1x1')
         branch_1 = slim.conv2d(branch_1, 224, [1, 7], scope='Conv2d_0b_1x7')
         branch_1 = slim.conv2d(branch_1, 256, [7, 1], scope='Conv2d_0c_7x1')
-      with tf.compat.v1.variable_scope('Branch_2'):
+      with tf.variable_scope('Branch_2'):
         branch_2 = slim.conv2d(inputs, 192, [1, 1], scope='Conv2d_0a_1x1')
         branch_2 = slim.conv2d(branch_2, 192, [7, 1], scope='Conv2d_0b_7x1')
         branch_2 = slim.conv2d(branch_2, 224, [1, 7], scope='Conv2d_0c_1x7')
         branch_2 = slim.conv2d(branch_2, 224, [7, 1], scope='Conv2d_0d_7x1')
         branch_2 = slim.conv2d(branch_2, 256, [1, 7], scope='Conv2d_0e_1x7')
-      with tf.compat.v1.variable_scope('Branch_3'):
+      with tf.variable_scope('Branch_3'):
         branch_3 = slim.avg_pool2d(inputs, [3, 3], scope='AvgPool_0a_3x3')
         branch_3 = slim.conv2d(branch_3, 128, [1, 1], scope='Conv2d_0b_1x1')
       return tf.concat(axis=3, values=[branch_0, branch_1, branch_2, branch_3])
@@ -103,19 +103,19 @@ def block_reduction_b(inputs, scope=None, reuse=None):
   # By default use stride=1 and SAME padding
   with slim.arg_scope([slim.conv2d, slim.avg_pool2d, slim.max_pool2d],
                       stride=1, padding='SAME'):
-    with tf.compat.v1.variable_scope(
+    with tf.variable_scope(
         scope, 'BlockReductionB', [inputs], reuse=reuse):
-      with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Branch_0'):
         branch_0 = slim.conv2d(inputs, 192, [1, 1], scope='Conv2d_0a_1x1')
         branch_0 = slim.conv2d(branch_0, 192, [3, 3], stride=2,
                                padding='VALID', scope='Conv2d_1a_3x3')
-      with tf.compat.v1.variable_scope('Branch_1'):
+      with tf.variable_scope('Branch_1'):
         branch_1 = slim.conv2d(inputs, 256, [1, 1], scope='Conv2d_0a_1x1')
         branch_1 = slim.conv2d(branch_1, 256, [1, 7], scope='Conv2d_0b_1x7')
         branch_1 = slim.conv2d(branch_1, 320, [7, 1], scope='Conv2d_0c_7x1')
         branch_1 = slim.conv2d(branch_1, 320, [3, 3], stride=2,
                                padding='VALID', scope='Conv2d_1a_3x3')
-      with tf.compat.v1.variable_scope('Branch_2'):
+      with tf.variable_scope('Branch_2'):
         branch_2 = slim.max_pool2d(inputs, [3, 3], stride=2, padding='VALID',
                                    scope='MaxPool_1a_3x3')
       return tf.concat(axis=3, values=[branch_0, branch_1, branch_2])
@@ -126,23 +126,23 @@ def block_inception_c(inputs, scope=None, reuse=None):
   # By default use stride=1 and SAME padding
   with slim.arg_scope([slim.conv2d, slim.avg_pool2d, slim.max_pool2d],
                       stride=1, padding='SAME'):
-    with tf.compat.v1.variable_scope(
+    with tf.variable_scope(
         scope, 'BlockInceptionC', [inputs], reuse=reuse):
-      with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Branch_0'):
         branch_0 = slim.conv2d(inputs, 256, [1, 1], scope='Conv2d_0a_1x1')
-      with tf.compat.v1.variable_scope('Branch_1'):
+      with tf.variable_scope('Branch_1'):
         branch_1 = slim.conv2d(inputs, 384, [1, 1], scope='Conv2d_0a_1x1')
         branch_1 = tf.concat(axis=3, values=[
             slim.conv2d(branch_1, 256, [1, 3], scope='Conv2d_0b_1x3'),
             slim.conv2d(branch_1, 256, [3, 1], scope='Conv2d_0c_3x1')])
-      with tf.compat.v1.variable_scope('Branch_2'):
+      with tf.variable_scope('Branch_2'):
         branch_2 = slim.conv2d(inputs, 384, [1, 1], scope='Conv2d_0a_1x1')
         branch_2 = slim.conv2d(branch_2, 448, [3, 1], scope='Conv2d_0b_3x1')
         branch_2 = slim.conv2d(branch_2, 512, [1, 3], scope='Conv2d_0c_1x3')
         branch_2 = tf.concat(axis=3, values=[
             slim.conv2d(branch_2, 256, [1, 3], scope='Conv2d_0d_1x3'),
             slim.conv2d(branch_2, 256, [3, 1], scope='Conv2d_0e_3x1')])
-      with tf.compat.v1.variable_scope('Branch_3'):
+      with tf.variable_scope('Branch_3'):
         branch_3 = slim.avg_pool2d(inputs, [3, 3], scope='AvgPool_0a_3x3')
         branch_3 = slim.conv2d(branch_3, 256, [1, 1], scope='Conv2d_0b_1x1')
       return tf.concat(axis=3, values=[branch_0, branch_1, branch_2, branch_3])
@@ -174,7 +174,7 @@ def inception_v4_base(inputs, final_endpoint='Mixed_7d', scope=None):
     end_points[name] = net
     return name == final_endpoint
 
-  with tf.compat.v1.variable_scope(scope, 'InceptionV4', [inputs]):
+  with tf.variable_scope(scope, 'InceptionV4', [inputs]):
     with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
                         stride=1, padding='SAME'):
       # 299 x 299 x 3
@@ -189,23 +189,23 @@ def inception_v4_base(inputs, final_endpoint='Mixed_7d', scope=None):
       net = slim.conv2d(net, 64, [3, 3], scope='Conv2d_2b_3x3')
       if add_and_check_final('Conv2d_2b_3x3', net): return net, end_points
       # 147 x 147 x 64
-      with tf.compat.v1.variable_scope('Mixed_3a'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_3a'):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
                                      scope='MaxPool_0a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, 96, [3, 3], stride=2, padding='VALID',
                                  scope='Conv2d_0a_3x3')
         net = tf.concat(axis=3, values=[branch_0, branch_1])
         if add_and_check_final('Mixed_3a', net): return net, end_points
 
       # 73 x 73 x 160
-      with tf.compat.v1.variable_scope('Mixed_4a'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_4a'):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, 64, [1, 1], scope='Conv2d_0a_1x1')
           branch_0 = slim.conv2d(branch_0, 96, [3, 3], padding='VALID',
                                  scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.conv2d(net, 64, [1, 1], scope='Conv2d_0a_1x1')
           branch_1 = slim.conv2d(branch_1, 64, [1, 7], scope='Conv2d_0b_1x7')
           branch_1 = slim.conv2d(branch_1, 64, [7, 1], scope='Conv2d_0c_7x1')
@@ -215,11 +215,11 @@ def inception_v4_base(inputs, final_endpoint='Mixed_7d', scope=None):
         if add_and_check_final('Mixed_4a', net): return net, end_points
 
       # 71 x 71 x 192
-      with tf.compat.v1.variable_scope('Mixed_5a'):
-        with tf.compat.v1.variable_scope('Branch_0'):
+      with tf.variable_scope('Mixed_5a'):
+        with tf.variable_scope('Branch_0'):
           branch_0 = slim.conv2d(net, 192, [3, 3], stride=2, padding='VALID',
                                  scope='Conv2d_1a_3x3')
-        with tf.compat.v1.variable_scope('Branch_1'):
+        with tf.variable_scope('Branch_1'):
           branch_1 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
                                      scope='MaxPool_1a_3x3')
         net = tf.concat(axis=3, values=[branch_0, branch_1])
@@ -284,7 +284,7 @@ def inception_v4(inputs, num_classes=1001, is_training=True,
     end_points: the set of end_points from the inception model.
   """
   end_points = {}
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV4', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
@@ -294,7 +294,7 @@ def inception_v4(inputs, num_classes=1001, is_training=True,
                           stride=1, padding='SAME'):
         # Auxiliary Head logits
         if create_aux_logits and num_classes:
-          with tf.compat.v1.variable_scope('AuxLogits'):
+          with tf.variable_scope('AuxLogits'):
             # 17 x 17 x 1024
             aux_logits = end_points['Mixed_6h']
             aux_logits = slim.avg_pool2d(aux_logits, [5, 5], stride=3,
@@ -314,7 +314,7 @@ def inception_v4(inputs, num_classes=1001, is_training=True,
         # Final pooling and prediction
         # TODO(sguada,arnoegw): Consider adding a parameter global_pool which
         # can be set to False to disable pooling here (as in resnet_*()).
-        with tf.compat.v1.variable_scope('Logits'):
+        with tf.variable_scope('Logits'):
           # 8 x 8 x 1536
           kernel_size = net.get_shape()[1:3]
           if kernel_size.is_fully_defined():

--- a/research/slim/nets/inception_v4_test.py
+++ b/research/slim/nets/inception_v4_test.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import inception
 
@@ -106,8 +106,7 @@ class InceptionTest(tf.test.TestCase):
                         'PreLogitsFlatten': [batch_size, 1536],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -128,7 +127,7 @@ class InceptionTest(tf.test.TestCase):
         'Mixed_5e', 'Mixed_6a', 'Mixed_6b', 'Mixed_6c', 'Mixed_6d',
         'Mixed_6e', 'Mixed_6f', 'Mixed_6g', 'Mixed_6h', 'Mixed_7a',
         'Mixed_7b', 'Mixed_7c', 'Mixed_7d']
-    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
+    self.assertItemsEqual(end_points.keys(), expected_endpoints)
     for name, op in end_points.items():
       self.assertTrue(op.name.startswith('InceptionV4/' + name))
 
@@ -148,8 +147,7 @@ class InceptionTest(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'InceptionV4/' + endpoint))
-        self.assertItemsEqual(all_endpoints[:index + 1],
-                              list(end_points.keys()))
+        self.assertItemsEqual(all_endpoints[:index + 1], end_points.keys())
 
   def testVariablesSetDevice(self):
     batch_size = 5
@@ -264,7 +262,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
-    with contrib_slim.arg_scope(inception.inception_v4_arg_scope()):
+    with slim.arg_scope(inception.inception_v4_arg_scope()):
       inception.inception_v4(inputs, num_classes, is_training=False)
 
     self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
@@ -273,7 +271,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
-    with contrib_slim.arg_scope(
+    with slim.arg_scope(
         inception.inception_v4_arg_scope(batch_norm_scale=True)):
       inception.inception_v4(inputs, num_classes, is_training=False)
 

--- a/research/slim/nets/inception_v4_test.py
+++ b/research/slim/nets/inception_v4_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import inception
@@ -106,7 +106,8 @@ class InceptionTest(tf.test.TestCase):
                         'PreLogitsFlatten': [batch_size, 1536],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
@@ -127,7 +128,7 @@ class InceptionTest(tf.test.TestCase):
         'Mixed_5e', 'Mixed_6a', 'Mixed_6b', 'Mixed_6c', 'Mixed_6d',
         'Mixed_6e', 'Mixed_6f', 'Mixed_6g', 'Mixed_6h', 'Mixed_7a',
         'Mixed_7b', 'Mixed_7c', 'Mixed_7d']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
     for name, op in end_points.items():
       self.assertTrue(op.name.startswith('InceptionV4/' + name))
 
@@ -147,7 +148,8 @@ class InceptionTest(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'InceptionV4/' + endpoint))
-        self.assertItemsEqual(all_endpoints[:index+1], end_points.keys())
+        self.assertItemsEqual(all_endpoints[:index + 1],
+                              list(end_points.keys()))
 
   def testVariablesSetDevice(self):
     batch_size = 5

--- a/research/slim/nets/inception_v4_test.py
+++ b/research/slim/nets/inception_v4_test.py
@@ -155,15 +155,15 @@ class InceptionTest(tf.test.TestCase):
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
     # Force all Variables to reside on the device.
-    with tf.compat.v1.variable_scope('on_cpu'), tf.device('/cpu:0'):
+    with tf.variable_scope('on_cpu'), tf.device('/cpu:0'):
       inception.inception_v4(inputs, num_classes)
-    with tf.compat.v1.variable_scope('on_gpu'), tf.device('/gpu:0'):
+    with tf.variable_scope('on_gpu'), tf.device('/gpu:0'):
       inception.inception_v4(inputs, num_classes)
-    for v in tf.compat.v1.get_collection(
-        tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
+    for v in tf.get_collection(
+        tf.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
       self.assertDeviceEqual(v.device, '/cpu:0')
-    for v in tf.compat.v1.get_collection(
-        tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
+    for v in tf.get_collection(
+        tf.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
       self.assertDeviceEqual(v.device, '/gpu:0')
 
   def testHalfSizeImages(self):
@@ -197,7 +197,7 @@ class InceptionTest(tf.test.TestCase):
     height, width = 350, 400
     num_classes = 1000
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(tf.float32, (batch_size, None, None, 3))
+      inputs = tf.placeholder(tf.float32, (batch_size, None, None, 3))
       logits, end_points = inception.inception_v4(
           inputs, num_classes, create_aux_logits=False)
       self.assertTrue(logits.op.name.startswith('InceptionV4/Logits'))
@@ -205,7 +205,7 @@ class InceptionTest(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Mixed_7d']
       images = tf.random.uniform((batch_size, height, width, 3))
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       logits_out, pre_pool_out = sess.run([logits, pre_pool],
                                           {inputs: images.eval()})
       self.assertTupleEqual(logits_out.shape, (batch_size, num_classes))
@@ -216,13 +216,13 @@ class InceptionTest(tf.test.TestCase):
     height, width = 299, 299
     num_classes = 1000
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+      inputs = tf.placeholder(tf.float32, (None, height, width, 3))
       logits, _ = inception.inception_v4(inputs, num_classes)
       self.assertTrue(logits.op.name.startswith('InceptionV4/Logits'))
       self.assertListEqual(logits.get_shape().as_list(),
                            [None, num_classes])
       images = tf.random.uniform((batch_size, height, width, 3))
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -236,7 +236,7 @@ class InceptionTest(tf.test.TestCase):
                                          num_classes,
                                          is_training=False)
       predictions = tf.argmax(input=logits, axis=1)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -254,32 +254,32 @@ class InceptionTest(tf.test.TestCase):
                                          is_training=False,
                                          reuse=True)
       predictions = tf.argmax(input=logits, axis=1)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
   def testNoBatchNormScaleByDefault(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(inception.inception_v4_arg_scope()):
       inception.inception_v4(inputs, num_classes, is_training=False)
 
-    self.assertEqual(tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'), [])
+    self.assertEqual(tf.global_variables('.*/BatchNorm/gamma:0$'), [])
 
   def testBatchNormScale(self):
     height, width = 299, 299
     num_classes = 1000
-    inputs = tf.compat.v1.placeholder(tf.float32, (1, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (1, height, width, 3))
     with slim.arg_scope(
         inception.inception_v4_arg_scope(batch_norm_scale=True)):
       inception.inception_v4(inputs, num_classes, is_training=False)
 
     gamma_names = set(
         v.op.name
-        for v in tf.compat.v1.global_variables('.*/BatchNorm/gamma:0$'))
+        for v in tf.global_variables('.*/BatchNorm/gamma:0$'))
     self.assertGreater(len(gamma_names), 0)
-    for v in tf.compat.v1.global_variables('.*/BatchNorm/moving_mean:0$'):
+    for v in tf.global_variables('.*/BatchNorm/moving_mean:0$'):
       self.assertIn(v.op.name[:-len('moving_mean')] + 'gamma', gamma_names)
 
 

--- a/research/slim/nets/lenet.py
+++ b/research/slim/nets/lenet.py
@@ -19,9 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def lenet(images, num_classes=10, is_training=False,

--- a/research/slim/nets/lenet.py
+++ b/research/slim/nets/lenet.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/lenet.py
+++ b/research/slim/nets/lenet.py
@@ -57,7 +57,7 @@ def lenet(images, num_classes=10, is_training=False,
   """
   end_points = {}
 
-  with tf.compat.v1.variable_scope(scope, 'LeNet', [images]):
+  with tf.variable_scope(scope, 'LeNet', [images]):
     net = end_points['conv1'] = slim.conv2d(images, 32, [5, 5], scope='conv1')
     net = end_points['pool1'] = slim.max_pool2d(net, [2, 2], 2, scope='pool1')
     net = end_points['conv2'] = slim.conv2d(net, 64, [5, 5], scope='conv2')
@@ -91,6 +91,6 @@ def lenet_arg_scope(weight_decay=0.0):
   with slim.arg_scope(
       [slim.conv2d, slim.fully_connected],
       weights_regularizer=slim.l2_regularizer(weight_decay),
-      weights_initializer=tf.compat.v1.truncated_normal_initializer(stddev=0.1),
+      weights_initializer=tf.truncated_normal_initializer(stddev=0.1),
       activation_fn=tf.nn.relu) as sc:
     return sc

--- a/research/slim/nets/mobilenet/README.md
+++ b/research/slim/nets/mobilenet/README.md
@@ -6,7 +6,7 @@ This folder contains building code for
 definition for each model is located in [mobilenet_v2.py](mobilenet_v2.py) and
 [mobilenet_v3.py](mobilenet_v3.py) respectively.
 
-For MobilenetV1 please refer to this [page](../mobilenet_v1.md)
+For MobilenetV1 please refer to [this page](../mobilenet_v1.md)
 
 We have also introduced a family of MobileNets customized for the Edge TPU
 accelerator found in
@@ -61,20 +61,20 @@ on CPU, we find that they are much more performant on GPU/DSP.
 
 | Imagenet Checkpoint | MACs (M) | Params (M) | Top1 | Pixel 1 | Pixel 2 | Pixel 3 |
 | ------------------ | -------- | ---------- | ---- | ------- | ------- | ------- |
-| [Large dm=1 (float)]   | 217      | 5.4        | 75.2 | 51.2    | 61      | 44      |
-| [Large dm=1 (8-bit)] | 217      | 5.4        | 73.9 | 44      | 42.5    | 32      |
+| [Large dm=1 (float)]    | 217      | 5.4        | 75.2 | 51.2    | 61      | 44      |
+| [Large dm=1 (8-bit)]    | 217      | 5.4        | 73.9 | 44      | 42.5    | 32      |
 | [Large dm=0.75 (float)] | 155      | 4.0        | 73.3 | 39.8    | 48      | 34      |
-| [Small dm=1 (float)]   | 66       | 2.9        | 67.5 | 15.8    | 19.4    | 14.4    |
-| [Small dm=1 (8-bit)]   | 66       | 2.9        | 64.9 | 15.5    | 15      | 10.7    |
+| [Small dm=1 (float)]    | 66       | 2.9        | 67.5 | 15.8    | 19.4    | 14.4    |
+| [Small dm=1 (8-bit)]    | 66       | 2.9        | 64.9 | 15.5    | 15      | 10.7    |
 | [Small dm=0.75 (float)] | 44       | 2.4        | 65.4 | 12.8    | 15.9    | 11.6    |
 
 #### Minimalistic checkpoints:
 
 | Imagenet Checkpoint | MACs (M) | Params (M) | Top1 | Pixel 1 | Pixel 2 | Pixel 3 |
 | -------------- | -------- | ---------- | ---- | ------- | ------- | ------- |
-| [Large minimalistic (float)]   | 209      | 3.9        | 72.3 | 44.1    | 51      | 35      |
+| [Large minimalistic (float)]        | 209      | 3.9        | 72.3 | 44.1    | 51      | 35      |
 | [Large minimalistic (8-bit)][lm8]   | 209      | 3.9        | 71.3 | 37      | 35      | 27      |
-| [Small minimalistic (float)]   | 65       | 2.0        | 61.9 | 12.2    | 15.1    | 11      |
+| [Small minimalistic (float)]        | 65       | 2.0        | 61.9 | 12.2    | 15.1    | 11      |
 
 #### Edge TPU checkpoints:
 
@@ -103,36 +103,88 @@ tool.
 
 ### Mobilenet V2 Imagenet Checkpoints
 
-Classification Checkpoint                                                                                  | MACs (M) | Parameters (M) | Top 1 Accuracy | Top 5 Accuracy | Mobile CPU (ms) Pixel 1
----------------------------------------------------------------------------------------------------------- | -------- | -------------- | -------------- | -------------- | -----------------------
-[mobilenet_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)   | 582      | 6.06           | 75.0           | 92.5           | 138.0
-[mobilenet_v2_1.3_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.3_224.tgz)   | 509      | 5.34           | 74.4           | 92.1           | 123.0
-[mobilenet_v2_1.0_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz)   | 300      | 3.47           | 71.8           | 91.0           | 73.8
-[mobilenet_v2_1.0_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_192.tgz)   | 221      | 3.47           | 70.7           | 90.1           | 55.1
-[mobilenet_v2_1.0_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_160.tgz)   | 154      | 3.47           | 68.8           | 89.0           | 40.2
-[mobilenet_v2_1.0_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_128.tgz)   | 99       | 3.47           | 65.3           | 86.9           | 27.6
-[mobilenet_v2_1.0_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_96.tgz)     | 56       | 3.47           | 60.3           | 83.2           | 17.6
-[mobilenet_v2_0.75_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_224.tgz) | 209      | 2.61           | 69.8           | 89.6           | 55.8
-[mobilenet_v2_0.75_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_192.tgz) | 153      | 2.61           | 68.7           | 88.9           | 41.6
-[mobilenet_v2_0.75_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_160.tgz) | 107      | 2.61           | 66.4           | 87.3           | 30.4
-[mobilenet_v2_0.75_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_128.tgz) | 69       | 2.61           | 63.2           | 85.3           | 21.9
-[mobilenet_v2_0.75_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_96.tgz)   | 39       | 2.61           | 58.8           | 81.6           | 14.2
-[mobilenet_v2_0.5_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_224.tgz)   | 97       | 1.95           | 65.4           | 86.4           | 28.7
-[mobilenet_v2_0.5_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_192.tgz)   | 71       | 1.95           | 63.9           | 85.4           | 21.1
-[mobilenet_v2_0.5_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_160.tgz)   | 50       | 1.95           | 61.0           | 83.2           | 14.9
-[mobilenet_v2_0.5_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_128.tgz)   | 32       | 1.95           | 57.7           | 80.8           | 9.9
-[mobilenet_v2_0.5_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_96.tgz)     | 18       | 1.95           | 51.2           | 75.8           | 6.4
-[mobilenet_v2_0.35_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_224.tgz) | 59       | 1.66           | 60.3           | 82.9           | 19.7
-[mobilenet_v2_0.35_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_192.tgz) | 43       | 1.66           | 58.2           | 81.2           | 14.6
-[mobilenet_v2_0.35_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_160.tgz) | 30       | 1.66           | 55.7           | 79.1           | 10.5
-[mobilenet_v2_0.35_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_128.tgz) | 20       | 1.66           | 50.8           | 75.0           | 6.9
-[mobilenet_v2_0.35_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_96.tgz)   | 11       | 1.66           | 45.5           | 70.4           | 4.5
+Classification Checkpoint                   | Quantized                                                               | MACs (M) | Parameters (M) | Top 1 Accuracy | Top 5 Accuracy | Mobile CPU (ms) Pixel 1
+------------------------------------------------------------------------------------------------------|-------------- | -------- | -------------- | -------------- | -------------- | -----------------------
+[float_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)      |  [uint8] [quantized_v2_1.4_224]  | 582      | 6.06           | 75.0           | 92.5           | 138.0
+[float_v2_1.3_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.3_224.tgz) |[uint8][quantized_v2_1.3_224]   | 509      | 5.34           | 74.4           | 92.1           | 123.0
+[float_v2_1.0_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz)  |[uint8] [quantized_v2_1.0_224]  | 300      | 3.47           | 71.8           | 91.0           | 73.8
+[float_v2_1.0_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_192.tgz)  |[uint8] [quantized_v2_1.0_192]  | 221      | 3.47           | 70.7           | 90.1           | 55.1
+[float_v2_1.0_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_160.tgz) | [uint8] [quantized_v2_1.0_160]  | 154      | 3.47           | 68.8           | 89.0           | 40.2
+[float_v2_1.0_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_128.tgz) |  [uint8][quantized_v2_1.0_128]  | 99       | 3.47           | 65.3           | 86.9           | 27.6
+[float_v2_1.0_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_96.tgz)    | [uint8][quantized_v2_1.0_96]   | 56       | 3.47           | 60.3           | 83.2           | 17.6
+[float_v2_0.75_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_224.tgz)|[uint8][quantized_v2_0.75_224] | 209      | 2.61           | 69.8           | 89.6           | 55.8
+[float_v2_0.75_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_192.tgz)|[uint8] [quantized_v2_0.75_192] | 153      | 2.61           | 68.7           | 88.9           | 41.6
+[float_v2_0.75_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_160.tgz)| [uint8][quantized_v2_0.75_160] | 107      | 2.61           | 66.4           | 87.3           | 30.4
+[float_v2_0.75_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_128.tgz)| [uint8][quantized_v2_0.75_128] | 69       | 2.61           | 63.2           | 85.3           | 21.9
+[float_v2_0.75_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_96.tgz)  |[uint8] [quantized_v2_0.75_96]  | 39       | 2.61           | 58.8           | 81.6           | 14.2
+[float_v2_0.5_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_224.tgz)  |[uint8] [quantized_v2_0.5_224] | 97       | 1.95           | 65.4           | 86.4           | 28.7
+[float_v2_0.5_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_192.tgz)  |[uint8] [quantized_v2_0.5_192]  | 71       | 1.95           | 63.9           | 85.4           | 21.1
+[float_v2_0.5_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_160.tgz)  |[uint8] [quantized_v2_0.5_160]  | 50       | 1.95           | 61.0           | 83.2           | 14.9
+[float_v2_0.5_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_128.tgz)  |[uint8] [quantized_v2_0.5_128]  | 32       | 1.95           | 57.7           | 80.8           | 9.9
+[float_v2_0.5_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_96.tgz)    |[uint8] [quantized_v2_0.5_96]   | 18       | 1.95           | 51.2           | 75.8           | 6.4
+[float_v2_0.35_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_224.tgz)|[uint8] [quantized_v2_0.35_224] | 59       | 1.66           | 60.3           | 82.9           | 19.7
+[float_v2_0.35_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_192.tgz)| [uint8][quantized_v2_0.35_192] | 43       | 1.66           | 58.2           | 81.2           | 14.6
+[float_v2_0.35_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_160.tgz)|[uint8] [quantized_v2_0.35_160] | 30       | 1.66           | 55.7           | 79.1           | 10.5
+[float_v2_0.35_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_128.tgz)|[uint8] [quantized_v2_0.35_128] | 20       | 1.66           | 50.8           | 75.0           | 6.9
+[float_v2_0.35_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_96.tgz)  |[uint8] [quantized_v2_0.35_96]  | 11       | 1.66           | 45.5           | 70.4           | 4.5
+
+[quantized_v2_1.4_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_140.tgz
+[quantized_v2_1.3_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_130.tgz
+[quantized_v2_1.0_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_100.tgz
+[quantized_v2_1.0_192]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_192_100.tgz
+[quantized_v2_1.0_160]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_160_100.tgz
+[quantized_v2_1.0_128]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_128_100.tgz
+[quantized_v2_1.0_96]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_96_100.tgz
+[quantized_v2_0.75_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_75.tgz
+[quantized_v2_0.75_192]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_192_75.tgz
+[quantized_v2_0.75_160]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_160_75.tgz
+[quantized_v2_0.75_128]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_128_75.tgz
+[quantized_v2_0.75_96]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_96_75.tgz
+[quantized_v2_0.5_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_50.tgz
+[quantized_v2_0.5_192]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_192_50.tgz
+[quantized_v2_0.5_160]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_160_50.tgz
+[quantized_v2_0.5_128]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_128_50.tgz
+[quantized_v2_0.5_96]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_96_50.tgz
+[quantized_v2_0.35_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_35.tgz
+[quantized_v2_0.35_192]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_192_35.tgz
+[quantized_v2_0.35_160]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_160_35.tgz
+[quantized_v2_0.35_128]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_128_35.tgz
+[quantized_v2_0.35_96]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_96_35.tgz
+
+
+
+
+
 
 ## Training
 
 ### V3
+The following configuration, achieves 74.6% using 8 GPU setup and 75.2% using
+2x2 TPU setup.
 
-TODO: Add V3 hyperparameters
+                          |    8 GPU setup  | Notes  |
+-------------------------- | ------------------| ----------|----|
+Final Top 1 Accuracy       |      74.6   |    |
+----------------------------|------------------|-----------|----|
+learning_rate               |   0.16     |Total learning rate. (Per clone learning rate is 0.02) |
+rmsprop_momentum            |   0.9      |    |
+rmsprop_decay               |   0.9      |    |
+rmsprop_epsilon             |   0.002    |    |
+learning_rate_decay_factor  |   0.99     |   |
+optimizer                   |   RMSProp  | |
+warmup_epochs               |   5        | Slim uses per clone epoch, so the actual flag value is 0.6  |
+num_epochs_per_decay        |   3        | Slim uses per clone epoch, so the actual flag value is 0.375 |
+batch_size (per chip)       |   192      |                   |
+moving_average_decay        |   0.9999   |                   |
+weight_decay                |   1e-5     |                   |
+init_stddev                 |    0.008   |                   |
+dropout_keep_prob           |   0.8      |                   |
+bn_moving_average_decay     |   0.997    |                   |
+bn_epsilon                  |      0.001 |                   |
+label_smoothing             |   0.1      |                   |
+
+
+
 
 ### V2
 

--- a/research/slim/nets/mobilenet/README.md
+++ b/research/slim/nets/mobilenet/README.md
@@ -171,8 +171,8 @@ rmsprop_decay               |   0.9      |    |
 rmsprop_epsilon             |   0.002    |    |
 learning_rate_decay_factor  |   0.99     |   |
 optimizer                   |   RMSProp  | |
-warmup_epochs               |   5        | Slim uses per clone epoch, so the actual flag value is 0.6  |
-num_epochs_per_decay        |   3        | Slim uses per clone epoch, so the actual flag value is 0.375 |
+warmup_epochs               |   5        | Slim uses per clone epoch, so the the flag value is 0.6  |
+num_epochs_per_decay        |   3        | Slim uses per clone epoch, so the  flag value is 0.375 |
 batch_size (per chip)       |   192      |                   |
 moving_average_decay        |   0.9999   |                   |
 weight_decay                |   1e-5     |                   |

--- a/research/slim/nets/mobilenet/README.md
+++ b/research/slim/nets/mobilenet/README.md
@@ -105,28 +105,28 @@ tool.
 
 Classification Checkpoint                   | Quantized                                                               | MACs (M) | Parameters (M) | Top 1 Accuracy | Top 5 Accuracy | Mobile CPU (ms) Pixel 1
 ------------------------------------------------------------------------------------------------------|-------------- | -------- | -------------- | -------------- | -------------- | -----------------------
-[float_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)      |  [uint8] [quantized_v2_1.4_224]  | 582      | 6.06           | 75.0           | 92.5           | 138.0
+[float_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)      |  [uint8][quantized_v2_1.4_224]  | 582      | 6.06           | 75.0           | 92.5           | 138.0
 [float_v2_1.3_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.3_224.tgz) |[uint8][quantized_v2_1.3_224]   | 509      | 5.34           | 74.4           | 92.1           | 123.0
-[float_v2_1.0_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz)  |[uint8] [quantized_v2_1.0_224]  | 300      | 3.47           | 71.8           | 91.0           | 73.8
-[float_v2_1.0_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_192.tgz)  |[uint8] [quantized_v2_1.0_192]  | 221      | 3.47           | 70.7           | 90.1           | 55.1
-[float_v2_1.0_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_160.tgz) | [uint8] [quantized_v2_1.0_160]  | 154      | 3.47           | 68.8           | 89.0           | 40.2
+[float_v2_1.0_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz)  |[uint8][quantized_v2_1.0_224]  | 300      | 3.47           | 71.8           | 91.0           | 73.8
+[float_v2_1.0_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_192.tgz)  |[uint8][quantized_v2_1.0_192]  | 221      | 3.47           | 70.7           | 90.1           | 55.1
+[float_v2_1.0_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_160.tgz) | [uint8][quantized_v2_1.0_160]  | 154      | 3.47           | 68.8           | 89.0           | 40.2
 [float_v2_1.0_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_128.tgz) |  [uint8][quantized_v2_1.0_128]  | 99       | 3.47           | 65.3           | 86.9           | 27.6
 [float_v2_1.0_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_96.tgz)    | [uint8][quantized_v2_1.0_96]   | 56       | 3.47           | 60.3           | 83.2           | 17.6
 [float_v2_0.75_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_224.tgz)|[uint8][quantized_v2_0.75_224] | 209      | 2.61           | 69.8           | 89.6           | 55.8
-[float_v2_0.75_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_192.tgz)|[uint8] [quantized_v2_0.75_192] | 153      | 2.61           | 68.7           | 88.9           | 41.6
+[float_v2_0.75_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_192.tgz)|[uint8][quantized_v2_0.75_192] | 153      | 2.61           | 68.7           | 88.9           | 41.6
 [float_v2_0.75_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_160.tgz)| [uint8][quantized_v2_0.75_160] | 107      | 2.61           | 66.4           | 87.3           | 30.4
 [float_v2_0.75_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_128.tgz)| [uint8][quantized_v2_0.75_128] | 69       | 2.61           | 63.2           | 85.3           | 21.9
-[float_v2_0.75_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_96.tgz)  |[uint8] [quantized_v2_0.75_96]  | 39       | 2.61           | 58.8           | 81.6           | 14.2
-[float_v2_0.5_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_224.tgz)  |[uint8] [quantized_v2_0.5_224] | 97       | 1.95           | 65.4           | 86.4           | 28.7
-[float_v2_0.5_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_192.tgz)  |[uint8] [quantized_v2_0.5_192]  | 71       | 1.95           | 63.9           | 85.4           | 21.1
-[float_v2_0.5_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_160.tgz)  |[uint8] [quantized_v2_0.5_160]  | 50       | 1.95           | 61.0           | 83.2           | 14.9
-[float_v2_0.5_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_128.tgz)  |[uint8] [quantized_v2_0.5_128]  | 32       | 1.95           | 57.7           | 80.8           | 9.9
+[float_v2_0.75_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.75_96.tgz)  |[uint8][quantized_v2_0.75_96]  | 39       | 2.61           | 58.8           | 81.6           | 14.2
+[float_v2_0.5_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_224.tgz)  |[uint8][quantized_v2_0.5_224] | 97       | 1.95           | 65.4           | 86.4           | 28.7
+[float_v2_0.5_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_192.tgz)  |[uint8][quantized_v2_0.5_192]  | 71       | 1.95           | 63.9           | 85.4           | 21.1
+[float_v2_0.5_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_160.tgz)  |[uint8][quantized_v2_0.5_160]  | 50       | 1.95           | 61.0           | 83.2           | 14.9
+[float_v2_0.5_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_128.tgz)  |[uint8][quantized_v2_0.5_128]  | 32       | 1.95           | 57.7           | 80.8           | 9.9
 [float_v2_0.5_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_96.tgz)    |[uint8] [quantized_v2_0.5_96]   | 18       | 1.95           | 51.2           | 75.8           | 6.4
-[float_v2_0.35_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_224.tgz)|[uint8] [quantized_v2_0.35_224] | 59       | 1.66           | 60.3           | 82.9           | 19.7
+[float_v2_0.35_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_224.tgz)|[uint8][quantized_v2_0.35_224] | 59       | 1.66           | 60.3           | 82.9           | 19.7
 [float_v2_0.35_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_192.tgz)| [uint8][quantized_v2_0.35_192] | 43       | 1.66           | 58.2           | 81.2           | 14.6
-[float_v2_0.35_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_160.tgz)|[uint8] [quantized_v2_0.35_160] | 30       | 1.66           | 55.7           | 79.1           | 10.5
-[float_v2_0.35_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_128.tgz)|[uint8] [quantized_v2_0.35_128] | 20       | 1.66           | 50.8           | 75.0           | 6.9
-[float_v2_0.35_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_96.tgz)  |[uint8] [quantized_v2_0.35_96]  | 11       | 1.66           | 45.5           | 70.4           | 4.5
+[float_v2_0.35_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_160.tgz)|[uint8][quantized_v2_0.35_160] | 30       | 1.66           | 55.7           | 79.1           | 10.5
+[float_v2_0.35_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_128.tgz)|[uint8][quantized_v2_0.35_128] | 20       | 1.66           | 50.8           | 75.0           | 6.9
+[float_v2_0.35_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_96.tgz)  |[uint8][quantized_v2_0.35_96]  | 11       | 1.66           | 45.5           | 70.4           | 4.5
 
 [quantized_v2_1.4_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_140.tgz
 [quantized_v2_1.3_224]: https://storage.googleapis.com/mobilenet_v2/checkpoints/quantized_v2_224_130.tgz
@@ -162,10 +162,9 @@ Classification Checkpoint                   | Quantized                         
 The following configuration, achieves 74.6% using 8 GPU setup and 75.2% using
 2x2 TPU setup.
 
-                          |    8 GPU setup  | Notes  |
--------------------------- | ------------------| ----------|----|
-Final Top 1 Accuracy       |      74.6   |    |
-----------------------------|------------------|-----------|----|
+
+Final Top 1 Accuracy        |      74.6         |           |
+----------------------------|------------------|-----------|
 learning_rate               |   0.16     |Total learning rate. (Per clone learning rate is 0.02) |
 rmsprop_momentum            |   0.9      |    |
 rmsprop_decay               |   0.9      |    |

--- a/research/slim/nets/mobilenet/README.md
+++ b/research/slim/nets/mobilenet/README.md
@@ -105,7 +105,7 @@ tool.
 
 Classification Checkpoint                   | Quantized                                                               | MACs (M) | Parameters (M) | Top 1 Accuracy | Top 5 Accuracy | Mobile CPU (ms) Pixel 1
 ------------------------------------------------------------------------------------------------------|-------------- | -------- | -------------- | -------------- | -------------- | -----------------------
-[float_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)      |  [uint8][quantized_v2_1.4_224]  | 582      | 6.06           | 75.0           | 92.5           | 138.0
+[float_v2_1.4_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz)  | [uint8][quantized_v2_1.4_224]  | 582      | 6.06           | 75.0           | 92.5           | 138.0
 [float_v2_1.3_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.3_224.tgz) |[uint8][quantized_v2_1.3_224]   | 509      | 5.34           | 74.4           | 92.1           | 123.0
 [float_v2_1.0_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz)  |[uint8][quantized_v2_1.0_224]  | 300      | 3.47           | 71.8           | 91.0           | 73.8
 [float_v2_1.0_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_192.tgz)  |[uint8][quantized_v2_1.0_192]  | 221      | 3.47           | 70.7           | 90.1           | 55.1
@@ -121,7 +121,7 @@ Classification Checkpoint                   | Quantized                         
 [float_v2_0.5_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_192.tgz)  |[uint8][quantized_v2_0.5_192]  | 71       | 1.95           | 63.9           | 85.4           | 21.1
 [float_v2_0.5_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_160.tgz)  |[uint8][quantized_v2_0.5_160]  | 50       | 1.95           | 61.0           | 83.2           | 14.9
 [float_v2_0.5_128](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_128.tgz)  |[uint8][quantized_v2_0.5_128]  | 32       | 1.95           | 57.7           | 80.8           | 9.9
-[float_v2_0.5_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_96.tgz)    |[uint8] [quantized_v2_0.5_96]   | 18       | 1.95           | 51.2           | 75.8           | 6.4
+[float_v2_0.5_96](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.5_96.tgz)    |[uint8][quantized_v2_0.5_96]   | 18       | 1.95           | 51.2           | 75.8           | 6.4
 [float_v2_0.35_224](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_224.tgz)|[uint8][quantized_v2_0.35_224] | 59       | 1.66           | 60.3           | 82.9           | 19.7
 [float_v2_0.35_192](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_192.tgz)| [uint8][quantized_v2_0.35_192] | 43       | 1.66           | 58.2           | 81.2           | 14.6
 [float_v2_0.35_160](https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_0.35_160.tgz)|[uint8][quantized_v2_0.35_160] | 30       | 1.66           | 55.7           | 79.1           | 10.5

--- a/research/slim/nets/mobilenet/conv_blocks.py
+++ b/research/slim/nets/mobilenet/conv_blocks.py
@@ -78,8 +78,8 @@ def _split_divisible(num, num_ways, divisible_by=8):
 def _v1_compatible_scope_naming(scope):
   """v1 compatible scope naming."""
   if scope is None:  # Create uniqified separable blocks.
-    with tf.compat.v1.variable_scope(None, default_name='separable') as s, \
-         tf.compat.v1.name_scope(s.original_name_scope):
+    with tf.variable_scope(None, default_name='separable') as s, \
+         tf.name_scope(s.original_name_scope):
       yield ''
   else:
     # We use scope_depthwise, scope_pointwise for compatibility with V1 ckpts.
@@ -298,8 +298,8 @@ def expanded_conv(input_tensor,
   if depthwise_activation_fn is not None:
     dw_defaults['activation_fn'] = depthwise_activation_fn
   # pylint: disable=g-backslash-continuation
-  with tf.compat.v1.variable_scope(scope, default_name='expanded_conv') as s, \
-       tf.compat.v1.name_scope(s.original_name_scope), \
+  with tf.variable_scope(scope, default_name='expanded_conv') as s, \
+       tf.name_scope(s.original_name_scope), \
       slim.arg_scope((slim.conv2d,), **conv_defaults), \
        slim.arg_scope((slim.separable_conv2d,), **dw_defaults):
     prev_depth = input_tensor.get_shape().as_list()[3]
@@ -432,7 +432,7 @@ def squeeze_excite(input_tensor,
   Returns:
     Gated input_tensor. (e.g. X * SE(X))
   """
-  with tf.compat.v1.variable_scope('squeeze_excite'):
+  with tf.variable_scope('squeeze_excite'):
     if squeeze_input_tensor is None:
       squeeze_input_tensor = input_tensor
     input_size = input_tensor.shape.as_list()[1:3]

--- a/research/slim/nets/mobilenet/conv_blocks.py
+++ b/research/slim/nets/mobilenet/conv_blocks.py
@@ -17,9 +17,7 @@ import contextlib
 import functools
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def _fixed_padding(inputs, kernel_size, rate=1):

--- a/research/slim/nets/mobilenet/conv_blocks.py
+++ b/research/slim/nets/mobilenet/conv_blocks.py
@@ -16,7 +16,7 @@
 import contextlib
 import functools
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -304,8 +304,8 @@ def mobilenet_base(  # pylint: disable=invalid-name
 
 @contextlib.contextmanager
 def _scope_all(scope, default_scope=None):
-  with tf.compat.v1.variable_scope(scope, default_name=default_scope) as s,\
-       tf.compat.v1.name_scope(s.original_name_scope):
+  with tf.variable_scope(scope, default_name=default_scope) as s,\
+       tf.name_scope(s.original_name_scope):
     yield s
 
 
@@ -364,7 +364,7 @@ def mobilenet(inputs,
   if len(input_shape) != 4:
     raise ValueError('Expected rank 4 input, was: %d' % len(input_shape))
 
-  with tf.compat.v1.variable_scope(scope, 'Mobilenet', reuse=reuse) as scope:
+  with tf.variable_scope(scope, 'Mobilenet', reuse=reuse) as scope:
     inputs = tf.identity(inputs, 'input')
     net, end_points = mobilenet_base(inputs, scope=scope, **mobilenet_args)
     if base_only:
@@ -372,7 +372,7 @@ def mobilenet(inputs,
 
     net = tf.identity(net, name='embedding')
 
-    with tf.compat.v1.variable_scope('Logits'):
+    with tf.variable_scope('Logits'):
       net = global_pool(net, use_reduce_mean_for_pooling)
       end_points['global_pool'] = net
       if not num_classes:
@@ -385,7 +385,7 @@ def mobilenet(inputs,
           num_classes, [1, 1],
           activation_fn=None,
           normalizer_fn=None,
-          biases_initializer=tf.compat.v1.zeros_initializer(),
+          biases_initializer=tf.zeros_initializer(),
           scope='Conv2d_1c_1x1')
 
       logits = tf.squeeze(logits, [1, 2])
@@ -470,7 +470,7 @@ def training_scope(is_training=True,
   if stddev < 0:
     weight_intitializer = slim.initializers.xavier_initializer()
   else:
-    weight_intitializer = tf.compat.v1.truncated_normal_initializer(
+    weight_intitializer = tf.truncated_normal_initializer(
         stddev=stddev)
 
   # Set weight_decay for weights in Conv and FC layers.

--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -23,9 +23,7 @@ import copy
 import os
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 @slim.add_arg_scope
@@ -401,7 +399,7 @@ def mobilenet(inputs,
 
 def global_pool(input_tensor,
                 use_reduce_mean_for_pooling=False,
-                pool_op=tf.compat.v2.nn.avg_pool2d):
+                pool_op=tf.nn.avg_pool2d):
   """Applies avg pool to produce 1x1 output.
 
   NOTE: This function is funcitonally equivalenet to reduce_mean, but it has
@@ -416,7 +414,7 @@ def global_pool(input_tensor,
   """
   if use_reduce_mean_for_pooling:
     return tf.reduce_mean(
-        input_tensor, [1, 2], keep_dims=True, name='ReduceMean')
+        input_tensor, [1, 2], keepdims=True, name='ReduceMean')
   else:
     shape = input_tensor.get_shape().as_list()
     if shape[1] is None or shape[2] is None:
@@ -442,7 +440,7 @@ def training_scope(is_training=True,
   """Defines Mobilenet training scope.
 
   Usage:
-     with tf.contrib.slim.arg_scope(mobilenet.training_scope()):
+     with slim.arg_scope(mobilenet.training_scope()):
        logits, endpoints = mobilenet_v2.mobilenet(input_tensor)
 
      # the network created will be trainble with dropout/batch norm

--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -22,7 +22,7 @@ import contextlib
 import copy
 import os
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim
@@ -318,6 +318,7 @@ def mobilenet(inputs,
               reuse=None,
               scope='Mobilenet',
               base_only=False,
+              use_reduce_mean_for_pooling=False,
               **mobilenet_args):
   """Mobilenet model for classification, supports both V1 and V2.
 
@@ -337,6 +338,8 @@ def mobilenet(inputs,
     scope: Optional variable_scope.
     base_only: if True will only create the base of the network (no pooling
     and no logits).
+    use_reduce_mean_for_pooling: if True use the reduce_mean for pooling. If
+    True use the global_pool function that provides some optimization.
     **mobilenet_args: passed to mobilenet_base verbatim.
       - conv_defs: list of conv defs
       - multiplier: Float multiplier for the depth (number of channels)
@@ -372,7 +375,7 @@ def mobilenet(inputs,
     net = tf.identity(net, name='embedding')
 
     with tf.compat.v1.variable_scope('Logits'):
-      net = global_pool(net)
+      net = global_pool(net, use_reduce_mean_for_pooling)
       end_points['global_pool'] = net
       if not num_classes:
         return net, end_points
@@ -396,7 +399,9 @@ def mobilenet(inputs,
   return logits, end_points
 
 
-def global_pool(input_tensor, pool_op=tf.compat.v2.nn.avg_pool2d):
+def global_pool(input_tensor,
+                use_reduce_mean_for_pooling=False,
+                pool_op=tf.compat.v2.nn.avg_pool2d):
   """Applies avg pool to produce 1x1 output.
 
   NOTE: This function is funcitonally equivalenet to reduce_mean, but it has
@@ -404,24 +409,29 @@ def global_pool(input_tensor, pool_op=tf.compat.v2.nn.avg_pool2d):
 
   Args:
     input_tensor: input tensor
+    use_reduce_mean_for_pooling: if True use reduce_mean for pooling
     pool_op: pooling op (avg pool is default)
   Returns:
     a tensor batch_size x 1 x 1 x depth.
   """
-  shape = input_tensor.get_shape().as_list()
-  if shape[1] is None or shape[2] is None:
-    kernel_size = tf.convert_to_tensor(value=[
-        1,
-        tf.shape(input=input_tensor)[1],
-        tf.shape(input=input_tensor)[2], 1
-    ])
+  if use_reduce_mean_for_pooling:
+    return tf.reduce_mean(
+        input_tensor, [1, 2], keep_dims=True, name='ReduceMean')
   else:
-    kernel_size = [1, shape[1], shape[2], 1]
-  output = pool_op(
-      input_tensor, ksize=kernel_size, strides=[1, 1, 1, 1], padding='VALID')
-  # Recover output shape, for unknown shape.
-  output.set_shape([None, 1, 1, None])
-  return output
+    shape = input_tensor.get_shape().as_list()
+    if shape[1] is None or shape[2] is None:
+      kernel_size = tf.convert_to_tensor(value=[
+          1,
+          tf.shape(input=input_tensor)[1],
+          tf.shape(input=input_tensor)[2], 1
+      ])
+    else:
+      kernel_size = [1, shape[1], shape[2], 1]
+    output = pool_op(
+        input_tensor, ksize=kernel_size, strides=[1, 1, 1, 1], padding='VALID')
+    # Recover output shape, for unknown shape.
+    output.set_shape([None, 1, 1, None])
+    return output
 
 
 def training_scope(is_training=True,

--- a/research/slim/nets/mobilenet/mobilenet_example.ipynb
+++ b/research/slim/nets/mobilenet/mobilenet_example.ipynb
@@ -227,7 +227,7 @@
       },
       "outputs": [],
       "source": [
-        "import tensorflow as tf\n",
+        "import tensorflow.compat.v1 as tf\n",
         "from nets.mobilenet import mobilenet_v2\n",
         "\n",
         "tf.reset_default_graph()\n",

--- a/research/slim/nets/mobilenet/mobilenet_v2.py
+++ b/research/slim/nets/mobilenet/mobilenet_v2.py
@@ -28,13 +28,11 @@ import copy
 import functools
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets.mobilenet import conv_blocks as ops
 from nets.mobilenet import mobilenet as lib
 
-slim = contrib_slim
 op = lib.op
 
 expand_input = ops.expand_input_by_factor
@@ -86,18 +84,17 @@ V2_DEF = dict(
 # Mobilenet v2 Definition with group normalization.
 V2_DEF_GROUP_NORM = copy.deepcopy(V2_DEF)
 V2_DEF_GROUP_NORM['defaults'] = {
-    (contrib_slim.conv2d, contrib_slim.fully_connected,
-     contrib_slim.separable_conv2d): {
-        'normalizer_fn': contrib_layers.group_norm,  # pylint: disable=C0330
+    (slim.conv2d, slim.fully_connected, slim.separable_conv2d): {
+        'normalizer_fn': slim.group_norm,  # pylint: disable=C0330
         'activation_fn': tf.nn.relu6,  # pylint: disable=C0330
     },  # pylint: disable=C0330
     (ops.expanded_conv,): {
         'expansion_size': ops.expand_input_by_factor(6),
         'split_expansion': 1,
-        'normalizer_fn': contrib_layers.group_norm,
+        'normalizer_fn': slim.group_norm,
         'residual': True
     },
-    (contrib_slim.conv2d, contrib_slim.separable_conv2d): {
+    (slim.conv2d, slim.separable_conv2d): {
         'padding': 'SAME'
     }
 }
@@ -119,7 +116,7 @@ def mobilenet(input_tensor,
   Inference mode is created by default. To create training use training_scope
   below.
 
-  with tf.contrib.slim.arg_scope(mobilenet_v2.training_scope()):
+  with slim.arg_scope(mobilenet_v2.training_scope()):
      logits, endpoints = mobilenet_v2.mobilenet(input_tensor)
 
   Args:
@@ -215,7 +212,7 @@ def mobilenet_base_group_norm(input_tensor, depth_multiplier=1.0, **kwargs):
   """Creates base of the mobilenet (no pooling and no logits) ."""
   kwargs['conv_defs'] = V2_DEF_GROUP_NORM
   kwargs['conv_defs']['defaults'].update({
-      (contrib_layers.group_norm,): {
+      (slim.group_norm,): {
           'groups': kwargs.pop('groups', 8)
       }
   })
@@ -227,10 +224,8 @@ def training_scope(**kwargs):
   """Defines MobilenetV2 training scope.
 
   Usage:
-     with tf.contrib.slim.arg_scope(mobilenet_v2.training_scope()):
+     with slim.arg_scope(mobilenet_v2.training_scope()):
        logits, endpoints = mobilenet_v2.mobilenet(input_tensor)
-
-  with slim.
 
   Args:
     **kwargs: Passed to mobilenet.training_scope. The following parameters

--- a/research/slim/nets/mobilenet/mobilenet_v2.py
+++ b/research/slim/nets/mobilenet/mobilenet_v2.py
@@ -27,7 +27,7 @@ from __future__ import print_function
 import copy
 import functools
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/nets/mobilenet/mobilenet_v2_test.py
+++ b/research/slim/nets/mobilenet/mobilenet_v2_test.py
@@ -34,7 +34,7 @@ def find_ops(optype):
   Returns:
      List of operations.
   """
-  gd = tf.compat.v1.get_default_graph()
+  gd = tf.get_default_graph()
   return [var for var in gd.get_operations() if var.type == optype]
 
 
@@ -43,7 +43,7 @@ class MobilenetV2Test(tf.test.TestCase):
   def testCreation(self):
     spec = dict(mobilenet_v2.V2_DEF)
     _, ep = mobilenet.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=spec)
     num_convs = len(find_ops('Conv2D'))
 
@@ -60,7 +60,7 @@ class MobilenetV2Test(tf.test.TestCase):
   def testCreationNoClasses(self):
     spec = copy.deepcopy(mobilenet_v2.V2_DEF)
     net, ep = mobilenet.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=spec,
         num_classes=None)
     self.assertIs(net, ep['global_pool'])
@@ -68,9 +68,9 @@ class MobilenetV2Test(tf.test.TestCase):
   def testImageSizes(self):
     for input_size, output_size in [(224, 7), (192, 6), (160, 5),
                                     (128, 4), (96, 3)]:
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       _, ep = mobilenet_v2.mobilenet(
-          tf.compat.v1.placeholder(tf.float32, (10, input_size, input_size, 3)))
+          tf.placeholder(tf.float32, (10, input_size, input_size, 3)))
 
       self.assertEqual(ep['layer_18/output'].get_shape().as_list()[1:3],
                        [output_size] * 2)
@@ -81,7 +81,7 @@ class MobilenetV2Test(tf.test.TestCase):
         (ops.expanded_conv,): dict(split_expansion=2),
     }
     _, _ = mobilenet.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=spec)
     num_convs = len(find_ops('Conv2D'))
     # All but 3 op has 3 conv operatore, the remainign 3 have one
@@ -90,16 +90,16 @@ class MobilenetV2Test(tf.test.TestCase):
 
   def testWithOutputStride8(self):
     out, _ = mobilenet.mobilenet_base(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=mobilenet_v2.V2_DEF,
         output_stride=8,
         scope='MobilenetV2')
     self.assertEqual(out.get_shape().as_list()[1:3], [28, 28])
 
   def testDivisibleBy(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     mobilenet_v2.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=mobilenet_v2.V2_DEF,
         divisible_by=16,
         min_depth=32)
@@ -109,12 +109,12 @@ class MobilenetV2Test(tf.test.TestCase):
                              1001], s)
 
   def testDivisibleByWithArgScope(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     # Verifies that depth_multiplier arg scope actually works
     # if no default min_depth is provided.
     with slim.arg_scope((mobilenet.depth_multiplier,), min_depth=32):
       mobilenet_v2.mobilenet(
-          tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 2)),
+          tf.placeholder(tf.float32, (10, 224, 224, 2)),
           conv_defs=mobilenet_v2.V2_DEF,
           depth_multiplier=0.1)
       s = [op.outputs[0].get_shape().as_list()[-1] for op in find_ops('Conv2D')]
@@ -122,12 +122,12 @@ class MobilenetV2Test(tf.test.TestCase):
       self.assertSameElements(s, [32, 192, 128, 1001])
 
   def testFineGrained(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     # Verifies that depth_multiplier arg scope actually works
     # if no default min_depth is provided.
 
     mobilenet_v2.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 2)),
+        tf.placeholder(tf.float32, (10, 224, 224, 2)),
         conv_defs=mobilenet_v2.V2_DEF,
         depth_multiplier=0.01,
         finegrain_classification_mode=True)
@@ -137,19 +137,19 @@ class MobilenetV2Test(tf.test.TestCase):
     self.assertSameElements(s, [8, 48, 1001, 1280])
 
   def testMobilenetBase(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     # Verifies that mobilenet_base returns pre-pooling layer.
     with slim.arg_scope((mobilenet.depth_multiplier,), min_depth=32):
       net, _ = mobilenet_v2.mobilenet_base(
-          tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+          tf.placeholder(tf.float32, (10, 224, 224, 16)),
           conv_defs=mobilenet_v2.V2_DEF,
           depth_multiplier=0.1)
       self.assertEqual(net.get_shape().as_list(), [10, 7, 7, 128])
 
   def testWithOutputStride16(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     out, _ = mobilenet.mobilenet_base(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=mobilenet_v2.V2_DEF,
         output_stride=16)
     self.assertEqual(out.get_shape().as_list()[1:3], [14, 14])
@@ -168,7 +168,7 @@ class MobilenetV2Test(tf.test.TestCase):
         multiplier_func=inverse_multiplier,
         num_outputs=16)
     _ = mobilenet_v2.mobilenet_base(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=new_def,
         depth_multiplier=0.1)
     s = [op.outputs[0].get_shape().as_list()[-1] for op in find_ops('Conv2D')]
@@ -177,9 +177,9 @@ class MobilenetV2Test(tf.test.TestCase):
     self.assertEqual([160, 8, 48, 8, 48], s[:5])
 
   def testWithOutputStride8AndExplicitPadding(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     out, _ = mobilenet.mobilenet_base(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=mobilenet_v2.V2_DEF,
         output_stride=8,
         use_explicit_padding=True,
@@ -187,9 +187,9 @@ class MobilenetV2Test(tf.test.TestCase):
     self.assertEqual(out.get_shape().as_list()[1:3], [28, 28])
 
   def testWithOutputStride16AndExplicitPadding(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     out, _ = mobilenet.mobilenet_base(
-        tf.compat.v1.placeholder(tf.float32, (10, 224, 224, 16)),
+        tf.placeholder(tf.float32, (10, 224, 224, 16)),
         conv_defs=mobilenet_v2.V2_DEF,
         output_stride=16,
         use_explicit_padding=True)

--- a/research/slim/nets/mobilenet/mobilenet_v2_test.py
+++ b/research/slim/nets/mobilenet/mobilenet_v2_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 import copy
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 from nets.mobilenet import conv_blocks as ops
 from nets.mobilenet import mobilenet

--- a/research/slim/nets/mobilenet/mobilenet_v2_test.py
+++ b/research/slim/nets/mobilenet/mobilenet_v2_test.py
@@ -20,13 +20,10 @@ from __future__ import print_function
 import copy
 from six.moves import range
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 from nets.mobilenet import conv_blocks as ops
 from nets.mobilenet import mobilenet
 from nets.mobilenet import mobilenet_v2
-
-
-slim = contrib_slim
 
 
 def find_ops(optype):
@@ -42,9 +39,6 @@ def find_ops(optype):
 
 
 class MobilenetV2Test(tf.test.TestCase):
-
-  def setUp(self):
-    tf.compat.v1.reset_default_graph()
 
   def testCreation(self):
     spec = dict(mobilenet_v2.V2_DEF)

--- a/research/slim/nets/mobilenet/mobilenet_v3.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3.py
@@ -378,7 +378,7 @@ _se4 = lambda expansion_tensor, input_tensor: squeeze_excite(expansion_tensor)
 
 
 def hard_swish(x):
-  with tf.compat.v1.name_scope('hard_swish'):
+  with tf.name_scope('hard_swish'):
     return x * tf.nn.relu6(x + np.float32(3)) * np.float32(1. / 6.)
 
 

--- a/research/slim/nets/mobilenet/mobilenet_v3.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3.py
@@ -12,7 +12,341 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Mobilenet V3 conv defs and helper functions."""
+"""Mobilenet V3 conv defs and helper functions.
+
+# pylint: disable=line-too-long
+
+Model definitions and layer breakdowns:
+==================
+==== V3 LARGE ====
+==================
+    Conv2D MobilenetV3/Conv/Conv2D                                                              351.2 k      1x224x224x3            432.0           5.42 M     1x112x112x16
+     Relu6 MobilenetV3/Conv/hard_swish/Relu6                                                          ?                -                ?                ?     1x112x112x16
+ DepthConv MobilenetV3/expanded_conv/depthwise/depthwise                                        401.4 k                -            144.0           1.81 M     1x112x112x16
+      Relu MobilenetV3/expanded_conv/depthwise/Relu                                                   ?                -                ?                ?     1x112x112x16
+    Conv2D MobilenetV3/expanded_conv/project/Conv2D                                             401.4 k     1x112x112x16            256.0           3.21 M     1x112x112x16
+    Conv2D MobilenetV3/expanded_conv_1/expand/Conv2D                                             1.00 M     1x112x112x16           1.02 k           12.8 M     1x112x112x64
+      Relu MobilenetV3/expanded_conv_1/expand/Relu                                                    ?                -                ?                ?     1x112x112x64
+ DepthConv MobilenetV3/expanded_conv_1/depthwise/depthwise                                       1.00 M                -            576.0           1.81 M       1x56x56x64
+      Relu MobilenetV3/expanded_conv_1/depthwise/Relu                                                 ?                -                ?                ?       1x56x56x64
+    Conv2D MobilenetV3/expanded_conv_1/project/Conv2D                                           276.0 k       1x56x56x64           1.54 k           4.82 M       1x56x56x24
+    Conv2D MobilenetV3/expanded_conv_2/expand/Conv2D                                            301.1 k       1x56x56x24           1.73 k           5.42 M       1x56x56x72
+      Relu MobilenetV3/expanded_conv_2/expand/Relu                                                    ?                -                ?                ?       1x56x56x72
+ DepthConv MobilenetV3/expanded_conv_2/depthwise/depthwise                                      451.6 k                -            648.0           2.03 M       1x56x56x72
+      Relu MobilenetV3/expanded_conv_2/depthwise/Relu                                                 ?                -                ?                ?       1x56x56x72
+    Conv2D MobilenetV3/expanded_conv_2/project/Conv2D                                           301.1 k       1x56x56x72           1.73 k           5.42 M       1x56x56x24
+    Conv2D MobilenetV3/expanded_conv_3/expand/Conv2D                                            301.1 k       1x56x56x24           1.73 k           5.42 M       1x56x56x72
+      Relu MobilenetV3/expanded_conv_3/expand/Relu                                                    ?                -                ?                ?       1x56x56x72
+ DepthConv MobilenetV3/expanded_conv_3/depthwise/depthwise                                      282.2 k                -           1.80 k           1.41 M       1x28x28x72
+      Relu MobilenetV3/expanded_conv_3/depthwise/Relu                                                 ?                -                ?                ?       1x28x28x72
+    Conv2D MobilenetV3/expanded_conv_3/squeeze_excite/Conv/Conv2D                                  96.0         1x1x1x72           1.73 k           1.73 k         1x1x1x24
+      Relu MobilenetV3/expanded_conv_3/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x24
+    Conv2D MobilenetV3/expanded_conv_3/squeeze_excite/Conv_1/Conv2D                                96.0         1x1x1x24           1.73 k           1.73 k         1x1x1x72
+     Relu6 MobilenetV3/expanded_conv_3/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?         1x1x1x72
+    Conv2D MobilenetV3/expanded_conv_3/project/Conv2D                                            87.8 k       1x28x28x72           2.88 k           2.26 M       1x28x28x40
+    Conv2D MobilenetV3/expanded_conv_4/expand/Conv2D                                            125.4 k       1x28x28x40           4.80 k           3.76 M      1x28x28x120
+      Relu MobilenetV3/expanded_conv_4/expand/Relu                                                    ?                -                ?                ?      1x28x28x120
+ DepthConv MobilenetV3/expanded_conv_4/depthwise/depthwise                                      188.2 k                -           3.00 k           2.35 M      1x28x28x120
+      Relu MobilenetV3/expanded_conv_4/depthwise/Relu                                                 ?                -                ?                ?      1x28x28x120
+    Conv2D MobilenetV3/expanded_conv_4/squeeze_excite/Conv/Conv2D                                 152.0        1x1x1x120           3.84 k           3.84 k         1x1x1x32
+      Relu MobilenetV3/expanded_conv_4/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x32
+    Conv2D MobilenetV3/expanded_conv_4/squeeze_excite/Conv_1/Conv2D                               152.0         1x1x1x32           3.84 k           3.84 k        1x1x1x120
+     Relu6 MobilenetV3/expanded_conv_4/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x120
+    Conv2D MobilenetV3/expanded_conv_4/project/Conv2D                                           125.4 k      1x28x28x120           4.80 k           3.76 M       1x28x28x40
+    Conv2D MobilenetV3/expanded_conv_5/expand/Conv2D                                            125.4 k       1x28x28x40           4.80 k           3.76 M      1x28x28x120
+      Relu MobilenetV3/expanded_conv_5/expand/Relu                                                    ?                -                ?                ?      1x28x28x120
+ DepthConv MobilenetV3/expanded_conv_5/depthwise/depthwise                                      188.2 k                -           3.00 k           2.35 M      1x28x28x120
+      Relu MobilenetV3/expanded_conv_5/depthwise/Relu                                                 ?                -                ?                ?      1x28x28x120
+    Conv2D MobilenetV3/expanded_conv_5/squeeze_excite/Conv/Conv2D                                 152.0        1x1x1x120           3.84 k           3.84 k         1x1x1x32
+      Relu MobilenetV3/expanded_conv_5/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x32
+    Conv2D MobilenetV3/expanded_conv_5/squeeze_excite/Conv_1/Conv2D                               152.0         1x1x1x32           3.84 k           3.84 k        1x1x1x120
+     Relu6 MobilenetV3/expanded_conv_5/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x120
+    Conv2D MobilenetV3/expanded_conv_5/project/Conv2D                                           125.4 k      1x28x28x120           4.80 k           3.76 M       1x28x28x40
+    Conv2D MobilenetV3/expanded_conv_6/expand/Conv2D                                            219.5 k       1x28x28x40           9.60 k           7.53 M      1x28x28x240
+     Relu6 MobilenetV3/expanded_conv_6/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x28x28x240
+ DepthConv MobilenetV3/expanded_conv_6/depthwise/depthwise                                      235.2 k                -           2.16 k          423.4 k      1x14x14x240
+     Relu6 MobilenetV3/expanded_conv_6/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x240
+    Conv2D MobilenetV3/expanded_conv_6/project/Conv2D                                            62.7 k      1x14x14x240           19.2 k           3.76 M       1x14x14x80
+    Conv2D MobilenetV3/expanded_conv_7/expand/Conv2D                                             54.9 k       1x14x14x80           16.0 k           3.14 M      1x14x14x200
+     Relu6 MobilenetV3/expanded_conv_7/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x200
+ DepthConv MobilenetV3/expanded_conv_7/depthwise/depthwise                                       78.4 k                -           1.80 k          352.8 k      1x14x14x200
+     Relu6 MobilenetV3/expanded_conv_7/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x200
+    Conv2D MobilenetV3/expanded_conv_7/project/Conv2D                                            54.9 k      1x14x14x200           16.0 k           3.14 M       1x14x14x80
+    Conv2D MobilenetV3/expanded_conv_8/expand/Conv2D                                             51.7 k       1x14x14x80           14.7 k           2.89 M      1x14x14x184
+     Relu6 MobilenetV3/expanded_conv_8/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x184
+ DepthConv MobilenetV3/expanded_conv_8/depthwise/depthwise                                       72.1 k                -           1.66 k          324.6 k      1x14x14x184
+     Relu6 MobilenetV3/expanded_conv_8/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x184
+    Conv2D MobilenetV3/expanded_conv_8/project/Conv2D                                            51.7 k      1x14x14x184           14.7 k           2.89 M       1x14x14x80
+    Conv2D MobilenetV3/expanded_conv_9/expand/Conv2D                                             51.7 k       1x14x14x80           14.7 k           2.89 M      1x14x14x184
+     Relu6 MobilenetV3/expanded_conv_9/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x184
+ DepthConv MobilenetV3/expanded_conv_9/depthwise/depthwise                                       72.1 k                -           1.66 k          324.6 k      1x14x14x184
+     Relu6 MobilenetV3/expanded_conv_9/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x184
+    Conv2D MobilenetV3/expanded_conv_9/project/Conv2D                                            51.7 k      1x14x14x184           14.7 k           2.89 M       1x14x14x80
+    Conv2D MobilenetV3/expanded_conv_10/expand/Conv2D                                           109.8 k       1x14x14x80           38.4 k           7.53 M      1x14x14x480
+     Relu6 MobilenetV3/expanded_conv_10/expand/hard_swish/Relu6                                       ?                -                ?                ?      1x14x14x480
+ DepthConv MobilenetV3/expanded_conv_10/depthwise/depthwise                                     188.2 k                -           4.32 k          846.7 k      1x14x14x480
+     Relu6 MobilenetV3/expanded_conv_10/depthwise/hard_swish/Relu6                                    ?                -                ?                ?      1x14x14x480
+    Conv2D MobilenetV3/expanded_conv_10/squeeze_excite/Conv/Conv2D                                600.0        1x1x1x480           57.6 k           57.6 k        1x1x1x120
+      Relu MobilenetV3/expanded_conv_10/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x120
+    Conv2D MobilenetV3/expanded_conv_10/squeeze_excite/Conv_1/Conv2D                              600.0        1x1x1x120           57.6 k           57.6 k        1x1x1x480
+     Relu6 MobilenetV3/expanded_conv_10/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x480
+    Conv2D MobilenetV3/expanded_conv_10/project/Conv2D                                          116.0 k      1x14x14x480           53.8 k           10.5 M      1x14x14x112
+    Conv2D MobilenetV3/expanded_conv_11/expand/Conv2D                                           153.7 k      1x14x14x112           75.3 k           14.8 M      1x14x14x672
+     Relu6 MobilenetV3/expanded_conv_11/expand/hard_swish/Relu6                                       ?                -                ?                ?      1x14x14x672
+ DepthConv MobilenetV3/expanded_conv_11/depthwise/depthwise                                     263.4 k                -           6.05 k           1.19 M      1x14x14x672
+     Relu6 MobilenetV3/expanded_conv_11/depthwise/hard_swish/Relu6                                    ?                -                ?                ?      1x14x14x672
+    Conv2D MobilenetV3/expanded_conv_11/squeeze_excite/Conv/Conv2D                                840.0        1x1x1x672          112.9 k          112.9 k        1x1x1x168
+      Relu MobilenetV3/expanded_conv_11/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x168
+    Conv2D MobilenetV3/expanded_conv_11/squeeze_excite/Conv_1/Conv2D                              840.0        1x1x1x168          112.9 k          112.9 k        1x1x1x672
+     Relu6 MobilenetV3/expanded_conv_11/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x672
+    Conv2D MobilenetV3/expanded_conv_11/project/Conv2D                                          153.7 k      1x14x14x672           75.3 k           14.8 M      1x14x14x112
+    Conv2D MobilenetV3/expanded_conv_12/expand/Conv2D                                           153.7 k      1x14x14x112           75.3 k           14.8 M      1x14x14x672
+     Relu6 MobilenetV3/expanded_conv_12/expand/hard_swish/Relu6                                       ?                -                ?                ?      1x14x14x672
+ DepthConv MobilenetV3/expanded_conv_12/depthwise/depthwise                                     164.6 k                -           16.8 k          823.2 k        1x7x7x672
+     Relu6 MobilenetV3/expanded_conv_12/depthwise/hard_swish/Relu6                                    ?                -                ?                ?        1x7x7x672
+    Conv2D MobilenetV3/expanded_conv_12/squeeze_excite/Conv/Conv2D                                840.0        1x1x1x672          112.9 k          112.9 k        1x1x1x168
+      Relu MobilenetV3/expanded_conv_12/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x168
+    Conv2D MobilenetV3/expanded_conv_12/squeeze_excite/Conv_1/Conv2D                              840.0        1x1x1x168          112.9 k          112.9 k        1x1x1x672
+     Relu6 MobilenetV3/expanded_conv_12/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x672
+    Conv2D MobilenetV3/expanded_conv_12/project/Conv2D                                           40.8 k        1x7x7x672          107.5 k           5.27 M        1x7x7x160
+    Conv2D MobilenetV3/expanded_conv_13/expand/Conv2D                                            54.9 k        1x7x7x160          153.6 k           7.53 M        1x7x7x960
+     Relu6 MobilenetV3/expanded_conv_13/expand/hard_swish/Relu6                                       ?                -                ?                ?        1x7x7x960
+ DepthConv MobilenetV3/expanded_conv_13/depthwise/depthwise                                      94.1 k                -           24.0 k           1.18 M        1x7x7x960
+     Relu6 MobilenetV3/expanded_conv_13/depthwise/hard_swish/Relu6                                    ?                -                ?                ?        1x7x7x960
+    Conv2D MobilenetV3/expanded_conv_13/squeeze_excite/Conv/Conv2D                               1.20 k        1x1x1x960          230.4 k          230.4 k        1x1x1x240
+      Relu MobilenetV3/expanded_conv_13/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x240
+    Conv2D MobilenetV3/expanded_conv_13/squeeze_excite/Conv_1/Conv2D                             1.20 k        1x1x1x240          230.4 k          230.4 k        1x1x1x960
+     Relu6 MobilenetV3/expanded_conv_13/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x960
+    Conv2D MobilenetV3/expanded_conv_13/project/Conv2D                                           54.9 k        1x7x7x960          153.6 k           7.53 M        1x7x7x160
+    Conv2D MobilenetV3/expanded_conv_14/expand/Conv2D                                            54.9 k        1x7x7x160          153.6 k           7.53 M        1x7x7x960
+     Relu6 MobilenetV3/expanded_conv_14/expand/hard_swish/Relu6                                       ?                -                ?                ?        1x7x7x960
+ DepthConv MobilenetV3/expanded_conv_14/depthwise/depthwise                                      94.1 k                -           24.0 k           1.18 M        1x7x7x960
+     Relu6 MobilenetV3/expanded_conv_14/depthwise/hard_swish/Relu6                                    ?                -                ?                ?        1x7x7x960
+    Conv2D MobilenetV3/expanded_conv_14/squeeze_excite/Conv/Conv2D                               1.20 k        1x1x1x960          230.4 k          230.4 k        1x1x1x240
+      Relu MobilenetV3/expanded_conv_14/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x240
+    Conv2D MobilenetV3/expanded_conv_14/squeeze_excite/Conv_1/Conv2D                             1.20 k        1x1x1x240          230.4 k          230.4 k        1x1x1x960
+     Relu6 MobilenetV3/expanded_conv_14/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x960
+    Conv2D MobilenetV3/expanded_conv_14/project/Conv2D                                           54.9 k        1x7x7x960          153.6 k           7.53 M        1x7x7x160
+    Conv2D MobilenetV3/Conv_1/Conv2D                                                             54.9 k        1x7x7x160          153.6 k           7.53 M        1x7x7x960
+     Relu6 MobilenetV3/Conv_1/hard_swish/Relu6                                                        ?                -                ?                ?        1x7x7x960
+   AvgPool MobilenetV3/AvgPool2D/AvgPool                                                              ?        1x7x7x960                ?           47.0 k        1x1x1x960
+    Conv2D MobilenetV3/Conv_2/Conv2D                                                             2.24 k        1x1x1x960           1.23 M           1.23 M       1x1x1x1280
+     Relu6 MobilenetV3/Conv_2/hard_swish/Relu6                                                        ?                -                ?                ?       1x1x1x1280
+    Conv2D MobilenetV3/Logits/Conv2d_1c_1x1/Conv2D                                               2.28 k       1x1x1x1280           1.28 M           1.28 M       1x1x1x1001
+-----
+
+
+==================
+==== V3 SMALL ====
+==================
+      op name                                                                                  ActMem        ConvInput   ConvParameters            Madds     OutputTensor
+    Conv2D MobilenetV3/Conv/Conv2D                                                              351.2 k      1x224x224x3            432.0           5.42 M     1x112x112x16
+     Relu6 MobilenetV3/Conv/hard_swish/Relu6                                                          ?                -                ?                ?     1x112x112x16
+ DepthConv MobilenetV3/expanded_conv/depthwise/depthwise                                        250.9 k                -            144.0          451.6 k       1x56x56x16
+      Relu MobilenetV3/expanded_conv/depthwise/Relu                                                   ?                -                ?                ?       1x56x56x16
+    Conv2D MobilenetV3/expanded_conv/squeeze_excite/Conv/Conv2D                                    24.0         1x1x1x16            128.0            128.0          1x1x1x8
+      Relu MobilenetV3/expanded_conv/squeeze_excite/Conv/Relu                                         ?                -                ?                ?          1x1x1x8
+    Conv2D MobilenetV3/expanded_conv/squeeze_excite/Conv_1/Conv2D                                  24.0          1x1x1x8            128.0            128.0         1x1x1x16
+     Relu6 MobilenetV3/expanded_conv/squeeze_excite/Conv_1/Relu6                                      ?                -                ?                ?         1x1x1x16
+    Conv2D MobilenetV3/expanded_conv/project/Conv2D                                             100.4 k       1x56x56x16            256.0          802.8 k       1x56x56x16
+    Conv2D MobilenetV3/expanded_conv_1/expand/Conv2D                                            276.0 k       1x56x56x16           1.15 k           3.61 M       1x56x56x72
+      Relu MobilenetV3/expanded_conv_1/expand/Relu                                                    ?                -                ?                ?       1x56x56x72
+ DepthConv MobilenetV3/expanded_conv_1/depthwise/depthwise                                      282.2 k                -            648.0          508.0 k       1x28x28x72
+      Relu MobilenetV3/expanded_conv_1/depthwise/Relu                                                 ?                -                ?                ?       1x28x28x72
+    Conv2D MobilenetV3/expanded_conv_1/project/Conv2D                                            75.3 k       1x28x28x72           1.73 k           1.35 M       1x28x28x24
+    Conv2D MobilenetV3/expanded_conv_2/expand/Conv2D                                             87.8 k       1x28x28x24           2.11 k           1.66 M       1x28x28x88
+      Relu MobilenetV3/expanded_conv_2/expand/Relu                                                    ?                -                ?                ?       1x28x28x88
+ DepthConv MobilenetV3/expanded_conv_2/depthwise/depthwise                                      138.0 k                -            792.0          620.9 k       1x28x28x88
+      Relu MobilenetV3/expanded_conv_2/depthwise/Relu                                                 ?                -                ?                ?       1x28x28x88
+    Conv2D MobilenetV3/expanded_conv_2/project/Conv2D                                            87.8 k       1x28x28x88           2.11 k           1.66 M       1x28x28x24
+    Conv2D MobilenetV3/expanded_conv_3/expand/Conv2D                                             94.1 k       1x28x28x24           2.30 k           1.81 M       1x28x28x96
+     Relu6 MobilenetV3/expanded_conv_3/expand/hard_swish/Relu6                                        ?                -                ?                ?       1x28x28x96
+ DepthConv MobilenetV3/expanded_conv_3/depthwise/depthwise                                       94.1 k                -           2.40 k          470.4 k       1x14x14x96
+     Relu6 MobilenetV3/expanded_conv_3/depthwise/hard_swish/Relu6                                     ?                -                ?                ?       1x14x14x96
+    Conv2D MobilenetV3/expanded_conv_3/squeeze_excite/Conv/Conv2D                                 120.0         1x1x1x96           2.30 k           2.30 k         1x1x1x24
+      Relu MobilenetV3/expanded_conv_3/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x24
+    Conv2D MobilenetV3/expanded_conv_3/squeeze_excite/Conv_1/Conv2D                               120.0         1x1x1x24           2.30 k           2.30 k         1x1x1x96
+     Relu6 MobilenetV3/expanded_conv_3/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?         1x1x1x96
+    Conv2D MobilenetV3/expanded_conv_3/project/Conv2D                                            26.7 k       1x14x14x96           3.84 k          752.6 k       1x14x14x40
+    Conv2D MobilenetV3/expanded_conv_4/expand/Conv2D                                             54.9 k       1x14x14x40           9.60 k           1.88 M      1x14x14x240
+     Relu6 MobilenetV3/expanded_conv_4/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x240
+ DepthConv MobilenetV3/expanded_conv_4/depthwise/depthwise                                       94.1 k                -           6.00 k           1.18 M      1x14x14x240
+     Relu6 MobilenetV3/expanded_conv_4/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x240
+    Conv2D MobilenetV3/expanded_conv_4/squeeze_excite/Conv/Conv2D                                 304.0        1x1x1x240           15.4 k           15.4 k         1x1x1x64
+      Relu MobilenetV3/expanded_conv_4/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x64
+    Conv2D MobilenetV3/expanded_conv_4/squeeze_excite/Conv_1/Conv2D                               304.0         1x1x1x64           15.4 k           15.4 k        1x1x1x240
+     Relu6 MobilenetV3/expanded_conv_4/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x240
+    Conv2D MobilenetV3/expanded_conv_4/project/Conv2D                                            54.9 k      1x14x14x240           9.60 k           1.88 M       1x14x14x40
+    Conv2D MobilenetV3/expanded_conv_5/expand/Conv2D                                             54.9 k       1x14x14x40           9.60 k           1.88 M      1x14x14x240
+     Relu6 MobilenetV3/expanded_conv_5/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x240
+ DepthConv MobilenetV3/expanded_conv_5/depthwise/depthwise                                       94.1 k                -           6.00 k           1.18 M      1x14x14x240
+     Relu6 MobilenetV3/expanded_conv_5/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x240
+    Conv2D MobilenetV3/expanded_conv_5/squeeze_excite/Conv/Conv2D                                 304.0        1x1x1x240           15.4 k           15.4 k         1x1x1x64
+      Relu MobilenetV3/expanded_conv_5/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x64
+    Conv2D MobilenetV3/expanded_conv_5/squeeze_excite/Conv_1/Conv2D                               304.0         1x1x1x64           15.4 k           15.4 k        1x1x1x240
+     Relu6 MobilenetV3/expanded_conv_5/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x240
+    Conv2D MobilenetV3/expanded_conv_5/project/Conv2D                                            54.9 k      1x14x14x240           9.60 k           1.88 M       1x14x14x40
+    Conv2D MobilenetV3/expanded_conv_6/expand/Conv2D                                             31.4 k       1x14x14x40           4.80 k          940.8 k      1x14x14x120
+     Relu6 MobilenetV3/expanded_conv_6/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x120
+ DepthConv MobilenetV3/expanded_conv_6/depthwise/depthwise                                       47.0 k                -           3.00 k          588.0 k      1x14x14x120
+     Relu6 MobilenetV3/expanded_conv_6/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x120
+    Conv2D MobilenetV3/expanded_conv_6/squeeze_excite/Conv/Conv2D                                 152.0        1x1x1x120           3.84 k           3.84 k         1x1x1x32
+      Relu MobilenetV3/expanded_conv_6/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x32
+    Conv2D MobilenetV3/expanded_conv_6/squeeze_excite/Conv_1/Conv2D                               152.0         1x1x1x32           3.84 k           3.84 k        1x1x1x120
+     Relu6 MobilenetV3/expanded_conv_6/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x120
+    Conv2D MobilenetV3/expanded_conv_6/project/Conv2D                                            32.9 k      1x14x14x120           5.76 k           1.13 M       1x14x14x48
+    Conv2D MobilenetV3/expanded_conv_7/expand/Conv2D                                             37.6 k       1x14x14x48           6.91 k           1.35 M      1x14x14x144
+     Relu6 MobilenetV3/expanded_conv_7/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x144
+ DepthConv MobilenetV3/expanded_conv_7/depthwise/depthwise                                       56.4 k                -           3.60 k          705.6 k      1x14x14x144
+     Relu6 MobilenetV3/expanded_conv_7/depthwise/hard_swish/Relu6                                     ?                -                ?                ?      1x14x14x144
+    Conv2D MobilenetV3/expanded_conv_7/squeeze_excite/Conv/Conv2D                                 184.0        1x1x1x144           5.76 k           5.76 k         1x1x1x40
+      Relu MobilenetV3/expanded_conv_7/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x40
+    Conv2D MobilenetV3/expanded_conv_7/squeeze_excite/Conv_1/Conv2D                               184.0         1x1x1x40           5.76 k           5.76 k        1x1x1x144
+     Relu6 MobilenetV3/expanded_conv_7/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x144
+    Conv2D MobilenetV3/expanded_conv_7/project/Conv2D                                            37.6 k      1x14x14x144           6.91 k           1.35 M       1x14x14x48
+    Conv2D MobilenetV3/expanded_conv_8/expand/Conv2D                                             65.9 k       1x14x14x48           13.8 k           2.71 M      1x14x14x288
+     Relu6 MobilenetV3/expanded_conv_8/expand/hard_swish/Relu6                                        ?                -                ?                ?      1x14x14x288
+ DepthConv MobilenetV3/expanded_conv_8/depthwise/depthwise                                       70.6 k                -           7.20 k          352.8 k        1x7x7x288
+     Relu6 MobilenetV3/expanded_conv_8/depthwise/hard_swish/Relu6                                     ?                -                ?                ?        1x7x7x288
+    Conv2D MobilenetV3/expanded_conv_8/squeeze_excite/Conv/Conv2D                                 360.0        1x1x1x288           20.7 k           20.7 k         1x1x1x72
+      Relu MobilenetV3/expanded_conv_8/squeeze_excite/Conv/Relu                                       ?                -                ?                ?         1x1x1x72
+    Conv2D MobilenetV3/expanded_conv_8/squeeze_excite/Conv_1/Conv2D                               360.0         1x1x1x72           20.7 k           20.7 k        1x1x1x288
+     Relu6 MobilenetV3/expanded_conv_8/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x288
+    Conv2D MobilenetV3/expanded_conv_8/project/Conv2D                                            18.8 k        1x7x7x288           27.6 k           1.35 M         1x7x7x96
+    Conv2D MobilenetV3/expanded_conv_9/expand/Conv2D                                             32.9 k         1x7x7x96           55.3 k           2.71 M        1x7x7x576
+     Relu6 MobilenetV3/expanded_conv_9/expand/hard_swish/Relu6                                        ?                -                ?                ?        1x7x7x576
+ DepthConv MobilenetV3/expanded_conv_9/depthwise/depthwise                                       56.4 k                -           14.4 k          705.6 k        1x7x7x576
+     Relu6 MobilenetV3/expanded_conv_9/depthwise/hard_swish/Relu6                                     ?                -                ?                ?        1x7x7x576
+    Conv2D MobilenetV3/expanded_conv_9/squeeze_excite/Conv/Conv2D                                 720.0        1x1x1x576           82.9 k           82.9 k        1x1x1x144
+      Relu MobilenetV3/expanded_conv_9/squeeze_excite/Conv/Relu                                       ?                -                ?                ?        1x1x1x144
+    Conv2D MobilenetV3/expanded_conv_9/squeeze_excite/Conv_1/Conv2D                               720.0        1x1x1x144           82.9 k           82.9 k        1x1x1x576
+     Relu6 MobilenetV3/expanded_conv_9/squeeze_excite/Conv_1/Relu6                                    ?                -                ?                ?        1x1x1x576
+    Conv2D MobilenetV3/expanded_conv_9/project/Conv2D                                            32.9 k        1x7x7x576           55.3 k           2.71 M         1x7x7x96
+    Conv2D MobilenetV3/expanded_conv_10/expand/Conv2D                                            32.9 k         1x7x7x96           55.3 k           2.71 M        1x7x7x576
+     Relu6 MobilenetV3/expanded_conv_10/expand/hard_swish/Relu6                                       ?                -                ?                ?        1x7x7x576
+ DepthConv MobilenetV3/expanded_conv_10/depthwise/depthwise                                      56.4 k                -           14.4 k          705.6 k        1x7x7x576
+     Relu6 MobilenetV3/expanded_conv_10/depthwise/hard_swish/Relu6                                    ?                -                ?                ?        1x7x7x576
+    Conv2D MobilenetV3/expanded_conv_10/squeeze_excite/Conv/Conv2D                                720.0        1x1x1x576           82.9 k           82.9 k        1x1x1x144
+      Relu MobilenetV3/expanded_conv_10/squeeze_excite/Conv/Relu                                      ?                -                ?                ?        1x1x1x144
+    Conv2D MobilenetV3/expanded_conv_10/squeeze_excite/Conv_1/Conv2D                              720.0        1x1x1x144           82.9 k           82.9 k        1x1x1x576
+     Relu6 MobilenetV3/expanded_conv_10/squeeze_excite/Conv_1/Relu6                                   ?                -                ?                ?        1x1x1x576
+    Conv2D MobilenetV3/expanded_conv_10/project/Conv2D                                           32.9 k        1x7x7x576           55.3 k           2.71 M         1x7x7x96
+    Conv2D MobilenetV3/Conv_1/Conv2D                                                             32.9 k         1x7x7x96           55.3 k           2.71 M        1x7x7x576
+     Relu6 MobilenetV3/Conv_1/hard_swish/Relu6                                                        ?                -                ?                ?        1x7x7x576
+   AvgPool MobilenetV3/AvgPool2D/AvgPool                                                              ?        1x7x7x576                ?           28.2 k        1x1x1x576
+    Conv2D MobilenetV3/Conv_2/Conv2D                                                             1.60 k        1x1x1x576          589.8 k          589.8 k       1x1x1x1024
+     Relu6 MobilenetV3/Conv_2/hard_swish/Relu6                                                        ?                -                ?                ?       1x1x1x1024
+    Conv2D MobilenetV3/Logits/Conv2d_1c_1x1/Conv2D                                               2.02 k       1x1x1x1024           1.03 M           1.03 M       1x1x1x1001
+-----
+     Total Total                                                                                 2.96 M                -           2.53 M           56.5 M                -
+
+
+====================
+==== V3 EDGETPU ====
+====================
+        op name                                                                                  ActMem        ConvInput   ConvParameters            Madds     OutputTensor
+    Conv2D MobilenetEdgeTPU/Conv/Conv2D                                                         551.9 k      1x224x224x3            864.0           10.8 M     1x112x112x32
+      Relu MobilenetEdgeTPU/Conv/Relu                                                                 ?                -                ?                ?     1x112x112x32
+    Conv2D MobilenetEdgeTPU/expanded_conv/project/Conv2D                                        602.1 k     1x112x112x32            512.0           6.42 M     1x112x112x16
+    Conv2D MobilenetEdgeTPU/expanded_conv_1/expand/Conv2D                                       602.1 k     1x112x112x16           18.4 k           57.8 M      1x56x56x128
+      Relu MobilenetEdgeTPU/expanded_conv_1/expand/Relu                                               ?                -                ?                ?      1x56x56x128
+    Conv2D MobilenetEdgeTPU/expanded_conv_1/project/Conv2D                                      501.8 k      1x56x56x128           4.10 k           12.8 M       1x56x56x32
+    Conv2D MobilenetEdgeTPU/expanded_conv_2/expand/Conv2D                                       501.8 k       1x56x56x32           36.9 k          115.6 M      1x56x56x128
+      Relu MobilenetEdgeTPU/expanded_conv_2/expand/Relu                                               ?                -                ?                ?      1x56x56x128
+    Conv2D MobilenetEdgeTPU/expanded_conv_2/project/Conv2D                                      501.8 k      1x56x56x128           4.10 k           12.8 M       1x56x56x32
+    Conv2D MobilenetEdgeTPU/expanded_conv_3/expand/Conv2D                                       501.8 k       1x56x56x32           36.9 k          115.6 M      1x56x56x128
+      Relu MobilenetEdgeTPU/expanded_conv_3/expand/Relu                                               ?                -                ?                ?      1x56x56x128
+    Conv2D MobilenetEdgeTPU/expanded_conv_3/project/Conv2D                                      501.8 k      1x56x56x128           4.10 k           12.8 M       1x56x56x32
+    Conv2D MobilenetEdgeTPU/expanded_conv_4/expand/Conv2D                                       501.8 k       1x56x56x32           36.9 k          115.6 M      1x56x56x128
+      Relu MobilenetEdgeTPU/expanded_conv_4/expand/Relu                                               ?                -                ?                ?      1x56x56x128
+    Conv2D MobilenetEdgeTPU/expanded_conv_4/project/Conv2D                                      501.8 k      1x56x56x128           4.10 k           12.8 M       1x56x56x32
+    Conv2D MobilenetEdgeTPU/expanded_conv_5/expand/Conv2D                                       301.1 k       1x56x56x32           73.7 k           57.8 M      1x28x28x256
+      Relu MobilenetEdgeTPU/expanded_conv_5/expand/Relu                                               ?                -                ?                ?      1x28x28x256
+    Conv2D MobilenetEdgeTPU/expanded_conv_5/project/Conv2D                                      238.3 k      1x28x28x256           12.3 k           9.63 M       1x28x28x48
+    Conv2D MobilenetEdgeTPU/expanded_conv_6/expand/Conv2D                                       188.2 k       1x28x28x48           82.9 k           65.0 M      1x28x28x192
+      Relu MobilenetEdgeTPU/expanded_conv_6/expand/Relu                                               ?                -                ?                ?      1x28x28x192
+    Conv2D MobilenetEdgeTPU/expanded_conv_6/project/Conv2D                                      188.2 k      1x28x28x192           9.22 k           7.23 M       1x28x28x48
+    Conv2D MobilenetEdgeTPU/expanded_conv_7/expand/Conv2D                                       188.2 k       1x28x28x48           82.9 k           65.0 M      1x28x28x192
+      Relu MobilenetEdgeTPU/expanded_conv_7/expand/Relu                                               ?                -                ?                ?      1x28x28x192
+    Conv2D MobilenetEdgeTPU/expanded_conv_7/project/Conv2D                                      188.2 k      1x28x28x192           9.22 k           7.23 M       1x28x28x48
+    Conv2D MobilenetEdgeTPU/expanded_conv_8/expand/Conv2D                                       188.2 k       1x28x28x48           82.9 k           65.0 M      1x28x28x192
+      Relu MobilenetEdgeTPU/expanded_conv_8/expand/Relu                                               ?                -                ?                ?      1x28x28x192
+    Conv2D MobilenetEdgeTPU/expanded_conv_8/project/Conv2D                                      188.2 k      1x28x28x192           9.22 k           7.23 M       1x28x28x48
+    Conv2D MobilenetEdgeTPU/expanded_conv_9/expand/Conv2D                                       338.7 k       1x28x28x48           18.4 k           14.5 M      1x28x28x384
+      Relu MobilenetEdgeTPU/expanded_conv_9/expand/Relu                                               ?                -                ?                ?      1x28x28x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_9/depthwise/depthwise                                 376.3 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_9/depthwise/Relu                                            ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_9/project/Conv2D                                       94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_10/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_10/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_10/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_10/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_10/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_11/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_11/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_11/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_11/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_11/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_12/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_12/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_12/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_12/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_12/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_13/expand/Conv2D                                      169.3 k       1x14x14x96           73.7 k           14.5 M      1x14x14x768
+      Relu MobilenetEdgeTPU/expanded_conv_13/expand/Relu                                              ?                -                ?                ?      1x14x14x768
+ DepthConv MobilenetEdgeTPU/expanded_conv_13/depthwise/depthwise                                301.1 k                -           6.91 k           1.35 M      1x14x14x768
+      Relu MobilenetEdgeTPU/expanded_conv_13/depthwise/Relu                                           ?                -                ?                ?      1x14x14x768
+    Conv2D MobilenetEdgeTPU/expanded_conv_13/project/Conv2D                                     169.3 k      1x14x14x768           73.7 k           14.5 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_14/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_14/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_14/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_14/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_14/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_15/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_15/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_15/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_15/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_15/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_16/expand/Conv2D                                       94.1 k       1x14x14x96           36.9 k           7.23 M      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_16/expand/Relu                                              ?                -                ?                ?      1x14x14x384
+ DepthConv MobilenetEdgeTPU/expanded_conv_16/depthwise/depthwise                                150.5 k                -           3.46 k          677.4 k      1x14x14x384
+      Relu MobilenetEdgeTPU/expanded_conv_16/depthwise/Relu                                           ?                -                ?                ?      1x14x14x384
+    Conv2D MobilenetEdgeTPU/expanded_conv_16/project/Conv2D                                      94.1 k      1x14x14x384           36.9 k           7.23 M       1x14x14x96
+    Conv2D MobilenetEdgeTPU/expanded_conv_17/expand/Conv2D                                      169.3 k       1x14x14x96           73.7 k           14.5 M      1x14x14x768
+      Relu MobilenetEdgeTPU/expanded_conv_17/expand/Relu                                              ?                -                ?                ?      1x14x14x768
+ DepthConv MobilenetEdgeTPU/expanded_conv_17/depthwise/depthwise                                188.2 k                -           19.2 k          940.8 k        1x7x7x768
+      Relu MobilenetEdgeTPU/expanded_conv_17/depthwise/Relu                                           ?                -                ?                ?        1x7x7x768
+    Conv2D MobilenetEdgeTPU/expanded_conv_17/project/Conv2D                                      45.5 k        1x7x7x768          122.9 k           6.02 M        1x7x7x160
+    Conv2D MobilenetEdgeTPU/expanded_conv_18/expand/Conv2D                                       39.2 k        1x7x7x160          102.4 k           5.02 M        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_18/expand/Relu                                              ?                -                ?                ?        1x7x7x640
+ DepthConv MobilenetEdgeTPU/expanded_conv_18/depthwise/depthwise                                 62.7 k                -           16.0 k          784.0 k        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_18/depthwise/Relu                                           ?                -                ?                ?        1x7x7x640
+    Conv2D MobilenetEdgeTPU/expanded_conv_18/project/Conv2D                                      39.2 k        1x7x7x640          102.4 k           5.02 M        1x7x7x160
+    Conv2D MobilenetEdgeTPU/expanded_conv_19/expand/Conv2D                                       39.2 k        1x7x7x160          102.4 k           5.02 M        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_19/expand/Relu                                              ?                -                ?                ?        1x7x7x640
+ DepthConv MobilenetEdgeTPU/expanded_conv_19/depthwise/depthwise                                 62.7 k                -           16.0 k          784.0 k        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_19/depthwise/Relu                                           ?                -                ?                ?        1x7x7x640
+    Conv2D MobilenetEdgeTPU/expanded_conv_19/project/Conv2D                                      39.2 k        1x7x7x640          102.4 k           5.02 M        1x7x7x160
+    Conv2D MobilenetEdgeTPU/expanded_conv_20/expand/Conv2D                                       39.2 k        1x7x7x160          102.4 k           5.02 M        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_20/expand/Relu                                              ?                -                ?                ?        1x7x7x640
+ DepthConv MobilenetEdgeTPU/expanded_conv_20/depthwise/depthwise                                 62.7 k                -           16.0 k          784.0 k        1x7x7x640
+      Relu MobilenetEdgeTPU/expanded_conv_20/depthwise/Relu                                           ?                -                ?                ?        1x7x7x640
+    Conv2D MobilenetEdgeTPU/expanded_conv_20/project/Conv2D                                      39.2 k        1x7x7x640          102.4 k           5.02 M        1x7x7x160
+    Conv2D MobilenetEdgeTPU/expanded_conv_21/expand/Conv2D                                       70.6 k        1x7x7x160          204.8 k           10.0 M       1x7x7x1280
+      Relu MobilenetEdgeTPU/expanded_conv_21/expand/Relu                                              ?                -                ?                ?       1x7x7x1280
+ DepthConv MobilenetEdgeTPU/expanded_conv_21/depthwise/depthwise                                125.4 k                -           11.5 k          564.5 k       1x7x7x1280
+      Relu MobilenetEdgeTPU/expanded_conv_21/depthwise/Relu                                           ?                -                ?                ?       1x7x7x1280
+    Conv2D MobilenetEdgeTPU/expanded_conv_21/project/Conv2D                                      72.1 k       1x7x7x1280          245.8 k           12.0 M        1x7x7x192
+    Conv2D MobilenetEdgeTPU/Conv_1/Conv2D                                                        72.1 k        1x7x7x192          245.8 k           12.0 M       1x7x7x1280
+      Relu MobilenetEdgeTPU/Conv_1/Relu                                                               ?                -                ?                ?       1x7x7x1280
+   AvgPool MobilenetEdgeTPU/Logits/AvgPool2D                                                          ?       1x7x7x1280                ?           62.7 k       1x1x1x1280
+    Conv2D MobilenetEdgeTPU/Logits/Conv2d_1c_1x1/Conv2D                                          2.28 k       1x1x1x1280           1.28 M           1.28 M       1x1x1x1001
+-----
+     Total Total                                                                                 11.6 M                -           4.05 M          990.7 M                -
+
+
+# pylint: enable=line-too-long
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -22,7 +356,8 @@ import copy
 import functools
 import numpy as np
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import slim as contrib_slim
 
 from nets.mobilenet import conv_blocks as ops
@@ -126,6 +461,17 @@ DEFAULTS = {
     },
 }
 
+DEFAULTS_GROUP_NORM = {
+    (ops.expanded_conv,):
+        dict(normalizer_fn=contrib_layers.group_norm, residual=True),
+    (slim.conv2d, slim.fully_connected, slim.separable_conv2d): {
+        'normalizer_fn': contrib_layers.group_norm,
+        'activation_fn': tf.nn.relu,
+    },
+    (contrib_layers.group_norm,): {
+        'groups': 8
+    },
+}
 # Compatible checkpoint: http://mldash/5511169891790690458#scalars
 V3_LARGE = dict(
     defaults=dict(DEFAULTS),
@@ -276,6 +622,7 @@ def mobilenet(input_tensor,
               scope='MobilenetV3',
               conv_defs=None,
               finegrain_classification_mode=False,
+              use_groupnorm=False,
               **kwargs):
   """Creates mobilenet V3 network.
 
@@ -288,20 +635,22 @@ def mobilenet(input_tensor,
   Args:
     input_tensor: The input tensor
     num_classes: number of classes
-    depth_multiplier: The multiplier applied to scale number of
-    channels in each layer.
+    depth_multiplier: The multiplier applied to scale number of channels in each
+      layer.
     scope: Scope of the operator
-    conv_defs: Which version to create. Could be large/small or
-    any conv_def (see mobilenet_v3.py for examples).
-    finegrain_classification_mode: When set to True, the model
-    will keep the last layer large even for small multipliers. Following
-    https://arxiv.org/abs/1801.04381
-    it improves performance for ImageNet-type of problems.
-      *Note* ignored if final_endpoint makes the builder exit earlier.
-    **kwargs: passed directly to mobilenet.mobilenet:
-      prediction_fn- what prediction function to use.
-      reuse-: whether to reuse variables (if reuse set to true, scope
-      must be given).
+    conv_defs: Which version to create. Could be large/small or any conv_def
+      (see mobilenet_v3.py for examples).
+    finegrain_classification_mode: When set to True, the model will keep the
+      last layer large even for small multipliers. Following
+    https://arxiv.org/abs/1801.04381 it improves performance for ImageNet-type
+      of problems. *Note* ignored if final_endpoint makes the builder exit
+      earlier.
+    use_groupnorm: When set to True, use group_norm as normalizer_fn.
+    **kwargs: passed directly to mobilenet.mobilenet: prediction_fn- what
+      prediction function to use.
+      reuse-: whether to reuse variables (if reuse set to true, scope must be
+        given).
+
   Returns:
     logits/endpoints pair
 
@@ -313,6 +662,16 @@ def mobilenet(input_tensor,
   if 'multiplier' in kwargs:
     raise ValueError('mobilenetv2 doesn\'t support generic '
                      'multiplier parameter use "depth_multiplier" instead.')
+
+  if use_groupnorm:
+    conv_defs = copy.deepcopy(conv_defs)
+    conv_defs['defaults'] = dict(DEFAULTS_GROUP_NORM)
+    conv_defs['defaults'].update({
+        (contrib_layers.group_norm,): {
+            'groups': kwargs.pop('groups', 8)
+        }
+    })
+
   if finegrain_classification_mode:
     conv_defs = copy.deepcopy(conv_defs)
     conv_defs['spec'][-1] = conv_defs['spec'][-1]._replace(

--- a/research/slim/nets/mobilenet/mobilenet_v3.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3.py
@@ -357,13 +357,11 @@ import functools
 import numpy as np
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets.mobilenet import conv_blocks as ops
 from nets.mobilenet import mobilenet as lib
 
-slim = contrib_slim
 op = lib.op
 expand_input = ops.expand_input_by_factor
 
@@ -462,13 +460,12 @@ DEFAULTS = {
 }
 
 DEFAULTS_GROUP_NORM = {
-    (ops.expanded_conv,):
-        dict(normalizer_fn=contrib_layers.group_norm, residual=True),
+    (ops.expanded_conv,): dict(normalizer_fn=slim.group_norm, residual=True),
     (slim.conv2d, slim.fully_connected, slim.separable_conv2d): {
-        'normalizer_fn': contrib_layers.group_norm,
+        'normalizer_fn': slim.group_norm,
         'activation_fn': tf.nn.relu,
     },
-    (contrib_layers.group_norm,): {
+    (slim.group_norm,): {
         'groups': 8
     },
 }
@@ -629,28 +626,28 @@ def mobilenet(input_tensor,
   Inference mode is created by default. To create training use training_scope
   below.
 
-  with tf.contrib.slim.arg_scope(mobilenet_v3.training_scope()):
+  with slim.arg_scope(mobilenet_v3.training_scope()):
      logits, endpoints = mobilenet_v3.mobilenet(input_tensor)
 
   Args:
     input_tensor: The input tensor
     num_classes: number of classes
-    depth_multiplier: The multiplier applied to scale number of channels in each
-      layer.
+    depth_multiplier: The multiplier applied to scale number of
+    channels in each layer.
     scope: Scope of the operator
-    conv_defs: Which version to create. Could be large/small or any conv_def
-      (see mobilenet_v3.py for examples).
-    finegrain_classification_mode: When set to True, the model will keep the
-      last layer large even for small multipliers. Following
-    https://arxiv.org/abs/1801.04381 it improves performance for ImageNet-type
-      of problems. *Note* ignored if final_endpoint makes the builder exit
-      earlier.
+    conv_defs: Which version to create. Could be large/small or
+    any conv_def (see mobilenet_v3.py for examples).
+    finegrain_classification_mode: When set to True, the model
+    will keep the last layer large even for small multipliers. Following
+    https://arxiv.org/abs/1801.04381
+    it improves performance for ImageNet-type of problems.
+      *Note* ignored if final_endpoint makes the builder exit earlier.
     use_groupnorm: When set to True, use group_norm as normalizer_fn.
-    **kwargs: passed directly to mobilenet.mobilenet: prediction_fn- what
-      prediction function to use.
-      reuse-: whether to reuse variables (if reuse set to true, scope must be
-        given).
 
+    **kwargs: passed directly to mobilenet.mobilenet:
+      prediction_fn- what prediction function to use.
+      reuse-: whether to reuse variables (if reuse set to true, scope
+      must be given).
   Returns:
     logits/endpoints pair
 
@@ -667,7 +664,7 @@ def mobilenet(input_tensor,
     conv_defs = copy.deepcopy(conv_defs)
     conv_defs['defaults'] = dict(DEFAULTS_GROUP_NORM)
     conv_defs['defaults'].update({
-        (contrib_layers.group_norm,): {
+        (slim.group_norm,): {
             'groups': kwargs.pop('groups', 8)
         }
     })

--- a/research/slim/nets/mobilenet/mobilenet_v3_test.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3_test.py
@@ -47,7 +47,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetV3Large(self, use_groupnorm):
     logits, endpoints = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         use_groupnorm=use_groupnorm)
     self.assertEqual(endpoints['layer_19'].shape, [1, 1, 1, 1280])
     self.assertEqual(logits.shape, [1, 1001])
@@ -57,7 +57,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetV3Small(self, use_groupnorm):
     _, endpoints = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         conv_defs=mobilenet_v3.V3_SMALL,
         use_groupnorm=use_groupnorm)
     self.assertEqual(endpoints['layer_15'].shape, [1, 1, 1, 1024])
@@ -67,7 +67,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetEdgeTpu(self, use_groupnorm):
     _, endpoints = mobilenet_v3.edge_tpu(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         use_groupnorm=use_groupnorm)
     self.assertIn('Inference mode is created by default',
                   mobilenet_v3.edge_tpu.__doc__)
@@ -78,7 +78,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
 
   def testMobilenetEdgeTpuChangeScope(self):
     _, endpoints = mobilenet_v3.edge_tpu(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)), scope='Scope')
+        tf.placeholder(tf.float32, (1, 224, 224, 3)), scope='Scope')
     self.assertStartsWith(
         endpoints['layer_24'].name, 'Scope')
 
@@ -86,7 +86,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetV3BaseOnly(self, use_groupnorm):
     result, endpoints = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         conv_defs=mobilenet_v3.V3_LARGE,
         use_groupnorm=use_groupnorm,
         base_only=True,
@@ -112,7 +112,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetV3WithReduceMean(self, use_groupnorm):
     _, _ = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         conv_defs=mobilenet_v3.V3_SMALL,
         use_groupnorm=use_groupnorm,
         use_reduce_mean_for_pooling=True)
@@ -125,7 +125,7 @@ class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
                                   ('with_groupnorm', True))
   def testMobilenetV3WithOutReduceMean(self, use_groupnorm):
     _, _ = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        tf.placeholder(tf.float32, (1, 224, 224, 3)),
         conv_defs=mobilenet_v3.V3_SMALL,
         use_groupnorm=use_groupnorm,
         use_reduce_mean_for_pooling=False)

--- a/research/slim/nets/mobilenet/mobilenet_v3_test.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3_test.py
@@ -18,38 +18,63 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from absl.testing import absltest
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from nets.mobilenet import mobilenet_v3
+from google3.testing.pybase import parameterized
 
 
-class MobilenetV3Test(absltest.TestCase):
+class MobilenetV3Test(tf.test.TestCase, parameterized.TestCase):
 
-  def setUp(self):
-    super(MobilenetV3Test, self).setUp()
-    tf.compat.v1.reset_default_graph()
+  # pylint: disable = g-unreachable-test-method
+  def assertVariablesHaveNormalizerFn(self, use_groupnorm):
+    global_variables = [v.name for v in tf.global_variables()]
+    has_batch_norm = False
+    has_group_norm = False
+    for global_variable in global_variables:
+      if 'BatchNorm' in global_variable:
+        has_batch_norm = True
+      if 'GroupNorm' in global_variable:
+        has_group_norm = True
+    if use_groupnorm:
+      self.assertFalse(has_batch_norm)
+      self.assertTrue(has_group_norm)
+    else:
+      self.assertTrue(has_batch_norm)
+      self.assertFalse(has_group_norm)
 
-  def testMobilenetV3Large(self):
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetV3Large(self, use_groupnorm):
     logits, endpoints = mobilenet_v3.mobilenet(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)))
+        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        use_groupnorm=use_groupnorm)
     self.assertEqual(endpoints['layer_19'].shape, [1, 1, 1, 1280])
     self.assertEqual(logits.shape, [1, 1001])
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
 
-  def testMobilenetV3Small(self):
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetV3Small(self, use_groupnorm):
     _, endpoints = mobilenet_v3.mobilenet(
         tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
-        conv_defs=mobilenet_v3.V3_SMALL)
+        conv_defs=mobilenet_v3.V3_SMALL,
+        use_groupnorm=use_groupnorm)
     self.assertEqual(endpoints['layer_15'].shape, [1, 1, 1, 1024])
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
 
-  def testMobilenetEdgeTpu(self):
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetEdgeTpu(self, use_groupnorm):
     _, endpoints = mobilenet_v3.edge_tpu(
-        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)))
+        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        use_groupnorm=use_groupnorm)
     self.assertIn('Inference mode is created by default',
                   mobilenet_v3.edge_tpu.__doc__)
     self.assertEqual(endpoints['layer_24'].shape, [1, 7, 7, 1280])
     self.assertStartsWith(
         endpoints['layer_24'].name, 'MobilenetEdgeTPU')
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
 
   def testMobilenetEdgeTpuChangeScope(self):
     _, endpoints = mobilenet_v3.edge_tpu(
@@ -57,15 +82,19 @@ class MobilenetV3Test(absltest.TestCase):
     self.assertStartsWith(
         endpoints['layer_24'].name, 'Scope')
 
-  def testMobilenetV3BaseOnly(self):
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetV3BaseOnly(self, use_groupnorm):
     result, endpoints = mobilenet_v3.mobilenet(
         tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
         conv_defs=mobilenet_v3.V3_LARGE,
+        use_groupnorm=use_groupnorm,
         base_only=True,
         final_endpoint='layer_17')
     # Get the latest layer before average pool.
     self.assertEqual(endpoints['layer_17'].shape, [1, 7, 7, 960])
     self.assertEqual(result, endpoints['layer_17'])
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
 
   def testMobilenetV3BaseOnly_VariableInput(self):
     result, endpoints = mobilenet_v3.mobilenet(
@@ -78,5 +107,34 @@ class MobilenetV3Test(absltest.TestCase):
                      [None, None, None, 960])
     self.assertEqual(result, endpoints['layer_17'])
 
+  # Use reduce mean for pooling and check for operation 'ReduceMean' in graph
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetV3WithReduceMean(self, use_groupnorm):
+    _, _ = mobilenet_v3.mobilenet(
+        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        conv_defs=mobilenet_v3.V3_SMALL,
+        use_groupnorm=use_groupnorm,
+        use_reduce_mean_for_pooling=True)
+    g = tf.get_default_graph()
+    reduce_mean = [v for v in g.get_operations() if 'ReduceMean' in v.name]
+    self.assertNotEmpty(reduce_mean)
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
+
+  @parameterized.named_parameters(('without_groupnorm', False),
+                                  ('with_groupnorm', True))
+  def testMobilenetV3WithOutReduceMean(self, use_groupnorm):
+    _, _ = mobilenet_v3.mobilenet(
+        tf.compat.v1.placeholder(tf.float32, (1, 224, 224, 3)),
+        conv_defs=mobilenet_v3.V3_SMALL,
+        use_groupnorm=use_groupnorm,
+        use_reduce_mean_for_pooling=False)
+    g = tf.get_default_graph()
+    reduce_mean = [v for v in g.get_operations() if 'ReduceMean' in v.name]
+    self.assertEmpty(reduce_mean)
+    self.assertVariablesHaveNormalizerFn(use_groupnorm)
+
+
 if __name__ == '__main__':
-  absltest.main()
+  # absltest.main()
+  tf.test.main()

--- a/research/slim/nets/mobilenet_v1.py
+++ b/research/slim/nets/mobilenet_v1.py
@@ -109,10 +109,7 @@ from collections import namedtuple
 import functools
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 # Conv and DepthSepConv namedtuple define layers of the MobileNet architecture
 # Conv defines 3x3 convolution layers
@@ -311,7 +308,7 @@ def mobilenet_v1(inputs,
                  min_depth=8,
                  depth_multiplier=1.0,
                  conv_defs=None,
-                 prediction_fn=contrib_layers.softmax,
+                 prediction_fn=slim.softmax,
                  spatial_squeeze=True,
                  reuse=None,
                  scope='MobilenetV1',
@@ -467,7 +464,7 @@ def mobilenet_v1_arg_scope(
 
   # Set weight_decay for weights in Conv and DepthSepConv layers.
   weights_init = tf.compat.v1.truncated_normal_initializer(stddev=stddev)
-  regularizer = contrib_layers.l2_regularizer(weight_decay)
+  regularizer = slim.l2_regularizer(weight_decay)
   if regularize_depthwise:
     depthwise_regularizer = regularizer
   else:

--- a/research/slim/nets/mobilenet_v1.py
+++ b/research/slim/nets/mobilenet_v1.py
@@ -108,7 +108,7 @@ from __future__ import print_function
 from collections import namedtuple
 import functools
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/nets/mobilenet_v1.py
+++ b/research/slim/nets/mobilenet_v1.py
@@ -230,7 +230,7 @@ def mobilenet_v1_base(inputs,
   padding = 'SAME'
   if use_explicit_padding:
     padding = 'VALID'
-  with tf.compat.v1.variable_scope(scope, 'MobilenetV1', [inputs]):
+  with tf.variable_scope(scope, 'MobilenetV1', [inputs]):
     with slim.arg_scope([slim.conv2d, slim.separable_conv2d], padding=padding):
       # The current_stride variable keeps track of the output stride of the
       # activations, i.e., the running product of convolution strides up to the
@@ -356,7 +356,7 @@ def mobilenet_v1(inputs,
     raise ValueError('Invalid input tensor rank, expected 4, was: %d' %
                      len(input_shape))
 
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'MobilenetV1', [inputs], reuse=reuse) as scope:
     with slim.arg_scope([slim.batch_norm, slim.dropout],
                         is_training=is_training):
@@ -364,7 +364,7 @@ def mobilenet_v1(inputs,
                                           min_depth=min_depth,
                                           depth_multiplier=depth_multiplier,
                                           conv_defs=conv_defs)
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         if global_pool:
           # Global average pooling.
           net = tf.reduce_mean(
@@ -432,7 +432,7 @@ def mobilenet_v1_arg_scope(
     regularize_depthwise=False,
     batch_norm_decay=0.9997,
     batch_norm_epsilon=0.001,
-    batch_norm_updates_collections=tf.compat.v1.GraphKeys.UPDATE_OPS,
+    batch_norm_updates_collections=tf.GraphKeys.UPDATE_OPS,
     normalizer_fn=slim.batch_norm):
   """Defines the default MobilenetV1 arg scope.
 
@@ -463,7 +463,7 @@ def mobilenet_v1_arg_scope(
     batch_norm_params['is_training'] = is_training
 
   # Set weight_decay for weights in Conv and DepthSepConv layers.
-  weights_init = tf.compat.v1.truncated_normal_initializer(stddev=stddev)
+  weights_init = tf.truncated_normal_initializer(stddev=stddev)
   regularizer = slim.l2_regularizer(weight_decay)
   if regularize_depthwise:
     depthwise_regularizer = regularizer

--- a/research/slim/nets/mobilenet_v1_eval.py
+++ b/research/slim/nets/mobilenet_v1_eval.py
@@ -19,16 +19,14 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import six
 import tensorflow.compat.v1 as tf
+import tf_slim as slim
+
 from tensorflow.contrib import quantize as contrib_quantize
-from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_factory
 from nets import mobilenet_v1
 from preprocessing import preprocessing_factory
-
-slim = contrib_slim
 
 flags = tf.compat.v1.app.flags
 
@@ -101,10 +99,10 @@ def metrics(logits, labels):
       'Recall_5':
           tf.compat.v1.metrics.recall_at_k(labels, logits, 5),
   })
-  for name, value in six.iteritems(names_to_values):
+  for name, value in names_to_values.iteritems():
     slim.summaries.add_scalar_summary(
         value, name, prefix='eval', print_summary=True)
-  return list(names_to_updates.values())
+  return names_to_updates.values()
 
 
 def build_model():

--- a/research/slim/nets/mobilenet_v1_eval.py
+++ b/research/slim/nets/mobilenet_v1_eval.py
@@ -28,7 +28,7 @@ from datasets import dataset_factory
 from nets import mobilenet_v1
 from preprocessing import preprocessing_factory
 
-flags = tf.compat.v1.app.flags
+flags = tf.app.flags
 
 flags.DEFINE_string('master', '', 'Session master')
 flags.DEFINE_integer('batch_size', 250, 'Batch size')
@@ -73,7 +73,7 @@ def imagenet_input(is_training):
 
   image = image_preprocessing_fn(image, FLAGS.image_size, FLAGS.image_size)
 
-  images, labels = tf.compat.v1.train.batch(
+  images, labels = tf.train.batch(
       tensors=[image, label],
       batch_size=FLAGS.batch_size,
       num_threads=4,
@@ -94,10 +94,10 @@ def metrics(logits, labels):
   labels = tf.squeeze(labels)
   names_to_values, names_to_updates = slim.metrics.aggregate_metric_map({
       'Accuracy':
-          tf.compat.v1.metrics.accuracy(
+          tf.metrics.accuracy(
               tf.argmax(input=logits, axis=1), labels),
       'Recall_5':
-          tf.compat.v1.metrics.recall_at_k(labels, logits, 5),
+          tf.metrics.recall_at_k(labels, logits, 5),
   })
   for name, value in names_to_values.iteritems():
     slim.summaries.add_scalar_summary(
@@ -153,4 +153,4 @@ def main(unused_arg):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run(main)
+  tf.app.run(main)

--- a/research/slim/nets/mobilenet_v1_eval.py
+++ b/research/slim/nets/mobilenet_v1_eval.py
@@ -19,7 +19,8 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import tensorflow as tf
+import six
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib import slim as contrib_slim
 
@@ -100,10 +101,10 @@ def metrics(logits, labels):
       'Recall_5':
           tf.compat.v1.metrics.recall_at_k(labels, logits, 5),
   })
-  for name, value in names_to_values.iteritems():
+  for name, value in six.iteritems(names_to_values):
     slim.summaries.add_scalar_summary(
         value, name, prefix='eval', print_summary=True)
-  return names_to_updates.values()
+  return list(names_to_updates.values())
 
 
 def build_model():

--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -20,11 +20,9 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import mobilenet_v1
-
-slim = contrib_slim
 
 
 class MobilenetV1Test(tf.test.TestCase):
@@ -79,7 +77,7 @@ class MobilenetV1Test(tf.test.TestCase):
                           'Conv2d_11_depthwise', 'Conv2d_11_pointwise',
                           'Conv2d_12_depthwise', 'Conv2d_12_pointwise',
                           'Conv2d_13_depthwise', 'Conv2d_13_pointwise']
-    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
+    self.assertItemsEqual(end_points.keys(), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -105,7 +103,7 @@ class MobilenetV1Test(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'MobilenetV1/' + endpoint))
-        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
+        self.assertItemsEqual(endpoints[:index + 1], end_points.keys())
 
   def testBuildCustomNetworkUsingConvDefs(self):
     batch_size = 5
@@ -127,7 +125,7 @@ class MobilenetV1Test(tf.test.TestCase):
                           'Conv2d_1_depthwise', 'Conv2d_1_pointwise',
                           'Conv2d_2_depthwise', 'Conv2d_2_pointwise',
                           'Conv2d_3_depthwise', 'Conv2d_3_pointwise']
-    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
+    self.assertItemsEqual(end_points.keys(), expected_endpoints)
 
   def testBuildAndCheckAllEndPointsUptoConv2d_13(self):
     batch_size = 5
@@ -168,14 +166,13 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 7, 7, 1024],
                         'Conv2d_13_depthwise': [batch_size, 7, 7, 1024],
                         'Conv2d_13_pointwise': [batch_size, 7, 7, 1024]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(),
+                          explicit_padding_end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -223,14 +220,13 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 14, 14, 1024],
                         'Conv2d_13_depthwise': [batch_size, 14, 14, 1024],
                         'Conv2d_13_pointwise': [batch_size, 14, 14, 1024]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(),
+                          explicit_padding_end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -278,14 +274,13 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 28, 28, 1024],
                         'Conv2d_13_depthwise': [batch_size, 28, 28, 1024],
                         'Conv2d_13_pointwise': [batch_size, 28, 28, 1024]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(),
+                          explicit_padding_end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -332,14 +327,13 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 4, 4, 768],
                         'Conv2d_13_depthwise': [batch_size, 4, 4, 768],
                         'Conv2d_13_pointwise': [batch_size, 4, 4, 768]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(),
+                          explicit_padding_end_points.keys())
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(

--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import mobilenet_v1
@@ -79,7 +79,7 @@ class MobilenetV1Test(tf.test.TestCase):
                           'Conv2d_11_depthwise', 'Conv2d_11_pointwise',
                           'Conv2d_12_depthwise', 'Conv2d_12_pointwise',
                           'Conv2d_13_depthwise', 'Conv2d_13_pointwise']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpoint(self):
     batch_size = 5
@@ -105,7 +105,7 @@ class MobilenetV1Test(tf.test.TestCase):
             inputs, final_endpoint=endpoint)
         self.assertTrue(out_tensor.op.name.startswith(
             'MobilenetV1/' + endpoint))
-        self.assertItemsEqual(endpoints[:index+1], end_points.keys())
+        self.assertItemsEqual(endpoints[:index + 1], list(end_points.keys()))
 
   def testBuildCustomNetworkUsingConvDefs(self):
     batch_size = 5
@@ -127,7 +127,7 @@ class MobilenetV1Test(tf.test.TestCase):
                           'Conv2d_1_depthwise', 'Conv2d_1_pointwise',
                           'Conv2d_2_depthwise', 'Conv2d_2_pointwise',
                           'Conv2d_3_depthwise', 'Conv2d_3_pointwise']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildAndCheckAllEndPointsUptoConv2d_13(self):
     batch_size = 5
@@ -168,13 +168,14 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 7, 7, 1024],
                         'Conv2d_13_depthwise': [batch_size, 7, 7, 1024],
                         'Conv2d_13_pointwise': [batch_size, 7, 7, 1024]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(endpoints_shapes.keys(),
-                          explicit_padding_end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -222,13 +223,14 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 14, 14, 1024],
                         'Conv2d_13_depthwise': [batch_size, 14, 14, 1024],
                         'Conv2d_13_pointwise': [batch_size, 14, 14, 1024]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(endpoints_shapes.keys(),
-                          explicit_padding_end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -276,13 +278,14 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 28, 28, 1024],
                         'Conv2d_13_depthwise': [batch_size, 28, 28, 1024],
                         'Conv2d_13_pointwise': [batch_size, 28, 28, 1024]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(endpoints_shapes.keys(),
-                          explicit_padding_end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(
@@ -329,13 +332,14 @@ class MobilenetV1Test(tf.test.TestCase):
                         'Conv2d_12_pointwise': [batch_size, 4, 4, 768],
                         'Conv2d_13_depthwise': [batch_size, 4, 4, 768],
                         'Conv2d_13_pointwise': [batch_size, 4, 4, 768]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)
-    self.assertItemsEqual(endpoints_shapes.keys(),
-                          explicit_padding_end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(explicit_padding_end_points.keys()))
     for endpoint_name, expected_shape in endpoints_shapes.items():
       self.assertTrue(endpoint_name in explicit_padding_end_points)
       self.assertListEqual(

--- a/research/slim/nets/mobilenet_v1_test.py
+++ b/research/slim/nets/mobilenet_v1_test.py
@@ -418,13 +418,13 @@ class MobilenetV1Test(tf.test.TestCase):
                          [batch_size, 4, 4, 1024])
 
   def testUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 2
     height, width = 224, 224
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = mobilenet_v1.mobilenet_v1(inputs, num_classes)
       self.assertTrue(logits.op.name.startswith('MobilenetV1/Logits'))
@@ -432,18 +432,18 @@ class MobilenetV1Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Conv2d_13_pointwise']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 7, 7, 1024])
 
   def testGlobalPoolUnknownImageShape(self):
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
     batch_size = 1
     height, width = 250, 300
     num_classes = 1000
     input_np = np.random.uniform(0, 1, (batch_size, height, width, 3))
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(
+      inputs = tf.placeholder(
           tf.float32, shape=(batch_size, None, None, 3))
       logits, end_points = mobilenet_v1.mobilenet_v1(inputs, num_classes,
                                                      global_pool=True)
@@ -452,7 +452,7 @@ class MobilenetV1Test(tf.test.TestCase):
                            [batch_size, num_classes])
       pre_pool = end_points['Conv2d_13_pointwise']
       feed_dict = {inputs: input_np}
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       pre_pool_out = sess.run(pre_pool, feed_dict=feed_dict)
       self.assertListEqual(list(pre_pool_out.shape), [batch_size, 8, 10, 1024])
 
@@ -461,7 +461,7 @@ class MobilenetV1Test(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
 
-    inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+    inputs = tf.placeholder(tf.float32, (None, height, width, 3))
     logits, _ = mobilenet_v1.mobilenet_v1(inputs, num_classes)
     self.assertTrue(logits.op.name.startswith('MobilenetV1/Logits'))
     self.assertListEqual(logits.get_shape().as_list(),
@@ -469,7 +469,7 @@ class MobilenetV1Test(tf.test.TestCase):
     images = tf.random.uniform((batch_size, height, width, 3))
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -484,7 +484,7 @@ class MobilenetV1Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -502,7 +502,7 @@ class MobilenetV1Test(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (eval_batch_size,))
 
@@ -514,7 +514,7 @@ class MobilenetV1Test(tf.test.TestCase):
                                           spatial_squeeze=False)
 
     with self.test_session() as sess:
-      tf.compat.v1.global_variables_initializer().run()
+      tf.global_variables_initializer().run()
       logits_out = sess.run(logits)
       self.assertListEqual(list(logits_out.shape), [1, 1, 1, num_classes])
 

--- a/research/slim/nets/mobilenet_v1_train.py
+++ b/research/slim/nets/mobilenet_v1_train.py
@@ -27,7 +27,7 @@ from datasets import dataset_factory
 from nets import mobilenet_v1
 from preprocessing import preprocessing_factory
 
-flags = tf.compat.v1.app.flags
+flags = tf.app.flags
 
 flags.DEFINE_string('master', '', 'Session master')
 flags.DEFINE_integer('task', 0, 'Task')
@@ -103,10 +103,10 @@ def imagenet_input(is_training):
 
   image = image_preprocessing_fn(image, FLAGS.image_size, FLAGS.image_size)
 
-  images, labels = tf.compat.v1.train.batch([image, label],
-                                            batch_size=FLAGS.batch_size,
-                                            num_threads=4,
-                                            capacity=5 * FLAGS.batch_size)
+  images, labels = tf.train.batch([image, label],
+                                  batch_size=FLAGS.batch_size,
+                                  num_threads=4,
+                                  capacity=5 * FLAGS.batch_size)
   labels = slim.one_hot_encoding(labels, FLAGS.num_classes)
   return images, labels
 
@@ -121,7 +121,7 @@ def build_model():
   """
   g = tf.Graph()
   with g.as_default(), tf.device(
-      tf.compat.v1.train.replica_device_setter(FLAGS.ps_tasks)):
+      tf.train.replica_device_setter(FLAGS.ps_tasks)):
     inputs, labels = imagenet_input(is_training=True)
     with slim.arg_scope(mobilenet_v1.mobilenet_v1_arg_scope(is_training=True)):
       logits, _ = mobilenet_v1.mobilenet_v1(
@@ -130,7 +130,7 @@ def build_model():
           depth_multiplier=FLAGS.depth_multiplier,
           num_classes=FLAGS.num_classes)
 
-    tf.compat.v1.losses.softmax_cross_entropy(labels, logits)
+    tf.losses.softmax_cross_entropy(labels, logits)
 
     # Call rewriter to produce graph with fake quant ops and folded batch norms
     # quant_delay delays start of quantization till quant_delay steps, allowing
@@ -138,19 +138,19 @@ def build_model():
     if FLAGS.quantize:
       contrib_quantize.create_training_graph(quant_delay=get_quant_delay())
 
-    total_loss = tf.compat.v1.losses.get_total_loss(name='total_loss')
+    total_loss = tf.losses.get_total_loss(name='total_loss')
     # Configure the learning rate using an exponential decay.
     num_epochs_per_decay = 2.5
     imagenet_size = 1271167
     decay_steps = int(imagenet_size / FLAGS.batch_size * num_epochs_per_decay)
 
-    learning_rate = tf.compat.v1.train.exponential_decay(
+    learning_rate = tf.train.exponential_decay(
         get_learning_rate(),
-        tf.compat.v1.train.get_or_create_global_step(),
+        tf.train.get_or_create_global_step(),
         decay_steps,
         _LEARNING_RATE_DECAY_FACTOR,
         staircase=True)
-    opt = tf.compat.v1.train.GradientDescentOptimizer(learning_rate)
+    opt = tf.train.GradientDescentOptimizer(learning_rate)
 
     train_tensor = slim.learning.create_train_op(
         total_loss,
@@ -165,8 +165,8 @@ def get_checkpoint_init_fn():
   """Returns the checkpoint init_fn if the checkpoint is provided."""
   if FLAGS.fine_tune_checkpoint:
     variables_to_restore = slim.get_variables_to_restore()
-    global_step_reset = tf.compat.v1.assign(
-        tf.compat.v1.train.get_or_create_global_step(), 0)
+    global_step_reset = tf.assign(
+        tf.train.get_or_create_global_step(), 0)
     # When restoring from a floating point model, the min/max values for
     # quantized weights and activations are not present.
     # We instruct slim to ignore variables that are missing during restoration
@@ -202,7 +202,7 @@ def train_model():
         save_summaries_secs=FLAGS.save_summaries_secs,
         save_interval_secs=FLAGS.save_interval_secs,
         init_fn=get_checkpoint_init_fn(),
-        global_step=tf.compat.v1.train.get_global_step())
+        global_step=tf.train.get_global_step())
 
 
 def main(unused_arg):
@@ -210,4 +210,4 @@ def main(unused_arg):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run(main)
+  tf.app.run(main)

--- a/research/slim/nets/mobilenet_v1_train.py
+++ b/research/slim/nets/mobilenet_v1_train.py
@@ -19,14 +19,13 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
+import tf_slim as slim
+
 from tensorflow.contrib import quantize as contrib_quantize
-from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_factory
 from nets import mobilenet_v1
 from preprocessing import preprocessing_factory
-
-slim = contrib_slim
 
 flags = tf.compat.v1.app.flags
 

--- a/research/slim/nets/mobilenet_v1_train.py
+++ b/research/slim/nets/mobilenet_v1_train.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/nets/nasnet/nasnet.py
+++ b/research/slim/nets/nasnet/nasnet.py
@@ -22,15 +22,12 @@ from __future__ import print_function
 
 import copy
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
-from tensorflow.contrib import slim as contrib_slim
-from tensorflow.contrib import training as contrib_training
+import tf_slim as slim
 
+from tensorflow.contrib import training as contrib_training
 from nets.nasnet import nasnet_utils
 
-arg_scope = contrib_framework.arg_scope
-slim = contrib_slim
+arg_scope = slim.arg_scope
 
 
 # Notes for training NASNet Cifar Model
@@ -142,9 +139,8 @@ def nasnet_cifar_arg_scope(weight_decay=5e-4,
       'scale': True,
       'fused': True,
   }
-  weights_regularizer = contrib_layers.l2_regularizer(weight_decay)
-  weights_initializer = contrib_layers.variance_scaling_initializer(
-      mode='FAN_OUT')
+  weights_regularizer = slim.l2_regularizer(weight_decay)
+  weights_initializer = slim.variance_scaling_initializer(mode='FAN_OUT')
   with arg_scope([slim.fully_connected, slim.conv2d, slim.separable_conv2d],
                  weights_regularizer=weights_regularizer,
                  weights_initializer=weights_initializer):
@@ -178,9 +174,8 @@ def nasnet_mobile_arg_scope(weight_decay=4e-5,
       'scale': True,
       'fused': True,
   }
-  weights_regularizer = contrib_layers.l2_regularizer(weight_decay)
-  weights_initializer = contrib_layers.variance_scaling_initializer(
-      mode='FAN_OUT')
+  weights_regularizer = slim.l2_regularizer(weight_decay)
+  weights_initializer = slim.variance_scaling_initializer(mode='FAN_OUT')
   with arg_scope([slim.fully_connected, slim.conv2d, slim.separable_conv2d],
                  weights_regularizer=weights_regularizer,
                  weights_initializer=weights_initializer):
@@ -214,9 +209,8 @@ def nasnet_large_arg_scope(weight_decay=5e-5,
       'scale': True,
       'fused': True,
   }
-  weights_regularizer = contrib_layers.l2_regularizer(weight_decay)
-  weights_initializer = contrib_layers.variance_scaling_initializer(
-      mode='FAN_OUT')
+  weights_regularizer = slim.l2_regularizer(weight_decay)
+  weights_initializer = slim.variance_scaling_initializer(mode='FAN_OUT')
   with arg_scope([slim.fully_connected, slim.conv2d, slim.separable_conv2d],
                  weights_regularizer=weights_regularizer,
                  weights_initializer=weights_initializer):
@@ -248,7 +242,7 @@ def _build_aux_head(net, end_points, num_classes, hparams, scope):
       aux_logits = slim.conv2d(aux_logits, 768, shape, padding='VALID')
       aux_logits = slim.batch_norm(aux_logits, scope='aux_bn1')
       aux_logits = activation_fn(aux_logits)
-      aux_logits = contrib_layers.flatten(aux_logits)
+      aux_logits = slim.flatten(aux_logits)
       aux_logits = slim.fully_connected(aux_logits, num_classes)
       end_points['AuxLogits'] = aux_logits
 

--- a/research/slim/nets/nasnet/nasnet.py
+++ b/research/slim/nets/nasnet/nasnet.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 from tensorflow.contrib import slim as contrib_slim

--- a/research/slim/nets/nasnet/nasnet.py
+++ b/research/slim/nets/nasnet/nasnet.py
@@ -225,9 +225,9 @@ def nasnet_large_arg_scope(weight_decay=5e-5,
 def _build_aux_head(net, end_points, num_classes, hparams, scope):
   """Auxiliary head used for all models across all datasets."""
   activation_fn = tf.nn.relu6 if hparams.use_bounded_activation else tf.nn.relu
-  with tf.compat.v1.variable_scope(scope):
+  with tf.variable_scope(scope):
     aux_logits = tf.identity(net)
-    with tf.compat.v1.variable_scope('aux_logits'):
+    with tf.variable_scope('aux_logits'):
       aux_logits = slim.avg_pool2d(
           aux_logits, [5, 5], stride=3, padding='VALID')
       aux_logits = slim.conv2d(aux_logits, 128, [1, 1], scope='proj')
@@ -296,7 +296,7 @@ def build_nasnet_cifar(images, num_classes,
   _update_hparams(hparams, is_training)
 
   if tf.test.is_gpu_available() and hparams.data_format == 'NHWC':
-    tf.compat.v1.logging.info(
+    tf.logging.info(
         'A GPU is available on the machine, consider using NCHW '
         'data format for increased speed on GPU.')
 
@@ -349,7 +349,7 @@ def build_nasnet_mobile(images, num_classes,
   _update_hparams(hparams, is_training)
 
   if tf.test.is_gpu_available() and hparams.data_format == 'NHWC':
-    tf.compat.v1.logging.info(
+    tf.logging.info(
         'A GPU is available on the machine, consider using NCHW '
         'data format for increased speed on GPU.')
 
@@ -405,7 +405,7 @@ def build_nasnet_large(images, num_classes,
   _update_hparams(hparams, is_training)
 
   if tf.test.is_gpu_available() and hparams.data_format == 'NHWC':
-    tf.compat.v1.logging.info(
+    tf.logging.info(
         'A GPU is available on the machine, consider using NCHW '
         'data format for increased speed on GPU.')
 
@@ -531,7 +531,7 @@ def _build_nasnet_base(images,
     cell_outputs.append(net)
 
   # Final softmax layer
-  with tf.compat.v1.variable_scope('final_layer'):
+  with tf.variable_scope('final_layer'):
     net = activation_fn(net)
     net = nasnet_utils.global_avg_pool(net)
     if add_and_check_endpoint('global_pool', net) or not num_classes:

--- a/research/slim/nets/nasnet/nasnet_test.py
+++ b/research/slim/nets/nasnet/nasnet_test.py
@@ -18,11 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets.nasnet import nasnet
-
-slim = contrib_slim
 
 
 class NASNetTest(tf.test.TestCase):
@@ -151,8 +149,7 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -203,8 +200,7 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -261,8 +257,7 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]

--- a/research/slim/nets/nasnet/nasnet_test.py
+++ b/research/slim/nets/nasnet/nasnet_test.py
@@ -30,7 +30,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
       logits, end_points = nasnet.build_nasnet_cifar(inputs, num_classes)
     auxlogits = end_points['AuxLogits']
@@ -47,7 +47,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
       logits, end_points = nasnet.build_nasnet_mobile(inputs, num_classes)
     auxlogits = end_points['AuxLogits']
@@ -64,7 +64,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_large_arg_scope()):
       logits, end_points = nasnet.build_nasnet_large(inputs, num_classes)
     auxlogits = end_points['AuxLogits']
@@ -81,7 +81,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = None
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
       net, end_points = nasnet.build_nasnet_cifar(inputs, num_classes)
     self.assertFalse('AuxLogits' in end_points)
@@ -94,7 +94,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = None
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
       net, end_points = nasnet.build_nasnet_mobile(inputs, num_classes)
     self.assertFalse('AuxLogits' in end_points)
@@ -107,7 +107,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = None
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_large_arg_scope()):
       net, end_points = nasnet.build_nasnet_large(inputs, num_classes)
     self.assertFalse('AuxLogits' in end_points)
@@ -120,7 +120,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
       _, end_points = nasnet.build_nasnet_cifar(inputs, num_classes)
     endpoints_shapes = {'Stem': [batch_size, 32, 32, 96],
@@ -151,7 +151,7 @@ class NASNetTest(tf.test.TestCase):
                         'Predictions': [batch_size, num_classes]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
-      tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
+      tf.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
@@ -162,9 +162,9 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     for use_aux_head in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
-      tf.compat.v1.train.create_global_step()
+      tf.train.create_global_step()
       config = nasnet.cifar_config()
       config.set_hparam('use_aux_head', int(use_aux_head))
       with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
@@ -177,7 +177,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
       _, end_points = nasnet.build_nasnet_mobile(inputs, num_classes)
     endpoints_shapes = {'Stem': [batch_size, 28, 28, 88],
@@ -202,7 +202,7 @@ class NASNetTest(tf.test.TestCase):
                         'Predictions': [batch_size, num_classes]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
-      tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
+      tf.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
@@ -213,9 +213,9 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     for use_aux_head in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
-      tf.compat.v1.train.create_global_step()
+      tf.train.create_global_step()
       config = nasnet.mobile_imagenet_config()
       config.set_hparam('use_aux_head', int(use_aux_head))
       with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
@@ -228,7 +228,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_large_arg_scope()):
       _, end_points = nasnet.build_nasnet_large(inputs, num_classes)
     endpoints_shapes = {'Stem': [batch_size, 42, 42, 336],
@@ -259,7 +259,7 @@ class NASNetTest(tf.test.TestCase):
                         'Predictions': [batch_size, num_classes]}
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
-      tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
+      tf.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
@@ -270,9 +270,9 @@ class NASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     for use_aux_head in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
-      tf.compat.v1.train.create_global_step()
+      tf.train.create_global_step()
       config = nasnet.large_imagenet_config()
       config.set_hparam('use_aux_head', int(use_aux_head))
       with slim.arg_scope(nasnet.nasnet_large_arg_scope()):
@@ -285,19 +285,19 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     # Force all Variables to reside on the device.
-    with tf.compat.v1.variable_scope('on_cpu'), tf.device('/cpu:0'):
+    with tf.variable_scope('on_cpu'), tf.device('/cpu:0'):
       with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
         nasnet.build_nasnet_mobile(inputs, num_classes)
-    with tf.compat.v1.variable_scope('on_gpu'), tf.device('/gpu:0'):
+    with tf.variable_scope('on_gpu'), tf.device('/gpu:0'):
       with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
         nasnet.build_nasnet_mobile(inputs, num_classes)
-    for v in tf.compat.v1.get_collection(
-        tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
+    for v in tf.get_collection(
+        tf.GraphKeys.GLOBAL_VARIABLES, scope='on_cpu'):
       self.assertDeviceEqual(v.device, '/cpu:0')
-    for v in tf.compat.v1.get_collection(
-        tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
+    for v in tf.get_collection(
+        tf.GraphKeys.GLOBAL_VARIABLES, scope='on_gpu'):
       self.assertDeviceEqual(v.device, '/gpu:0')
 
   def testUnknownBatchSizeMobileModel(self):
@@ -305,13 +305,13 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     with self.test_session() as sess:
-      inputs = tf.compat.v1.placeholder(tf.float32, (None, height, width, 3))
+      inputs = tf.placeholder(tf.float32, (None, height, width, 3))
       with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
         logits, _ = nasnet.build_nasnet_mobile(inputs, num_classes)
       self.assertListEqual(logits.get_shape().as_list(),
                            [None, num_classes])
       images = tf.random.uniform((batch_size, height, width, 3))
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEquals(output.shape, (batch_size, num_classes))
 
@@ -326,7 +326,7 @@ class NASNetTest(tf.test.TestCase):
                                                num_classes,
                                                is_training=False)
       predictions = tf.argmax(input=logits, axis=1)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 
@@ -335,7 +335,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     config = nasnet.cifar_config()
     config.set_hparam('data_format', 'NCHW')
     with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
@@ -349,7 +349,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     config = nasnet.mobile_imagenet_config()
     config.set_hparam('data_format', 'NCHW')
     with slim.arg_scope(nasnet.nasnet_mobile_arg_scope()):
@@ -363,7 +363,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     config = nasnet.large_imagenet_config()
     config.set_hparam('data_format', 'NCHW')
     with slim.arg_scope(nasnet.nasnet_large_arg_scope()):
@@ -377,7 +377,7 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    global_step = tf.compat.v1.train.create_global_step()
+    global_step = tf.train.create_global_step()
     with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
       logits, end_points = nasnet.build_nasnet_cifar(inputs,
                                                      num_classes,
@@ -396,14 +396,14 @@ class NASNetTest(tf.test.TestCase):
     height, width = 32, 32
     num_classes = 10
     for use_bounded_activation in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
       config = nasnet.cifar_config()
       config.set_hparam('use_bounded_activation', use_bounded_activation)
       with slim.arg_scope(nasnet.nasnet_cifar_arg_scope()):
         _, _ = nasnet.build_nasnet_cifar(
             inputs, num_classes, config=config)
-      for node in tf.compat.v1.get_default_graph().as_graph_def().node:
+      for node in tf.get_default_graph().as_graph_def().node:
         if node.op.startswith('Relu'):
           self.assertEqual(node.op == 'Relu6', use_bounded_activation)
 

--- a/research/slim/nets/nasnet/nasnet_test.py
+++ b/research/slim/nets/nasnet/nasnet_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets.nasnet import nasnet
@@ -151,7 +151,8 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -202,7 +203,8 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -259,7 +261,8 @@ class NASNetTest(tf.test.TestCase):
                         'AuxLogits': [batch_size, num_classes],
                         'Logits': [batch_size, num_classes],
                         'Predictions': [batch_size, num_classes]}
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]

--- a/research/slim/nets/nasnet/nasnet_utils.py
+++ b/research/slim/nets/nasnet/nasnet_utils.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import slim as contrib_slim
 

--- a/research/slim/nets/nasnet/nasnet_utils.py
+++ b/research/slim/nets/nasnet/nasnet_utils.py
@@ -32,12 +32,10 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import slim as contrib_slim
 
-arg_scope = contrib_framework.arg_scope
-slim = contrib_slim
+import tf_slim as slim
 
+arg_scope = slim.arg_scope
 DATA_FORMAT_NCHW = 'NCHW'
 DATA_FORMAT_NHWC = 'NHWC'
 INVALID = 'null'
@@ -56,14 +54,14 @@ def calc_reduction_layers(num_cells, num_reduction_layers):
   return reduction_layers
 
 
-@contrib_framework.add_arg_scope
+@slim.add_arg_scope
 def get_channel_index(data_format=INVALID):
   assert data_format != INVALID
   axis = 3 if data_format == 'NHWC' else 1
   return axis
 
 
-@contrib_framework.add_arg_scope
+@slim.add_arg_scope
 def get_channel_dim(shape, data_format=INVALID):
   assert data_format != INVALID
   assert len(shape) == 4
@@ -75,7 +73,7 @@ def get_channel_dim(shape, data_format=INVALID):
     raise ValueError('Not a valid data_format', data_format)
 
 
-@contrib_framework.add_arg_scope
+@slim.add_arg_scope
 def global_avg_pool(x, data_format=INVALID):
   """Average pool away the height and width spatial dimensions of x."""
   assert data_format != INVALID
@@ -87,7 +85,7 @@ def global_avg_pool(x, data_format=INVALID):
     return tf.reduce_mean(input_tensor=x, axis=[2, 3])
 
 
-@contrib_framework.add_arg_scope
+@slim.add_arg_scope
 def factorized_reduction(net, output_filters, stride, data_format=INVALID):
   """Reduces the shape of net without information loss due to striding."""
   assert data_format != INVALID
@@ -138,7 +136,7 @@ def factorized_reduction(net, output_filters, stride, data_format=INVALID):
   return final_path
 
 
-@contrib_framework.add_arg_scope
+@slim.add_arg_scope
 def drop_path(net, keep_prob, is_training=True):
   """Drops out a whole example hiddenstate with the specified probability."""
   if is_training:
@@ -431,7 +429,7 @@ class NasNetABaseCell(object):
     net = tf.concat(values=states_to_combine, axis=concat_axis)
     return net
 
-  @contrib_framework.add_arg_scope  # No public API. For internal use only.
+  @slim.add_arg_scope  # No public API. For internal use only.
   def _apply_drop_path(self, net, current_step=None,
                        use_summaries=False, drop_connect_version='v3'):
     """Apply drop_path regularization.

--- a/research/slim/nets/nasnet/nasnet_utils_test.py
+++ b/research/slim/nets/nasnet/nasnet_utils_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from nets.nasnet import nasnet_utils
 

--- a/research/slim/nets/nasnet/nasnet_utils_test.py
+++ b/research/slim/nets/nasnet/nasnet_utils_test.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
 import tensorflow.compat.v1 as tf
 
 from nets.nasnet import nasnet_utils
@@ -51,11 +50,19 @@ class NasnetUtilsTest(tf.test.TestCase):
 
   def testGlobalAvgPool(self):
     data_formats = ['NHWC', 'NCHW']
-    inputs = tf.compat.v1.placeholder(tf.float32, (5, 10, 20, 10))
+    inputs = tf.placeholder(tf.float32, (5, 10, 20, 10))
     for data_format in data_formats:
       output = nasnet_utils.global_avg_pool(
           inputs, data_format)
       self.assertEqual(output.shape, [5, 10])
+
+  def test_factorized_reduction(self):
+    data_format = 'NHWC'
+    output_shape = (5, 10, 20, 16)
+    inputs = tf.placeholder(tf.float32, (5, 10, 20, 10))
+    output = nasnet_utils.factorized_reduction(
+        inputs, 16, stride=1, data_format=data_format)
+    self.assertSequenceEqual(output_shape, output.shape.as_list())
 
 
 if __name__ == '__main__':

--- a/research/slim/nets/nasnet/pnasnet.py
+++ b/research/slim/nets/nasnet/pnasnet.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import slim as contrib_slim
 from tensorflow.contrib import training as contrib_training

--- a/research/slim/nets/nasnet/pnasnet.py
+++ b/research/slim/nets/nasnet/pnasnet.py
@@ -23,15 +23,13 @@ from __future__ import print_function
 
 import copy
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 from tensorflow.contrib import training as contrib_training
 
 from nets.nasnet import nasnet
 from nets.nasnet import nasnet_utils
 
-arg_scope = contrib_framework.arg_scope
-slim = contrib_slim
+arg_scope = slim.arg_scope
 
 
 def large_imagenet_config():

--- a/research/slim/nets/nasnet/pnasnet.py
+++ b/research/slim/nets/nasnet/pnasnet.py
@@ -145,7 +145,7 @@ def _build_pnasnet_base(images,
       # pylint: enable=protected-access
 
   # Final softmax layer
-  with tf.compat.v1.variable_scope('final_layer'):
+  with tf.variable_scope('final_layer'):
     net = activation_fn(net)
     net = nasnet_utils.global_avg_pool(net)
     if add_and_check_endpoint('global_pool', net) or not num_classes:
@@ -174,7 +174,7 @@ def build_pnasnet_large(images,
   # pylint: enable=protected-access
 
   if tf.test.is_gpu_available() and hparams.data_format == 'NHWC':
-    tf.compat.v1.logging.info(
+    tf.logging.info(
         'A GPU is available on the machine, consider using NCHW '
         'data format for increased speed on GPU.')
 
@@ -223,7 +223,7 @@ def build_pnasnet_mobile(images,
   # pylint: enable=protected-access
 
   if tf.test.is_gpu_available() and hparams.data_format == 'NHWC':
-    tf.compat.v1.logging.info(
+    tf.logging.info(
         'A GPU is available on the machine, consider using NCHW '
         'data format for increased speed on GPU.')
 

--- a/research/slim/nets/nasnet/pnasnet_test.py
+++ b/research/slim/nets/nasnet/pnasnet_test.py
@@ -18,11 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets.nasnet import pnasnet
-
-slim = contrib_slim
 
 
 class PNASNetTest(tf.test.TestCase):
@@ -136,8 +134,7 @@ class PNASNetTest(tf.test.TestCase):
                         'Logits': [batch_size, 1000],
                        }
     self.assertEqual(len(end_points), 17)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -172,8 +169,7 @@ class PNASNetTest(tf.test.TestCase):
         'Logits': [batch_size, num_classes],
     }
     self.assertEqual(len(end_points), 14)
-    self.assertItemsEqual(
-        list(endpoints_shapes.keys()), list(end_points.keys()))
+    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]

--- a/research/slim/nets/nasnet/pnasnet_test.py
+++ b/research/slim/nets/nasnet/pnasnet_test.py
@@ -30,7 +30,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
       logits, end_points = pnasnet.build_pnasnet_large(inputs, num_classes)
     auxlogits = end_points['AuxLogits']
@@ -47,7 +47,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
       logits, end_points = pnasnet.build_pnasnet_mobile(inputs, num_classes)
     auxlogits = end_points['AuxLogits']
@@ -62,20 +62,20 @@ class PNASNetTest(tf.test.TestCase):
   def testBuildNonExistingLayerLargeModel(self):
     """Tests that the model is built correctly without unnecessary layers."""
     inputs = tf.random.uniform((5, 331, 331, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
       pnasnet.build_pnasnet_large(inputs, 1000)
-    vars_names = [x.op.name for x in tf.compat.v1.trainable_variables()]
+    vars_names = [x.op.name for x in tf.trainable_variables()]
     self.assertIn('cell_stem_0/1x1/weights', vars_names)
     self.assertNotIn('cell_stem_1/comb_iter_0/right/1x1/weights', vars_names)
 
   def testBuildNonExistingLayerMobileModel(self):
     """Tests that the model is built correctly without unnecessary layers."""
     inputs = tf.random.uniform((5, 224, 224, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
       pnasnet.build_pnasnet_mobile(inputs, 1000)
-    vars_names = [x.op.name for x in tf.compat.v1.trainable_variables()]
+    vars_names = [x.op.name for x in tf.trainable_variables()]
     self.assertIn('cell_stem_0/1x1/weights', vars_names)
     self.assertNotIn('cell_stem_1/comb_iter_0/right/1x1/weights', vars_names)
 
@@ -84,7 +84,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = None
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
       net, end_points = pnasnet.build_pnasnet_large(inputs, num_classes)
     self.assertFalse('AuxLogits' in end_points)
@@ -97,7 +97,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = None
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
       net, end_points = pnasnet.build_pnasnet_mobile(inputs, num_classes)
     self.assertFalse('AuxLogits' in end_points)
@@ -110,7 +110,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
       _, end_points = pnasnet.build_pnasnet_large(inputs, num_classes)
 
@@ -136,7 +136,7 @@ class PNASNetTest(tf.test.TestCase):
     self.assertEqual(len(end_points), 17)
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
-      tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
+      tf.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertIn(endpoint_name, end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
@@ -147,7 +147,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
       _, end_points = pnasnet.build_pnasnet_mobile(inputs, num_classes)
 
@@ -171,7 +171,7 @@ class PNASNetTest(tf.test.TestCase):
     self.assertEqual(len(end_points), 14)
     self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
     for endpoint_name in endpoints_shapes:
-      tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
+      tf.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
       self.assertIn(endpoint_name, end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
@@ -182,9 +182,9 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     for use_aux_head in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
-      tf.compat.v1.train.create_global_step()
+      tf.train.create_global_step()
       config = pnasnet.large_imagenet_config()
       config.set_hparam('use_aux_head', int(use_aux_head))
       with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
@@ -197,9 +197,9 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     for use_aux_head in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
-      tf.compat.v1.train.create_global_step()
+      tf.train.create_global_step()
       config = pnasnet.mobile_imagenet_config()
       config.set_hparam('use_aux_head', int(use_aux_head))
       with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
@@ -212,7 +212,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 331, 331
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     config = pnasnet.large_imagenet_config()
     config.set_hparam('data_format', 'NCHW')
     with slim.arg_scope(pnasnet.pnasnet_large_arg_scope()):
@@ -226,7 +226,7 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     inputs = tf.random.uniform((batch_size, height, width, 3))
-    tf.compat.v1.train.create_global_step()
+    tf.train.create_global_step()
     config = pnasnet.mobile_imagenet_config()
     config.set_hparam('data_format', 'NCHW')
     with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
@@ -240,14 +240,14 @@ class PNASNetTest(tf.test.TestCase):
     height, width = 224, 224
     num_classes = 1000
     for use_bounded_activation in (True, False):
-      tf.compat.v1.reset_default_graph()
+      tf.reset_default_graph()
       inputs = tf.random.uniform((batch_size, height, width, 3))
       config = pnasnet.mobile_imagenet_config()
       config.set_hparam('use_bounded_activation', use_bounded_activation)
       with slim.arg_scope(pnasnet.pnasnet_mobile_arg_scope()):
         _, _ = pnasnet.build_pnasnet_mobile(
             inputs, num_classes, config=config)
-      for node in tf.compat.v1.get_default_graph().as_graph_def().node:
+      for node in tf.get_default_graph().as_graph_def().node:
         if node.op.startswith('Relu'):
           self.assertEqual(node.op == 'Relu6', use_bounded_activation)
 

--- a/research/slim/nets/nasnet/pnasnet_test.py
+++ b/research/slim/nets/nasnet/pnasnet_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets.nasnet import pnasnet
@@ -136,7 +136,8 @@ class PNASNetTest(tf.test.TestCase):
                         'Logits': [batch_size, 1000],
                        }
     self.assertEqual(len(end_points), 17)
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]
@@ -171,7 +172,8 @@ class PNASNetTest(tf.test.TestCase):
         'Logits': [batch_size, num_classes],
     }
     self.assertEqual(len(end_points), 14)
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
     for endpoint_name in endpoints_shapes:
       tf.compat.v1.logging.info('Endpoint name: {}'.format(endpoint_name))
       expected_shape = endpoints_shapes[endpoint_name]

--- a/research/slim/nets/nets_factory.py
+++ b/research/slim/nets/nets_factory.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import functools
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import alexnet
 from nets import cifarnet
@@ -36,8 +36,6 @@ from nets.mobilenet import mobilenet_v3
 from nets.nasnet import nasnet
 from nets.nasnet import pnasnet
 
-
-slim = contrib_slim
 
 networks_map = {
     'alexnet_v2': alexnet.alexnet_v2,

--- a/research/slim/nets/nets_factory_test.py
+++ b/research/slim/nets/nets_factory_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from nets import nets_factory
 

--- a/research/slim/nets/overfeat.py
+++ b/research/slim/nets/overfeat.py
@@ -32,9 +32,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 # pylint: disable=g-long-lambda
 trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(

--- a/research/slim/nets/overfeat.py
+++ b/research/slim/nets/overfeat.py
@@ -35,7 +35,7 @@ import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 
 
@@ -43,7 +43,7 @@ def overfeat_arg_scope(weight_decay=0.0005):
   with slim.arg_scope([slim.conv2d, slim.fully_connected],
                       activation_fn=tf.nn.relu,
                       weights_regularizer=slim.l2_regularizer(weight_decay),
-                      biases_initializer=tf.compat.v1.zeros_initializer()):
+                      biases_initializer=tf.zeros_initializer()):
     with slim.arg_scope([slim.conv2d], padding='SAME'):
       with slim.arg_scope([slim.max_pool2d], padding='VALID') as arg_sc:
         return arg_sc
@@ -89,7 +89,7 @@ def overfeat(inputs,
       None).
     end_points: a dict of tensors with intermediate activations.
   """
-  with tf.compat.v1.variable_scope(scope, 'overfeat', [inputs]) as sc:
+  with tf.variable_scope(scope, 'overfeat', [inputs]) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     # Collect outputs for conv2d, fully_connected and max_pool2d
     with slim.arg_scope([slim.conv2d, slim.fully_connected, slim.max_pool2d],
@@ -108,7 +108,7 @@ def overfeat(inputs,
       with slim.arg_scope(
           [slim.conv2d],
           weights_initializer=trunc_normal(0.005),
-          biases_initializer=tf.compat.v1.constant_initializer(0.1)):
+          biases_initializer=tf.constant_initializer(0.1)):
         net = slim.conv2d(net, 3072, [6, 6], padding='VALID', scope='fc6')
         net = slim.dropout(net, dropout_keep_prob, is_training=is_training,
                            scope='dropout6')
@@ -128,7 +128,7 @@ def overfeat(inputs,
               num_classes, [1, 1],
               activation_fn=None,
               normalizer_fn=None,
-              biases_initializer=tf.compat.v1.zeros_initializer(),
+              biases_initializer=tf.zeros_initializer(),
               scope='fc8')
           if spatial_squeeze:
             net = tf.squeeze(net, [1, 2], name='fc8/squeezed')

--- a/research/slim/nets/overfeat.py
+++ b/research/slim/nets/overfeat.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/overfeat_test.py
+++ b/research/slim/nets/overfeat_test.py
@@ -152,7 +152,7 @@ class OverFeatTest(tf.test.TestCase):
       logits, _ = overfeat.overfeat(train_inputs)
       self.assertListEqual(logits.get_shape().as_list(),
                            [train_batch_size, num_classes])
-      tf.compat.v1.get_variable_scope().reuse_variables()
+      tf.get_variable_scope().reuse_variables()
       eval_inputs = tf.random.uniform(
           (eval_batch_size, eval_height, eval_width, 3))
       logits, _ = overfeat.overfeat(eval_inputs, is_training=False,
@@ -169,7 +169,7 @@ class OverFeatTest(tf.test.TestCase):
     with self.test_session() as sess:
       inputs = tf.random.uniform((batch_size, height, width, 3))
       logits, _ = overfeat.overfeat(inputs)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits)
       self.assertTrue(output.any())
 

--- a/research/slim/nets/overfeat_test.py
+++ b/research/slim/nets/overfeat_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import overfeat

--- a/research/slim/nets/overfeat_test.py
+++ b/research/slim/nets/overfeat_test.py
@@ -18,11 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import overfeat
-
-slim = contrib_slim
 
 
 class OverFeatTest(tf.test.TestCase):

--- a/research/slim/nets/pix2pix.py
+++ b/research/slim/nets/pix2pix.py
@@ -55,8 +55,7 @@ def pix2pix_arg_scope():
       [slim.conv2d, slim.conv2d_transpose],
       normalizer_fn=slim.instance_norm,
       normalizer_params=instance_norm_params,
-      weights_initializer=tf.compat.v1.random_normal_initializer(0,
-                                                                 0.02)) as sc:
+      weights_initializer=tf.random_normal_initializer(0, 0.02)) as sc:
     return sc
 
 
@@ -165,7 +164,7 @@ def pix2pix_generator(net,
   ###########
   # Encoder #
   ###########
-  with tf.compat.v1.variable_scope('encoder'):
+  with tf.variable_scope('encoder'):
     with slim.arg_scope([slim.conv2d],
                         kernel_size=[4, 4],
                         stride=2,
@@ -193,7 +192,7 @@ def pix2pix_generator(net,
   reversed_blocks = list(blocks)
   reversed_blocks.reverse()
 
-  with tf.compat.v1.variable_scope('decoder'):
+  with tf.variable_scope('decoder'):
     # Dropout is used at both train and test time as per 'Image-to-Image',
     # Section 2.1 (last paragraph).
     with slim.arg_scope([slim.dropout], is_training=True):
@@ -209,7 +208,7 @@ def pix2pix_generator(net,
           net = slim.dropout(net, keep_prob=block.decoder_keep_prob)
         end_points['decoder%d' % block_id] = net
 
-  with tf.compat.v1.variable_scope('output'):
+  with tf.variable_scope('output'):
     # Explicitly set the normalizer_fn to None to override any default value
     # that may come from an arg_scope, such as pix2pix_arg_scope.
     logits = slim.conv2d(
@@ -248,7 +247,7 @@ def pix2pix_discriminator(net, num_filters, padding=2, pad_mode='REFLECT',
 
   def padded(net, scope):
     if padding:
-      with tf.compat.v1.variable_scope(scope):
+      with tf.variable_scope(scope):
         spatial_pad = tf.constant(
             [[0, 0], [padding, padding], [padding, padding], [0, 0]],
             dtype=tf.int32)

--- a/research/slim/nets/pix2pix.py
+++ b/research/slim/nets/pix2pix.py
@@ -33,10 +33,7 @@ import collections
 import functools
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
-
-layers = contrib_layers
+import tf_slim as slim
 
 
 def pix2pix_arg_scope():
@@ -54,9 +51,9 @@ def pix2pix_arg_scope():
       'epsilon': 0.00001,
   }
 
-  with contrib_framework.arg_scope(
-      [layers.conv2d, layers.conv2d_transpose],
-      normalizer_fn=layers.instance_norm,
+  with slim.arg_scope(
+      [slim.conv2d, slim.conv2d_transpose],
+      normalizer_fn=slim.instance_norm,
       normalizer_params=instance_norm_params,
       weights_initializer=tf.compat.v1.random_normal_initializer(0,
                                                                  0.02)) as sc:
@@ -89,9 +86,9 @@ def upsample(net, num_outputs, kernel_size, method='nn_upsample_conv'):
     net = tf.image.resize(
         net, [kernel_size[0] * height, kernel_size[1] * width],
         method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
-    net = layers.conv2d(net, num_outputs, [4, 4], activation_fn=None)
+    net = slim.conv2d(net, num_outputs, [4, 4], activation_fn=None)
   elif method == 'conv2d_transpose':
-    net = layers.conv2d_transpose(
+    net = slim.conv2d_transpose(
         net, num_outputs, [4, 4], stride=kernel_size, activation_fn=None)
   else:
     raise ValueError('Unknown method: [%s]' % method)
@@ -169,22 +166,22 @@ def pix2pix_generator(net,
   # Encoder #
   ###########
   with tf.compat.v1.variable_scope('encoder'):
-    with contrib_framework.arg_scope([layers.conv2d],
-                                     kernel_size=[4, 4],
-                                     stride=2,
-                                     activation_fn=tf.nn.leaky_relu):
+    with slim.arg_scope([slim.conv2d],
+                        kernel_size=[4, 4],
+                        stride=2,
+                        activation_fn=tf.nn.leaky_relu):
 
       for block_id, block in enumerate(blocks):
         # No normalizer for the first encoder layers as per 'Image-to-Image',
         # Section 5.1.1
         if block_id == 0:
           # First layer doesn't use normalizer_fn
-          net = layers.conv2d(net, block.num_filters, normalizer_fn=None)
+          net = slim.conv2d(net, block.num_filters, normalizer_fn=None)
         elif block_id < len(blocks) - 1:
-          net = layers.conv2d(net, block.num_filters)
+          net = slim.conv2d(net, block.num_filters)
         else:
           # Last layer doesn't use activation_fn nor normalizer_fn
-          net = layers.conv2d(
+          net = slim.conv2d(
               net, block.num_filters, activation_fn=None, normalizer_fn=None)
 
         encoder_activations.append(net)
@@ -199,7 +196,7 @@ def pix2pix_generator(net,
   with tf.compat.v1.variable_scope('decoder'):
     # Dropout is used at both train and test time as per 'Image-to-Image',
     # Section 2.1 (last paragraph).
-    with contrib_framework.arg_scope([layers.dropout], is_training=True):
+    with slim.arg_scope([slim.dropout], is_training=True):
 
       for block_id, block in enumerate(reversed_blocks):
         if block_id > 0:
@@ -209,13 +206,13 @@ def pix2pix_generator(net,
         net = tf.nn.relu(net)
         net = upsample_fn(net, block.num_filters, [2, 2])
         if block.decoder_keep_prob > 0:
-          net = layers.dropout(net, keep_prob=block.decoder_keep_prob)
+          net = slim.dropout(net, keep_prob=block.decoder_keep_prob)
         end_points['decoder%d' % block_id] = net
 
   with tf.compat.v1.variable_scope('output'):
     # Explicitly set the normalizer_fn to None to override any default value
     # that may come from an arg_scope, such as pix2pix_arg_scope.
-    logits = layers.conv2d(
+    logits = slim.conv2d(
         net, num_outputs, [4, 4], activation_fn=None, normalizer_fn=None)
     logits = tf.reshape(logits, input_size)
 
@@ -236,7 +233,7 @@ def pix2pix_discriminator(net, num_filters, padding=2, pad_mode='REFLECT',
       list determines the number of layers in the discriminator.
     padding: Amount of reflection padding applied before each convolution.
     pad_mode: mode for tf.pad, one of "CONSTANT", "REFLECT", or "SYMMETRIC".
-    activation_fn: activation fn for layers.conv2d.
+    activation_fn: activation fn for slim.conv2d.
     is_training: Whether or not the model is training or testing.
 
   Returns:
@@ -259,25 +256,25 @@ def pix2pix_discriminator(net, num_filters, padding=2, pad_mode='REFLECT',
     else:
       return net
 
-  with contrib_framework.arg_scope([layers.conv2d],
-                                   kernel_size=[4, 4],
-                                   stride=2,
-                                   padding='valid',
-                                   activation_fn=activation_fn):
+  with slim.arg_scope([slim.conv2d],
+                      kernel_size=[4, 4],
+                      stride=2,
+                      padding='valid',
+                      activation_fn=activation_fn):
 
     # No normalization on the input layer.
-    net = layers.conv2d(
+    net = slim.conv2d(
         padded(net, 'conv0'), num_filters[0], normalizer_fn=None, scope='conv0')
 
     end_points['conv0'] = net
 
     for i in range(1, num_layers - 1):
-      net = layers.conv2d(
+      net = slim.conv2d(
           padded(net, 'conv%d' % i), num_filters[i], scope='conv%d' % i)
       end_points['conv%d' % i] = net
 
     # Stride 1 on the last layer.
-    net = layers.conv2d(
+    net = slim.conv2d(
         padded(net, 'conv%d' % (num_layers - 1)),
         num_filters[-1],
         stride=1,
@@ -285,7 +282,7 @@ def pix2pix_discriminator(net, num_filters, padding=2, pad_mode='REFLECT',
     end_points['conv%d' % (num_layers - 1)] = net
 
     # 1-dim logits, stride 1, no activation, no normalization.
-    logits = layers.conv2d(
+    logits = slim.conv2d(
         padded(net, 'conv%d' % num_layers),
         1,
         stride=1,

--- a/research/slim/nets/pix2pix.py
+++ b/research/slim/nets/pix2pix.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 import collections
 import functools
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 

--- a/research/slim/nets/pix2pix_test.py
+++ b/research/slim/nets/pix2pix_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from nets import pix2pix
 

--- a/research/slim/nets/pix2pix_test.py
+++ b/research/slim/nets/pix2pix_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
+import tf_slim as slim
 from nets import pix2pix
 
 
@@ -36,7 +36,7 @@ class GeneratorTest(tf.test.TestCase):
     num_outputs = 4
 
     images = tf.ones((batch_size, height, width, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       logits, _ = pix2pix.pix2pix_generator(
           images, num_outputs, blocks=self._reduced_default_blocks(),
           upsample_method='nn_upsample_conv')
@@ -53,7 +53,7 @@ class GeneratorTest(tf.test.TestCase):
     num_outputs = 4
 
     images = tf.ones((batch_size, height, width, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       logits, _ = pix2pix.pix2pix_generator(
           images, num_outputs, blocks=self._reduced_default_blocks(),
           upsample_method='conv2d_transpose')
@@ -74,7 +74,7 @@ class GeneratorTest(tf.test.TestCase):
         pix2pix.Block(64, 0.5),
         pix2pix.Block(128, 0),
     ]
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       _, end_points = pix2pix.pix2pix_generator(
           images, num_outputs, blocks)
 
@@ -106,7 +106,7 @@ class DiscriminatorTest(tf.test.TestCase):
     output_size = self._layer_output_size(output_size, stride=1)
 
     images = tf.ones((batch_size, input_size, input_size, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       logits, end_points = pix2pix.pix2pix_discriminator(
           images, num_filters=[64, 128, 256, 512])
     self.assertListEqual([batch_size, output_size, output_size, 1],
@@ -125,7 +125,7 @@ class DiscriminatorTest(tf.test.TestCase):
     output_size = self._layer_output_size(output_size, stride=1, pad=0)
 
     images = tf.ones((batch_size, input_size, input_size, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       logits, end_points = pix2pix.pix2pix_discriminator(
           images, num_filters=[64, 128, 256, 512], padding=0)
     self.assertListEqual([batch_size, output_size, output_size, 1],
@@ -138,7 +138,7 @@ class DiscriminatorTest(tf.test.TestCase):
     input_size = 256
 
     images = tf.ones((batch_size, input_size, input_size, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       with self.assertRaises(TypeError):
         pix2pix.pix2pix_discriminator(
             images, num_filters=[64, 128, 256, 512], padding=1.5)
@@ -148,7 +148,7 @@ class DiscriminatorTest(tf.test.TestCase):
     input_size = 256
 
     images = tf.ones((batch_size, input_size, input_size, 3))
-    with contrib_framework.arg_scope(pix2pix.pix2pix_arg_scope()):
+    with slim.arg_scope(pix2pix.pix2pix_arg_scope()):
       with self.assertRaises(ValueError):
         pix2pix.pix2pix_discriminator(
             images, num_filters=[64, 128, 256, 512], padding=-1)

--- a/research/slim/nets/pix2pix_test.py
+++ b/research/slim/nets/pix2pix_test.py
@@ -42,7 +42,7 @@ class GeneratorTest(tf.test.TestCase):
           upsample_method='nn_upsample_conv')
 
     with self.test_session() as session:
-      session.run(tf.compat.v1.global_variables_initializer())
+      session.run(tf.global_variables_initializer())
       np_outputs = session.run(logits)
       self.assertListEqual([batch_size, height, width, num_outputs],
                            list(np_outputs.shape))
@@ -59,7 +59,7 @@ class GeneratorTest(tf.test.TestCase):
           upsample_method='conv2d_transpose')
 
     with self.test_session() as session:
-      session.run(tf.compat.v1.global_variables_initializer())
+      session.run(tf.global_variables_initializer())
       np_outputs = session.run(logits)
       self.assertListEqual([batch_size, height, width, num_outputs],
                            list(np_outputs.shape))

--- a/research/slim/nets/post_training_quantization.py
+++ b/research/slim/nets/post_training_quantization.py
@@ -127,7 +127,7 @@ def _representative_dataset_gen():
   dataset = tfds.builder(FLAGS.dataset_name, data_dir=FLAGS.dataset_dir)
   dataset.download_and_prepare()
   data = dataset.as_dataset()[FLAGS.dataset_split]
-  iterator = tf.compat.v1.data.make_one_shot_iterator(data)
+  iterator = tf.data.make_one_shot_iterator(data)
   if FLAGS.use_model_specific_preprocessing:
     preprocess_fn = functools.partial(
         preprocessing_factory.get_preprocessing(name=FLAGS.model_name),

--- a/research/slim/nets/post_training_quantization.py
+++ b/research/slim/nets/post_training_quantization.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 import functools
 from absl import app
 from absl import flags
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
 from nets import nets_factory
 from preprocessing import preprocessing_factory

--- a/research/slim/nets/resnet_utils.py
+++ b/research/slim/nets/resnet_utils.py
@@ -38,7 +38,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/resnet_utils.py
+++ b/research/slim/nets/resnet_utils.py
@@ -179,7 +179,7 @@ def stack_blocks_dense(net, blocks, output_stride=None,
   rate = 1
 
   for block in blocks:
-    with tf.compat.v1.variable_scope(block.scope, 'block', [net]) as sc:
+    with tf.variable_scope(block.scope, 'block', [net]) as sc:
       block_stride = 1
       for i, unit in enumerate(block.args):
         if store_non_strided_activations and i == len(block.args) - 1:
@@ -187,7 +187,7 @@ def stack_blocks_dense(net, blocks, output_stride=None,
           block_stride = unit.get('stride', 1)
           unit = dict(unit, stride=1)
 
-        with tf.compat.v1.variable_scope('unit_%d' % (i + 1), values=[net]):
+        with tf.variable_scope('unit_%d' % (i + 1), values=[net]):
           # If we have reached the target output_stride, then we need to employ
           # atrous convolution with stride=1 and multiply the atrous rate by the
           # current unit's stride for use in subsequent layers.
@@ -226,7 +226,7 @@ def resnet_arg_scope(
     batch_norm_scale=True,
     activation_fn=tf.nn.relu,
     use_batch_norm=True,
-    batch_norm_updates_collections=tf.compat.v1.GraphKeys.UPDATE_OPS):
+    batch_norm_updates_collections=tf.GraphKeys.UPDATE_OPS):
   """Defines the default ResNet arg scope.
 
   TODO(gpapan): The batch-normalization related default values above are

--- a/research/slim/nets/resnet_utils.py
+++ b/research/slim/nets/resnet_utils.py
@@ -39,9 +39,7 @@ from __future__ import print_function
 
 import collections
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 class Block(collections.namedtuple('Block', ['scope', 'unit_fn', 'args'])):

--- a/research/slim/nets/resnet_v1.py
+++ b/research/slim/nets/resnet_v1.py
@@ -34,7 +34,7 @@ units.
 
 Typical use:
 
-   from tensorflow.contrib.slim.nets import resnet_v1
+   from tf_slim.nets import resnet_v1
 
 ResNet-101 for image classification into 1000 classes:
 
@@ -57,13 +57,12 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import resnet_utils
 
 
 resnet_arg_scope = resnet_utils.resnet_arg_scope
-slim = contrib_slim
 
 
 class NoOpScope(object):

--- a/research/slim/nets/resnet_v1.py
+++ b/research/slim/nets/resnet_v1.py
@@ -56,7 +56,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import resnet_utils

--- a/research/slim/nets/resnet_v1.py
+++ b/research/slim/nets/resnet_v1.py
@@ -108,7 +108,7 @@ def bottleneck(inputs,
   Returns:
     The ResNet unit's output.
   """
-  with tf.compat.v1.variable_scope(scope, 'bottleneck_v1', [inputs]) as sc:
+  with tf.variable_scope(scope, 'bottleneck_v1', [inputs]) as sc:
     depth_in = slim.utils.last_dimension(inputs.get_shape(), min_rank=4)
     if depth == depth_in:
       shortcut = resnet_utils.subsample(inputs, stride, 'shortcut')
@@ -218,7 +218,7 @@ def resnet_v1(inputs,
   Raises:
     ValueError: If the target output_stride is not valid.
   """
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'resnet_v1', [inputs], reuse=reuse) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     with slim.arg_scope([slim.conv2d, bottleneck,

--- a/research/slim/nets/resnet_v1_test.py
+++ b/research/slim/nets/resnet_v1_test.py
@@ -25,7 +25,7 @@ import tf_slim as slim
 from nets import resnet_utils
 from nets import resnet_v1
 
-tf.compat.v1.disable_resource_variables()
+tf.disable_resource_variables()
 
 
 def create_test_input(batch_size, height, width, channels):
@@ -43,8 +43,7 @@ def create_test_input(batch_size, height, width, channels):
     constant `Tensor` with the mesh grid values along the spatial dimensions.
   """
   if None in [batch_size, height, width, channels]:
-    return tf.compat.v1.placeholder(tf.float32,
-                                    (batch_size, height, width, channels))
+    return tf.placeholder(tf.float32, (batch_size, height, width, channels))
   else:
     return tf.cast(
         np.tile(
@@ -81,9 +80,9 @@ class ResnetUtilsTest(tf.test.TestCase):
     w = create_test_input(1, 3, 3, 1)
     w = tf.reshape(w, [3, 3, 1, 1])
 
-    tf.compat.v1.get_variable('Conv/weights', initializer=w)
-    tf.compat.v1.get_variable('Conv/biases', initializer=tf.zeros([1]))
-    tf.compat.v1.get_variable_scope().reuse_variables()
+    tf.get_variable('Conv/weights', initializer=w)
+    tf.get_variable('Conv/biases', initializer=tf.zeros([1]))
+    tf.get_variable_scope().reuse_variables()
 
     y1 = slim.conv2d(x, 1, [3, 3], stride=1, scope='Conv')
     y1_expected = tf.cast([[14, 28, 43, 26], [28, 48, 66, 37], [43, 66, 84, 46],
@@ -103,7 +102,7 @@ class ResnetUtilsTest(tf.test.TestCase):
     y4_expected = tf.reshape(y4_expected, [1, n2, n2, 1])
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       self.assertAllClose(y1.eval(), y1_expected.eval())
       self.assertAllClose(y2.eval(), y2_expected.eval())
       self.assertAllClose(y3.eval(), y3_expected.eval())
@@ -119,9 +118,9 @@ class ResnetUtilsTest(tf.test.TestCase):
     w = create_test_input(1, 3, 3, 1)
     w = tf.reshape(w, [3, 3, 1, 1])
 
-    tf.compat.v1.get_variable('Conv/weights', initializer=w)
-    tf.compat.v1.get_variable('Conv/biases', initializer=tf.zeros([1]))
-    tf.compat.v1.get_variable_scope().reuse_variables()
+    tf.get_variable('Conv/weights', initializer=w)
+    tf.get_variable('Conv/biases', initializer=tf.zeros([1]))
+    tf.get_variable_scope().reuse_variables()
 
     y1 = slim.conv2d(x, 1, [3, 3], stride=1, scope='Conv')
     y1_expected = tf.cast(
@@ -142,7 +141,7 @@ class ResnetUtilsTest(tf.test.TestCase):
     y4_expected = y2_expected
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       self.assertAllClose(y1.eval(), y1_expected.eval())
       self.assertAllClose(y2.eval(), y2_expected.eval())
       self.assertAllClose(y3.eval(), y3_expected.eval())
@@ -150,7 +149,7 @@ class ResnetUtilsTest(tf.test.TestCase):
 
   def _resnet_plain(self, inputs, blocks, output_stride=None, scope=None):
     """A plain ResNet without extra layers before or after the ResNet blocks."""
-    with tf.compat.v1.variable_scope(scope, values=[inputs]):
+    with tf.variable_scope(scope, values=[inputs]):
       with slim.arg_scope([slim.conv2d], outputs_collections='end_points'):
         net = resnet_utils.stack_blocks_dense(inputs, blocks, output_stride)
         end_points = slim.utils.convert_collection_to_dict('end_points')
@@ -187,9 +186,9 @@ class ResnetUtilsTest(tf.test.TestCase):
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
     for block in blocks:
-      with tf.compat.v1.variable_scope(block.scope, 'block', [net]):
+      with tf.variable_scope(block.scope, 'block', [net]):
         for i, unit in enumerate(block.args):
-          with tf.compat.v1.variable_scope('unit_%d' % (i + 1), values=[net]):
+          with tf.variable_scope('unit_%d' % (i + 1), values=[net]):
             net = block.unit_fn(net, rate=1, **unit)
     return net
 
@@ -217,7 +216,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         for output_stride in [1, 2, 4, 8, None]:
           with tf.Graph().as_default():
             with self.test_session() as sess:
-              tf.compat.v1.set_random_seed(0)
+              tf.set_random_seed(0)
               inputs = create_test_input(1, height, width, 3)
               # Dense feature extraction followed by subsampling.
               output = resnet_utils.stack_blocks_dense(inputs,
@@ -230,10 +229,10 @@ class ResnetUtilsTest(tf.test.TestCase):
 
               output = resnet_utils.subsample(output, factor)
               # Make the two networks use the same weights.
-              tf.compat.v1.get_variable_scope().reuse_variables()
+              tf.get_variable_scope().reuse_variables()
               # Feature extraction at the nominal network rate.
               expected = self._stack_blocks_nondense(inputs, blocks)
-              sess.run(tf.compat.v1.global_variables_initializer())
+              sess.run(tf.global_variables_initializer())
               output, expected = sess.run([output, expected])
               self.assertAllClose(output, expected, atol=1e-4, rtol=1e-4)
 
@@ -260,7 +259,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         for output_stride in [1, 2, 4, 8, None]:
           with tf.Graph().as_default():
             with self.test_session() as sess:
-              tf.compat.v1.set_random_seed(0)
+              tf.set_random_seed(0)
               inputs = create_test_input(1, height, width, 3)
 
               # Subsampling at the last unit of the block.
@@ -272,7 +271,7 @@ class ResnetUtilsTest(tf.test.TestCase):
                   'output')
 
               # Make the two networks use the same weights.
-              tf.compat.v1.get_variable_scope().reuse_variables()
+              tf.get_variable_scope().reuse_variables()
 
               # Subsample activations at the end of the blocks.
               expected = resnet_utils.stack_blocks_dense(
@@ -282,7 +281,7 @@ class ResnetUtilsTest(tf.test.TestCase):
               expected_end_points = slim.utils.convert_collection_to_dict(
                   'expected')
 
-              sess.run(tf.compat.v1.global_variables_initializer())
+              sess.run(tf.global_variables_initializer())
 
               # Make sure that the final output is the same.
               output, expected = sess.run([output, expected])
@@ -473,7 +472,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       with slim.arg_scope(resnet_utils.resnet_arg_scope()):
         with tf.Graph().as_default():
           with self.test_session() as sess:
-            tf.compat.v1.set_random_seed(0)
+            tf.set_random_seed(0)
             inputs = create_test_input(2, 81, 81, 3)
             # Dense feature extraction followed by subsampling.
             output, _ = self._resnet_small(inputs, None, is_training=False,
@@ -485,11 +484,11 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
               factor = nominal_stride // output_stride
             output = resnet_utils.subsample(output, factor)
             # Make the two networks use the same weights.
-            tf.compat.v1.get_variable_scope().reuse_variables()
+            tf.get_variable_scope().reuse_variables()
             # Feature extraction at the nominal network rate.
             expected, _ = self._resnet_small(inputs, None, is_training=False,
                                              global_pool=False)
-            sess.run(tf.compat.v1.global_variables_initializer())
+            sess.run(tf.global_variables_initializer())
             self.assertAllClose(output.eval(), expected.eval(),
                                 atol=1e-4, rtol=1e-4)
 
@@ -509,7 +508,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [None, 1, 1, num_classes])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 1, 1, num_classes))
 
@@ -524,7 +523,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [batch, None, None, 32])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(output, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 3, 3, 32))
 
@@ -543,7 +542,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [batch, None, None, 32])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(output, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 9, 9, 32))
 

--- a/research/slim/nets/resnet_v1_test.py
+++ b/research/slim/nets/resnet_v1_test.py
@@ -19,15 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from six.moves import range
-from six.moves import zip
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import resnet_utils
 from nets import resnet_v1
-
-slim = contrib_slim
 
 tf.compat.v1.disable_resource_variables()
 
@@ -186,7 +182,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         'tiny/block2/unit_2/bottleneck_v1/conv1',
         'tiny/block2/unit_2/bottleneck_v1/conv2',
         'tiny/block2/unit_2/bottleneck_v1/conv3']
-    self.assertItemsEqual(expected, list(end_points.keys()))
+    self.assertItemsEqual(expected, end_points.keys())
 
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
@@ -393,7 +389,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       expected.append('resnet/block%d' % block)
     expected.extend(['global_pool', 'resnet/logits', 'resnet/spatial_squeeze',
                      'predictions'])
-    self.assertItemsEqual(list(end_points.keys()), expected)
+    self.assertItemsEqual(end_points.keys(), expected)
 
   def testClassificationShapes(self):
     global_pool = True

--- a/research/slim/nets/resnet_v1_test.py
+++ b/research/slim/nets/resnet_v1_test.py
@@ -19,7 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+from six.moves import range
+from six.moves import zip
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import resnet_utils
@@ -184,7 +186,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         'tiny/block2/unit_2/bottleneck_v1/conv1',
         'tiny/block2/unit_2/bottleneck_v1/conv2',
         'tiny/block2/unit_2/bottleneck_v1/conv3']
-    self.assertItemsEqual(expected, end_points.keys())
+    self.assertItemsEqual(expected, list(end_points.keys()))
 
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
@@ -391,7 +393,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       expected.append('resnet/block%d' % block)
     expected.extend(['global_pool', 'resnet/logits', 'resnet/spatial_squeeze',
                      'predictions'])
-    self.assertItemsEqual(end_points.keys(), expected)
+    self.assertItemsEqual(list(end_points.keys()), expected)
 
   def testClassificationShapes(self):
     global_pool = True

--- a/research/slim/nets/resnet_v2.py
+++ b/research/slim/nets/resnet_v2.py
@@ -28,7 +28,7 @@ The key difference of the full preactivation 'v2' variant compared to the
 
 Typical use:
 
-   from tensorflow.contrib.slim.nets import resnet_v2
+   from tf_slim.nets import resnet_v2
 
 ResNet-101 for image classification into 1000 classes:
 
@@ -51,11 +51,10 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import resnet_utils
 
-slim = contrib_slim
 resnet_arg_scope = resnet_utils.resnet_arg_scope
 
 

--- a/research/slim/nets/resnet_v2.py
+++ b/research/slim/nets/resnet_v2.py
@@ -50,7 +50,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import resnet_utils

--- a/research/slim/nets/resnet_v2.py
+++ b/research/slim/nets/resnet_v2.py
@@ -83,7 +83,7 @@ def bottleneck(inputs, depth, depth_bottleneck, stride, rate=1,
   Returns:
     The ResNet unit's output.
   """
-  with tf.compat.v1.variable_scope(scope, 'bottleneck_v2', [inputs]) as sc:
+  with tf.variable_scope(scope, 'bottleneck_v2', [inputs]) as sc:
     depth_in = slim.utils.last_dimension(inputs.get_shape(), min_rank=4)
     preact = slim.batch_norm(inputs, activation_fn=tf.nn.relu, scope='preact')
     if depth == depth_in:
@@ -180,7 +180,7 @@ def resnet_v2(inputs,
   Raises:
     ValueError: If the target output_stride is not valid.
   """
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'resnet_v2', [inputs], reuse=reuse) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     with slim.arg_scope([slim.conv2d, bottleneck,

--- a/research/slim/nets/resnet_v2_test.py
+++ b/research/slim/nets/resnet_v2_test.py
@@ -19,7 +19,8 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+from six.moves import range
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import resnet_utils
@@ -184,7 +185,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         'tiny/block2/unit_2/bottleneck_v2/conv1',
         'tiny/block2/unit_2/bottleneck_v2/conv2',
         'tiny/block2/unit_2/bottleneck_v2/conv3']
-    self.assertItemsEqual(expected, end_points.keys())
+    self.assertItemsEqual(expected, list(end_points.keys()))
 
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
@@ -308,7 +309,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       expected.append('resnet/block%d' % block)
     expected.extend(['global_pool', 'resnet/logits', 'resnet/spatial_squeeze',
                      'predictions'])
-    self.assertItemsEqual(end_points.keys(), expected)
+    self.assertItemsEqual(list(end_points.keys()), expected)
 
   def testClassificationShapes(self):
     global_pool = True

--- a/research/slim/nets/resnet_v2_test.py
+++ b/research/slim/nets/resnet_v2_test.py
@@ -19,14 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from six.moves import range
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import resnet_utils
 from nets import resnet_v2
-
-slim = contrib_slim
 
 tf.compat.v1.disable_resource_variables()
 
@@ -185,7 +182,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         'tiny/block2/unit_2/bottleneck_v2/conv1',
         'tiny/block2/unit_2/bottleneck_v2/conv2',
         'tiny/block2/unit_2/bottleneck_v2/conv3']
-    self.assertItemsEqual(expected, list(end_points.keys()))
+    self.assertItemsEqual(expected, end_points.keys())
 
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
@@ -309,7 +306,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       expected.append('resnet/block%d' % block)
     expected.extend(['global_pool', 'resnet/logits', 'resnet/spatial_squeeze',
                      'predictions'])
-    self.assertItemsEqual(list(end_points.keys()), expected)
+    self.assertItemsEqual(end_points.keys(), expected)
 
   def testClassificationShapes(self):
     global_pool = True

--- a/research/slim/nets/resnet_v2_test.py
+++ b/research/slim/nets/resnet_v2_test.py
@@ -25,7 +25,7 @@ import tf_slim as slim
 from nets import resnet_utils
 from nets import resnet_v2
 
-tf.compat.v1.disable_resource_variables()
+tf.disable_resource_variables()
 
 
 def create_test_input(batch_size, height, width, channels):
@@ -43,8 +43,7 @@ def create_test_input(batch_size, height, width, channels):
     constant `Tensor` with the mesh grid values along the spatial dimensions.
   """
   if None in [batch_size, height, width, channels]:
-    return tf.compat.v1.placeholder(tf.float32,
-                                    (batch_size, height, width, channels))
+    return tf.placeholder(tf.float32, (batch_size, height, width, channels))
   else:
     return tf.cast(
         np.tile(
@@ -81,9 +80,9 @@ class ResnetUtilsTest(tf.test.TestCase):
     w = create_test_input(1, 3, 3, 1)
     w = tf.reshape(w, [3, 3, 1, 1])
 
-    tf.compat.v1.get_variable('Conv/weights', initializer=w)
-    tf.compat.v1.get_variable('Conv/biases', initializer=tf.zeros([1]))
-    tf.compat.v1.get_variable_scope().reuse_variables()
+    tf.get_variable('Conv/weights', initializer=w)
+    tf.get_variable('Conv/biases', initializer=tf.zeros([1]))
+    tf.get_variable_scope().reuse_variables()
 
     y1 = slim.conv2d(x, 1, [3, 3], stride=1, scope='Conv')
     y1_expected = tf.cast([[14, 28, 43, 26], [28, 48, 66, 37], [43, 66, 84, 46],
@@ -103,7 +102,7 @@ class ResnetUtilsTest(tf.test.TestCase):
     y4_expected = tf.reshape(y4_expected, [1, n2, n2, 1])
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       self.assertAllClose(y1.eval(), y1_expected.eval())
       self.assertAllClose(y2.eval(), y2_expected.eval())
       self.assertAllClose(y3.eval(), y3_expected.eval())
@@ -119,9 +118,9 @@ class ResnetUtilsTest(tf.test.TestCase):
     w = create_test_input(1, 3, 3, 1)
     w = tf.reshape(w, [3, 3, 1, 1])
 
-    tf.compat.v1.get_variable('Conv/weights', initializer=w)
-    tf.compat.v1.get_variable('Conv/biases', initializer=tf.zeros([1]))
-    tf.compat.v1.get_variable_scope().reuse_variables()
+    tf.get_variable('Conv/weights', initializer=w)
+    tf.get_variable('Conv/biases', initializer=tf.zeros([1]))
+    tf.get_variable_scope().reuse_variables()
 
     y1 = slim.conv2d(x, 1, [3, 3], stride=1, scope='Conv')
     y1_expected = tf.cast(
@@ -142,7 +141,7 @@ class ResnetUtilsTest(tf.test.TestCase):
     y4_expected = y2_expected
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       self.assertAllClose(y1.eval(), y1_expected.eval())
       self.assertAllClose(y2.eval(), y2_expected.eval())
       self.assertAllClose(y3.eval(), y3_expected.eval())
@@ -150,7 +149,7 @@ class ResnetUtilsTest(tf.test.TestCase):
 
   def _resnet_plain(self, inputs, blocks, output_stride=None, scope=None):
     """A plain ResNet without extra layers before or after the ResNet blocks."""
-    with tf.compat.v1.variable_scope(scope, values=[inputs]):
+    with tf.variable_scope(scope, values=[inputs]):
       with slim.arg_scope([slim.conv2d], outputs_collections='end_points'):
         net = resnet_utils.stack_blocks_dense(inputs, blocks, output_stride)
         end_points = slim.utils.convert_collection_to_dict('end_points')
@@ -187,9 +186,9 @@ class ResnetUtilsTest(tf.test.TestCase):
   def _stack_blocks_nondense(self, net, blocks):
     """A simplified ResNet Block stacker without output stride control."""
     for block in blocks:
-      with tf.compat.v1.variable_scope(block.scope, 'block', [net]):
+      with tf.variable_scope(block.scope, 'block', [net]):
         for i, unit in enumerate(block.args):
-          with tf.compat.v1.variable_scope('unit_%d' % (i + 1), values=[net]):
+          with tf.variable_scope('unit_%d' % (i + 1), values=[net]):
             net = block.unit_fn(net, rate=1, **unit)
     return net
 
@@ -217,7 +216,7 @@ class ResnetUtilsTest(tf.test.TestCase):
         for output_stride in [1, 2, 4, 8, None]:
           with tf.Graph().as_default():
             with self.test_session() as sess:
-              tf.compat.v1.set_random_seed(0)
+              tf.set_random_seed(0)
               inputs = create_test_input(1, height, width, 3)
               # Dense feature extraction followed by subsampling.
               output = resnet_utils.stack_blocks_dense(inputs,
@@ -230,10 +229,10 @@ class ResnetUtilsTest(tf.test.TestCase):
 
               output = resnet_utils.subsample(output, factor)
               # Make the two networks use the same weights.
-              tf.compat.v1.get_variable_scope().reuse_variables()
+              tf.get_variable_scope().reuse_variables()
               # Feature extraction at the nominal network rate.
               expected = self._stack_blocks_nondense(inputs, blocks)
-              sess.run(tf.compat.v1.global_variables_initializer())
+              sess.run(tf.global_variables_initializer())
               output, expected = sess.run([output, expected])
               self.assertAllClose(output, expected, atol=1e-4, rtol=1e-4)
 
@@ -390,7 +389,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
       with slim.arg_scope(resnet_utils.resnet_arg_scope()):
         with tf.Graph().as_default():
           with self.test_session() as sess:
-            tf.compat.v1.set_random_seed(0)
+            tf.set_random_seed(0)
             inputs = create_test_input(2, 81, 81, 3)
             # Dense feature extraction followed by subsampling.
             output, _ = self._resnet_small(inputs, None,
@@ -403,12 +402,12 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
               factor = nominal_stride // output_stride
             output = resnet_utils.subsample(output, factor)
             # Make the two networks use the same weights.
-            tf.compat.v1.get_variable_scope().reuse_variables()
+            tf.get_variable_scope().reuse_variables()
             # Feature extraction at the nominal network rate.
             expected, _ = self._resnet_small(inputs, None,
                                              is_training=False,
                                              global_pool=False)
-            sess.run(tf.compat.v1.global_variables_initializer())
+            sess.run(tf.global_variables_initializer())
             self.assertAllClose(output.eval(), expected.eval(),
                                 atol=1e-4, rtol=1e-4)
 
@@ -428,7 +427,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [None, 1, 1, num_classes])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 1, 1, num_classes))
 
@@ -444,7 +443,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [batch, None, None, 32])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(output, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 3, 3, 32))
 
@@ -463,7 +462,7 @@ class ResnetCompleteNetworkTest(tf.test.TestCase):
                          [batch, None, None, 32])
     images = create_test_input(batch, height, width, 3)
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(output, {inputs: images.eval()})
       self.assertEqual(output.shape, (batch, 9, 9, 32))
 

--- a/research/slim/nets/s3dg.py
+++ b/research/slim/nets/s3dg.py
@@ -30,7 +30,7 @@ import tf_slim as slim
 from nets import i3d_utils
 
 # pylint: disable=g-long-lambda
-trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(
     0.0, stddev)
 conv3d_spatiotemporal = i3d_utils.conv3d_spatiotemporal
 inception_block_v1_3d = i3d_utils.inception_block_v1_3d
@@ -207,7 +207,7 @@ def s3dg_base(inputs,
     raise ValueError('depth_multiplier is not greater than zero.')
   depth = lambda d: max(int(d * depth_multiplier), min_depth)
 
-  with tf.compat.v1.variable_scope(scope, 'InceptionV1', [inputs]):
+  with tf.variable_scope(scope, 'InceptionV1', [inputs]):
     with arg_scope([slim.conv3d], weights_initializer=trunc_normal(0.01)):
       with arg_scope([slim.conv3d, slim.max_pool3d, conv3d_spatiotemporal],
                      stride=1,
@@ -549,7 +549,7 @@ def s3dg(inputs,
   """
   assert data_format in ['NDHWC', 'NCDHW']
   # Final pooling and prediction
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'InceptionV1', [inputs, num_classes], reuse=reuse) as scope:
     with arg_scope([slim.batch_norm, slim.dropout], is_training=is_training):
       net, end_points = s3dg_base(
@@ -562,7 +562,7 @@ def s3dg(inputs,
           depth_multiplier=depth_multiplier,
           data_format=data_format,
           scope=scope)
-      with tf.compat.v1.variable_scope('Logits'):
+      with tf.variable_scope('Logits'):
         if data_format.startswith('NC'):
           net = tf.transpose(a=net, perm=[0, 2, 3, 4, 1])
         kernel_size = i3d_utils.reduced_kernel_size_3d(net, [2, 7, 7])

--- a/research/slim/nets/s3dg.py
+++ b/research/slim/nets/s3dg.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import framework as contrib_framework
 from tensorflow.contrib import layers as contrib_layers
 

--- a/research/slim/nets/s3dg.py
+++ b/research/slim/nets/s3dg.py
@@ -25,8 +25,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import framework as contrib_framework
-from tensorflow.contrib import layers as contrib_layers
+import tf_slim as slim
 
 from nets import i3d_utils
 
@@ -36,10 +35,8 @@ trunc_normal = lambda stddev: tf.compat.v1.truncated_normal_initializer(
 conv3d_spatiotemporal = i3d_utils.conv3d_spatiotemporal
 inception_block_v1_3d = i3d_utils.inception_block_v1_3d
 
-# Orignaly, arg_scope = slim.arg_scope and layers = slim, now switch to more
-# update-to-date tf.contrib.* API.
-arg_scope = contrib_framework.arg_scope
-layers = contrib_layers
+
+arg_scope = slim.arg_scope
 
 
 def s3dg_arg_scope(weight_decay=1e-7,
@@ -72,12 +69,11 @@ def s3dg_arg_scope(weight_decay=1e-7,
       }
   }
 
-  with arg_scope(
-      [layers.conv3d, conv3d_spatiotemporal],
-      weights_regularizer=layers.l2_regularizer(weight_decay),
-      activation_fn=tf.nn.relu,
-      normalizer_fn=layers.batch_norm,
-      normalizer_params=batch_norm_params):
+  with arg_scope([slim.conv3d, conv3d_spatiotemporal],
+                 weights_regularizer=slim.l2_regularizer(weight_decay),
+                 activation_fn=tf.nn.relu,
+                 normalizer_fn=slim.batch_norm,
+                 normalizer_params=batch_norm_params):
     with arg_scope([conv3d_spatiotemporal], separable=True) as sc:
       return sc
 
@@ -115,13 +111,13 @@ def self_gating(input_tensor, scope, data_format='NDHWC'):
   h = input_shape[index_h]
   num_channels = input_shape[index_c]
 
-  spatiotemporal_average = layers.avg_pool3d(
+  spatiotemporal_average = slim.avg_pool3d(
       input_tensor, [t, w, h],
       stride=1,
       data_format=data_format,
       scope=scope + '/self_gating/avg_pool3d')
 
-  weights = layers.conv3d(
+  weights = slim.conv3d(
       spatiotemporal_average,
       num_channels, [1, 1, 1],
       activation_fn=None,
@@ -212,12 +208,11 @@ def s3dg_base(inputs,
   depth = lambda d: max(int(d * depth_multiplier), min_depth)
 
   with tf.compat.v1.variable_scope(scope, 'InceptionV1', [inputs]):
-    with arg_scope([layers.conv3d], weights_initializer=trunc_normal(0.01)):
-      with arg_scope(
-          [layers.conv3d, layers.max_pool3d, conv3d_spatiotemporal],
-          stride=1,
-          data_format=data_format,
-          padding='SAME'):
+    with arg_scope([slim.conv3d], weights_initializer=trunc_normal(0.01)):
+      with arg_scope([slim.conv3d, slim.max_pool3d, conv3d_spatiotemporal],
+                     stride=1,
+                     data_format=data_format,
+                     padding='SAME'):
         # batch_size x 32 x 112 x 112 x 64
         end_point = 'Conv2d_1a_7x7'
         if first_temporal_kernel_size not in [1, 3, 5, 7]:
@@ -235,14 +230,13 @@ def s3dg_base(inputs,
           return net, end_points
         # batch_size x 32 x 56 x 56 x 64
         end_point = 'MaxPool_2a_3x3'
-        net = layers.max_pool3d(
-            net, [1, 3, 3], stride=[1, 2, 2], scope=end_point)
+        net = slim.max_pool3d(net, [1, 3, 3], stride=[1, 2, 2], scope=end_point)
         end_points[end_point] = net
         if final_endpoint == end_point:
           return net, end_points
         # batch_size x 32 x 56 x 56 x 64
         end_point = 'Conv2d_2b_1x1'
-        net = layers.conv3d(net, depth(64), [1, 1, 1], scope=end_point)
+        net = slim.conv3d(net, depth(64), [1, 1, 1], scope=end_point)
         end_points[end_point] = net
         if final_endpoint == end_point:
           return net, end_points
@@ -261,8 +255,7 @@ def s3dg_base(inputs,
           return net, end_points
         # batch_size x 32 x 28 x 28 x 192
         end_point = 'MaxPool_3a_3x3'
-        net = layers.max_pool3d(
-            net, [1, 3, 3], stride=[1, 2, 2], scope=end_point)
+        net = slim.max_pool3d(net, [1, 3, 3], stride=[1, 2, 2], scope=end_point)
         end_points[end_point] = net
         if final_endpoint == end_point:
           return net, end_points
@@ -313,8 +306,7 @@ def s3dg_base(inputs,
           return net, end_points
 
         end_point = 'MaxPool_4a_3x3'
-        net = layers.max_pool3d(
-            net, [3, 3, 3], stride=[2, 2, 2], scope=end_point)
+        net = slim.max_pool3d(net, [3, 3, 3], stride=[2, 2, 2], scope=end_point)
         end_points[end_point] = net
         if final_endpoint == end_point:
           return net, end_points
@@ -435,8 +427,7 @@ def s3dg_base(inputs,
           return net, end_points
 
         end_point = 'MaxPool_5a_2x2'
-        net = layers.max_pool3d(
-            net, [2, 2, 2], stride=[2, 2, 2], scope=end_point)
+        net = slim.max_pool3d(net, [2, 2, 2], stride=[2, 2, 2], scope=end_point)
         end_points[end_point] = net
         if final_endpoint == end_point:
           return net, end_points
@@ -499,7 +490,7 @@ def s3dg(inputs,
          depth_multiplier=1.0,
          dropout_keep_prob=0.8,
          is_training=True,
-         prediction_fn=layers.softmax,
+         prediction_fn=slim.softmax,
          spatial_squeeze=True,
          reuse=None,
          data_format='NDHWC',
@@ -560,8 +551,7 @@ def s3dg(inputs,
   # Final pooling and prediction
   with tf.compat.v1.variable_scope(
       scope, 'InceptionV1', [inputs, num_classes], reuse=reuse) as scope:
-    with arg_scope(
-        [layers.batch_norm, layers.dropout], is_training=is_training):
+    with arg_scope([slim.batch_norm, slim.dropout], is_training=is_training):
       net, end_points = s3dg_base(
           inputs,
           first_temporal_kernel_size=first_temporal_kernel_size,
@@ -576,14 +566,14 @@ def s3dg(inputs,
         if data_format.startswith('NC'):
           net = tf.transpose(a=net, perm=[0, 2, 3, 4, 1])
         kernel_size = i3d_utils.reduced_kernel_size_3d(net, [2, 7, 7])
-        net = layers.avg_pool3d(
+        net = slim.avg_pool3d(
             net,
             kernel_size,
             stride=1,
             data_format='NDHWC',
             scope='AvgPool_0a_7x7')
-        net = layers.dropout(net, dropout_keep_prob, scope='Dropout_0b')
-        logits = layers.conv3d(
+        net = slim.dropout(net, dropout_keep_prob, scope='Dropout_0b')
+        logits = slim.conv3d(
             net,
             num_classes, [1, 1, 1],
             activation_fn=None,

--- a/research/slim/nets/s3dg_test.py
+++ b/research/slim/nets/s3dg_test.py
@@ -143,7 +143,7 @@ class S3DGTest(tf.test.TestCase):
     predictions = tf.argmax(input=logits, axis=1)
 
     with self.test_session() as sess:
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(predictions)
       self.assertEquals(output.shape, (batch_size,))
 

--- a/research/slim/nets/s3dg_test.py
+++ b/research/slim/nets/s3dg_test.py
@@ -18,7 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import six
+import tensorflow.compat.v1 as tf
 
 from nets import s3dg
 
@@ -55,7 +56,7 @@ class S3DGTest(tf.test.TestCase):
                           'Mixed_3c', 'MaxPool_4a_3x3', 'Mixed_4b', 'Mixed_4c',
                           'Mixed_4d', 'Mixed_4e', 'Mixed_4f', 'MaxPool_5a_2x2',
                           'Mixed_5b', 'Mixed_5c']
-    self.assertItemsEqual(end_points.keys(), expected_endpoints)
+    self.assertItemsEqual(list(end_points.keys()), expected_endpoints)
 
   def testBuildOnlyUptoFinalEndpointNoGating(self):
     batch_size = 5
@@ -101,8 +102,9 @@ class S3DGTest(tf.test.TestCase):
                         'Mixed_5b': [5, 8, 7, 7, 832],
                         'Mixed_5c': [5, 8, 7, 7, 1024]}
 
-    self.assertItemsEqual(endpoints_shapes.keys(), end_points.keys())
-    for endpoint_name, expected_shape in endpoints_shapes.iteritems():
+    self.assertItemsEqual(
+        list(endpoints_shapes.keys()), list(end_points.keys()))
+    for endpoint_name, expected_shape in six.iteritems(endpoints_shapes):
       self.assertTrue(endpoint_name in end_points)
       self.assertListEqual(end_points[endpoint_name].get_shape().as_list(),
                            expected_shape)

--- a/research/slim/nets/vgg.py
+++ b/research/slim/nets/vgg.py
@@ -42,9 +42,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
+import tf_slim as slim
 
 
 def vgg_arg_scope(weight_decay=0.0005):

--- a/research/slim/nets/vgg.py
+++ b/research/slim/nets/vgg.py
@@ -41,7 +41,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/nets/vgg.py
+++ b/research/slim/nets/vgg.py
@@ -57,7 +57,7 @@ def vgg_arg_scope(weight_decay=0.0005):
   with slim.arg_scope([slim.conv2d, slim.fully_connected],
                       activation_fn=tf.nn.relu,
                       weights_regularizer=slim.l2_regularizer(weight_decay),
-                      biases_initializer=tf.compat.v1.zeros_initializer()):
+                      biases_initializer=tf.zeros_initializer()):
     with slim.arg_scope([slim.conv2d], padding='SAME') as arg_sc:
       return arg_sc
 
@@ -103,7 +103,7 @@ def vgg_a(inputs,
       or the input to the logits layer (if num_classes is 0 or None).
     end_points: a dict of tensors with intermediate activations.
   """
-  with tf.compat.v1.variable_scope(scope, 'vgg_a', [inputs], reuse=reuse) as sc:
+  with tf.variable_scope(scope, 'vgg_a', [inputs], reuse=reuse) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     # Collect outputs for conv2d, fully_connected and max_pool2d.
     with slim.arg_scope([slim.conv2d, slim.max_pool2d],
@@ -185,7 +185,7 @@ def vgg_16(inputs,
       or the input to the logits layer (if num_classes is 0 or None).
     end_points: a dict of tensors with intermediate activations.
   """
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'vgg_16', [inputs], reuse=reuse) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     # Collect outputs for conv2d, fully_connected and max_pool2d.
@@ -269,7 +269,7 @@ def vgg_19(inputs,
       None).
     end_points: a dict of tensors with intermediate activations.
   """
-  with tf.compat.v1.variable_scope(
+  with tf.variable_scope(
       scope, 'vgg_19', [inputs], reuse=reuse) as sc:
     end_points_collection = sc.original_name_scope + '_end_points'
     # Collect outputs for conv2d, fully_connected and max_pool2d.

--- a/research/slim/nets/vgg_test.py
+++ b/research/slim/nets/vgg_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 from nets import vgg

--- a/research/slim/nets/vgg_test.py
+++ b/research/slim/nets/vgg_test.py
@@ -168,7 +168,7 @@ class VGGATest(tf.test.TestCase):
       logits, _ = vgg.vgg_a(train_inputs)
       self.assertListEqual(logits.get_shape().as_list(),
                            [train_batch_size, num_classes])
-      tf.compat.v1.get_variable_scope().reuse_variables()
+      tf.get_variable_scope().reuse_variables()
       eval_inputs = tf.random.uniform(
           (eval_batch_size, eval_height, eval_width, 3))
       logits, _ = vgg.vgg_a(eval_inputs, is_training=False,
@@ -185,7 +185,7 @@ class VGGATest(tf.test.TestCase):
     with self.test_session() as sess:
       inputs = tf.random.uniform((batch_size, height, width, 3))
       logits, _ = vgg.vgg_a(inputs)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits)
       self.assertTrue(output.any())
 
@@ -355,7 +355,7 @@ class VGG16Test(tf.test.TestCase):
       logits, _ = vgg.vgg_16(train_inputs)
       self.assertListEqual(logits.get_shape().as_list(),
                            [train_batch_size, num_classes])
-      tf.compat.v1.get_variable_scope().reuse_variables()
+      tf.get_variable_scope().reuse_variables()
       eval_inputs = tf.random.uniform(
           (eval_batch_size, eval_height, eval_width, 3))
       logits, _ = vgg.vgg_16(eval_inputs, is_training=False,
@@ -372,7 +372,7 @@ class VGG16Test(tf.test.TestCase):
     with self.test_session() as sess:
       inputs = tf.random.uniform((batch_size, height, width, 3))
       logits, _ = vgg.vgg_16(inputs)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits)
       self.assertTrue(output.any())
 
@@ -557,7 +557,7 @@ class VGG19Test(tf.test.TestCase):
       logits, _ = vgg.vgg_19(train_inputs)
       self.assertListEqual(logits.get_shape().as_list(),
                            [train_batch_size, num_classes])
-      tf.compat.v1.get_variable_scope().reuse_variables()
+      tf.get_variable_scope().reuse_variables()
       eval_inputs = tf.random.uniform(
           (eval_batch_size, eval_height, eval_width, 3))
       logits, _ = vgg.vgg_19(eval_inputs, is_training=False,
@@ -574,7 +574,7 @@ class VGG19Test(tf.test.TestCase):
     with self.test_session() as sess:
       inputs = tf.random.uniform((batch_size, height, width, 3))
       logits, _ = vgg.vgg_19(inputs)
-      sess.run(tf.compat.v1.global_variables_initializer())
+      sess.run(tf.global_variables_initializer())
       output = sess.run(logits)
       self.assertTrue(output.any())
 

--- a/research/slim/nets/vgg_test.py
+++ b/research/slim/nets/vgg_test.py
@@ -18,11 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+import tf_slim as slim
 
 from nets import vgg
-
-slim = contrib_slim
 
 
 class VGGATest(tf.test.TestCase):

--- a/research/slim/preprocessing/cifarnet_preprocessing.py
+++ b/research/slim/preprocessing/cifarnet_preprocessing.py
@@ -21,11 +21,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
+
 
 _PADDING = 4
-
-slim = contrib_slim
 
 
 def preprocess_for_train(image,

--- a/research/slim/preprocessing/cifarnet_preprocessing.py
+++ b/research/slim/preprocessing/cifarnet_preprocessing.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 _PADDING = 4

--- a/research/slim/preprocessing/inception_preprocessing.py
+++ b/research/slim/preprocessing/inception_preprocessing.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from tensorflow.python.ops import control_flow_ops
 

--- a/research/slim/preprocessing/lenet_preprocessing.py
+++ b/research/slim/preprocessing/lenet_preprocessing.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/preprocessing/lenet_preprocessing.py
+++ b/research/slim/preprocessing/lenet_preprocessing.py
@@ -19,9 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
-
-slim = contrib_slim
 
 
 def preprocess_image(image,

--- a/research/slim/preprocessing/preprocessing_factory.py
+++ b/research/slim/preprocessing/preprocessing_factory.py
@@ -17,14 +17,11 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from tensorflow.contrib import slim as contrib_slim
 
 from preprocessing import cifarnet_preprocessing
 from preprocessing import inception_preprocessing
 from preprocessing import lenet_preprocessing
 from preprocessing import vgg_preprocessing
-
-slim = contrib_slim
 
 
 def get_preprocessing(name, is_training=False, use_grayscale=False):

--- a/research/slim/preprocessing/vgg_preprocessing.py
+++ b/research/slim/preprocessing/vgg_preprocessing.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import slim as contrib_slim
 
 slim = contrib_slim

--- a/research/slim/preprocessing/vgg_preprocessing.py
+++ b/research/slim/preprocessing/vgg_preprocessing.py
@@ -33,9 +33,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
-from tensorflow.contrib import slim as contrib_slim
 
-slim = contrib_slim
 
 _R_MEAN = 123.68
 _G_MEAN = 116.78

--- a/research/slim/setup.py
+++ b/research/slim/setup.py
@@ -17,10 +17,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+install_requires = [
+    'six',
+    'tf-slim>=1.1',
+]
 
 setup(
     name='slim',
     version='0.1',
+    install_requires=install_requires,
     include_package_data=True,
     packages=find_packages(),
     description='tf-slim',

--- a/research/slim/slim_walkthrough.ipynb
+++ b/research/slim/slim_walkthrough.ipynb
@@ -58,13 +58,13 @@
     "import matplotlib.pyplot as plt\n",
     "import math\n",
     "import numpy as np\n",
-    "import tensorflow as tf\n",
+    "import tensorflow.compat.v1 as tf\n",
     "import time\n",
     "\n",
     "from datasets import dataset_utils\n",
     "\n",
     "# Main slim library\n",
-    "from tensorflow.contrib import slim"
+    "import tf_slim as slim"
    ]
   },
   {
@@ -452,7 +452,7 @@
    },
    "outputs": [],
    "source": [
-    "import tensorflow as tf\n",
+    "import tensorflow.compat.v1 as tf\n",
     "from datasets import dataset_utils\n",
     "\n",
     "url = \"http://download.tensorflow.org/data/flowers.tar.gz\"\n",
@@ -480,7 +480,7 @@
    "outputs": [],
    "source": [
     "from datasets import flowers\n",
-    "import tensorflow as tf\n",
+    "import tensorflow.compat.v1 as tf\n",
     "\n",
     "from tensorflow.contrib import slim\n",
     "\n",

--- a/research/slim/train_image_classifier.py
+++ b/research/slim/train_image_classifier.py
@@ -18,16 +18,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
+import tf_slim as slim
+
 from tensorflow.contrib import quantize as contrib_quantize
-from tensorflow.contrib import slim as contrib_slim
 
 from datasets import dataset_factory
 from deployment import model_deploy
 from nets import nets_factory
 from preprocessing import preprocessing_factory
-
-slim = contrib_slim
 
 tf.app.flags.DEFINE_string(
     'master', '', 'The address of the TensorFlow master to use.')

--- a/research/slim/train_image_classifier.py
+++ b/research/slim/train_image_classifier.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tf_slim as slim
 
 from tensorflow.contrib import quantize as contrib_quantize

--- a/research/slim/train_image_classifier.py
+++ b/research/slim/train_image_classifier.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.contrib import quantize as contrib_quantize
 from tensorflow.contrib import slim as contrib_slim
 


### PR DESCRIPTION
# Description
Bringing in internal changes. Moves slim from contrib.slim to tf_slim, updates some internal implementation details in MobilenetV3. 

## Type of change

Upgrading research.slim to eliminate most dependencies on contrib.slim - a few are still lingering particularly in some dusty corners of quantization and training. 

Note: Please delete options that are not relevant.

- [x] Documentation update
- [x] TensorFlow 2 migration
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
