### PR TITLE
Fixed Object Detection Tutorial version problem

### DIFF
--- a/research/object_detection/object_detection_tutorial.ipynb
+++ b/research/object_detection/object_detection_tutorial.ipynb
@@ -257,10 +257,13 @@
       "outputs": [],
       "source": [
         "# patch tf1 into `utils.ops`\n",
-        "utils_ops.tf = tf.compat.v1\n",
+        "utils_ops.tf = tf.compat.v2\n",
         "\n",
         "# Patch the location of gfile\n",
-        "tf.gfile = tf.io.gfile"
+        "tf.gfile = tf.io.gfile\n",
+        "\n",
+        "# Enable Eager Execution for Tensorflow Version < 2\n",
+        "tf.compat.v1.enable_eager_execution()"
       ]
     },
     {
@@ -317,7 +320,7 @@
         "\n",
         "  model_dir = pathlib.Path(model_dir)/\"saved_model\"\n",
         "\n",
-        "  model = tf.saved_model.load(str(model_dir))\n",
+        "  model = tf.compat.v2.saved_model.load(str(model_dir))\n",
         "  model = model.signatures['serving_default']\n",
         "\n",
         "  return model"


### PR DESCRIPTION
# Object Detection Tutorial now works both on TensorFlow 1.15 and TensorFlow 2.0

## Problem 
Despite both  [Object Detection Readme](https://github.com/tensorflow/models/blob/master/research/object_detection/README.md) and [installation.md](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/installation.md) tells to install __Tensorflow 1.15__ 
 [Object Detection Tutorial](https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb) uses __TensorFlow 2.0__

Trying to execute *object_detection_tutorial.ipynb* after following installation guide with Tensorflow 1.15 results in errors which newcomers will find it hard to solve.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes: 
* #7773 
* #7942

### Loading model
`tf.saved_model.load` requires 2 positional arguments: `'tags' and 'export_dir'` in __version 1.15__ 

Using:
`model = tf.saved_model.load_v2(str(model_dir))` 
Solves issue for Tensorflow 1.15
Using:
`model = tf.compat.v2.saved_model.load(str(model_dir))` 
Solves issue for both Tensorflow 1.15 and Tensorflow 2

### Eager Execution
Without running session we can't get numeric results on Tensorflow 1, so you will see this error:
> int() argument must be a string, a bytes-like object or a number, not 'Tensor'

on line:
`num_detections = int(output_dict.pop('num_detections'))`

Since `int()` function expects a numeric value, we need to enable eager execution just after imports with 
`tf.compat.v1.enable_eager_execution()`

## Tests

 :memo:
  After applying this commit:
 * Clone fresh [models repo](https://github.com/tensorflow/models)
 * Follow [installation.md](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/installation.md)
 * Run *object_detection_tutorial.ipynb* on local with Tensorflow 1.15 in jupyter-notebook and jupyter-lab without __Install part__
 * Run *object_detection_tutorial.ipynb* on local with Tensorflow 2.0 in jupyter-notebook and jupyter-lab  without __Install part__
 * Run *object_detection_tutorial.ipynb* on Colab with relevant changes with Tensorflow 2.0
 * Change Tensorflow version on Colab with `pip install -U --pre tensorflow=="1.15"`
 * Run *object_detection_tutorial.ipynb* on Colab with relevant changes with Tensorflow 1.15

## Reproduce Error

 :memo:
  
 * Clone fresh [models repo](https://github.com/tensorflow/models)
 * Follow [installation.md](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/installation.md)
 * Install dependencies including Tensorflow (1.15.0)
 * Run [object_detection_tutorial.ipynb](https://github.com/tensorflow/models/blob/master/research/object_detection/object_detection_tutorial.ipynb) on local with jupyter-notebook or jupyter-lab
* You will stumble into this error #7773 

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
