### PR TITLE
[MobileNet] Add Mobilenet Backbone Implementation

### DIFF
--- a/official/modeling/activations/__init__.py
+++ b/official/modeling/activations/__init__.py
@@ -17,3 +17,5 @@ from official.modeling.activations.gelu import gelu
 from official.modeling.activations.swish import hard_swish
 from official.modeling.activations.swish import identity
 from official.modeling.activations.swish import simple_swish
+from official.modeling.activations.relu import relu6
+from official.modeling.activations.sigmoid import hard_sigmoid

--- a/official/modeling/activations/relu.py
+++ b/official/modeling/activations/relu.py
@@ -1,0 +1,38 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Customized Relu activation."""
+
+import tensorflow as tf
+
+
+@tf.keras.utils.register_keras_serializable(package='Text')
+def relu6(features):
+  """Computes the Swish activation function.
+
+  The tf.nn.relu6 operation uses a custom gradient to reduce memory usage.
+  Since saving custom gradients in SavedModel is currently not supported, and
+  one would not be able to use an exported TF-Hub module for fine-tuning, we
+  provide this wrapper that can allow to select whether to use the native
+  TensorFlow relu operation, or whether to use a customized operation that
+  has uses default TensorFlow gradient computation.
+
+  Args:
+    features: A `Tensor` representing preactivation values.
+
+  Returns:
+    The activation value.
+  """
+  features = tf.convert_to_tensor(features)
+  return tf.nn.relu6(features)

--- a/official/modeling/activations/relu.py
+++ b/official/modeling/activations/relu.py
@@ -19,14 +19,7 @@ import tensorflow as tf
 
 @tf.keras.utils.register_keras_serializable(package='Text')
 def relu6(features):
-  """Computes the Swish activation function.
-
-  The tf.nn.relu6 operation uses a custom gradient to reduce memory usage.
-  Since saving custom gradients in SavedModel is currently not supported, and
-  one would not be able to use an exported TF-Hub module for fine-tuning, we
-  provide this wrapper that can allow to select whether to use the native
-  TensorFlow relu operation, or whether to use a customized operation that
-  has uses default TensorFlow gradient computation.
+  """Computes the Relu6 activation function.
 
   Args:
     features: A `Tensor` representing preactivation values.

--- a/official/modeling/activations/relu_test.py
+++ b/official/modeling/activations/relu_test.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Tests for the customized Relu activation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf
 
 from tensorflow.python.keras import \

--- a/official/modeling/activations/relu_test.py
+++ b/official/modeling/activations/relu_test.py
@@ -1,0 +1,39 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the customized Relu activation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorflow.python.keras import \
+  keras_parameterized  # pylint: disable=g-direct-tensorflow-import
+from official.modeling import activations
+
+
+@keras_parameterized.run_all_keras_modes
+class CustomizedReluTest(keras_parameterized.TestCase):
+
+  def test_relu6(self):
+    features = [[.25, 0, -.25], [-1, -2, 3]]
+    customized_relu6_data = activations.relu6(features)
+    relu6_data = tf.nn.relu6(features)
+    self.assertAllClose(customized_relu6_data, relu6_data)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/official/modeling/activations/sigmoid.py
+++ b/official/modeling/activations/sigmoid.py
@@ -1,0 +1,38 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Customized Sigmoid activation."""
+
+import tensorflow as tf
+
+
+@tf.keras.utils.register_keras_serializable(package='Text')
+def hard_sigmoid(features):
+  """Computes the Swish activation function.
+
+  The tf.nn.relu6 operation uses a custom gradient to reduce memory usage.
+  Since saving custom gradients in SavedModel is currently not supported, and
+  one would not be able to use an exported TF-Hub module for fine-tuning, we
+  provide this wrapper that can allow to select whether to use the native
+  TensorFlow relu operation, or whether to use a customized operation that
+  has uses default TensorFlow gradient computation.
+
+  Args:
+    features: A `Tensor` representing preactivation values.
+
+  Returns:
+    The activation value.
+  """
+  features = tf.convert_to_tensor(features)
+  return tf.nn.relu6(features + tf.constant(3.)) * 0.16667

--- a/official/modeling/activations/sigmoid.py
+++ b/official/modeling/activations/sigmoid.py
@@ -19,14 +19,7 @@ import tensorflow as tf
 
 @tf.keras.utils.register_keras_serializable(package='Text')
 def hard_sigmoid(features):
-  """Computes the Swish activation function.
-
-  The tf.nn.relu6 operation uses a custom gradient to reduce memory usage.
-  Since saving custom gradients in SavedModel is currently not supported, and
-  one would not be able to use an exported TF-Hub module for fine-tuning, we
-  provide this wrapper that can allow to select whether to use the native
-  TensorFlow relu operation, or whether to use a customized operation that
-  has uses default TensorFlow gradient computation.
+  """Computes the hard sigmoid activation function.
 
   Args:
     features: A `Tensor` representing preactivation values.

--- a/official/modeling/activations/sigmoid_test.py
+++ b/official/modeling/activations/sigmoid_test.py
@@ -1,0 +1,44 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the customized Sigmoid activation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.python.keras import \
+  keras_parameterized  # pylint: disable=g-direct-tensorflow-import
+from official.modeling import activations
+
+
+@keras_parameterized.run_all_keras_modes
+class CustomizedSigmoidTest(keras_parameterized.TestCase):
+
+  def _hard_sigmoid_nn(self, x):
+    x = np.float32(x)
+    return tf.nn.relu6(x + 3.) * 0.16667
+
+  def test_hard_sigmoid(self):
+    features = [[.25, 0, -.25], [-1, -2, 3]]
+    customized_hard_sigmoid_data = activations.hard_sigmoid(features)
+    sigmoid_data = self._hard_sigmoid_nn(features)
+    self.assertAllClose(customized_hard_sigmoid_data, sigmoid_data)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/official/modeling/activations/sigmoid_test.py
+++ b/official/modeling/activations/sigmoid_test.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Tests for the customized Sigmoid activation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import tensorflow as tf
 

--- a/official/modeling/tf_utils.py
+++ b/official/modeling/tf_utils.py
@@ -104,6 +104,8 @@ def get_activation(identifier):
         "gelu": activations.gelu,
         "simple_swish": activations.simple_swish,
         "hard_swish": activations.hard_swish,
+        "relu6": activations.relu6,
+        "hard_sigmoid": activations.hard_sigmoid,
         "identity": activations.identity,
     }
     identifier = str(identifier).lower()

--- a/official/vision/beta/configs/backbones.py
+++ b/official/vision/beta/configs/backbones.py
@@ -37,6 +37,14 @@ class EfficientNet(hyperparams.Config):
 
 
 @dataclasses.dataclass
+class MobileNet(hyperparams.Config):
+  """Mobilenet config."""
+  model_id: str = 'MobileNetV2'
+  width_multiplier: float = 1.0
+  stochastic_depth_drop_rate: float = 0.0
+
+
+@dataclasses.dataclass
 class SpineNet(hyperparams.Config):
   """SpineNet config."""
   model_id: str = '49'
@@ -59,9 +67,11 @@ class Backbone(hyperparams.OneOfConfig):
     revnet: revnet backbone config.
     efficientnet: efficientnet backbone config.
     spinenet: spinenet backbone config.
