### PR TITLE
DeepLab: Cityscapes splits refactoring

### DIFF
--- a/research/deeplab/datasets/build_cityscapes_data.py
+++ b/research/deeplab/datasets/build_cityscapes_data.py
@@ -119,12 +119,12 @@ def _get_files(data, dataset_split):
     A list of sorted file names or None when getting label for
       test set.
   """
-  if data == 'label' and dataset_split == 'test_fine':
-    return None
   if dataset_split == 'train_fine':
     split_dir = 'train'
   elif dataset_split == 'val_fine':
     split_dir = 'val'
+  elif dataset_split == 'test_fine':
+    split_dir = 'test'
   else:
     raise RuntimeError("Split {} is not supported".format(dataset_split))
   pattern = '*%s.%s' % (_POSTFIX_MAP[data], _DATA_FORMAT_MAP[data])
@@ -189,8 +189,8 @@ def _convert_dataset(dataset_split):
 
 
 def main(unused_argv):
-  # Only support converting 'train_fine' and 'val_fine' sets for now.
-  for dataset_split in ['train_fine', 'val_fine']:
+  # Only support converting 'train_fine', 'val_fine' and 'test_fine' sets for now.
+  for dataset_split in ['train_fine', 'val_fine', 'test_fine']:
     _convert_dataset(dataset_split)
 
 

--- a/research/deeplab/datasets/build_cityscapes_data.py
+++ b/research/deeplab/datasets/build_cityscapes_data.py
@@ -113,17 +113,23 @@ def _get_files(data, dataset_split):
 
   Args:
     data: String, desired data ('image' or 'label').
-    dataset_split: String, dataset split ('train', 'val', 'test')
+    dataset_split: String, dataset split ('train_fine', 'val_fine', 'test_fine')
 
   Returns:
     A list of sorted file names or None when getting label for
       test set.
   """
-  if data == 'label' and dataset_split == 'test':
+  if data == 'label' and dataset_split == 'test_fine':
     return None
+  if dataset_split == 'train_fine':
+    split_dir = 'train'
+  elif dataset_split == 'val_fine':
+    split_dir = 'val'
+  else:
+    raise RuntimeError("Split {} is not supported".format(dataset_split))
   pattern = '*%s.%s' % (_POSTFIX_MAP[data], _DATA_FORMAT_MAP[data])
   search_files = os.path.join(
-      FLAGS.cityscapes_root, _FOLDERS_MAP[data], dataset_split, '*', pattern)
+      FLAGS.cityscapes_root, _FOLDERS_MAP[data], split_dir, '*', pattern)
   filenames = glob.glob(search_files)
   return sorted(filenames)
 
@@ -132,7 +138,7 @@ def _convert_dataset(dataset_split):
   """Converts the specified dataset split to TFRecord format.
 
   Args:
-    dataset_split: The dataset split (e.g., train, val).
+    dataset_split: The dataset split (e.g., train_fine, val_fine).
 
   Raises:
     RuntimeError: If loaded image and label have different shape, or if the
@@ -152,7 +158,7 @@ def _convert_dataset(dataset_split):
   label_reader = build_data.ImageReader('png', channels=1)
 
   for shard_id in range(_NUM_SHARDS):
-    shard_filename = '%s_fine-%05d-of-%05d.tfrecord' % (
+    shard_filename = '%s-%05d-of-%05d.tfrecord' % (
         dataset_split, shard_id, _NUM_SHARDS)
     output_filename = os.path.join(FLAGS.output_dir, shard_filename)
     with tf.python_io.TFRecordWriter(output_filename) as tfrecord_writer:
@@ -183,8 +189,8 @@ def _convert_dataset(dataset_split):
 
 
 def main(unused_argv):
-  # Only support converting 'train' and 'val' sets for now.
-  for dataset_split in ['train', 'val']:
+  # Only support converting 'train_fine' and 'val_fine' sets for now.
+  for dataset_split in ['train_fine', 'val_fine']:
     _convert_dataset(dataset_split)
 
 


### PR DESCRIPTION
# Description

Refactoring, follow-up for https://github.com/tensorflow/models/pull/8866

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

```
python deeplab/train.py \
    --logtostderr \
    --training_number_of_steps=100 \
    --train_split="train_fine" \
    --model_variant="xception_65" \
    --fine_tune_batch_norm=False \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --train_crop_size="769,769" \
    --train_batch_size=1 \
    --dataset="cityscapes" \
    --tf_initial_checkpoint=${PATH_TO_INITIAL_CHECKPOINT} \
    --train_logdir=${PATH_TO_TRAIN_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

```
python deeplab/eval.py \
    --logtostderr \
    --eval_split="val_fine" \
    --model_variant="xception_65" \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --eval_crop_size="1025,2049" \
    --dataset="cityscapes" \
    --max_number_of_evaluations=1 \
    --checkpoint_dir=${PATH_TO_CHECKPOINT} \
    --eval_logdir=${PATH_TO_EVAL_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

```
python deeplab/vis.py \
    --logtostderr \
    --vis_split="val_fine" \
    --model_variant="xception_65" \
    --atrous_rates=6 \
    --atrous_rates=12 \
    --atrous_rates=18 \
    --output_stride=16 \
    --decoder_output_stride=4 \
    --vis_crop_size="1025,2049" \
    --dataset="cityscapes" \
    --max_number_of_iterations=1 \
    --colormap_type="cityscapes" \
    --checkpoint_dir=${PATH_TO_CHECKPOINT} \
    --vis_logdir=${PATH_TO_VIS_DIR} \
    --dataset_dir=${PATH_TO_DATASET}
```

- Ubuntu 18.04.4
- CUDA 10.2
- Tensorflow 1.15.2

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
