### PR TITLE
Fix preprocessing order in preprocess_for_train

### DIFF
--- a/official/vision/image_classification/preprocessing.py
+++ b/official/vision/image_classification/preprocessing.py
@@ -379,12 +379,12 @@ def preprocess_for_train(image_bytes: tf.Tensor,
   """
   images = decode_crop_and_flip(image_bytes=image_bytes)
   images = resize_image(images, height=image_size, width=image_size)
+  if augmenter is not None:
+    images = augmenter.distort(images)
   if mean_subtract:
     images = mean_image_subtraction(image_bytes=images, means=MEAN_RGB)
   if standardize:
     images = standardize_image(image_bytes=images, stddev=STDDEV_RGB)
-  if augmenter is not None:
-    images = augmenter.distort(images)
   if dtype is not None:
     images = tf.image.convert_image_dtype(images, dtype)
 


### PR DESCRIPTION
# Description

The original order of preprocessing in `preprocess_for_train` consists of doing mean_subtraction and standardisation first and then applying augmentation. 

This order might result in issue. Mean subtraction and standardisation make some value in the image tensor negative. Then the image tensor will be first clipped to 0 to 255 inside `augmenter.distort` method, and then converted to `tf.uint8` dtype. This might result in loss of image content. For example, imagine mean subtraction and standardisation make all pixel values have the range of -5.0 to 5.0 and `augmenter.distort` convert those values to `tf.uint8` dtype. The content of image is completely changed even before any augmentation (such as affine transform, brightness, etc) is applied.

Therefore mean subtraction and standardisation should be done after augmentation, as changed in this PR.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