+    mobilenet: mobilenet backbone config.
   """
   type: Optional[str] = None
   resnet: ResNet = ResNet()
   revnet: RevNet = RevNet()
   efficientnet: EfficientNet = EfficientNet()
   spinenet: SpineNet = SpineNet()
+  mobilenet: MobileNet = MobileNet()

--- a/official/vision/beta/modeling/backbones/__init__.py
+++ b/official/vision/beta/modeling/backbones/__init__.py
@@ -20,3 +20,4 @@ from official.vision.beta.modeling.backbones.resnet import ResNet
 from official.vision.beta.modeling.backbones.resnet_3d import ResNet3D
 from official.vision.beta.modeling.backbones.revnet import RevNet
 from official.vision.beta.modeling.backbones.spinenet import SpineNet
+from official.vision.beta.modeling.backbones.mobilenet import MobileNet

--- a/official/vision/beta/modeling/backbones/factory.py
+++ b/official/vision/beta/modeling/backbones/factory.py
@@ -87,6 +87,16 @@ def build_backbone(input_specs: tf.keras.layers.InputSpec,
         norm_momentum=norm_activation_config.norm_momentum,
         norm_epsilon=norm_activation_config.norm_epsilon,
         kernel_regularizer=l2_regularizer)
+  elif backbone_type == 'mobilenet':
+    backbone = backbones.MobileNet(
+        model_id=backbone_cfg.model_id,
+        width_multiplier=backbone_cfg.width_multiplier,
+        input_specs=input_specs,
+        stochastic_depth_drop_rate=backbone_cfg.stochastic_depth_drop_rate,
+        use_sync_bn=norm_activation_config.use_sync_bn,
+        norm_momentum=norm_activation_config.norm_momentum,
+        norm_epsilon=norm_activation_config.norm_epsilon,
+        kernel_regularizer=l2_regularizer)
   else:
     raise ValueError('Backbone {!r} not implement'.format(backbone_type))
 

--- a/official/vision/beta/modeling/backbones/factory_test.py
+++ b/official/vision/beta/modeling/backbones/factory_test.py
@@ -86,7 +86,41 @@ class FactoryTest(tf.test.TestCase, parameterized.TestCase):
 
     self.assertEqual(network_config, factory_network_config)
 
-  @combinations.generate(combinations.combine(model_id=['49'],))
+  @combinations.generate(
+      combinations.combine(
+          model_id=['MobileNetV1', 'MobileNetV2',
+                    'MobileNetV3Large', 'MobileNetV3Small',
+                    'MobileNetV3EdgeTPU'],
+          width_multiplier=[1.0, 0.75],
+      ))
+  def test_mobilenet_creation(self, model_id, width_multiplier):
+    """Test creation of Mobilenet models."""
+
+    network = backbones.MobileNet(
+        model_id=model_id,
+        width_multiplier=width_multiplier,
+        norm_momentum=0.99,
+        norm_epsilon=1e-5)
+
+    backbone_config = backbones_cfg.Backbone(
+        type='mobilenet',
+        mobilenet=backbones_cfg.MobileNet(
+            model_id=model_id, width_multiplier=width_multiplier))
+    norm_activation_config = common_cfg.NormActivation(
+        norm_momentum=0.99, norm_epsilon=1e-5)
+    model_config = retinanet_cfg.RetinaNet(
+        backbone=backbone_config, norm_activation=norm_activation_config)
+
+    factory_network = factory.build_backbone(
+        input_specs=tf.keras.layers.InputSpec(shape=[None, None, None, 3]),
+        model_config=model_config)
+
+    network_config = network.get_config()
+    factory_network_config = factory_network.get_config()
+
+    self.assertEqual(network_config, factory_network_config)
+
+  @combinations.generate(combinations.combine(model_id=['49'], ))
   def test_spinenet_creation(self, model_id):
     """Test creation of SpineNet models."""
     input_size = 128

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -632,6 +632,7 @@ class MobileNet(tf.keras.Model):
             norm_epsilon=self._norm_epsilon,
             stochastic_depth_drop_rate=self._stochastic_depth_drop_rate,
             divisible_by=self._divisible_by,
+            target_backbone='mobilenet'
         )(net)
 
       elif block_def.block_fn == 'gpooling':

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -15,7 +15,7 @@
 """Contains definitions of EfficientNet Networks."""
 
 import math
-from typing import Text, Optional
+from typing import Text, Optional, List, Dict
 
 # Import libraries
 from absl import logging
@@ -136,3 +136,516 @@ class Conv2DBNBlock(tf.keras.layers.Layer):
     if self._use_normalization:
       x = self._norm0(x)
     return self._activation_fn(x)
+
+
+class GlobalPoolingBlock(tf.keras.layers.Layer):
+  def __init__(self, **kwargs):
+    super(GlobalPoolingBlock, self).__init__(**kwargs)
+
+  def call(self, inputs, training=None):
+    x = layers.GlobalAveragePooling2D()(inputs)
+    outputs = layers.Reshape((1, 1, x.shape[1]))(x)
+    return outputs
+
+
+MNV2_BLOCK_SPECS = {
+    'spec_name': 'MobileNetV2',
+    'block_spec_schema': ['block_fn', 'kernel_size', 'strides',
+                          'filters', 'expand_ratio'],
+    'block_specs': [
+        ('convbn', 3, 2, 32, None),
+        ('mbconv', 3, 1, 16, 1),
+
+        ('mbconv', 3, 2, 24, 6),
+        ('mbconv', 3, 1, 24, 6),
+
+        ('mbconv', 3, 2, 32, 6),
+        ('mbconv', 3, 1, 32, 6),
+        ('mbconv', 3, 1, 32, 6),
+
+        ('mbconv', 3, 2, 64, 6),
+        ('mbconv', 3, 1, 64, 6),
+        ('mbconv', 3, 1, 64, 6),
+        ('mbconv', 3, 1, 64, 6),
+
+        ('mbconv', 3, 1, 96, 6),
+        ('mbconv', 3, 1, 96, 6),
+        ('mbconv', 3, 1, 96, 6),
+
+        ('mbconv', 3, 2, 160, 6),
+        ('mbconv', 3, 1, 160, 6),
+        ('mbconv', 3, 1, 160, 6),
+
+        ('mbconv', 3, 1, 320, 6),
+
+        ('convbn', 1, 2, 1280, None),
+    ]
+}
+
+MNV3Large_BLOCK_SPECS = {
+    'spec_name': 'MobileNetV3Large',
+    'block_spec_schema': ['block_fn', 'kernel_size', 'strides',
+                          'filters', 'activation',
+                          'se_ratio', 'expand_ratio',
+                          'use_normalization', 'use_biase'],
+    'block_specs': [
+        ('convbn', 3, 2, 16, 'hard_swish', None, None, True, False),
+
+        ('mbconv', 3, 1, 16, 'relu', None, 1., True, False),
+
+        ('mbconv', 3, 2, 24, 'relu', None, 4., True, False),
+        ('mbconv', 3, 1, 24, 'relu', None, 3., True, False),
+
+        ('mbconv', 5, 2, 40, 'relu', 1. / 4, 3., True, False),
+        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., True, False),
+        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., True, False),
+
+        ('mbconv', 3, 2, 80, 'hard_swish', None, 6., True, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.5, True, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, True, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, True, False),
+
+        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., True, False),
+
+        ('mbconv', 5, 2, 160, 'hard_swish', 1. / 4, 6, True, False),
+        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, True, False),
+        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, True, False),
+
+        ('convbn', 1, 1, 960, 'hard_swish', None, None, True, False),
+        ('gpooling', None, None, None, None, None, None, None, None),
+        ('convbn', 1, 1, 1280, 'hard_swish', None, None, False, True),
+    ]
+}
+
+MNV3Small_BLOCK_SPECS = {
+    'spec_name': 'MobileNetV3Small',
+    'block_spec_schema': ['block_fn', 'kernel_size', 'strides',
+                          'filters', 'activation',
+                          'se_ratio', 'expand_ratio',
+                          'use_normalization', 'use_biase'],
+    'block_specs': [
+        ('convbn', 3, 2, 16, 'hard_swish', None, None, True, False),
+
+        ('mbconv', 3, 2, 16, 'relu', None, 1, True, False),
+
+        ('mbconv', 3, 2, 24, 'relu', None, 72. / 16, True, False),
+        ('mbconv', 3, 1, 24, 'relu', None, 88. / 24, True, False),
+
+        ('mbconv', 5, 2, 40, 'hard_swish', 1. / 4, 4., True, False),
+        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., True, False),
+
+        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., True, False),
+        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., True, False),
+
+        ('mbconv', 5, 2, 96, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., True, False),
+
+        ('convbn', 1, 1, 576, 'hard_swish', None, None, True, False),
+        ('gpooling', None, None, None, None, None, None, None, None),
+        ('convbn', 1, 1, 1024, 'hard_swish', None, None, False, True),
+    ]
+}
+
+MNV3EdgeTPU_BLOCK_SPECS = {
+    'spec_name': 'MobileNetV3EdgeTPU',
+    'block_spec_schema': ['block_fn', 'kernel_size', 'strides',
+                          'filters', 'activation',
+                          'se_ratio', 'expand_ratio',
+                          'use_residual', 'use_depthwise'],
+    'block_specs': [
+        ('convbn', 3, 2, 32, 'relu', None, None, None, None),
+
+        ('mbconv', 3, 1, 16, 'relu', None, 1, True, False),
+
+        ('mbconv', 3, 2, 32, 'relu', None, 8., True, False),
+        ('mbconv', 3, 1, 32, 'relu', None, 4., True, False),
+        ('mbconv', 3, 2, 32, 'relu', None, 4., True, False),
+        ('mbconv', 3, 1, 32, 'relu', None, 4., True, False),
+
+        ('mbconv', 3, 2, 48, 'relu', None, 8., True, False),
+        ('mbconv', 3, 1, 48, 'relu', None, 4., True, False),
+        ('mbconv', 3, 2, 48, 'relu', None, 4., True, False),
+        ('mbconv', 3, 1, 48, 'relu', None, 4., True, False),
+
+        ('mbconv', 3, 2, 96, 'relu', None, 8., True, True),
+        ('mbconv', 3, 1, 96, 'relu', None, 4., True, True),
+        ('mbconv', 3, 2, 96, 'relu', None, 4., True, True),
+        ('mbconv', 3, 1, 96, 'relu', None, 4., True, True),
+
+        ('mbconv', 3, 1, 96, 'relu', None, 8., False, True),
+        ('mbconv', 3, 1, 96, 'relu', None, 4., True, True),
+        ('mbconv', 3, 2, 96, 'relu', None, 4., True, True),
+        ('mbconv', 3, 1, 96, 'relu', None, 4., True, True),
+
+        ('mbconv', 5, 2, 160, 'relu', None, 8., True, True),
+        ('mbconv', 5, 1, 160, 'relu', None, 4., True, True),
+        ('mbconv', 5, 2, 160, 'relu', None, 4., True, True),
+        ('mbconv', 5, 1, 160, 'relu', None, 4., True, True),
+
+        ('mbconv', 3, 1, 192, 'relu', None, 8., True, False),
+
+        ('convbn', 1, 1, 1280, 'relu', None, None, None, None),
+    ]
+}
+
+SUPPORTED_SPECS_MAP = {
+    'MobileNetV2': MNV2_BLOCK_SPECS,
+    'MobileNetV3Large': MNV3Large_BLOCK_SPECS,
+    'MobileNetV3Small': MNV3Small_BLOCK_SPECS,
+    'MobileNetV3EdgeTPU': MNV3EdgeTPU_BLOCK_SPECS
+}
+
+BLOCK_FN_MAP = {
+    'convbn': Conv2DBNBlock,
+    'gpooling': GlobalPoolingBlock,
+    'mbconv': nn_blocks.InvertedBottleneckBlock,
+
+}
+
+
+class BlockSpec(object):
+  """A container class that specifies the block configuration for MnasNet."""
+
+  def __init__(self,
+               block_fn: Text = 'convbn',
+               kernel_size: int = 3,
+               strides: int = 1,
+               filters: int = 32,
+               use_biase: bool = False,
+               use_normalization: bool = True,
+               activation: Text = 'relu6',
+               # used for block type InvertedResConv
+               expand_ratio: Optional[float] = 6.,
+               # used for block type InvertedResConv with SE
+               se_ratio: Optional[float] = None,
+               use_depthwise: bool = True,
+               use_residual: bool = True, ):
+    self.block_fn = block_fn
+    self.kernel_size = kernel_size
+    self.strides = strides
+    self.filters = filters
+    self.use_biase = use_biase
+    self.use_normalization = use_normalization
+    self.activation = activation
+    self.expand_ratio = expand_ratio
+    self.se_ratio = se_ratio
+    self.use_depthwise = use_depthwise
+    self.use_residual = use_residual
+
+
+def block_spec_decoder(specs,
+                       width_multiplier,
+                       # set to 1 for mobilenetv1
+                       divisible_by: int = 8,
+                       finegrain_classification_mode: bool = True):
+  """Decode specs for a block."""
+
+  spec_name = specs['spec_name']
+  block_spec_schema = specs['block_spec_schema']
+  block_specs = specs['block_specs']
+
+  if spec_name not in SUPPORTED_SPECS_MAP:
+    raise ValueError('Model spec: {} is not supported !'.format(spec_name))
+
+  if len(block_specs) == 0:
+    raise ValueError('The block spec cannot be empty for {} !'.format(spec_name))
+
+  if len(block_specs[0]) != len(block_spec_schema):
+    raise ValueError('The block spec values {} do not match with '
+                     'the schema {}'.format(block_specs[0], block_spec_schema))
+
+  decoded_specs = []
+
+  for s in block_specs:
+    kw_s = dict(zip(block_spec_schema, s))
+    decoded_specs.append(BlockSpec(**kw_s))
+
+  # This adjustment applies to V2 and V3
+  if (spec_name != 'MobileNetV1'
+      and finegrain_classification_mode
+      and width_multiplier < 1.0):
+    decoded_specs[-1].filters /= width_multiplier
+
+  for ds in decoded_specs:
+    ds.filters = nn_layers.round_filters(filters=ds.filters,
+                                         multiplier=width_multiplier,
+                                         divisor=divisible_by,
+                                         min_depth=8)
+
+    return decoded_specs
+
+
+def mobilenet_base(inputs: tf.Tensor,
+                   spec_blocks: List[BlockSpec],
+                   divisible_by: int = 8,
+                   output_stride: int = None,
+                   stochastic_depth_drop_rate=0.0,
+                   regularize_depthwise=False,
+                   kernel_initializer='VarianceScaling',
+                   kernel_regularizer=None,
+                   bias_regularizer=None,
+                   use_sync_bn=False,
+                   norm_momentum=0.99,
+                   norm_epsilon=0.001,
+                   ) -> (tf.Tensor, Dict[tf.Tensor]):
+  """Build the base MobileNet architecture."""
+
+  input_shape = inputs.get_shape().as_list()
+  if len(input_shape) != 4:
+    raise ValueError('Expected rank 4 input, was: %d' % len(input_shape))
+
+  # The current_stride variable keeps track of the output stride of the
+  # activations, i.e., the running product of convolution strides up to the
+  # current network layer. This allows us to invoke atrous convolution
+  # whenever applying the next convolution would result in the activations
+  # having output stride larger than the target output_stride.
+  current_stride = 1
+
+  # The atrous convolution rate parameter.
+  rate = 1
+
+  net = inputs
+  endpoints = {}
+  endpoint_level = 1
+  for i, block_def in enumerate(spec_blocks):
+    name = 'block_group_{}_{}'.format(block_def.block_fn, i)
+    if output_stride is not None and current_stride == output_stride:
+      # If we have reached the target output_stride, then we need to employ
+      # atrous convolution with stride=1 and multiply the atrous rate by the
+      # current unit's stride for use in subsequent layers.
+      layer_stride = 1
+      layer_rate = rate
+      rate *= block_def.strides
+    else:
+      layer_stride = block_def.strides
+      layer_rate = 1
+      current_stride *= block_def.strides
+
+    if block_def.block_fn == 'convbn':
+
+      net = Conv2DBNBlock(
+          filters=block_def.filters,
+          kernel_size=block_def.kernel_size,
+          strides=block_def.strides,
+          activation=block_def.activation,
+          use_biase=block_def.use_biase,
+          kernel_initializer=kernel_initializer,
+          kernel_regularizer=kernel_regularizer,
+          bias_regularizer=bias_regularizer,
+          use_normalization=block_def.use_normalization,
+          use_sync_bn=use_sync_bn,
+          norm_momentum=norm_momentum,
+          norm_epsilon=norm_epsilon
+      )(net)
+
+    elif block_def.block_fn == 'mbconv':
+      use_rate = rate
+      if layer_rate > 1 and block_def.kernel_size != 1:
+        # We will apply atrous rate in the following cases:
+        # 1) When kernel_size is not in params, the operation then uses
+        #   default kernel size 3x3.
+        # 2) When kernel_size is in params, and if the kernel_size is not
+        #   equal to (1, 1) (there is no need to apply atrous convolution to
+        #   any 1x1 convolution).
+        use_rate = layer_rate
+      in_filters = net.shape.as_list()[-1]
+      net = nn_blocks.InvertedBottleneckBlock(
+          in_filters=in_filters,
+          out_filters=block_def.filters,
+          kernel_size=block_def.kernel_size,
+          strides=layer_stride,
+          expand_ratio=block_def.expand_ratio,
+          se_ratio=block_def.se_ratio,
+          activation=block_def.activation,
+          use_biase=block_def.use_biase,
+          use_residual=block_def.use_residual,
+          use_normalization=block_def.use_normalization,
+          dilation_rate=use_rate,
+          regularize_depthwise=regularize_depthwise,
+          kernel_initializer=kernel_initializer,
+          kernel_regularizer=kernel_regularizer,
+          bias_regularizer=bias_regularizer,
+          use_sync_bn=use_sync_bn,
+          norm_momentum=norm_momentum,
+          norm_epsilon=norm_epsilon,
+          stochastic_depth_drop_rate=stochastic_depth_drop_rate,
+          divisible_by=divisible_by,
+      )(net)
+
+    elif block_def.block_fn == 'gpooling':
+      net = GlobalPoolingBlock()(net)
+    else:
+      raise ValueError('Unknown block type {} for layer {}'.format(
+          block_def.block_fn, i))
+
+    endpoints[endpoint_level] = net
+    endpoint_level += 1
+    net = tf.identity(net, name=name)
+  return net, endpoints
+
+
+@tf.keras.utils.register_keras_serializable(package='Vision')
+class MobileNet(tf.keras.Model):
+  def __init__(self,
+               version: Text = 'MobileNetV2',
+               width_multiplier: float = 1.0,
+               input_specs: layers.InputSpec = layers.InputSpec(
+                   shape=[None, None, None, 3]),
+               # The followings are for hyper-parameter tuning
+               norm_momentum: float = 0.99,
+               norm_epsilon: float = 0.001,
+               dropout_keep_prob: float = 0.8,
+               kernel_initializer: Text = 'VarianceScaling',
+               kernel_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               bias_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               # The followings should be kept the same most of the times
+               output_stride: int = None,
+               min_depth: int = 8,
+               # divisible is not used in MobileNetV1
+               divisible_by: int = 8,
+               stochastic_depth_drop_rate: float = 0.0,
+               regularize_depthwise: bool = False,
+               use_sync_bn: bool = False,
+               # finegrain is not used in MobileNetV1
+               finegrain_classification_mode: bool = True,
+               **kwargs):
+    """
+
+    Args:
+      version: `str` version of MobileNet. The supported values are MobileNetV2',
+      'MobileNetV3Large', 'MobileNetV3Small', and 'MobileNetV3EdgeTPU'.
+      width_multiplier: `float` multiplier for the depth (number of channels)
+        for all convolution ops. The value must be greater than zero. Typical
+        usage will be to set this value in (0, 1) to reduce the number of
+        parameters or computation cost of the model.
+      input_specs: `tf.keras.layers.InputSpec` specs of the input tensor.
+      norm_momentum: `float` normalization omentum for the moving average.
+      norm_epsilon: `float` small float added to variance to avoid dividing by
+        zero.
+      dropout_keep_prob: `float` the percentage of activation values that are
+        retained.
+      kernel_initializer: `str` kernel_initializer for convolutional layers.
+      kernel_regularizer: tf.keras.regularizers.Regularizer object for Conv2D.
+        Default to None.
+      bias_regularizer: tf.keras.regularizers.Regularizer object for Conv2d.
+        Default to None.
+      output_stride: `int` specifies the requested ratio of input to
+        output spatial resolution. If not None, then we invoke atrous convolution
+        if necessary to prevent the network from reducing the spatial resolution
+        of activation maps. Allowed values are 8 (accurate fully convolutional
+        mode), 16 (fast fully convolutional mode), 32 (classification mode).
+      min_depth: `int` minimum depth (number of channels) for all conv ops.
+        Enforced when width_multiplier < 1, and not an active constraint when
+        width_multiplier >= 1.
+      divisible_by: `int` ensures all inner dimensions are divisible by
+        this number.
+      stochastic_depth_drop_rate: `float` drop rate for drop connect layer.
+      regularize_depthwise: if Ture, apply regularization on depthwise.
+      use_sync_bn: if True, use synchronized batch normalization.
+      finegrain_classification_mode: if True, the model
+        will keep the last layer large even for small multipliers. Following
+        https://arxiv.org/abs/1801.04381
+      **kwargs: keyword arguments to be passed.
+    """
+    if version not in SUPPORTED_SPECS_MAP:
+      raise ValueError('The MobileNet version {} '
+                       'is not supported'.format(version))
+
+    if width_multiplier <= 0:
+      raise ValueError('depth_multiplier is not greater than zero.')
+
+    if output_stride is not None:
+      if version == 'MobileNetV1':
+        if output_stride not in [8, 16, 32]:
+          raise ValueError('Only allowed output_stride values are 8, 16, 32.')
+      else:
+        if output_stride == 0 or (output_stride > 1 and output_stride % 2):
+          raise ValueError('Output stride must be None, 1 or a multiple of 2.')
+
+    if version == 'MobileNetV1':
+      divisible_by = 1
+
+    self._version = version
+    self._input_specs = input_specs
+    self._width_multiplier = width_multiplier
+    self._min_depth = min_depth
+    self._output_stride = output_stride
+    self._divisible_by = divisible_by
+    self._stochastic_depth_drop_rate = stochastic_depth_drop_rate
+    self._regularize_depthwise = regularize_depthwise
+    self._kernel_initializer = kernel_initializer
+    self._kernel_regularizer = kernel_regularizer
+    self._bias_regularizer = bias_regularizer
+    self._use_sync_bn = use_sync_bn
+    self._norm_momentum = norm_momentum
+    self._norm_epsilon = norm_epsilon
+    self._dropout_keep_prob = dropout_keep_prob
+    self._finegrain_classification_mode = finegrain_classification_mode
+    if use_sync_bn:
+      self._norm = layers.experimental.SyncBatchNormalization
+    else:
+      self._norm = layers.BatchNormalization
+
+    inputs = tf.keras.Input(shape=input_specs.shape[1:])
+
+    block_specs = SUPPORTED_SPECS_MAP.get(version)
+    decoded_specs = block_spec_decoder(
+        specs=block_specs,
+        width_multiplier=self._width_multiplier,
+        # set to 1 for mobilenetv1
+        divisible_by=self._divisible_by,
+        finegrain_classification_mode=self._finegrain_classification_mode)
+
+    x, endpoints = mobilenet_base(
+        inputs=inputs,
+        spec_blocks=decoded_specs,
+        divisible_by=self._divisible_by,
+        output_stride=self._output_stride,
+        stochastic_depth_drop_rate=self._stochastic_depth_drop_rate,
+        regularize_depthwise=self._regularize_depthwise,
+        kernel_initializer=self._kernel_initializer,
+        kernel_regularizer=self._kernel_regularizer,
+        bias_regularizer=self._bias_regularizer,
+        use_sync_bn=self._use_sync_bn,
+        norm_momentum=self._norm_momentum,
+        norm_epsilon=self._norm_epsilon)
+
+    endpoints[max(endpoints.keys()) + 1] = x
+    self._output_specs = {l: endpoints[l].get_shape() for l in endpoints}
+
+    super(MobileNet, self).__init__(
+        inputs=inputs, outputs=endpoints, **kwargs)
+
+  def get_config(self):
+    config_dict = {
+        'version': self._version,
+        'width_multiplier': self._width_multiplier,
+        'min_depth': self._min_depth,
+        'output_stride': self._output_stride,
+        'divisible_by': self._divisible_by,
+        'stochastic_depth_drop_rate': self._stochastic_depth_drop_rate,
+        'regularize_depthwise': self._regularize_depthwise,
+        'kernel_initializer': self._kernel_initializer,
+        'kernel_regularizer': self._kernel_regularizer,
+        'bias_regularizer': self._bias_regularizer,
+        'use_sync_bn': self._use_sync_bn,
+        'norm_momentum': self._norm_momentum,
+        'norm_epsilon': self._norm_epsilon,
+        'dropout_keep_prob': self._dropout_keep_prob,
+        'finegrain_classification_mode': self._finegrain_classification_mode,
+    }
+    return config_dict
+
+  @classmethod
+  def from_config(cls, config, custom_objects=None):
+    return cls(**config)
+
+  @property
+  def output_specs(self):
+    """A dict of {level: TensorShape} pairs for the model output."""
+    return self._output_specs

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -417,7 +417,7 @@ def block_spec_decoder(specs: Dict,
 @tf.keras.utils.register_keras_serializable(package='Vision')
 class MobileNet(tf.keras.Model):
   def __init__(self,
-               version: Text = 'MobileNetV2',
+               model_id: Text = 'MobileNetV2',
                width_multiplier: float = 1.0,
                input_specs: layers.InputSpec = layers.InputSpec(
                    shape=[None, None, None, 3]),
@@ -441,7 +441,7 @@ class MobileNet(tf.keras.Model):
     """
 
     Args:
