### PR TITLE
Fix problem with not loading checkpoint weights.

### DIFF
--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -23,6 +23,7 @@ from absl import flags
 import tensorflow.compat.v1 as tf
 
 from object_detection import model_lib
+from object_detection import model_hparams
 
 flags.DEFINE_string(
     'model_dir', None, 'Path to output model directory '
@@ -63,6 +64,7 @@ def main(unused_argv):
 
   train_and_eval_dict = model_lib.create_estimator_and_inputs(
       run_config=config,
+      hparams=model_hparams.create_hparams(FLAGS.hparams_overrides),
       pipeline_config_path=FLAGS.pipeline_config_path,
       train_steps=FLAGS.num_train_steps,
       sample_1_of_n_eval_examples=FLAGS.sample_1_of_n_eval_examples,


### PR DESCRIPTION

# Description

The train process doesn't load weights from checkpoints defined by `train_config.fine_tune_checkpoint`.
The reason is that hparams is not defined in `model_main.py` and then https://github.com/tensorflow/models/blob/master/research/object_detection/model_lib.py#L459 skips block of code for weight initialization.

## Type of change
Problem mentioned here: https://github.com/tensorflow/models/issues/9138

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
