### PR TITLE
Fix binary data being read as text

### DIFF
--- a/research/object_detection/dataset_tools/create_oid_tf_record.py
+++ b/research/object_detection/dataset_tools/create_oid_tf_record.py
@@ -103,7 +103,7 @@ def main(_):
       image_id, image_annotations = image_data
       # In OID image file names are formed by appending ".jpg" to the image ID.
       image_path = os.path.join(FLAGS.input_images_directory, image_id + '.jpg')
-      with tf.gfile.Open(image_path) as image_file:
+      with tf.gfile.Open(image_path, 'rb') as image_file:
         encoded_image = image_file.read()
 
       tf_example = oid_tfrecord_creation.tf_example_from_annotations_data_frame(


### PR DESCRIPTION
Tensorflow's `gfile` opens in text mode by default, which is not the right method for reading binary data such as JPG data. This creates downstream problems for Python3, which will attempt to decode the text data as UTF-8.