### PR TITLE
Add description about the option 'num_gpus' for NCF model

### DIFF
--- a/official/recommendation/README.md
+++ b/official/recommendation/README.md
@@ -67,5 +67,6 @@ Arguments:
   * `--model_dir`: Directory to save model training checkpoints. By default, it is `/tmp/ncf/`.
   * `--data_dir`: This should be set to the same directory given to the `data_download`'s `data_dir` argument.
   * `--dataset`: The dataset name to be downloaded and preprocessed. By default, it is `ml-1m`.
+  * `--num_gpus`: The number of GPUs used for training/evaluation of the model. Use CPU if this flag is 0. By default, it is 1.
 
 There are other arguments about models and training process. Refer to the [Flags package](https://abseil.io/docs/python/guides/flags) documentation or use the `--helpfull` flag to get a full list of possible arguments with detailed descriptions.


### PR DESCRIPTION
# Description

In paragraph [Train and evaluate model](https://github.com/tensorflow/models/tree/master/official/recommendation#train-and-evaluate-model), there is a description about training/evaluation with GPU.
However, there is no clue how to specify the number of GPUs used for training/evaluation the model.

This PR adds the description about the option 'num_gpus' in reference to [Transformer model](https://github.com/tensorflow/models/tree/master/official/nlp/transformer#using-multiple-gpus).

## Type of change

- [x] Documentation update


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
