### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/official/core/train_utils.py
+++ b/official/core/train_utils.py
@@ -43,7 +43,7 @@ class BestCheckpointExporter:
   def __init__(self, export_dir: str, metric_name: str, metric_comp: str):
     """Initialization.
 
-    Arguments:
+    Args:
       export_dir: The directory that will contain exported checkpoints.
       metric_name: Indicates which metric to look at, when determining which
         result is better.

--- a/official/nlp/bert/model_saving_utils.py
+++ b/official/nlp/bert/model_saving_utils.py
@@ -27,7 +27,7 @@ def export_bert_model(model_export_path: typing.Text,
                       restore_model_using_load_weights: bool = False) -> None:
   """Export BERT model for serving which does not include the optimizer.
 
-  Arguments:
+  Args:
       model_export_path: Path to which exported model will be saved.
       model: Keras model object to export.
       checkpoint_dir: Path from which model weights will be loaded, if

--- a/official/nlp/bert/model_training_utils.py
+++ b/official/nlp/bert/model_training_utils.py
@@ -132,7 +132,7 @@ def run_customized_training_loop(
     allreduce_bytes_per_pack=0):
   """Run BERT pretrain model training using low-level API.
 
-  Arguments:
+  Args:
       _sentinel: Used to prevent positional parameters. Internal, do not use.
       strategy: Distribution strategy on which to run low level training loop.
       model_fn: Function that returns a tuple (model, sub_model). Caller of this

--- a/official/nlp/data/classifier_data_lib.py
+++ b/official/nlp/data/classifier_data_lib.py
@@ -944,7 +944,7 @@ class XtremePawsxProcessor(DataProcessor):
                only_use_en_dev=True):
     """See base class.
 
-    Arguments:
+    Args:
       process_text_fn: See base class.
       translated_data_dir: If specified, will also include translated data in
         the training and testing data.
@@ -1061,7 +1061,7 @@ class XtremeXnliProcessor(DataProcessor):
                only_use_en_dev=True):
     """See base class.
 
-    Arguments:
+    Args:
       process_text_fn: See base class.
       translated_data_dir: If specified, will also include translated data in
         the training data.
@@ -1350,7 +1350,7 @@ def generate_tf_record_from_data_file(processor,
                                       max_seq_length=128):
   """Generates and saves training data into a tf record file.
 
-  Arguments:
+  Args:
       processor: Input processor object to be used for generating data. Subclass
         of `DataProcessor`.
       data_dir: Directory that contains train/eval/test data to process.

--- a/official/nlp/data/create_pretraining_data.py
+++ b/official/nlp/data/create_pretraining_data.py
@@ -390,7 +390,7 @@ def _window(iterable, size):
     _window(input, 4) => [1, 2, 3, 4]
     _window(input, 5) => None
 
-  Arguments:
+  Args:
     iterable: elements to iterate over.
     size: size of the window.
 
@@ -414,7 +414,7 @@ def _window(iterable, size):
 def _contiguous(sorted_grams):
   """Test whether a sequence of grams is contiguous.
 
-  Arguments:
+  Args:
     sorted_grams: _Grams which are sorted in increasing order.
   Returns:
     True if `sorted_grams` are touching each other.
@@ -454,7 +454,7 @@ def _masking_ngrams(grams, max_ngram_size, max_masked_tokens, rng):
   The length of the selected n-gram follows a zipf weighting to
   favor shorter n-gram sizes (weight(1)=1, weight(2)=1/2, weight(3)=1/3, ...).
 
-  Arguments:
+  Args:
     grams: List of one-grams.
     max_ngram_size: Maximum number of contiguous one-grams combined to create
       an n-gram.
@@ -542,7 +542,7 @@ def _wordpieces_to_grams(tokens):
      tokens: ['[CLS]', 'That', 'lit', '##tle', 'blue', 'tru', '##ck', '[SEP]']
       grams: [          [1,2), [2,         4),  [4,5) , [5,       6)]
 
-  Arguments:
+  Args:
     tokens: list of wordpieces
   Returns:
     List of _Grams representing spans of whole words

--- a/official/nlp/data/tagging_data_lib.py
+++ b/official/nlp/data/tagging_data_lib.py
@@ -96,7 +96,7 @@ class PanxProcessor(classifier_data_lib.DataProcessor):
                only_use_en_dev=True):
     """See base class.
 
-    Arguments:
+    Args:
       process_text_fn: See base class.
       only_use_en_train: If True, only use english training data. Otherwise, use
         training data from all languages.
