### PR TITLE
Update deeplab/local_test.sh

### DIFF
--- a/research/deeplab/local_test.sh
+++ b/research/deeplab/local_test.sh
@@ -37,7 +37,7 @@ CURRENT_DIR=$(pwd)
 WORK_DIR="${CURRENT_DIR}/deeplab"
 
 # Run model_test first to make sure the PYTHONPATH is correctly set.
-python "${WORK_DIR}"/model_test.py -v
+python "${WORK_DIR}"/model_test.py
 
 # Go to datasets folder and download PASCAL VOC 2012 segmentation dataset.
 DATASET_DIR="datasets"


### PR DESCRIPTION
# Description
model_test.py doesn't support -v (--verbose) parameter. Removed -v param while calling this script.
To fix the following error:
File "/usr/local/lib/python3.6/dist-packages/absl/flags/_flagvalues.py", line 698, in get_value raise _exceptions.Error('Missing value for flag ' + arg) # pylint: disable=undefined-loop-variable absl.flags._exceptions.Error: Missing value for flag -
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
From tensorflow/models/research/deeplab
sh local_test.sh

**Test Configuration**:

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