-      version: `str` version of MobileNet. The supported values are MobileNetV2',
+      model_id: `str` version of MobileNet. The supported values are MobileNetV2',
       'MobileNetV3Large', 'MobileNetV3Small', and 'MobileNetV3EdgeTPU'.
       width_multiplier: `float` multiplier for the depth (number of channels)
         for all convolution ops. The value must be greater than zero. Typical
@@ -474,22 +474,22 @@ class MobileNet(tf.keras.Model):
         https://arxiv.org/abs/1801.04381
       **kwargs: keyword arguments to be passed.
     """
-    if version not in SUPPORTED_SPECS_MAP:
+    if model_id not in SUPPORTED_SPECS_MAP:
       raise ValueError('The MobileNet version {} '
-                       'is not supported'.format(version))
+                       'is not supported'.format(model_id))
 
     if width_multiplier <= 0:
       raise ValueError('depth_multiplier is not greater than zero.')
 
     if output_stride is not None:
-      if version == 'MobileNetV1':
+      if model_id == 'MobileNetV1':
         if output_stride not in [8, 16, 32]:
           raise ValueError('Only allowed output_stride values are 8, 16, 32.')
       else:
         if output_stride == 0 or (output_stride > 1 and output_stride % 2):
           raise ValueError('Output stride must be None, 1 or a multiple of 2.')
 
-    self._version = version
+    self._model_id = model_id
     self._input_specs = input_specs
     self._width_multiplier = width_multiplier
     self._min_depth = min_depth
@@ -507,7 +507,7 @@ class MobileNet(tf.keras.Model):
 
     inputs = tf.keras.Input(shape=input_specs.shape[1:])
 
-    block_specs = SUPPORTED_SPECS_MAP.get(version)
+    block_specs = SUPPORTED_SPECS_MAP.get(model_id)
     self._decoded_specs = block_spec_decoder(
         specs=block_specs,
         width_multiplier=self._width_multiplier,
@@ -523,7 +523,7 @@ class MobileNet(tf.keras.Model):
         inputs=inputs, outputs=endpoints, **kwargs)
 
   def _get_divisible_by(self):
-    if self._version == 'MobileNetV1':
+    if self._model_id == 'MobileNetV1':
       return 1
     else:
       return self._divisible_by
@@ -655,7 +655,7 @@ class MobileNet(tf.keras.Model):
 
   def get_config(self):
     config_dict = {
-        'version': self._version,
+        'model_id': self._model_id,
         'width_multiplier': self._width_multiplier,
         'min_depth': self._min_depth,
         'output_stride': self._output_stride,

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -524,7 +524,9 @@ class MobileNet(tf.keras.Model):
     super(MobileNet, self).__init__(
         inputs=inputs, outputs=endpoints, **kwargs)
 
-  def _mobilenet_base(self, inputs: tf.Tensor) -> (tf.Tensor, Dict[tf.Tensor]):
+  def _mobilenet_base(self,
+                      inputs: tf.Tensor
+                      ) -> (tf.Tensor, Dict[int, tf.Tensor]):
     """Build the base MobileNet architecture.
 
     Args:

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -1,0 +1,138 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains definitions of EfficientNet Networks."""
+
+import math
+from typing import Text, Optional
+
+# Import libraries
+from absl import logging
+import tensorflow as tf
+from official.modeling import tf_utils
+from official.vision.beta.modeling.layers import nn_blocks
+from official.vision.beta.modeling.layers import nn_layers
+
+layers = tf.keras.layers
+
+
+class Conv2DBNBlock(tf.keras.layers.Layer):
+  """An convolution block with batch normalization."""
+
+  def __init__(self,
+               filters: int,
+               kernel_size: int = 3,
+               strides: int = 1,
+               use_biase: bool = False,
+               activation: Text = 'relu6',
+               kernel_initializer: Text = 'VarianceScaling',
+               kernel_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               bias_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               use_normalization: bool = True,
+               use_sync_bn: bool = False,
+               norm_momentum: float = 0.99,
+               norm_epsilon: float = 0.001,
+               **kwargs):
+    """An convolution block with batch normalization.
+
+    Args:
+      filters: `int` number of filters for the first two convolutions. Note that
+        the third and final convolution will use 4 times as many filters.
+      kernel_size: `int` an integer specifying the height and width of the
+      2D convolution window.
+      strides: `int` block stride. If greater than 1, this block will ultimately
+        downsample the input.
+      use_biase: if True, use biase in the convolution layer.
+      activation: `str` name of the activation function.
+      kernel_size: `int` kernel_size of the conv layer.
+      kernel_initializer: kernel_initializer for convolutional layers.
+      kernel_regularizer: tf.keras.regularizers.Regularizer object for Conv2D.
+                          Default to None.
+      bias_regularizer: tf.keras.regularizers.Regularizer object for Conv2d.
+                        Default to None.
+      use_normalization: if True, use batch normalization.
+      use_sync_bn: if True, use synchronized batch normalization.
+      norm_momentum: `float` normalization omentum for the moving average.
+      norm_epsilon: `float` small float added to variance to avoid dividing by
+        zero.
+      **kwargs: keyword arguments to be passed.
+    """
+    super(Conv2DBNBlock, self).__init__(**kwargs)
+    self._filters = filters
+    self._kernel_size = kernel_size
+    self._strides = strides
+    self._activation = activation
+    self._use_biase = use_biase
+    self._kernel_initializer = kernel_initializer
+    self._kernel_regularizer = kernel_regularizer
+    self._bias_regularizer = bias_regularizer
+    self._use_normalization = use_normalization
+    self._use_sync_bn = use_sync_bn
+    self._norm_momentum = norm_momentum
+    self._norm_epsilon = norm_epsilon
+
+    if use_sync_bn:
+      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
+    else:
+      self._norm = tf.keras.layers.BatchNormalization
+    if tf.keras.backend.image_data_format() == 'channels_last':
+      self._bn_axis = -1
+    else:
+      self._bn_axis = 1
+    self._activation_fn = tf_utils.get_activation(activation)
+
+  def get_config(self):
+    config = {
+        'filters': self._filters,
+        'strides': self._strides,
+        'use_biase': self._use_biase,
+        'stochastic_depth_drop_rate': self._stochastic_depth_drop_rate,
+        'kernel_initializer': self._kernel_initializer,
+        'kernel_regularizer': self._kernel_regularizer,
+        'bias_regularizer': self._bias_regularizer,
+        'activation': self._activation,
+        'use_sync_bn': self._use_sync_bn,
+        'use_normalization': self._use_normalization,
+        'norm_momentum': self._norm_momentum,
+        'norm_epsilon': self._norm_epsilon
+    }
+    base_config = super(Conv2DBNBlock, self).get_config()
+    return dict(list(base_config.items()) + list(config.items()))
+
+  def build(self, input_shape):
+
+    self._conv0 = tf.keras.layers.Conv2D(
+        filters=self._filters,
+        kernel_size=1,
+        strides=self._strides,
+        padding='same',
+        use_bias=self._use_biase,
+        kernel_initializer=self._kernel_initializer,
+        kernel_regularizer=self._kernel_regularizer,
+        bias_regularizer=self._bias_regularizer)
+    if self._use_normalization:
+      self._norm0 = self._norm(
+          axis=self._bn_axis,
+          momentum=self._norm_momentum,
+          epsilon=self._norm_epsilon)
+
+    super(Conv2DBNBlock, self).build(input_shape)
+
+  def call(self, inputs, training=None):
+    x = self._conv0(inputs)
+    if self._use_normalization:
+      x = self._norm0(x)
+    return self._activation_fn(x)

--- a/official/vision/beta/modeling/backbones/mobilenet.py
+++ b/official/vision/beta/modeling/backbones/mobilenet.py
@@ -97,8 +97,8 @@ class Conv2DBNBlock(tf.keras.layers.Layer):
     config = {
         'filters': self._filters,
         'strides': self._strides,
+        'kernel_size': self._kernel_size,
         'use_bias': self._use_bias,
-        'stochastic_depth_drop_rate': self._stochastic_depth_drop_rate,
         'kernel_initializer': self._kernel_initializer,
         'kernel_regularizer': self._kernel_regularizer,
         'bias_regularizer': self._bias_regularizer,
@@ -114,7 +114,7 @@ class Conv2DBNBlock(tf.keras.layers.Layer):
   def build(self, input_shape):
     self._conv0 = tf.keras.layers.Conv2D(
         filters=self._filters,
-        kernel_size=1,
+        kernel_size=self._kernel_size,
         strides=self._strides,
         padding='same',
         use_bias=self._use_bias,
@@ -210,26 +210,26 @@ MNV3Large_BLOCK_SPECS = {
     'block_specs': [
         ('convbn', 3, 2, 16, 'hard_swish', None, None, True, False),
 
-        ('mbconv', 3, 1, 16, 'relu', None, 1., True, False),
+        ('mbconv', 3, 1, 16, 'relu', None, 1., None, False),
 
-        ('mbconv', 3, 2, 24, 'relu', None, 4., True, False),
-        ('mbconv', 3, 1, 24, 'relu', None, 3., True, False),
+        ('mbconv', 3, 2, 24, 'relu', None, 4., None, False),
+        ('mbconv', 3, 1, 24, 'relu', None, 3., None, False),
 
-        ('mbconv', 5, 2, 40, 'relu', 1. / 4, 3., True, False),
-        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., True, False),
-        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., True, False),
+        ('mbconv', 5, 2, 40, 'relu', 1. / 4, 3., None, False),
+        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., None, False),
+        ('mbconv', 5, 1, 40, 'relu', 1. / 4, 3., None, False),
 
-        ('mbconv', 3, 2, 80, 'hard_swish', None, 6., True, False),
-        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.5, True, False),
-        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, True, False),
-        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, True, False),
+        ('mbconv', 3, 2, 80, 'hard_swish', None, 6., None, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.5, None, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, None, False),
+        ('mbconv', 3, 1, 80, 'hard_swish', None, 2.3, None, False),
 
-        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., True, False),
-        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., None, False),
+        ('mbconv', 3, 1, 112, 'hard_swish', 1. / 4, 6., None, False),
 
-        ('mbconv', 5, 2, 160, 'hard_swish', 1. / 4, 6, True, False),
-        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, True, False),
-        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, True, False),
+        ('mbconv', 5, 2, 160, 'hard_swish', 1. / 4, 6, None, False),
+        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, None, False),
+        ('mbconv', 5, 1, 160, 'hard_swish', 1. / 4, 6, None, False),
 
         ('convbn', 1, 1, 960, 'hard_swish', None, None, True, False),
         ('gpooling', None, None, None, None, None, None, None, None),
@@ -245,21 +245,21 @@ MNV3Small_BLOCK_SPECS = {
     'block_specs': [
         ('convbn', 3, 2, 16, 'hard_swish', None, None, True, False),
 
-        ('mbconv', 3, 2, 16, 'relu', 1. / 4, 1, True, False),
+        ('mbconv', 3, 2, 16, 'relu', 1. / 4, 1, None, False),
 
-        ('mbconv', 3, 2, 24, 'relu', None, 72. / 16, True, False),
-        ('mbconv', 3, 1, 24, 'relu', None, 88. / 24, True, False),
+        ('mbconv', 3, 2, 24, 'relu', None, 72. / 16, None, False),
+        ('mbconv', 3, 1, 24, 'relu', None, 88. / 24, None, False),
 
-        ('mbconv', 5, 2, 40, 'hard_swish', 1. / 4, 4., True, False),
-        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., True, False),
-        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 5, 2, 40, 'hard_swish', 1. / 4, 4., None, False),
+        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., None, False),
+        ('mbconv', 5, 1, 40, 'hard_swish', 1. / 4, 6., None, False),
 
-        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., True, False),
-        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., True, False),
+        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., None, False),
+        ('mbconv', 5, 1, 48, 'hard_swish', 1. / 4, 3., None, False),
 
-        ('mbconv', 5, 2, 96, 'hard_swish', 1. / 4, 6., True, False),
-        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., True, False),
-        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., True, False),
+        ('mbconv', 5, 2, 96, 'hard_swish', 1. / 4, 6., None, False),
+        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., None, False),
+        ('mbconv', 5, 1, 96, 'hard_swish', 1. / 4, 6., None, False),
 
         ('convbn', 1, 1, 576, 'hard_swish', None, None, True, False),
         ('gpooling', None, None, None, None, None, None, None, None),
@@ -279,12 +279,12 @@ MNV3EdgeTPU_BLOCK_SPECS = {
 
         ('mbconv', 3, 2, 32, 'relu', None, 8., True, False),
         ('mbconv', 3, 1, 32, 'relu', None, 4., True, False),
-        ('mbconv', 3, 2, 32, 'relu', None, 4., True, False),
+        ('mbconv', 3, 1, 32, 'relu', None, 4., True, False),
         ('mbconv', 3, 1, 32, 'relu', None, 4., True, False),
 
         ('mbconv', 3, 2, 48, 'relu', None, 8., True, False),
         ('mbconv', 3, 1, 48, 'relu', None, 4., True, False),
-        ('mbconv', 3, 2, 48, 'relu', None, 4., True, False),
+        ('mbconv', 3, 1, 48, 'relu', None, 4., True, False),
         ('mbconv', 3, 1, 48, 'relu', None, 4., True, False),
 
         ('mbconv', 3, 2, 96, 'relu', None, 8., True, True),
@@ -302,7 +302,7 @@ MNV3EdgeTPU_BLOCK_SPECS = {
         ('mbconv', 5, 1, 160, 'relu', None, 4., True, True),
         ('mbconv', 5, 1, 160, 'relu', None, 4., True, True),
 
-        ('mbconv', 3, 1, 192, 'relu', None, 8., True, False),
+        ('mbconv', 3, 1, 192, 'relu', None, 8., True, True),
 
         ('convbn', 1, 1, 1280, 'relu', None, None, None, None),
     ]
@@ -405,12 +405,13 @@ def block_spec_decoder(specs: Dict,
     decoded_specs[-1].filters /= width_multiplier
 
   for ds in decoded_specs:
-    ds.filters = nn_layers.round_filters(filters=ds.filters,
-                                         multiplier=width_multiplier,
-                                         divisor=divisible_by,
-                                         min_depth=8)
+    if ds.filters:
+      ds.filters = nn_layers.round_filters(filters=ds.filters,
+                                           multiplier=width_multiplier,
+                                           divisor=divisible_by,
+                                           min_depth=8)
 
-    return decoded_specs
+  return decoded_specs
 
 
 @tf.keras.utils.register_keras_serializable(package='Vision')
@@ -488,9 +489,6 @@ class MobileNet(tf.keras.Model):
         if output_stride == 0 or (output_stride > 1 and output_stride % 2):
           raise ValueError('Output stride must be None, 1 or a multiple of 2.')
 
-    if version == 'MobileNetV1':
-      divisible_by = 1
-
     self._version = version
     self._input_specs = input_specs
     self._width_multiplier = width_multiplier
@@ -513,7 +511,7 @@ class MobileNet(tf.keras.Model):
     self._decoded_specs = block_spec_decoder(
         specs=block_specs,
         width_multiplier=self._width_multiplier,
-        divisible_by=self._divisible_by,
+        divisible_by=self._get_divisible_by(),
         finegrain_classification_mode=self._finegrain_classification_mode)
 
     x, endpoints = self._mobilenet_base(inputs=inputs)
@@ -523,6 +521,12 @@ class MobileNet(tf.keras.Model):
 
     super(MobileNet, self).__init__(
         inputs=inputs, outputs=endpoints, **kwargs)
+
+  def _get_divisible_by(self):
+    if self._version == 'MobileNetV1':
+      return 1
+    else:
+      return self._divisible_by
 
   def _mobilenet_base(self,
                       inputs: tf.Tensor
@@ -553,8 +557,11 @@ class MobileNet(tf.keras.Model):
     net = inputs
     endpoints = {}
     endpoint_level = 1
-    for i, block_def in enumerate(self._spec_blocks):
+    for i, block_def in enumerate(self._decoded_specs):
       block_name = 'block_group_{}_{}'.format(block_def.block_fn, i)
+      # A small catch for gpooling block with None strides
+      if not block_def.strides:
+        block_def.strides = 1
       if self._output_stride is not None \
           and current_stride == self._output_stride:
         # If we have reached the target output_stride, then we need to employ
@@ -591,7 +598,6 @@ class MobileNet(tf.keras.Model):
             kernel_size=block_def.kernel_size,
             strides=block_def.strides,
             activation=block_def.activation,
-            use_normalization=block_def.use_normalization,
             dilation_rate=layer_rate,
             regularize_depthwise=self._regularize_depthwise,
             kernel_initializer=self._kernel_initializer,
@@ -620,8 +626,8 @@ class MobileNet(tf.keras.Model):
             expand_ratio=block_def.expand_ratio,
             se_ratio=block_def.se_ratio,
             activation=block_def.activation,
+            use_depthwise=block_def.use_depthwise,
             use_residual=block_def.use_residual,
-            use_normalization=block_def.use_normalization,
             dilation_rate=use_rate,
             regularize_depthwise=self._regularize_depthwise,
             kernel_initializer=self._kernel_initializer,
@@ -631,7 +637,7 @@ class MobileNet(tf.keras.Model):
             norm_momentum=self._norm_momentum,
             norm_epsilon=self._norm_epsilon,
             stochastic_depth_drop_rate=self._stochastic_depth_drop_rate,
-            divisible_by=self._divisible_by,
+            divisible_by=self._get_divisible_by(),
             target_backbone='mobilenet'
         )(net)
 

--- a/official/vision/beta/modeling/backbones/mobilenet_test.py
+++ b/official/vision/beta/modeling/backbones/mobilenet_test.py
@@ -1,0 +1,255 @@
+# Lint as: python3
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for MobileNet."""
+
+# Import libraries
+from absl.testing import parameterized
+from itertools import product
+
+import tensorflow as tf
+
+from official.vision.beta.modeling.backbones import mobilenet
+
+
+class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
+  @parameterized.parameters('MobileNetV1', 'MobileNetV2',
+                            'MobileNetV3Large', 'MobileNetV3Small',
+                            'MobileNetV3EdgeTPU')
+  def test_serialize_deserialize(self, version):
+    # Create a network object that sets all of its config options.
+    kwargs = dict(
+        version=version,
+        width_multiplier=1.0,
+        stochastic_depth_drop_rate=None,
+        use_sync_bn=False,
+        kernel_initializer='VarianceScaling',
+        kernel_regularizer=None,
+        bias_regularizer=None,
+        norm_momentum=0.99,
+        norm_epsilon=0.001,
+        output_stride=None,
+        min_depth=8,
+        divisible_by=8,
+        regularize_depthwise=False,
+        finegrain_classification_mode=True
+    )
+    network = mobilenet.MobileNet(**kwargs)
+
+    expected_config = dict(kwargs)
+    self.assertEqual(network.get_config(), expected_config)
+
+    # Create another network object from the first object's config.
+    new_network = mobilenet.MobileNet.from_config(network.get_config())
+
+    # Validate that the config can be forced to JSON.
+    _ = new_network.to_json()
+
+    # If the serialization was successful, the new config should match the old.
+    self.assertAllEqual(network.get_config(), new_network.get_config())
+
+  @parameterized.parameters(
+      product((1, 3),
+              ('MobileNetV1', 'MobileNetV2',
+               'MobileNetV3Large', 'MobileNetV3Small',
+               'MobileNetV3EdgeTPU'))
+  )
+  def test_input_specs(self, input_dim, version):
+    """Test different input feature dimensions."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    input_specs = tf.keras.layers.InputSpec(shape=[None, None, None, input_dim])
+    network = mobilenet.MobileNet(version=version, input_specs=input_specs)
+
+    inputs = tf.keras.Input(shape=(128, 128, input_dim), batch_size=1)
+    _ = network(inputs)
+
+  @parameterized.parameters(32, 224)
+  def test_mobilenet_v1_creation(self, input_size):
+    """Test creation of EfficientNet family models."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = mobilenet.MobileNet(version='MobileNetV1', width_multiplier=0.75)
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 24],
+                        endpoints[1].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 48],
+                        endpoints[2].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 96],
+                        endpoints[3].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 96],
+                        endpoints[4].shape.as_list())
+
+  @parameterized.parameters(32, 224)
+  def test_mobilenet_v2_creation(self, input_size):
+    """Test creation of EfficientNet family models."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = mobilenet.MobileNet(version='MobileNetV2', width_multiplier=1.0)
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 32],
+                        endpoints[1].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 16],
+                        endpoints[2].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[3].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[4].shape.as_list())
+
+  @parameterized.parameters(32, 224)
+  def test_mobilenet_v3_small_creation(self, input_size):
+    """Test creation of EfficientNet family models."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = mobilenet.MobileNet(version='MobileNetV3Small',
+                                  width_multiplier=0.75)
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 16],
+                        endpoints[1].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 16],
+                        endpoints[2].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 3, input_size / 2 ** 3, 24],
+                        endpoints[3].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 3, input_size / 2 ** 3, 24],
+                        endpoints[4].shape.as_list())
+
+  @parameterized.parameters(32, 224)
+  def test_mobilenet_v3_large_creation(self, input_size):
+    """Test creation of EfficientNet family models."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = mobilenet.MobileNet(version='MobileNetV3Large',
+                                  width_multiplier=0.75)
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 16],
+                        endpoints[1].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 16],
+                        endpoints[2].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[3].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[4].shape.as_list())
+
+  @parameterized.parameters(32, 224)
+  def test_mobilenet_v3_edgetpu_creation(self, input_size):
+    """Test creation of EfficientNet family models."""
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = mobilenet.MobileNet(version='MobileNetV3EdgeTPU',
+                                  width_multiplier=0.75)
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 24],
+                        endpoints[1].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 1, input_size / 2 ** 1, 16],
+                        endpoints[2].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[3].shape.as_list())
+    self.assertAllEqual([1, input_size / 2 ** 2, input_size / 2 ** 2, 24],
+                        endpoints[4].shape.as_list())
+
+  @parameterized.parameters(1.0, 0.75)
+  def test_mobilenet_v1_scaling(self, width_multiplier):
+    mobilenet_v1_params = {
+        1.0: 3228864,
+        0.75: 1832976
+    }
+
+    input_size = 224
+    network = mobilenet.MobileNet(version='MobileNetV1',
+                                  width_multiplier=width_multiplier)
+    self.assertEqual(network.count_params(),
+                     mobilenet_v1_params[width_multiplier])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    _ = network(inputs)
+
+  @parameterized.parameters(1.0, 0.75)
+  def test_mobilenet_v2_scaling(self, width_multiplier):
+    mobilenet_v2_params = {
+        1.0: 2257984,
+        0.75: 1382064
+    }
+
+    input_size = 224
+    network = mobilenet.MobileNet(version='MobileNetV2',
+                                  width_multiplier=width_multiplier)
+    self.assertEqual(network.count_params(),
+                     mobilenet_v2_params[width_multiplier])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    _ = network(inputs)
+
+  @parameterized.parameters(1.0, 0.75)
+  def test_mobilenet_v3_large_scaling(self, width_multiplier):
+    mobilenet_v3_large_params = {
+        1.0: 4226432,
+        0.75: 2731616
+    }
+
+    input_size = 224
+    network = mobilenet.MobileNet(version='MobileNetV3Large',
+                                  width_multiplier=width_multiplier)
+    self.assertEqual(network.count_params(),
+                     mobilenet_v3_large_params[width_multiplier])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    _ = network(inputs)
+
+  @parameterized.parameters(1.0, 0.75)
+  def test_mobilenet_v3_small_scaling(self, width_multiplier):
+    mobilenet_v3_small_params = {
+        1.0: 1529968,
+        0.75: 1026552
+    }
+
+    input_size = 224
+    network = mobilenet.MobileNet(version='MobileNetV3Small',
+                                  width_multiplier=width_multiplier)
+    self.assertEqual(network.count_params(),
+                     mobilenet_v3_small_params[width_multiplier])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    _ = network(inputs)
+
+  @parameterized.parameters(1.0, 0.75)
+  def test_mobilenet_v3_edgetpu_scaling(self, width_multiplier):
+    mobilenet_v3_edgetpu_params = {
+        1.0: 2849312,
+        0.75: 1737288
+    }
+
+    input_size = 224
+    network = mobilenet.MobileNet(version='MobileNetV3EdgeTPU',
+                                  width_multiplier=width_multiplier)
+    self.assertEqual(network.count_params(),
+                     mobilenet_v3_edgetpu_params[width_multiplier])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    _ = network(inputs)

--- a/official/vision/beta/modeling/backbones/mobilenet_test.py
+++ b/official/vision/beta/modeling/backbones/mobilenet_test.py
@@ -28,10 +28,10 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
   @parameterized.parameters('MobileNetV1', 'MobileNetV2',
                             'MobileNetV3Large', 'MobileNetV3Small',
                             'MobileNetV3EdgeTPU')
-  def test_serialize_deserialize(self, version):
+  def test_serialize_deserialize(self, model_id):
     # Create a network object that sets all of its config options.
     kwargs = dict(
-        version=version,
+        model_id=model_id,
         width_multiplier=1.0,
         stochastic_depth_drop_rate=None,
         use_sync_bn=False,
@@ -66,12 +66,12 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
                'MobileNetV3Large', 'MobileNetV3Small',
                'MobileNetV3EdgeTPU'))
   )
-  def test_input_specs(self, input_dim, version):
+  def test_input_specs(self, input_dim, model_id):
     """Test different input feature dimensions."""
     tf.keras.backend.set_image_data_format('channels_last')
 
     input_specs = tf.keras.layers.InputSpec(shape=[None, None, None, input_dim])
-    network = mobilenet.MobileNet(version=version, input_specs=input_specs)
+    network = mobilenet.MobileNet(model_id=model_id, input_specs=input_specs)
 
     inputs = tf.keras.Input(shape=(128, 128, input_dim), batch_size=1)
     _ = network(inputs)
@@ -81,7 +81,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     """Test creation of EfficientNet family models."""
     tf.keras.backend.set_image_data_format('channels_last')
 
-    network = mobilenet.MobileNet(version='MobileNetV1', width_multiplier=0.75)
+    network = mobilenet.MobileNet(model_id='MobileNetV1', width_multiplier=0.75)
 
     inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
     endpoints = network(inputs)
@@ -100,7 +100,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     """Test creation of EfficientNet family models."""
     tf.keras.backend.set_image_data_format('channels_last')
 
-    network = mobilenet.MobileNet(version='MobileNetV2', width_multiplier=1.0)
+    network = mobilenet.MobileNet(model_id='MobileNetV2', width_multiplier=1.0)
 
     inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
     endpoints = network(inputs)
@@ -119,7 +119,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     """Test creation of EfficientNet family models."""
     tf.keras.backend.set_image_data_format('channels_last')
 
-    network = mobilenet.MobileNet(version='MobileNetV3Small',
+    network = mobilenet.MobileNet(model_id='MobileNetV3Small',
                                   width_multiplier=0.75)
 
     inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
@@ -139,7 +139,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     """Test creation of EfficientNet family models."""
     tf.keras.backend.set_image_data_format('channels_last')
 
-    network = mobilenet.MobileNet(version='MobileNetV3Large',
+    network = mobilenet.MobileNet(model_id='MobileNetV3Large',
                                   width_multiplier=0.75)
 
     inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
@@ -159,7 +159,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     """Test creation of EfficientNet family models."""
     tf.keras.backend.set_image_data_format('channels_last')
 
-    network = mobilenet.MobileNet(version='MobileNetV3EdgeTPU',
+    network = mobilenet.MobileNet(model_id='MobileNetV3EdgeTPU',
                                   width_multiplier=0.75)
 
     inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
@@ -182,7 +182,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     }
 
     input_size = 224
-    network = mobilenet.MobileNet(version='MobileNetV1',
+    network = mobilenet.MobileNet(model_id='MobileNetV1',
                                   width_multiplier=width_multiplier)
     self.assertEqual(network.count_params(),
                      mobilenet_v1_params[width_multiplier])
@@ -198,7 +198,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     }
 
     input_size = 224
-    network = mobilenet.MobileNet(version='MobileNetV2',
+    network = mobilenet.MobileNet(model_id='MobileNetV2',
                                   width_multiplier=width_multiplier)
     self.assertEqual(network.count_params(),
                      mobilenet_v2_params[width_multiplier])
@@ -214,7 +214,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     }
 
     input_size = 224
-    network = mobilenet.MobileNet(version='MobileNetV3Large',
+    network = mobilenet.MobileNet(model_id='MobileNetV3Large',
                                   width_multiplier=width_multiplier)
     self.assertEqual(network.count_params(),
                      mobilenet_v3_large_params[width_multiplier])
@@ -230,7 +230,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     }
 
     input_size = 224
-    network = mobilenet.MobileNet(version='MobileNetV3Small',
+    network = mobilenet.MobileNet(model_id='MobileNetV3Small',
                                   width_multiplier=width_multiplier)
     self.assertEqual(network.count_params(),
                      mobilenet_v3_small_params[width_multiplier])
@@ -246,7 +246,7 @@ class MobileNetTest(parameterized.TestCase, tf.test.TestCase):
     }
 
     input_size = 224
-    network = mobilenet.MobileNet(version='MobileNetV3EdgeTPU',
+    network = mobilenet.MobileNet(model_id='MobileNetV3EdgeTPU',
                                   width_multiplier=width_multiplier)
     self.assertEqual(network.count_params(),
                      mobilenet_v3_edgetpu_params[width_multiplier])

--- a/official/vision/beta/modeling/layers/nn_blocks.py
+++ b/official/vision/beta/modeling/layers/nn_blocks.py
@@ -1186,3 +1186,113 @@ class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
     x = self._conv1(x)
     x = self._norm1(x)
     return self._activation_fn(x)
+
+
+class Conv2DBNBlock(tf.keras.layers.Layer):
+  """A convolution block with batch normalization."""
+
+  def __init__(self,
+               filters: int,
+               kernel_size: int = 3,
+               strides: int = 1,
+               use_bias: bool = False,
+               activation: Text = 'relu6',
+               kernel_initializer: Text = 'VarianceScaling',
+               kernel_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               bias_regularizer: Optional[
+                 tf.keras.regularizers.Regularizer] = None,
+               use_normalization: bool = True,
+               use_sync_bn: bool = False,
+               norm_momentum: float = 0.99,
+               norm_epsilon: float = 0.001,
+               **kwargs):
+    """A convolution block with batch normalization.
+
+    Args:
+      filters: `int` number of filters for the first two convolutions. Note that
+        the third and final convolution will use 4 times as many filters.
+      kernel_size: `int` an integer specifying the height and width of the
+      2D convolution window.
+      strides: `int` block stride. If greater than 1, this block will ultimately
+        downsample the input.
+      use_bias: if True, use biase in the convolution layer.
+      activation: `str` name of the activation function.
+      kernel_size: `int` kernel_size of the conv layer.
+      kernel_initializer: kernel_initializer for convolutional layers.
+      kernel_regularizer: tf.keras.regularizers.Regularizer object for Conv2D.
+                          Default to None.
+      bias_regularizer: tf.keras.regularizers.Regularizer object for Conv2d.
+                        Default to None.
+      use_normalization: if True, use batch normalization.
+      use_sync_bn: if True, use synchronized batch normalization.
+      norm_momentum: `float` normalization momentum for the moving average.
+      norm_epsilon: `float` small float added to variance to avoid dividing by
+        zero.
+      **kwargs: keyword arguments to be passed.
+    """
+    super(Conv2DBNBlock, self).__init__(**kwargs)
+    self._filters = filters
+    self._kernel_size = kernel_size
+    self._strides = strides
+    self._activation = activation
+    self._use_bias = use_bias
+    self._kernel_initializer = kernel_initializer
+    self._kernel_regularizer = kernel_regularizer
+    self._bias_regularizer = bias_regularizer
+    self._use_normalization = use_normalization
+    self._use_sync_bn = use_sync_bn
+    self._norm_momentum = norm_momentum
+    self._norm_epsilon = norm_epsilon
+
+    if use_sync_bn:
+      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
+    else:
+      self._norm = tf.keras.layers.BatchNormalization
+    if tf.keras.backend.image_data_format() == 'channels_last':
+      self._bn_axis = -1
+    else:
+      self._bn_axis = 1
+    self._activation_fn = tf_utils.get_activation(activation)
+
+  def get_config(self):
+    config = {
+        'filters': self._filters,
+        'strides': self._strides,
+        'kernel_size': self._kernel_size,
+        'use_bias': self._use_bias,
+        'kernel_initializer': self._kernel_initializer,
+        'kernel_regularizer': self._kernel_regularizer,
+        'bias_regularizer': self._bias_regularizer,
+        'activation': self._activation,
+        'use_sync_bn': self._use_sync_bn,
+        'use_normalization': self._use_normalization,
+        'norm_momentum': self._norm_momentum,
+        'norm_epsilon': self._norm_epsilon
+    }
+    base_config = super(Conv2DBNBlock, self).get_config()
+    return dict(list(base_config.items()) + list(config.items()))
+
+  def build(self, input_shape):
+    self._conv0 = tf.keras.layers.Conv2D(
+        filters=self._filters,
+        kernel_size=self._kernel_size,
+        strides=self._strides,
+        padding='same',
+        use_bias=self._use_bias,
+        kernel_initializer=self._kernel_initializer,
+        kernel_regularizer=self._kernel_regularizer,
+        bias_regularizer=self._bias_regularizer)
+    if self._use_normalization:
+      self._norm0 = self._norm(
+          axis=self._bn_axis,
+          momentum=self._norm_momentum,
+          epsilon=self._norm_epsilon)
+
+    super(Conv2DBNBlock, self).build(input_shape)
+
+  def call(self, inputs, training=None):
+    x = self._conv0(inputs)
+    if self._use_normalization:
+      x = self._norm0(x)
+    return self._activation_fn(x)

--- a/official/vision/beta/modeling/layers/nn_layers.py
+++ b/official/vision/beta/modeling/layers/nn_layers.py
@@ -71,7 +71,6 @@ class SqueezeExcitation(tf.keras.layers.Layer):
   def __init__(self,
                in_filters,
                se_ratio,
-               expand_ratio,
                divisible_by=1,
                kernel_initializer='VarianceScaling',
                kernel_regularizer=None,
@@ -85,7 +84,6 @@ class SqueezeExcitation(tf.keras.layers.Layer):
       in_filters: `int` number of filters of the input tensor.
       se_ratio: `float` or None. If not None, se ratio for the squeeze and
         excitation layer.
-      expand_ratio: `int` expand_ratio for a MBConv block.
       divisible_by: `int` ensures all inner dimensions are divisible by this number.
       kernel_initializer: kernel_initializer for convolutional layers.
       kernel_regularizer: tf.keras.regularizers.Regularizer object for Conv2D.
@@ -100,7 +98,6 @@ class SqueezeExcitation(tf.keras.layers.Layer):
 
     self._in_filters = in_filters
     self._se_ratio = se_ratio
-    self._expand_ratio = expand_ratio
     self._divisible_by = divisible_by
     self._activation = activation
     self._gating_activation = gating_activation
@@ -116,42 +113,43 @@ class SqueezeExcitation(tf.keras.layers.Layer):
 
   def build(self, input_shape):
     num_reduced_filters = make_divisible(
-      max(1, int(self._in_filters * self._se_ratio)), divisor=self._divisible_by)
+        max(1, int(self._in_filters * self._se_ratio)),
+        divisor=self._divisible_by)
 
     self._se_reduce = tf.keras.layers.Conv2D(
-      filters=num_reduced_filters,
-      kernel_size=1,
-      strides=1,
-      padding='same',
-      use_bias=True,
-      kernel_initializer=self._kernel_initializer,
-      kernel_regularizer=self._kernel_regularizer,
-      bias_regularizer=self._bias_regularizer)
+        filters=num_reduced_filters,
+        kernel_size=1,
+        strides=1,
+        padding='same',
+        use_bias=True,
+        kernel_initializer=self._kernel_initializer,
+        kernel_regularizer=self._kernel_regularizer,
+        bias_regularizer=self._bias_regularizer)
 
     self._se_expand = tf.keras.layers.Conv2D(
-      filters=self._in_filters * self._expand_ratio,
-      kernel_size=1,
-      strides=1,
-      padding='same',
-      use_bias=True,
-      kernel_initializer=self._kernel_initializer,
-      kernel_regularizer=self._kernel_regularizer,
-      bias_regularizer=self._bias_regularizer)
+        filters=self._in_filters,
+        kernel_size=1,
+        strides=1,
+        padding='same',
+        use_bias=True,
+        kernel_initializer=self._kernel_initializer,
+        kernel_regularizer=self._kernel_regularizer,
+        bias_regularizer=self._bias_regularizer)
 
     super(SqueezeExcitation, self).build(input_shape)
 
   def get_config(self):
     config = {
-      'in_filters': self._in_filters,
-      'se_ratio': self._se_ratio,
-      'expand_ratio': self._expand_ratio,
-      'divisible_by': self._divisible_by,
-      'strides': self._strides,
-      'kernel_initializer': self._kernel_initializer,
-      'kernel_regularizer': self._kernel_regularizer,
-      'bias_regularizer': self._bias_regularizer,
-      'activation': self._activation,
-      'gating_activation': self._gating_activation,
+        'in_filters': self._in_filters,
+        'se_ratio': self._se_ratio,
+        'expand_ratio': self._expand_ratio,
+        'divisible_by': self._divisible_by,
+        'strides': self._strides,
+        'kernel_initializer': self._kernel_initializer,
+        'kernel_regularizer': self._kernel_regularizer,
+        'bias_regularizer': self._bias_regularizer,
+        'activation': self._activation,
+        'gating_activation': self._gating_activation,
     }
     base_config = super(SqueezeExcitation, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))
@@ -195,7 +193,7 @@ class StochasticDepth(tf.keras.layers.Layer):
     batch_size = tf.shape(inputs)[0]
     random_tensor = keep_prob
     random_tensor += tf.random.uniform(
-      [batch_size, 1, 1, 1], dtype=inputs.dtype)
+        [batch_size, 1, 1, 1], dtype=inputs.dtype)
     binary_tensor = tf.floor(random_tensor)
     output = tf.math.divide(inputs, keep_prob) * binary_tensor
     return output

--- a/official/vision/beta/modeling/layers/nn_layers.py
+++ b/official/vision/beta/modeling/layers/nn_layers.py
@@ -70,6 +70,7 @@ class SqueezeExcitation(tf.keras.layers.Layer):
 
   def __init__(self,
                in_filters,
+               out_filters,
                se_ratio,
                divisible_by=1,
                kernel_initializer='VarianceScaling',
@@ -82,6 +83,7 @@ class SqueezeExcitation(tf.keras.layers.Layer):
 
     Args:
       in_filters: `int` number of filters of the input tensor.
+      out_filters: `int` number of filters of the output tensor.
       se_ratio: `float` or None. If not None, se ratio for the squeeze and
         excitation layer.
       divisible_by: `int` ensures all inner dimensions are divisible by this number.
@@ -97,6 +99,7 @@ class SqueezeExcitation(tf.keras.layers.Layer):
     super(SqueezeExcitation, self).__init__(**kwargs)
 
     self._in_filters = in_filters
+    self._out_filters = out_filters
     self._se_ratio = se_ratio
     self._divisible_by = divisible_by
     self._activation = activation
@@ -127,7 +130,7 @@ class SqueezeExcitation(tf.keras.layers.Layer):
         bias_regularizer=self._bias_regularizer)
 
     self._se_expand = tf.keras.layers.Conv2D(
-        filters=self._in_filters,
+        filters=self._out_filters,
         kernel_size=1,
         strides=1,
         padding='same',
@@ -141,8 +144,8 @@ class SqueezeExcitation(tf.keras.layers.Layer):
   def get_config(self):
     config = {
         'in_filters': self._in_filters,
+        'out_filters': self._out_filters,
         'se_ratio': self._se_ratio,
-        'expand_ratio': self._expand_ratio,
         'divisible_by': self._divisible_by,
         'strides': self._strides,
         'kernel_initializer': self._kernel_initializer,


### PR DESCRIPTION
The Mobilenet V1, V2, V3 (small, large, edgetpu) versions have been implemented and integrated into the tf-vision framework.

In particular, some existing blocks and layers have been modified to make them usable in the Mobilenet implementation.

1. I have modified SqueezeExcitation for the Mobilenet migration.
  - added two additional parameter: `divisible_by` and `gating_activation`
  - removed `expand_ratio` and added explicit `out_filters`
2. I have modified InvertedBottleneckBlock for the Mobilenet migration.
  - added `use_depthwise`, `use_residual`, `regularize_depthwise` boolean flag; 
  - added explicit activiation function for embedded `SqueezeExcitation` call and depthwise part
  - added a parameter `target_backbone` to indicate where the `InvertedBottleneckBlock` is used. It is because the 
  `SqueezeExcitation` call for building EfficientNet and MobileNet are slightly different.
3. I have added a `DepthwiseSeparableConvBlock` block in nn_blocks.py as well for building MobilenetV1

One more thing to mention, since the implementation of `hard_sigmoid` implemented in `keras.activations.hard_sigmoid` is different from that required in Mobilenet. I have implemented a customized one as well.
