### PR TITLE
deeplab/local_test.sh: Use 'bash' instead of 'sh'

### DIFF
--- a/research/deeplab/g3doc/installation.md
+++ b/research/deeplab/g3doc/installation.md
@@ -68,6 +68,6 @@ Quick running the whole code on the PASCAL VOC 2012 dataset:
 
 ```bash
 # From tensorflow/models/research/deeplab
-sh local_test.sh
+bash local_test.sh
 ```
 

--- a/research/deeplab/local_test.sh
+++ b/research/deeplab/local_test.sh
@@ -19,7 +19,7 @@
 #
 # Usage:
 #   # From the tensorflow/models/research/deeplab directory.
-#   sh ./local_test.sh
+#   bash ./local_test.sh
 #
 #
 
@@ -42,7 +42,7 @@ python "${WORK_DIR}"/model_test.py
 # Go to datasets folder and download PASCAL VOC 2012 segmentation dataset.
 DATASET_DIR="datasets"
 cd "${WORK_DIR}/${DATASET_DIR}"
-sh download_and_convert_voc2012.sh
+bash download_and_convert_voc2012.sh
 
 # Go back to original directory.
 cd "${CURRENT_DIR}"


### PR DESCRIPTION
# Description

Use 'bash' instead of 'sh' in `deeplab/local_test.sh`:

- Make it consistent with '/bin/bash' shebang
- Fix "Bad substitution" error in BASH_SOURCE[0]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

```
[research/deeplab]> bash local_test.sh
```

**Test Configuration**:

- Tensorflow 1.15.2
- Ubuntu 18.04.4 LTS
- CUDA 10.1

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] My changes generate no new warnings.
