### PR TITLE
Bugfix: keep highest N candidates instead of removing

### DIFF
--- a/research/im2txt/im2txt/inference_utils/caption_generator.py
+++ b/research/im2txt/im2txt/inference_utils/caption_generator.py
@@ -179,7 +179,7 @@ class CaptionGenerator(object):
         # Sort the indexes with numpy, select the last self.beam_size
         # (3 by default) (ie, the most likely) and then reverse the sorted
         # indexes with [::-1] to sort them from higher to lower.
-        most_likely_words = np.argsort(word_probabilities)[:-self.beam_size][::-1]
+        most_likely_words = np.argsort(word_probabilities)[-self.beam_size:][::-1]
 
         for w in most_likely_words:
           p = word_probabilities[w]


### PR DESCRIPTION
# Description

The comment says "select the last self.beam_size", but `[:-self.beam_size]` actually means the opposite, i.e., removing the last self.beam_size.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Before the bugfix, the output was not a sentence:

```
Captions for image COCO_val2014_000000224477.jpg:
  0)  (p=0.000001)
  1) surfer (p=0.000000)
  2) two (p=0.000000)
```

After the bugfix, the output looks good:

```
Captions for image COCO_val2014_000000224477.jpg:
  0) a man riding a wave on top of a surfboard . (p=0.035869)
  1) a person riding a surf board on a wave (p=0.018637)
  2) a man riding a wave on a surfboard in the ocean . (p=0.004625)
```

**Test Configuration**:

* Python 3.6
* TensorFlow 1.0
* Pretrained model from [KranthiGV/Pretrained-Show-and-Tell-model](https://github.com/KranthiGV/Pretrained-Show-and-Tell-model)

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
