### PR TITLE
Fix an example command about ncf_keras_main.py in README.md

### DIFF
--- a/official/recommendation/README.md
+++ b/official/recommendation/README.md
@@ -61,7 +61,7 @@ features in TF 2.x. Users can train the model on both GPU and TPU.
 
 To train and evaluate the model, issue the following command:
 ```
-python ncf_keras_main.py
+python ncf_keras_main.py --eval_batch_size=1000
 ```
 Arguments:
   * `--model_dir`: Directory to save model training checkpoints. By default, it is `/tmp/ncf/`.


### PR DESCRIPTION
# Description

Example command in README raises error, which is also mentioned at #8388.
I think an example command in README should not raise any errors because many users may execute this command as is.
This PR fixes the example command not to raise error.

## Type of change

- [x] Documentation update


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.