### PR TITLE
intermediate dropout in layers/transformer

### DIFF
--- a/official/nlp/modeling/layers/transformer_test.py
+++ b/official/nlp/modeling/layers/transformer_test.py
@@ -230,7 +230,8 @@ class TransformerArgumentTest(keras_parameterized.TestCase):
         attention_dropout_rate=0.1,
         use_bias=False,
         norm_first=True,
-        norm_epsilon=1e-6)
+        norm_epsilon=1e-6,
+        intermediate_dropout=0.1)
     # Forward path.
     dummy_tensor = tf.zeros([2, 4, 16], dtype=tf.float32)
     dummy_mask = tf.zeros([2, 4, 4], dtype=tf.float32)
@@ -248,7 +249,8 @@ class TransformerArgumentTest(keras_parameterized.TestCase):
         attention_dropout_rate=0.1,
         use_bias=False,
         norm_first=True,
-        norm_epsilon=1e-6)
+        norm_epsilon=1e-6,
+        intermediate_dropout=0.1)
     encoder_block_config = encoder_block.get_config()
     new_encoder_block = transformer.Transformer.from_config(
         encoder_block_config)
@@ -299,7 +301,8 @@ class TransformerDecoderLayerTest(keras_parameterized.TestCase):
         attention_dropout_rate=0.1,
         use_bias=False,
         norm_first=True,
-        norm_epsilon=1e-6)
+        norm_epsilon=1e-6,
+        intermediate_dropout=0.1)
     # Forward path.
     dummy_tensor = tf.zeros([2, 4, 16], dtype=tf.float32)
     dummy_mask = tf.zeros([2, 4, 4], dtype=tf.float32)
@@ -317,7 +320,8 @@ class TransformerDecoderLayerTest(keras_parameterized.TestCase):
         attention_dropout_rate=0.1,
         use_bias=False,
         norm_first=True,
-        norm_epsilon=1e-6)
+        norm_epsilon=1e-6,
+        intermediate_dropout=0.1)
     decoder_block_config = decoder_block.get_config()
     new_decoder_block = transformer.TransformerDecoderLayer.from_config(
         decoder_block_config)


### PR DESCRIPTION
# Description

> :memo: Please include a summary of the change. 
>  
> * Add intermediate_dropout argument in Transformer, TransformerDecoderLayer to enable intermediate_dropout_layer

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] TensorFlow 2 migration

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
