### PR TITLE
DeepLab: Fix generation of tfrecord for Cityscapes

### DIFF
--- a/research/deeplab/datasets/build_cityscapes_data.py
+++ b/research/deeplab/datasets/build_cityscapes_data.py
@@ -152,7 +152,7 @@ def _convert_dataset(dataset_split):
   label_reader = build_data.ImageReader('png', channels=1)
 
   for shard_id in range(_NUM_SHARDS):
-    shard_filename = '%s-%05d-of-%05d.tfrecord' % (
+    shard_filename = '%s_fine-%05d-of-%05d.tfrecord' % (
         dataset_split, shard_id, _NUM_SHARDS)
     output_filename = os.path.join(FLAGS.output_dir, shard_filename)
     with tf.python_io.TFRecordWriter(output_filename) as tfrecord_writer:

--- a/research/deeplab/datasets/build_cityscapes_data.py
+++ b/research/deeplab/datasets/build_cityscapes_data.py
@@ -142,7 +142,11 @@ def _convert_dataset(dataset_split):
   label_files = _get_files('label', dataset_split)
 
   num_images = len(image_files)
+  num_labels = len(label_files)
   num_per_shard = int(math.ceil(num_images / _NUM_SHARDS))
+
+  if num_images != num_labels:
+    raise RuntimeError("The number of images and labels doesn't match: {} {}".format(num_images, num_labels))
 
   image_reader = build_data.ImageReader('png', channels=3)
   label_reader = build_data.ImageReader('png', channels=1)

--- a/research/deeplab/datasets/convert_cityscapes.sh
+++ b/research/deeplab/datasets/convert_cityscapes.sh
@@ -42,6 +42,8 @@ WORK_DIR="."
 # Root path for Cityscapes dataset.
 CITYSCAPES_ROOT="${WORK_DIR}/cityscapes"
 
+export PYTHONPATH="${CITYSCAPES_ROOT}:${PYTHONPATH}"
+
 # Create training labels.
 python "${CITYSCAPES_ROOT}/cityscapesscripts/preparation/createTrainIdLabelImgs.py"
 

--- a/research/deeplab/deprecated/segmentation_dataset.py
+++ b/research/deeplab/deprecated/segmentation_dataset.py
@@ -81,8 +81,8 @@ DatasetDescriptor = collections.namedtuple(
 
 _CITYSCAPES_INFORMATION = DatasetDescriptor(
     splits_to_sizes={
-        'train': 2975,
-        'val': 500,
+        'train_fine': 2975,
+        'val_fine': 500,
     },
     num_classes=19,
     ignore_label=255,

--- a/research/deeplab/g3doc/cityscapes.md
+++ b/research/deeplab/g3doc/cityscapes.md
@@ -43,7 +43,7 @@ A local training job using `xception_65` can be run with the following command:
 python deeplab/train.py \
     --logtostderr \
     --training_number_of_steps=90000 \
-    --train_split="train" \
+    --train_split="train_fine" \
     --model_variant="xception_65" \
     --atrous_rates=6 \
     --atrous_rates=12 \
@@ -95,7 +95,7 @@ command:
 # From tensorflow/models/research/
 python deeplab/eval.py \
     --logtostderr \
-    --eval_split="val" \
+    --eval_split="val_fine" \
     --model_variant="xception_65" \
     --atrous_rates=6 \
     --atrous_rates=12 \
@@ -121,7 +121,7 @@ command:
 # From tensorflow/models/research/
 python deeplab/vis.py \
     --logtostderr \
-    --vis_split="val" \
+    --vis_split="val_fine" \
     --model_variant="xception_65" \
     --atrous_rates=6 \
     --atrous_rates=12 \


### PR DESCRIPTION
# Description

Fix generation of tfrecord for Cityscapes and update documentation to use the correct split `--train_split="train_fine"`/`--eval_split="val_fine"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

```
python deeplab/train.py \
    --logtostderr \
    --training_number_of_steps=100 \
    --train_split="train_fine" \
    --model_variant="xception_65" \
    --fine_tune_batch_norm=False \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --train_crop_size="769,769" \
    --train_batch_size=1 \
    --dataset="cityscapes" \
    --tf_initial_checkpoint=${PATH_TO_INITIAL_CHECKPOINT} \
    --train_logdir=${PATH_TO_TRAIN_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

```
python deeplab/eval.py \
    --logtostderr \
    --eval_split="val_fine" \
    --model_variant="xception_65" \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --eval_crop_size="1025,2049" \
    --dataset="cityscapes" \
    --max_number_of_evaluations=1 \
    --checkpoint_dir=${PATH_TO_CHECKPOINT} \
    --eval_logdir=${PATH_TO_EVAL_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

```
python deeplab/vis.py \
    --logtostderr \
    --vis_split="val_fine" \
    --model_variant="xception_65" \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --vis_crop_size="1025,2049" \
    --dataset="cityscapes" \
    --max_number_of_iterations=1 \
    --colormap_type="cityscapes" \
    --checkpoint_dir=${PATH_TO_CHECKPOINT} \
    --vis_logdir=${PATH_TO_VIS_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

- Ubuntu 18.04.4
- CUDA 10.2
- Tensorflow 1.15.2

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
