### PR TITLE
Fixed object detection off the shelf inference tutorial link

### DIFF
--- a/research/object_detection/g3doc/running_notebook.md
+++ b/research/object_detection/g3doc/running_notebook.md
@@ -14,5 +14,5 @@ jupyter notebook
 ```
 
 The notebook should open in your favorite web browser. Click the
-[`object_detection_tutorial.ipynb`](../object_detection_tutorial.ipynb) link to
+[`object_detection_tutorial.ipynb`](../colab_tutorials/object_detection_tutorial.ipynb) link to
 open the demo.


### PR DESCRIPTION
# Description

Changed link address to point to correct notebook location, previous link resulted in page not found error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Tests

Accessed object_detection_tutorial.ipynb through new link

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
