### PR TITLE
Change input signature on object detection exporter v2

### DIFF
--- a/research/object_detection/exporter_lib_v2.py
+++ b/research/object_detection/exporter_lib_v2.py
@@ -130,7 +130,7 @@ class DetectionFromImageModule(DetectionInferenceModule):
     """
     if zipped_side_inputs is None:
       zipped_side_inputs = []
-    sig = [tf.TensorSpec(shape=[1, None, None, 3],
+    sig = [tf.TensorSpec(shape=[None, None, None, 3],
                          dtype=tf.uint8,
                          name='input_tensor')]
     if use_side_inputs:
@@ -154,7 +154,7 @@ class DetectionFromFloatImageModule(DetectionInferenceModule):
 
   @tf.function(
       input_signature=[
-          tf.TensorSpec(shape=[1, None, None, 3], dtype=tf.float32)])
+          tf.TensorSpec(shape=[None, None, None, 3], dtype=tf.float32)])
   def __call__(self, input_tensor):
     return self._run_inference_on_images(input_tensor)
 
@@ -162,7 +162,7 @@ class DetectionFromFloatImageModule(DetectionInferenceModule):
 class DetectionFromEncodedImageModule(DetectionInferenceModule):
   """Detection Inference Module for encoded image string inputs."""
 
-  @tf.function(input_signature=[tf.TensorSpec(shape=[1], dtype=tf.string)])
+  @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.string)])
   def __call__(self, input_tensor):
     with tf.device('cpu:0'):
       image = tf.map_fn(
@@ -177,7 +177,7 @@ class DetectionFromEncodedImageModule(DetectionInferenceModule):
 class DetectionFromTFExampleModule(DetectionInferenceModule):
   """Detection Inference Module for TF.Example inputs."""
 
-  @tf.function(input_signature=[tf.TensorSpec(shape=[1], dtype=tf.string)])
+  @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.string)])
   def __call__(self, input_tensor):
     with tf.device('cpu:0'):
       image = tf.map_fn(


### PR DESCRIPTION
# Description

> The object detection API v2 did not allow exported models to perform inference on batches.
> This pull requests changes the input signatures in `exporter_lib_v2.py` in order to allow this.

## Type of change

- [x] New feature

## Tests

> Exported models using the adapted exporter code.
> Tested model on batches in a variety of ways, including deployment on TF serving

**Test Configuration**:

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
