### PR TITLE
Improve numerical stability of PenaltyReducedLogisticFocalLoss.

### DIFF
--- a/research/object_detection/core/losses.py
+++ b/research/object_detection/core/losses.py
@@ -762,19 +762,19 @@ class PenaltyReducedLogisticFocalLoss(Loss):
     """
 
     is_present_tensor = tf.math.equal(target_tensor, 1.0)
-    sigmoid_prediction_tensor = tf.sigmoid(prediction_tensor)
+    sigmoid_prediction = tf.sigmoid(prediction_tensor)
 
-    log_sigmoid_prediction_tensor = tf.math.log_sigmoid(prediction_tensor)
-    log_1_minus_sigmoid_prediction_tensor = log_sigmoid_prediction_tensor \
-      - prediction_tensor
+    log1p_exp_neg_abs = tf.math.log1p(tf.math.exp(-tf.math.abs(-prediction_tensor)))
+    neg_log_sigmoid_prediction = log1p_exp_neg_abs + tf.nn.relu(-prediction_tensor)
+    neg_log1m_sigmoid_prediction = log1p_exp_neg_abs + tf.nn.relu(prediction_tensor)
 
-    positive_loss = (tf.math.pow((1 - sigmoid_prediction_tensor), self._alpha)*
-                     log_sigmoid_prediction_tensor)
-    negative_loss = (tf.math.pow((1 - target_tensor), self._beta)*
-                     tf.math.pow(sigmoid_prediction_tensor, self._alpha)*
-                     log_1_minus_sigmoid_prediction_tensor)
+    positive_loss = (tf.math.pow((1 - sigmoid_prediction), self._alpha) *
+                     neg_log_sigmoid_prediction)
+    negative_loss = (tf.math.pow((1 - target_tensor), self._beta) *
+                     tf.math.pow(sigmoid_prediction, self._alpha) *
+                     neg_log1m_sigmoid_prediction)
 
-    loss = -tf.where(is_present_tensor, positive_loss, negative_loss)
+    loss = tf.where(is_present_tensor, positive_loss, negative_loss)
     return loss * weights
 
 

--- a/research/object_detection/core/losses.py
+++ b/research/object_detection/core/losses.py
@@ -764,15 +764,16 @@ class PenaltyReducedLogisticFocalLoss(Loss):
     is_present_tensor = tf.math.equal(target_tensor, 1.0)
     sigmoid_prediction = tf.sigmoid(prediction_tensor)
 
-    log1p_exp_neg_abs = tf.math.log1p(tf.math.exp(-tf.math.abs(-prediction_tensor)))
-    neg_log_sigmoid_prediction = log1p_exp_neg_abs + tf.nn.relu(-prediction_tensor)
-    neg_log1m_sigmoid_prediction = log1p_exp_neg_abs + tf.nn.relu(prediction_tensor)
+    log1p_exp_neg_abs = tf.math.log1p(
+        tf.math.exp(-tf.math.abs(-prediction_tensor)))
+    neg_log_sigmoid = log1p_exp_neg_abs + tf.nn.relu(-prediction_tensor)
+    neg_log1m_sigmoid = log1p_exp_neg_abs + tf.nn.relu(prediction_tensor)
 
     positive_loss = (tf.math.pow((1 - sigmoid_prediction), self._alpha) *
-                     neg_log_sigmoid_prediction)
+                     neg_log_sigmoid)
     negative_loss = (tf.math.pow((1 - target_tensor), self._beta) *
                      tf.math.pow(sigmoid_prediction, self._alpha) *
-                     neg_log1m_sigmoid_prediction)
+                     neg_log1m_sigmoid)
 
     loss = tf.where(is_present_tensor, positive_loss, negative_loss)
     return loss * weights

--- a/research/object_detection/core/losses.py
+++ b/research/object_detection/core/losses.py
@@ -765,7 +765,8 @@ class PenaltyReducedLogisticFocalLoss(Loss):
     sigmoid_prediction_tensor = tf.sigmoid(prediction_tensor)
 
     log_sigmoid_prediction_tensor = tf.math.log_sigmoid(prediction_tensor)
-    log_1_minus_sigmoid_prediction_tensor = log_sigmoid_prediction_tensor - prediction_tensor
+    log_1_minus_sigmoid_prediction_tensor = log_sigmoid_prediction_tensor \
+      - prediction_tensor
 
     positive_loss = (tf.math.pow((1 - sigmoid_prediction_tensor), self._alpha)*
                      log_sigmoid_prediction_tensor)


### PR DESCRIPTION
# Description

PR improves the numerical stability of PenaltyReducedLogisticFocalLoss. The line of reasoning is the same as in https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits.

In particular, it uses the fact that `-log(sigmoid(x)) = log(1+exp(-abs(-x))) + max(-x,0)`. See https://www.tensorflow.org/api_docs/python/tf/math/log_sigmoid for reference. 

With that, we can also derive:
``` 
  - log(1 - sigmoid(x))
= - log(sigmoid(x)) - log(exp(-x))
= - log(sigmoid(x)) + x
=   log(1+exp(-abs(-x))) + max(-x,0) + x
=   log(1+exp(-abs(-x))) + max(x,0)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (Improved numerical stability)

## Tests
`research/object_detection/core/losses_test.py` passes the tests without `_sigmoid_clip_value` even for +inf and -inf.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
