### PR TITLE
Change NCF eval_input_dataset not to use experimental_distribute_dataset.

### DIFF
--- a/official/recommendation/ncf_keras_main.py
+++ b/official/recommendation/ncf_keras_main.py
@@ -488,19 +488,19 @@ def run_ncf_custom_training(params,
         c.on_batch_end(current_step)
 
     train_loss /= num_train_steps
-    logging.info("Done training epoch %s, epoch loss=%s.", epoch + 1,
+    logging.info("Done training epoch %s, epoch loss=%.3f", epoch + 1,
                  train_loss)
 
-    eval_input_iterator = iter(
-        strategy.experimental_distribute_dataset(eval_input_dataset))
-    hr_sum = 0
-    hr_count = 0
+    eval_input_iterator = iter(eval_input_dataset)
+
+    hr_sum = 0.0
+    hr_count = 0.0
     for _ in range(num_eval_steps):
       step_hr_sum, step_hr_count = eval_step(eval_input_iterator)
       hr_sum += step_hr_sum
       hr_count += step_hr_count
 
-    logging.info("Done eval epoch %s, hit_rate=%s.", epoch + 1,
+    logging.info("Done eval epoch %s, hit_rate=%.3f", epoch + 1,
                  hr_sum / hr_count)
     if eval_summary_writer:
       with eval_summary_writer.as_default():


### PR DESCRIPTION
PiperOrigin-RevId: 322844988

# Description

This is [a cherry pick](https://github.com/tensorflow/models/commit/a829e6480d88bc19ac6f25fe6cbc3da702eb1bfa) from a master branch.

Changed eval_input_dataset not to use experimental_distribute_dataset as it was failing on TPU pods

## Type of change


-  Bug fix (non-breaking change which fixes an issue)

## Tests

Added to our tests for TPU and GPUs.


## Checklist

A [cherry pick](https://github.com/tensorflow/models/commit/a829e6480d88bc19ac6f25fe6cbc3da702eb1bfa) from master branch.
