### PR TITLE
Fixed the BUG "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x…

### DIFF
--- a/research/object_detection/utils/label_map_util.py
+++ b/research/object_detection/utils/label_map_util.py
@@ -152,8 +152,8 @@ def load_labelmap(path):
   Returns:
     a StringIntLabelMapProto
   """
-  with tf.io.gfile.GFile(path, 'r') as fid:
-    label_map_string = fid.read()
+  with tf.io.gfile.GFile(path, 'rb') as fid:
+    label_map_string = fid.read(-1)
     label_map = string_int_label_map_pb2.StringIntLabelMap()
     try:
       text_format.Merge(label_map_string, label_map)


### PR DESCRIPTION
…d5 in position 74: invalid continuation byte" in object_detection process

# Description

> :memo:  I meet the BUG "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 74: invalid continuation byte" when I train a custom model to detect some objects through tensorflow object_detection API, Across the error information, I found the BUG located at "object_detection\utils\label_map_util.py line:155 & line:156", then I fixed this BUG according to the description in https://www.tensorflow.org/api_docs/python/tf/io/gfile/GFile 

>**Error Info:**
>.........
0 01:14:28.650435 15460 efficientnet_model.py:460] Building model efficientnet with params ModelConfig(width_coefficient=1.0, depth_coefficient=1.0, resolution=224, dropout_rate=0.2, blocks=(BlockConfig(input_filters=32, output_filters=16, kernel_size=3, num_repeat=1, expand_ratio=1, strides=(1, 1), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=16, output_filters=24, kernel_size=3, num_repeat=2, expand_ratio=6, strides=(2, 2), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=24, output_filters=40, kernel_size=5, num_repeat=2, expand_ratio=6, strides=(2, 2), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=40, output_filters=80, kernel_size=3, num_repeat=3, expand_ratio=6, strides=(2, 2), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=80, output_filters=112, kernel_size=5, num_repeat=3, expand_ratio=6, strides=(1, 1), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=112, output_filters=192, kernel_size=5, num_repeat=4, expand_ratio=6, strides=(2, 2), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise'), BlockConfig(input_filters=192, output_filters=320, kernel_size=3, num_repeat=1, expand_ratio=6, strides=(1, 1), se_ratio=0.25, id_skip=True, fused_conv=False, conv_type='depthwise')), stem_base_filters=32, top_base_filters=1280, activation='simple_swish', batch_norm='default', bn_momentum=0.99, bn_epsilon=0.001, weight_decay=5e-06, drop_connect_rate=0.2, depth_divisor=8, min_depth=None, use_se=True, input_channels=3, num_classes=1000, model_name='efficientnet', rescale_input=False, data_format='channels_last', dtype='float32')
Traceback (most recent call last):
  File "models\research\object_detection\model_main_tf2.py", line 113, in <module>
    tf.compat.v1.app.run()
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\platform\app.py", line 40, in run
    _run(main=main, argv=argv, flags_parser=_parse_flags_tolerate_undef)
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\absl\app.py", line 300, in run
    _run_main(main, args)
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\absl\app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "models\research\object_detection\model_main_tf2.py", line 104, in main
    model_lib_v2.train_loop(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\model_lib_v2.py", line 525, in train_loop
    train_input = strategy.experimental_distribute_datasets_from_function(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\distribute\distribute_lib.py", line 1127, in experimental_distribute_datasets_from_function
    return self._extended._experimental_distribute_datasets_from_function(  # pylint: disable=protected-access
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\distribute\mirrored_strategy.py", line 499, in _experimental_distribute_datasets_from_function
    return input_lib.get_distributed_datasets_from_function(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\distribute\input_lib.py", line 132, in get_distributed_datasets_from_function
    return DistributedDatasetsFromFunction(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\distribute\input_lib.py", line 1181, in __init__
    _create_datasets_per_worker_with_input_context(self._input_contexts,
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\distribute\input_lib.py", line 1767, in _create_datasets_per_worker_with_input_context
    dataset = dataset_fn(ctx)
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\model_lib_v2.py", line 516, in train_dataset_fn
    train_input = inputs.train_input(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\inputs.py", line 833, in train_input
    dataset = INPUT_BUILDER_UTIL_MAP['dataset_build'](
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\builders\dataset_builder.py", line 148, in build
    decoder = decoder_builder.build(input_reader_config)
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\builders\decoder_builder.py", line 52, in build
    decoder = tf_example_decoder.TfExampleDecoder(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\data_decoders\tf_example_decoder.py", line 383, in __init__
    _ClassTensorHandler(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\data_decoders\tf_example_decoder.py", line 88, in __init__
    name_to_id = label_map_util.get_label_map_dict(
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\utils\label_map_util.py", line 189, in get_label_map_dict
    label_map = load_labelmap(label_map_path_or_proto)
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\object_detection\utils\label_map_util.py", line 156, in load_labelmap
    label_map_string = fid.read()
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\lib\io\file_io.py", line 116, in read
    self._preread_check()
  File "C:\Users\zwbhe\.conda\envs\thelasttry\lib\site-packages\tensorflow\python\lib\io\file_io.py", line 78, in _preread_check
    self._read_buf = _pywrap_file_io.BufferedInputStream(
**UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 74: invalid continuation byte**


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

> :memo: N/A

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