@@ -162,7 +162,7 @@ class UdposProcessor(classifier_data_lib.DataProcessor):
                only_use_en_dev=True):
     """See base class.
 
-    Arguments:
+    Args:
       process_text_fn: See base class.
       only_use_en_train: If True, only use english training data. Otherwise, use
         training data from all languages.

--- a/official/nlp/keras_nlp/encoders/bert_encoder.py
+++ b/official/nlp/keras_nlp/encoders/bert_encoder.py
@@ -39,7 +39,7 @@ class BertEncoder(tf.keras.Model):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     vocab_size: The size of the token vocabulary.
     hidden_size: The size of the transformer hidden layers.
     num_layers: The number of transformer layers.

--- a/official/nlp/keras_nlp/layers/masked_lm.py
+++ b/official/nlp/keras_nlp/layers/masked_lm.py
@@ -31,7 +31,7 @@ class MaskedLM(tf.keras.layers.Layer):
   lm_layer=MaskedLM(embedding_table=encoder.get_embedding_table())
   ```
 
-  Arguments:
+  Args:
     embedding_table: The embedding table from encoder network.
     activation: The activation, if any, for the dense layer.
     initializer: The initializer for the dense layer. Defaults to a Glorot

--- a/official/nlp/keras_nlp/layers/on_device_embedding.py
+++ b/official/nlp/keras_nlp/layers/on_device_embedding.py
@@ -25,7 +25,7 @@ class OnDeviceEmbedding(tf.keras.layers.Layer):
   This layer uses either tf.gather or tf.one_hot to translate integer indices to
   float embeddings.
 
-  Arguments:
+  Args:
     vocab_size: Number of elements in the vocabulary.
     embedding_width: Output size of the embedding layer.
     initializer: The initializer to use for the embedding weights. Defaults to

--- a/official/nlp/keras_nlp/layers/position_embedding.py
+++ b/official/nlp/keras_nlp/layers/position_embedding.py
@@ -29,7 +29,7 @@ class PositionEmbedding(tf.keras.layers.Layer):
   ```
 
 
-  Arguments:
+  Args:
     max_length: The maximum size of the dynamic sequence.
     initializer: The initializer to use for the embedding weights. Defaults to
       "glorot_uniform".

--- a/official/nlp/keras_nlp/layers/transformer_encoder_block.py
+++ b/official/nlp/keras_nlp/layers/transformer_encoder_block.py
@@ -54,7 +54,7 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
                **kwargs):
     """Initializes `TransformerEncoderBlock`.
 
-    Arguments:
+    Args:
       num_attention_heads: Number of attention heads.
       inner_dim: The output dimension of the first Dense layer in a two-layer
         feedforward network.

--- a/official/nlp/modeling/layers/dense_einsum.py
+++ b/official/nlp/modeling/layers/dense_einsum.py
@@ -28,7 +28,7 @@ class DenseEinsum(tf.keras.layers.Layer):
 
   This layer can perform einsum calculations of arbitrary dimensionality.
 
-  Arguments:
+  Args:
     output_shape: Positive integer or tuple, dimensionality of the output space.
     num_summed_dimensions: The number of dimensions to sum over. Standard 2D
       matmul should use 1, 3D matmul should use 2, and so forth.

--- a/official/nlp/modeling/layers/gated_feedforward.py
+++ b/official/nlp/modeling/layers/gated_feedforward.py
@@ -28,7 +28,7 @@ class GatedFeedforward(tf.keras.layers.Layer):
   (https://arxiv.org/abs/2002.05202). In additional, it allows to stack
   multiple feedforward blocks and specify the position of dropout layer.
 
-  Arguments:
+  Args:
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.
     dropout: Dropout probability for the output dropout.

--- a/official/nlp/modeling/layers/masked_softmax.py
+++ b/official/nlp/modeling/layers/masked_softmax.py
@@ -39,7 +39,7 @@ def _large_compatible_negative(tensor_type):
 class MaskedSoftmax(tf.keras.layers.Layer):
   """Performs a softmax with optional masking on a tensor.
 
-  Arguments:
+  Args:
     mask_expansion_axes: Any axes that should be padded on the mask tensor.
     normalization_axes: On which axes the softmax should perform.
   """

--- a/official/nlp/modeling/layers/mat_mul_with_margin.py
+++ b/official/nlp/modeling/layers/mat_mul_with_margin.py
@@ -26,7 +26,7 @@ from official.modeling import tf_utils
 class MatMulWithMargin(tf.keras.layers.Layer):
   """This layer computs a dot product matrix given two encoded inputs.
 
-  Arguments:
+  Args:
     logit_scale: The scaling factor of dot products when doing training.
     logit_margin: The margin value between the positive and negative examples
       when doing training.

--- a/official/nlp/modeling/layers/mobile_bert_layers.py
+++ b/official/nlp/modeling/layers/mobile_bert_layers.py
@@ -41,7 +41,7 @@ class NoNorm(tf.keras.layers.Layer):
 def _get_norm_layer(normalization_type='no_norm', name=None):
   """Get normlization layer.
 
-  Arguments:
+  Args:
       normalization_type: String. The type of normalization_type, only
         'no_norm' and 'layer_norm' are supported.
       name: Name for the norm layer.
@@ -80,7 +80,7 @@ class MobileBertEmbedding(tf.keras.layers.Layer):
                **kwargs):
     """Class initialization.
 
-    Arguments:
+    Args:
       word_vocab_size: Number of words in the vocabulary.
       word_embed_size: Word embedding size.
       type_vocab_size: Number of word types.
@@ -189,7 +189,7 @@ class MobileBertTransformer(tf.keras.layers.Layer):
                **kwargs):
     """Class initialization.
 
