### PR TITLE
Consider regression model in predict mode

### DIFF
--- a/official/nlp/bert/run_classifier.py
+++ b/official/nlp/bert/run_classifier.py
@@ -448,7 +448,7 @@ def custom_main(custom_callbacks=None, custom_metrics=None):
   if FLAGS.mode == 'predict':
     with strategy.scope():
       classifier_model = bert_models.classifier_model(
-          bert_config, input_meta_data['num_labels'])[0]
+          bert_config, input_meta_data.get('num_labels', 1))[0]
       checkpoint = tf.train.Checkpoint(model=classifier_model)
       latest_checkpoint_file = (
           FLAGS.predict_checkpoint_path or


### PR DESCRIPTION
# Description

The key `input_meta_data['num_labels']` doesn't always exist, it is defaulted to 1 when the Bert model is a regression model. In both modes `train_and_eval` and `export`, the "default to 1" setting is considered but not in `predict` mode.

Another issue this PR tries to solve is the unnecessary softmax applied to logit for regression model.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Create a customized `DataProcessor` class with attribute `is_regression = True`, the output meta data will look something like follows where key `num_labels` is absent.

```
{
    "processor_type": "RegressionDataProcessor",
    "train_data_size": 19765218,
    "max_seq_length": 128,
    "task_type": "bert_regression",
    "label_type": "int",
    "eval_data_size": 1260452
}
```

This lets the finetuning process to create a regression Bert model. Finetuning finished without issue, prediction ran fine too after the proposed change, otherwise prediction will raise exception as follows.

```
KeyError: 'num_labels'
```

**Test Configuration**:

With `tf_models_nightly-2.2.0.dev20200720`

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
