### PR TITLE
Fix notebook URL

### DIFF
--- a/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
+++ b/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
@@ -10,11 +10,11 @@
         "# Object Detection API Demo\n",
         "\n",
         "\u003ctable align=\"left\"\u003e\u003ctd\u003e\n",
-        "  \u003ca target=\"_blank\"  href=\"https://colab.sandbox.google.com/github/tensorflow/models/blob/master/research/object_detection/colab_tutorials/colab_tutorials/object_detection_tutorial.ipynb\"\u003e\n",
+        "  \u003ca target=\"_blank\"  href=\"https://colab.sandbox.google.com/github/tensorflow/models/blob/master/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb\"\u003e\n",
         "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\n",
         "  \u003c/a\u003e\n",
         "\u003c/td\u003e\u003ctd\u003e\n",
-        "  \u003ca target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/research/object_detection/colab_tutorials/colab_tutorials/object_detection_tutorial.ipynb\"\u003e\n",
+        "  \u003ca target=\"_blank\"  href=\"https://github.com/tensorflow/models/blob/master/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb\"\u003e\n",
         "    \u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
         "\u003c/td\u003e\u003c/table\u003e"
       ]


### PR DESCRIPTION
There's an extraneous `colab_tutorials/` in there.

# Description

Just a simple typo fix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

N/A

**Test Configuration**:

## Checklist

- [X] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [X] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [X] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [X] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