-    Arguments:
+    Args:
       hidden_size: Hidden size for the Transformer input and output tensor.
       num_attention_heads: Number of attention heads in the Transformer.
       intermediate_size: The size of the "intermediate" (a.k.a., feed
@@ -343,7 +343,7 @@ class MobileBertTransformer(tf.keras.layers.Layer):
            return_attention_scores=False):
     """Implementes the forward pass.
 
-    Arguments:
+    Args:
       input_tensor: Float tensor of shape [batch_size, seq_length, hidden_size].
       attention_mask: (optional) int32 tensor of shape [batch_size, seq_length,
         seq_length], with 1 for positions that can be attended to and 0 in

--- a/official/nlp/modeling/layers/multi_channel_attention.py
+++ b/official/nlp/modeling/layers/multi_channel_attention.py
@@ -26,7 +26,7 @@ from official.nlp.modeling.layers import masked_softmax
 class VotingAttention(tf.keras.layers.Layer):
   """Voting Attention layer.
 
-  Arguments:
+  Args:
     num_heads: the number of attention heads.
     head_size: per-head hidden size.
     kernel_initializer: Initializer for dense layer kernels.

--- a/official/nlp/modeling/layers/position_embedding.py
+++ b/official/nlp/modeling/layers/position_embedding.py
@@ -31,7 +31,7 @@ class RelativePositionEmbedding(tf.keras.layers.Layer):
    "Attention is All You Need", section 3.5.
   (https://arxiv.org/abs/1706.03762).
 
-  Arguments:
+  Args:
     hidden_size: Size of the hidden layer.
     min_timescale: Minimum scale that will be applied at each position
     max_timescale: Maximum scale that will be applied at each position.

--- a/official/nlp/modeling/layers/rezero_transformer.py
+++ b/official/nlp/modeling/layers/rezero_transformer.py
@@ -29,7 +29,7 @@ class ReZeroTransformer(tf.keras.layers.Layer):
   The residual connection implements the ReZero method.
   (https://arxiv.org/abs/2003.04887)
 
-  Arguments:
+  Args:
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.

--- a/official/nlp/modeling/layers/talking_heads_attention.py
+++ b/official/nlp/modeling/layers/talking_heads_attention.py
@@ -35,7 +35,7 @@ class TalkingHeadsAttention(tf.keras.layers.MultiHeadAttention):
 
   See the base class `MultiHeadAttention` for more details.
 
-  Arguments:
+  Args:
     num_heads: Number of attention heads.
     key_dim: Size of each attention head for query and key.
     value_dim:  Size of each attention head for value.

--- a/official/nlp/modeling/layers/tn_expand_condense.py
+++ b/official/nlp/modeling/layers/tn_expand_condense.py
@@ -36,7 +36,7 @@ class TNExpandCondense(Layer):
 
   Note the input shape and output shape will be identical.
 
-  Arguments:
+  Args:
     proj_multiplier: Positive integer, multiple of input_shape[-1] to project
       up to. Must be one of [2, 4, 6, 8].
     use_bias: Boolean, whether the layer uses a bias vector.

--- a/official/nlp/modeling/layers/tn_transformer_expand_condense.py
+++ b/official/nlp/modeling/layers/tn_transformer_expand_condense.py
@@ -31,7 +31,7 @@ class TNTransformerExpandCondense(tf.keras.layers.Layer):
   tensor network layer replacing the usual intermediate and output Dense
   layers.
 
-  Arguments:
+  Args:
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.

--- a/official/nlp/modeling/layers/transformer.py
+++ b/official/nlp/modeling/layers/transformer.py
@@ -31,7 +31,7 @@ class Transformer(keras_nlp.layers.TransformerEncoderBlock):
   This layer implements the Transformer from "Attention Is All You Need".
   (https://arxiv.org/abs/1706.03762).
 
-  Arguments:
+  Args:
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.
@@ -117,7 +117,7 @@ class TransformerDecoderBlock(tf.keras.layers.Layer):
   (2) a encoder-decoder attention.
   (3) a positionwise fully connected feed-forward network.
 
-  Arguments:
+  Args:
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.

--- a/official/nlp/modeling/layers/transformer_scaffold.py
+++ b/official/nlp/modeling/layers/transformer_scaffold.py
@@ -35,7 +35,7 @@ class TransformerScaffold(tf.keras.layers.Layer):
   instantiate the class with the config, or pass a class instance to
   `attention_cls`/`feedforward_cls`.
 
-  Arguments:
+  Args:
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate layer.
     intermediate_activation: Activation for the intermediate layer.

--- a/official/nlp/modeling/layers/transformer_xl.py
+++ b/official/nlp/modeling/layers/transformer_xl.py
@@ -25,7 +25,7 @@ from official.nlp.modeling.layers import relative_attention
 def _cache_memory(current_state, previous_state, memory_length, reuse_length=0):
   """Caches hidden states into memory.
 
-  Arguments:
+  Args:
     current_state: `Tensor`, the current state.
     previous_state: `Tensor`, the previous state.
     memory_length: `int`, the number of tokens to cache.
@@ -228,7 +228,7 @@ class TransformerXLBlock(tf.keras.layers.Layer):
            target_mapping=None):
     """Implements `call` for the Layer.
 
-    Arguments:
+    Args:
       content_stream: `Tensor`, the input content stream. This is the standard
         input to Transformer XL and is commonly referred to as `h` in XLNet.
       content_attention_bias: Bias `Tensor` for content based attention of shape
@@ -476,7 +476,7 @@ class TransformerXL(tf.keras.layers.Layer):
            target_mapping=None):
     """Implements call() for the layer.
 
-    Arguments:
+    Args:
       content_stream: `Tensor`, the input content stream. This is the standard
         input to Transformer XL and is commonly referred to as `h` in XLNet.
       relative_position_encoding: Relative positional encoding `Tensor` of shape

--- a/official/nlp/modeling/models/bert_classifier.py
+++ b/official/nlp/modeling/models/bert_classifier.py
@@ -36,7 +36,7 @@ class BertClassifier(tf.keras.Model):
   *Note* that the model is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     network: A transformer network. This network should output a sequence output
       and a classification output. Furthermore, it should expose its embedding
       table via a "get_embedding_table" method.

--- a/official/nlp/modeling/models/bert_pretrainer.py
+++ b/official/nlp/modeling/models/bert_pretrainer.py
@@ -39,7 +39,7 @@ class BertPretrainer(tf.keras.Model):
   *Note* that the model is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     network: A transformer network. This network should output a sequence output
       and a classification output.
     num_classes: Number of classes to predict from the classification network.
@@ -165,7 +165,7 @@ class BertPretrainerV2(tf.keras.Model):
   Adds the masked language model head and optional classification heads upon the
   transformer encoder.
 
-  Arguments:
+  Args:
     encoder_network: A transformer network. This network should output a
       sequence output and a classification output.
     mlm_activation: The activation (if any) to use in the masked LM network. If

--- a/official/nlp/modeling/models/bert_span_labeler.py
+++ b/official/nlp/modeling/models/bert_span_labeler.py
@@ -34,7 +34,7 @@ class BertSpanLabeler(tf.keras.Model):
   *Note* that the model is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     network: A transformer network. This network should output a sequence output
       and a classification output. Furthermore, it should expose its embedding
       table via a "get_embedding_table" method.

--- a/official/nlp/modeling/models/bert_token_classifier.py
+++ b/official/nlp/modeling/models/bert_token_classifier.py
@@ -33,7 +33,7 @@ class BertTokenClassifier(tf.keras.Model):
   *Note* that the model is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     network: A transformer network. This network should output a sequence output
       and a classification output. Furthermore, it should expose its embedding
       table via a "get_embedding_table" method.

--- a/official/nlp/modeling/models/dual_encoder.py
+++ b/official/nlp/modeling/models/dual_encoder.py
@@ -31,7 +31,7 @@ class DualEncoder(tf.keras.Model):
   The DualEncoder allows a user to pass in a transformer stack, and build a dual
   encoder model based on the transformer stack.
 
-  Arguments:
+  Args:
     network: A transformer network which should output an encoding output.
     max_seq_length: The maximum allowed sequence length for transformer.
     normalize: If set to True, normalize the encoding produced by transfomer.

--- a/official/nlp/modeling/models/electra_pretrainer.py
+++ b/official/nlp/modeling/models/electra_pretrainer.py
@@ -39,7 +39,7 @@ class ElectraPretrainer(tf.keras.Model):
   *Note* that the model is constructed by Keras Subclass API, where layers are
   defined inside __init__ and call() implements the computation.
 
-  Arguments:
+  Args:
     generator_network: A transformer network for generator, this network should
       output a sequence output and an optional classification output.
     discriminator_network: A transformer network for discriminator, this network

--- a/official/nlp/modeling/models/seq2seq_transformer.py
+++ b/official/nlp/modeling/models/seq2seq_transformer.py
@@ -57,7 +57,7 @@ class Seq2SeqTransformer(tf.keras.Model):
                **kwargs):
     """Initialize layers to build Transformer model.
 
-    Arguments:
+    Args:
       vocab_size: Size of vocabulary.
       embedding_width: Size of hidden layer for embedding.
       dropout_rate: Dropout probability.
@@ -359,7 +359,7 @@ class TransformerEncoder(tf.keras.layers.Layer):
     1. Self-attention layer
     2. Feedforward network (which is 2 fully-connected layers)
 
-  Arguments:
+  Args:
     num_layers: Number of layers.
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate (Feedforward) layer.
@@ -468,7 +468,7 @@ class TransformerDecoder(tf.keras.layers.Layer):
        the previous self-attention layer.
     3. Feedforward network (2 fully-connected layers)
 
-  Arguments:
+  Args:
     num_layers: Number of layers.
     num_attention_heads: Number of attention heads.
     intermediate_size: Size of the intermediate (Feedforward) layer.

--- a/official/nlp/modeling/models/xlnet.py
+++ b/official/nlp/modeling/models/xlnet.py
@@ -84,7 +84,7 @@ class XLNetPretrainer(tf.keras.Model):
   Transformer-XL encoder as described in "XLNet: Generalized Autoregressive
   Pretraining for Language Understanding" (https://arxiv.org/abs/1906.08237).
 
-  Arguments:
+  Args:
     network: An XLNet/Transformer-XL based network. This network should output a
       sequence output and list of `state` tensors.
     mlm_activation: The activation (if any) to use in the Masked LM network. If
@@ -163,7 +163,7 @@ class XLNetClassifier(tf.keras.Model):
   Note: This model does not use utilize the memory mechanism used in the
   original XLNet Classifier.
 
-  Arguments:
+  Args:
     network: An XLNet/Transformer-XL based network. This network should output a
       sequence output and list of `state` tensors.
     num_classes: Number of classes to predict from the classification network.
@@ -249,7 +249,7 @@ class XLNetSpanLabeler(tf.keras.Model):
   Transformer-XL encoder as described in "XLNet: Generalized Autoregressive
   Pretraining for Language Understanding" (https://arxiv.org/abs/1906.08237).
 
-  Arguments:
+  Args:
     network: A transformer network. This network should output a sequence output
       and a classification output. Furthermore, it should expose its embedding
       table via a "get_embedding_table" method.

--- a/official/nlp/modeling/networks/albert_encoder.py
+++ b/official/nlp/modeling/networks/albert_encoder.py
@@ -39,7 +39,7 @@ class AlbertEncoder(tf.keras.Model):
 
   *Note* that the network is constructed by Keras Functional API.
 
-  Arguments:
+  Args:
     vocab_size: The size of the token vocabulary.
     embedding_width: The width of the word embeddings. If the embedding width is
       not equal to hidden size, embedding parameters will be factorized into two

--- a/official/nlp/modeling/networks/bert_encoder.py
+++ b/official/nlp/modeling/networks/bert_encoder.py
@@ -41,7 +41,7 @@ class BertEncoder(keras_nlp.encoders.BertEncoder):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     vocab_size: The size of the token vocabulary.
     hidden_size: The size of the transformer hidden layers.
     num_layers: The number of transformer layers.

--- a/official/nlp/modeling/networks/classification.py
+++ b/official/nlp/modeling/networks/classification.py
@@ -28,7 +28,7 @@ class Classification(tf.keras.Model):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     input_width: The innermost dimension of the input tensor to this network.
     num_classes: The number of classes that this network should classify to. If
       equal to 1, a regression problem is assumed.

--- a/official/nlp/modeling/networks/encoder_scaffold.py
+++ b/official/nlp/modeling/networks/encoder_scaffold.py
@@ -49,7 +49,7 @@ class EncoderScaffold(tf.keras.Model):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     pooled_output_dim: The dimension of pooled output.
     pooler_layer_initializer: The initializer for the classification layer.
     embedding_cls: The class or instance to use to embed the input data. This

--- a/official/nlp/modeling/networks/mobile_bert_encoder.py
+++ b/official/nlp/modeling/networks/mobile_bert_encoder.py
@@ -45,7 +45,7 @@ class MobileBERTEncoder(tf.keras.Model):
                **kwargs):
     """Class initialization.
 
-    Arguments:
+    Args:
       word_vocab_size: Number of words in the vocabulary.
       word_embed_size: Word embedding size.
       type_vocab_size: Number of word types.

--- a/official/nlp/modeling/networks/packed_sequence_embedding.py
+++ b/official/nlp/modeling/networks/packed_sequence_embedding.py
@@ -32,7 +32,7 @@ class PackedSequenceEmbedding(tf.keras.Model):
   to (1) pack multiple sequences into one sequence and (2) allow additional
   "position_ids" as input.
 
-  Arguments:
+  Args:
     vocab_size: The size of the token vocabulary.
     type_vocab_size: The size of the type vocabulary.
     hidden_size: The hidden size for this encoder.
@@ -194,7 +194,7 @@ class PositionEmbeddingWithSubSeqMask(tf.keras.layers.Layer):
   can have a dynamic 1st dimension, while if `use_dynamic_slicing` is False the
   input size must be fixed.
 
-  Arguments:
+  Args:
     initializer: The initializer to use for the embedding weights. Defaults to
       "glorot_uniform".
     use_dynamic_slicing: Whether to use the dynamic slicing path.

--- a/official/nlp/modeling/networks/span_labeling.py
+++ b/official/nlp/modeling/networks/span_labeling.py
@@ -32,7 +32,7 @@ class SpanLabeling(tf.keras.Model):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     input_width: The innermost dimension of the input tensor to this network.
     activation: The activation, if any, for the dense layer in this network.
     initializer: The initializer for the dense layer in this network. Defaults
@@ -123,7 +123,7 @@ class XLNetSpanLabeling(tf.keras.layers.Layer):
   **Note: `compute_with_beam_search` will not work with the Functional API
   (https://www.tensorflow.org/guide/keras/functional).
 
-  Arguments:
+  Args:
     input_width: The innermost dimension of the input tensor to this network.
     start_n_top: Beam size for span start.
     end_n_top: Beam size for span end.

--- a/official/nlp/modeling/networks/xlnet_base.py
+++ b/official/nlp/modeling/networks/xlnet_base.py
@@ -52,7 +52,7 @@ def _create_causal_attention_mask(
   We then flip the matrix values in order to match the representation where
   real values are 1s.
 
-  Arguments:
+  Args:
     seq_length: int, The length of each sequence.
     memory_length: int, The length of memory blocks.
     dtype: dtype of the mask.
@@ -392,7 +392,7 @@ class RelativePositionEncoding(tf.keras.layers.Layer):
   def call(self, pos_seq, batch_size=None):
     """Implements call() for the layer.
 
-    Arguments:
+    Args:
       pos_seq: A 1-D `Tensor`
       batch_size: The optionally provided batch size that tiles the relative
         positional encoding.

--- a/official/nlp/projects/bigbird/encoder.py
+++ b/official/nlp/projects/bigbird/encoder.py
@@ -30,7 +30,7 @@ class BigBirdEncoder(tf.keras.Model):
   *Note* that the network is constructed by
   [Keras Functional API](https://keras.io/guides/functional_api/).
 
-  Arguments:
+  Args:
     vocab_size: The size of the token vocabulary.
     hidden_size: The size of the transformer hidden layers.
     num_layers: The number of transformer layers.

--- a/official/nlp/xlnet/xlnet_modeling.py
+++ b/official/nlp/xlnet/xlnet_modeling.py
@@ -114,7 +114,7 @@ class RelativePositionEncoding(tf.keras.layers.Layer):
   def call(self, pos_seq, batch_size=None):
     """Implements call() for the layer.
 
-    Arguments:
+    Args:
       pos_seq: A 1-D `Tensor`
       batch_size: The optionally provided batch size that tiles the relative
         positional encoding.

--- a/official/staging/training/grad_utils.py
+++ b/official/staging/training/grad_utils.py
@@ -57,7 +57,7 @@ def _filter_and_allreduce_gradients(grads_and_vars,
   The allreduced gradients are then passed to optimizer.apply_gradients(
   experimental_aggregate_gradients=False).
 
-  Arguments:
+  Args:
       grads_and_vars: gradients and variables pairs.
       allreduce_precision: Whether to allreduce gradients in float32 or float16.
       bytes_per_pack: A non-negative integer. Breaks collective operations into
@@ -101,7 +101,7 @@ def minimize_using_explicit_allreduce(tape,
   For TPU and GPU training using FP32, explicit allreduce will aggregate
   gradients in FP32 format.
 
-  Arguments:
+  Args:
       tape: An instance of `tf.GradientTape`.
       optimizer: An instance of `tf.keras.optimizers.Optimizer`.
       loss: the loss tensor.

--- a/official/vision/beta/losses/retinanet_losses.py
+++ b/official/vision/beta/losses/retinanet_losses.py
@@ -68,7 +68,7 @@ class FocalLoss(tf.keras.losses.Loss):
                name=None):
     """Initializes `FocalLoss`.
 
-    Arguments:
+    Args:
       alpha: The `alpha` weight factor for binary class imbalance.
       gamma: The `gamma` focusing parameter to re-weight loss.
       num_classes: Number of foreground classes.
@@ -91,7 +91,7 @@ class FocalLoss(tf.keras.losses.Loss):
   def call(self, y_true, y_pred):
     """Invokes the `FocalLoss`.
 
-    Arguments:
+    Args:
       y_true: Ordered Dict with level to [batch, height, width, num_anchors].
         for example,
         {3: tf.Tensor(shape=[32, 512, 512, 9], dtype=tf.float32),
@@ -143,7 +143,7 @@ class RetinanetBoxLoss(tf.keras.losses.Loss):
                name=None):
     """Initializes `RetinanetBoxLoss`.
 
-    Arguments:
+    Args:
       delta: A float, the point where the Huber loss function changes from a
         quadratic to linear.
       reduction: (Optional) Type of `tf.keras.losses.Reduction` to apply to
@@ -167,7 +167,7 @@ class RetinanetBoxLoss(tf.keras.losses.Loss):
 
     Computes total detection loss including box and class loss from all levels.
 
-    Arguments:
+    Args:
       y_true: Ordered Dict with level to [batch, height, width,
         num_anchors * 4] for example,
         {3: tf.Tensor(shape=[32, 512, 512, 9 * 4], dtype=tf.float32),

--- a/official/vision/detection/executor/distributed_executor.py
+++ b/official/vision/detection/executor/distributed_executor.py
@@ -108,7 +108,7 @@ class SummaryWriter(object):
   def __init__(self, model_dir: Text, name: Text):
     """Inits SummaryWriter with paths.
 
-    Arguments:
+    Args:
       model_dir: the model folder path.
       name: the summary subfolder name.
     """

--- a/official/vision/keras_cv/layers/deeplab.py
+++ b/official/vision/keras_cv/layers/deeplab.py
@@ -42,7 +42,7 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
       **kwargs):
     """Initializes `SpatialPyramidPooling`.
 
-    Arguments:
+    Args:
       output_channels: Number of channels produced by SpatialPyramidPooling.
       dilation_rates: A list of integers for parallel dilated conv.
       pool_kernel_size: A list of integers or None. If None, global average

--- a/official/vision/keras_cv/losses/focal_loss.py
+++ b/official/vision/keras_cv/losses/focal_loss.py
@@ -31,7 +31,7 @@ class FocalLoss(tf.keras.losses.Loss):
                name=None):
     """Initializes `FocalLoss`.
 
-    Arguments:
+    Args:
       alpha: The `alpha` weight factor for binary class imbalance.
       gamma: The `gamma` focusing parameter to re-weight loss.
       reduction: (Optional) Type of `tf.keras.losses.Reduction` to apply to
@@ -52,7 +52,7 @@ class FocalLoss(tf.keras.losses.Loss):
   def call(self, y_true, y_pred):
     """Invokes the `FocalLoss`.
 
-    Arguments:
+    Args:
       y_true: A tensor of size [batch, num_anchors, num_classes]
       y_pred: A tensor of size [batch, num_anchors, num_classes]
 

--- a/official/vision/keras_cv/losses/loss_utils.py
+++ b/official/vision/keras_cv/losses/loss_utils.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 def multi_level_flatten(multi_level_inputs, last_dim=None):
   """Flattens a multi-level input.
 
-  Arguments:
+  Args:
     multi_level_inputs: Ordered Dict with level to [batch, d1, ..., dm].
     last_dim: Whether the output should be [batch_size, None], or [batch_size,
       None, last_dim]. Defaults to `None`.

--- a/research/a3c_blogpost/a3c_cartpole.py
+++ b/research/a3c_blogpost/a3c_cartpole.py
@@ -59,7 +59,7 @@ def record(episode,
            num_steps):
   """Helper function to store score and print statistics.
 
-  Arguments:
+  Args:
     episode: Current episode
     episode_reward: Reward accumulated over the current episode
     worker_idx: Which thread (worker)
@@ -87,7 +87,7 @@ def record(episode,
 class RandomAgent:
   """Random Agent that will play the specified game
 
-    Arguments:
+    Args:
       env_name: Name of the environment to be played
       max_eps: Maximum number of episodes to run agent for.
   """

--- a/research/deep_speech/decoder.py
+++ b/research/deep_speech/decoder.py
@@ -30,7 +30,7 @@ class DeepSpeechDecoder(object):
   def __init__(self, labels, blank_index=28):
     """Decoder initialization.
 
-    Arguments:
+    Args:
       labels: a string specifying the speech labels for the decoder to use.
       blank_index: an integer specifying index for the blank character.
         Defaults to 28.

--- a/research/object_detection/core/freezable_batch_norm.py
+++ b/research/object_detection/core/freezable_batch_norm.py
@@ -35,7 +35,7 @@ class FreezableBatchNorm(tf.keras.layers.BatchNormalization):
   i.e. applies a transformation that maintains the mean activation
   close to 0 and the activation standard deviation close to 1.
 
-  Arguments:
+  Args:
     training: If False, the layer will normalize using the moving average and
       std. dev, without updating the learned avg and std. dev.
       If None or True, the layer will follow the keras BatchNormalization layer

--- a/research/object_detection/models/keras_models/base_models/original_mobilenet_v2.py
+++ b/research/object_detection/models/keras_models/base_models/original_mobilenet_v2.py
@@ -117,7 +117,7 @@ def _obtain_input_shape(
     require_flatten):
   """Internal utility to compute/validate an ImageNet model's input shape.
 
-  Arguments:
+  Args:
       input_shape: either None (will return the default network input shape),
           or a user-provided shape to be validated.
       default_size: default input width/height for the model.
@@ -198,7 +198,7 @@ def preprocess_input(x):
   the RGB values from [0, 255] to [-1, 1]. Note that this preprocessing
   function is different from `imagenet_utils.preprocess_input()`.
 
-  Arguments:
+  Args:
     x: a 4D numpy array consists of RGB values within [0, 255].
 
   Returns:
@@ -237,7 +237,7 @@ def mobilenet_v2(input_shape=None,
   model = load_model('mobilenet.h5', custom_objects={
                      'relu6': mobilenet.relu6})
 
-  Arguments:
+  Args:
     input_shape: optional shape tuple, to be specified if you would
       like to use a model with an input img resolution that is not
       (224, 224, 3).

--- a/research/object_detection/models/keras_models/resnet_v1.py
+++ b/research/object_detection/models/keras_models/resnet_v1.py
@@ -408,7 +408,7 @@ def block_basic(x,
                 name=None):
   """A residual block for ResNet18/34.
 
-  Arguments:
+  Args:
       x: input tensor.
       filters: integer, filters of the bottleneck layer.
       kernel_size: default 3, kernel size of the bottleneck layer.
@@ -465,7 +465,7 @@ def block_basic(x,
 def stack_basic(x, filters, blocks, stride1=2, name=None):
   """A set of stacked residual blocks for ResNet18/34.
 
-  Arguments:
+  Args:
       x: input tensor.
       filters: integer, filters of the bottleneck layer in a block.
       blocks: integer, blocks in the stacked blocks.

--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -127,7 +127,7 @@ class NoOpScope(object):
 def safe_arg_scope(funcs, **kwargs):
   """Returns `slim.arg_scope` with all None arguments removed.
 
-  Arguments:
+  Args:
     funcs: Functions to pass to `arg_scope`.
     **kwargs: Arguments to pass to `arg_scope`.
 


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420