### PR TITLE
[research/**.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/research/a3c_blogpost/a3c_cartpole.py
+++ b/research/a3c_blogpost/a3c_cartpole.py
@@ -59,7 +59,7 @@ def record(episode,
            num_steps):
   """Helper function to store score and print statistics.
 
-  Arguments:
+  Args:
     episode: Current episode
     episode_reward: Reward accumulated over the current episode
     worker_idx: Which thread (worker)
@@ -87,7 +87,7 @@ def record(episode,
 class RandomAgent:
   """Random Agent that will play the specified game
 
-    Arguments:
+    Args:
       env_name: Name of the environment to be played
       max_eps: Maximum number of episodes to run agent for.
   """

--- a/research/deep_speech/decoder.py
+++ b/research/deep_speech/decoder.py
@@ -30,7 +30,7 @@ class DeepSpeechDecoder(object):
   def __init__(self, labels, blank_index=28):
     """Decoder initialization.
 
-    Arguments:
+    Args:
       labels: a string specifying the speech labels for the decoder to use.
       blank_index: an integer specifying index for the blank character.
         Defaults to 28.

--- a/research/object_detection/core/freezable_batch_norm.py
+++ b/research/object_detection/core/freezable_batch_norm.py
@@ -35,7 +35,7 @@ class FreezableBatchNorm(tf.keras.layers.BatchNormalization):
   i.e. applies a transformation that maintains the mean activation
   close to 0 and the activation standard deviation close to 1.
 
-  Arguments:
+  Args:
     training: If False, the layer will normalize using the moving average and
       std. dev, without updating the learned avg and std. dev.
       If None or True, the layer will follow the keras BatchNormalization layer

--- a/research/object_detection/models/keras_models/base_models/original_mobilenet_v2.py
+++ b/research/object_detection/models/keras_models/base_models/original_mobilenet_v2.py
@@ -117,7 +117,7 @@ def _obtain_input_shape(
     require_flatten):
   """Internal utility to compute/validate an ImageNet model's input shape.
 
-  Arguments:
+  Args:
       input_shape: either None (will return the default network input shape),
           or a user-provided shape to be validated.
       default_size: default input width/height for the model.
@@ -198,7 +198,7 @@ def preprocess_input(x):
   the RGB values from [0, 255] to [-1, 1]. Note that this preprocessing
   function is different from `imagenet_utils.preprocess_input()`.
 
-  Arguments:
+  Args:
     x: a 4D numpy array consists of RGB values within [0, 255].
 
   Returns:
@@ -237,7 +237,7 @@ def mobilenet_v2(input_shape=None,
   model = load_model('mobilenet.h5', custom_objects={
                      'relu6': mobilenet.relu6})
 
-  Arguments:
+  Args:
     input_shape: optional shape tuple, to be specified if you would
       like to use a model with an input img resolution that is not
       (224, 224, 3).

--- a/research/object_detection/models/keras_models/resnet_v1.py
+++ b/research/object_detection/models/keras_models/resnet_v1.py
@@ -408,7 +408,7 @@ def block_basic(x,
                 name=None):
   """A residual block for ResNet18/34.
 
-  Arguments:
+  Args:
       x: input tensor.
       filters: integer, filters of the bottleneck layer.
       kernel_size: default 3, kernel size of the bottleneck layer.
@@ -465,7 +465,7 @@ def block_basic(x,
 def stack_basic(x, filters, blocks, stride1=2, name=None):
   """A set of stacked residual blocks for ResNet18/34.
 
-  Arguments:
+  Args:
       x: input tensor.
       filters: integer, filters of the bottleneck layer in a block.
       blocks: integer, blocks in the stacked blocks.

--- a/research/slim/nets/mobilenet/mobilenet.py
+++ b/research/slim/nets/mobilenet/mobilenet.py
@@ -127,7 +127,7 @@ class NoOpScope(object):
 def safe_arg_scope(funcs, **kwargs):
   """Returns `slim.arg_scope` with all None arguments removed.
 
-  Arguments:
+  Args:
     funcs: Functions to pass to `arg_scope`.
     **kwargs: Arguments to pass to `arg_scope`.
 


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420