### PR TITLE
Added parameter num_visualizations to train config

### DIFF
--- a/research/object_detection/protos/train.proto
+++ b/research/object_detection/protos/train.proto
@@ -134,5 +134,8 @@ message TrainConfig {
   // Whether to summarize gradients.
   optional bool summarize_gradients = 27 [default=false];
 
+  // Number of visualization images to generate.
+  optional uint32 num_visualizations = 29 [default = 0];
+
 }
 


### PR DESCRIPTION
# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

Added parameter num_visualizations to the train config (train.proto) to allow users to adjust the number of visualized input images during the training. This is particularly relevant when summaries get too big in longer training runs.

Added rescaling of the images from range (-1, 1) to (0, 1) as required by [tf.summary.image](https://www.tensorflow.org/api_docs/python/tf/summary/image#arguments). This enables TensorBoard to correctly visualize the images.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

Tested with model_lib_tf2_test.py and by training "SSD MobileNet V2 FPNLite 640x640" from "TensorFlow 2 Detection Model Zoo"

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
