### PR TITLE
Updating dataset download path.

### DIFF
--- a/research/deeplab/datasets/download_and_convert_voc2012.sh
+++ b/research/deeplab/datasets/download_and_convert_voc2012.sh
@@ -51,19 +51,20 @@ download_and_uncompress() {
     wget -nd -c "${BASE_URL}/${FILENAME}"
   fi
   echo "Uncompressing ${FILENAME}"
-  tar -xf "${FILENAME}"
+  sudo apt install unzip
+  unzip "${FILENAME}"
 }
 
 # Download the images.
-BASE_URL="http://host.robots.ox.ac.uk/pascal/VOC/voc2012/"
-FILENAME="VOCtrainval_11-May-2012.tar"
+BASE_URL="https://data.deepai.org/"
+FILENAME="PascalVOC2012.zip"
 
 download_and_uncompress "${BASE_URL}" "${FILENAME}"
 
 cd "${CURRENT_DIR}"
 
 # Root path for PASCAL VOC 2012 dataset.
-PASCAL_ROOT="${WORK_DIR}/VOCdevkit/VOC2012"
+PASCAL_ROOT="${WORK_DIR}/VOC2012"
 
 # Remove the colormap in the ground truth annotations.
 SEG_FOLDER="${PASCAL_ROOT}/SegmentationClass"


### PR DESCRIPTION
Old link (http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) is not available. So need to update the location of the dataset.

# Description
Location used to download PascalVOC2012 data that was used in the script is not available anymore. So need to update it to new location. Also, at new location we have zip compression instead of tar. So there are few changes for that.
