### PR TITLE
Update WikiTableQuestions info

### DIFF
--- a/research/neural_programmer/README.md
+++ b/research/neural_programmer/README.md
@@ -4,20 +4,23 @@
 
 # Neural Programmer
 
-Implementation of the Neural Programmer model described in [paper](https://openreview.net/pdf?id=ry2YOrcge)
+Implementation of the Neural Programmer model as described in this [paper](https://openreview.net/pdf?id=ry2YOrcge).
 
-Download and extract the data from [dropbox](https://www.dropbox.com/s/9tvtcv6lmy51zfw/data.zip?dl=0). Change the ``data_dir FLAG`` to the location of the data.
+Download and extract the data from the [WikiTableQuestions](https://ppasupat.github.io/WikiTableQuestions/) site. The dataset contains
+11321, 2831, and 4344 examples for training, development, and testing respectively. We use their tokenization, number and date pre-processing. Please note that the above paper used the [initial release](https://github.com/ppasupat/WikiTableQuestions/releases/tag/v0.2) for training, development and testing. 
+
+Change the `data_dir FLAG` to the location of the data.
 
 ### Training 
-``python neural_programmer.py`` 
+Run `python neural_programmer.py` 
 
-The models are written to FLAGS.output_dir
+The models are written to `FLAGS.output_dir`.
 
 ### Testing 
-``python neural_programmer.py --evaluator_job=True``
+Run `python neural_programmer.py --evaluator_job=True`
 
-The models are loaded from ``FLAGS.output_dir``. The evaluation is done on development data.
+The models are loaded from `FLAGS.output_dir`. The evaluation is done on development data.
 
-In case of errors because of encoding, add ``"# -*- coding: utf-8 -*-"`` as the first line in ``wiki_data.py``
+In case of errors because of encoding, add `"# -*- coding: utf-8 -*-"` as the first line in `wiki_data.py`
 
 Maintained by Arvind Neelakantan (arvind2505)


### PR DESCRIPTION
# Description

Adds the WikiTableQuestions link. The old dropbox link was outdated, also put in some details about the current version of the data against the one used by the original authors. **No further maintenance intended.**

> Fixes #8531 

## Type of change

- [x] Documentation update

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
