### PR TITLE
Add bert's instruction about using a checkpoint on local storage

### DIFF
--- a/official/nlp/bert/README.md
+++ b/official/nlp/bert/README.md
@@ -142,6 +142,7 @@ Users can download the
 [GLUE data](https://gluebenchmark.com/tasks) by running
 [this script](https://gist.github.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e)
 and unpack it to some directory `$GLUE_DIR`.
+Also, users can download [Pretrained Checkpoint](#access-to-pretrained-checkpoints) and locate on some directory `$BERT_DIR` instead of using checkpoints on Google Cloud Storage.
 
 ```shell
 export GLUE_DIR=~/glue


### PR DESCRIPTION
# Description

Current README.md in bert model does not include an instruction about using a checkpoint on local storage.
I think this makes some users confused.

This PR adds a supplemental explanation when users use checkpoint located on local storage.


## Type of change

- [x] Documentation update


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.