### PR TITLE
Fixed serialization (dropout layers' names) + deleted one dropout layer

### DIFF
--- a/official/nlp/keras_nlp/layers/transformer_encoder_block.py
+++ b/official/nlp/keras_nlp/layers/transformer_encoder_block.py
@@ -1,6 +1,3 @@
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -20,10 +17,12 @@ import tensorflow as tf
 @tf.keras.utils.register_keras_serializable(package="keras_nlp")
 class TransformerEncoderBlock(tf.keras.layers.Layer):
   """TransformerEncoderBlock layer.
+
   This layer implements the Transformer Encoder from
   "Attention Is All You Need". (https://arxiv.org/abs/1706.03762),
   which combines a `tf.keras.layers.MultiHeadAttention` layer with a
   two-layer feedforward network.
+
   References:
     [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
     [BERT: Pre-training of Deep Bidirectional Transformers for Language
@@ -51,6 +50,7 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
                attention_initializer=None,
                **kwargs):
     """Initializes `TransformerEncoderBlock`.
+
     Arguments:
       num_attention_heads: Number of attention heads.
       inner_dim: The output dimension of the first Dense layer in a two-layer
@@ -145,6 +145,8 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
         kernel_initializer=self._attention_initializer,
         name="self_attention",
         **common_kwargs)
+    self._attention_dropout_layer = tf.keras.layers.Dropout(
+        rate=self._output_dropout)
     # Use float32 in layernorm for numeric stability.
     # It is probably safe in mixed_float16, but we haven't validated this yet.
     self._attention_layer_norm = (
@@ -178,7 +180,7 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
         kernel_initializer=self._kernel_initializer,
         **common_kwargs)
     self._output_dropout_layer = tf.keras.layers.Dropout(
-      rate=self._output_dropout)
+        rate=self._output_dropout)
     # Use float32 in layernorm for numeric stability.
     self._output_layer_norm = tf.keras.layers.LayerNormalization(
         name="output_layer_norm",
@@ -251,6 +253,8 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
 
     attention_output = self._attention_layer(
         query=target_tensor, value=input_tensor, attention_mask=attention_mask)
+    attention_output = self._attention_dropout_layer(attention_output)
+    
     if self._norm_first:
       attention_output = source_tensor + attention_output
     else:

--- a/official/nlp/keras_nlp/layers/transformer_encoder_block.py
+++ b/official/nlp/keras_nlp/layers/transformer_encoder_block.py
@@ -20,12 +20,10 @@ import tensorflow as tf
 @tf.keras.utils.register_keras_serializable(package="keras_nlp")
 class TransformerEncoderBlock(tf.keras.layers.Layer):
   """TransformerEncoderBlock layer.
-
   This layer implements the Transformer Encoder from
   "Attention Is All You Need". (https://arxiv.org/abs/1706.03762),
   which combines a `tf.keras.layers.MultiHeadAttention` layer with a
   two-layer feedforward network.
-
   References:
     [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
     [BERT: Pre-training of Deep Bidirectional Transformers for Language
@@ -53,7 +51,6 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
                attention_initializer=None,
                **kwargs):
     """Initializes `TransformerEncoderBlock`.
-
     Arguments:
       num_attention_heads: Number of attention heads.
       inner_dim: The output dimension of the first Dense layer in a two-layer
@@ -148,7 +145,6 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
         kernel_initializer=self._attention_initializer,
         name="self_attention",
         **common_kwargs)
-    self._attention_dropout = tf.keras.layers.Dropout(rate=self._output_dropout)
     # Use float32 in layernorm for numeric stability.
     # It is probably safe in mixed_float16, but we haven't validated this yet.
     self._attention_layer_norm = (
@@ -181,7 +177,8 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
         name="output",
         kernel_initializer=self._kernel_initializer,
         **common_kwargs)
-    self._output_dropout = tf.keras.layers.Dropout(rate=self._output_dropout)
+    self._output_dropout_layer = tf.keras.layers.Dropout(
+      rate=self._output_dropout)
     # Use float32 in layernorm for numeric stability.
     self._output_layer_norm = tf.keras.layers.LayerNormalization(
         name="output_layer_norm",
@@ -254,7 +251,6 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
 
     attention_output = self._attention_layer(
         query=target_tensor, value=input_tensor, attention_mask=attention_mask)
-    attention_output = self._attention_dropout(attention_output)
     if self._norm_first:
       attention_output = source_tensor + attention_output
     else:
@@ -267,7 +263,7 @@ class TransformerEncoderBlock(tf.keras.layers.Layer):
     inner_output = self._intermediate_activation_layer(inner_output)
     inner_output = self._inner_dropout_layer(inner_output)
     layer_output = self._output_dense(inner_output)
-    layer_output = self._output_dropout(layer_output)
+    layer_output = self._output_dropout_layer(layer_output)
 
     if self._norm_first:
       return source_attention_output + layer_output

--- a/official/nlp/keras_nlp/layers/transformer_encoder_block.py
+++ b/official/nlp/keras_nlp/layers/transformer_encoder_block.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ===============================================================================
+# ==============================================================================
 """Keras-based TransformerEncoder block layer."""
 
 import tensorflow as tf

--- a/official/nlp/keras_nlp/layers/transformer_encoder_block.py
+++ b/official/nlp/keras_nlp/layers/transformer_encoder_block.py
@@ -1,3 +1,6 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -8,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+# ===============================================================================
 """Keras-based TransformerEncoder block layer."""
 
 import tensorflow as tf


### PR DESCRIPTION
Two changes:
- Dropout layers were taking the same names as the dropout rates, hence messing deserialization process (`ValueError: rate is neither scalar nor scalar tensor <tensorflow.python.keras.layers.core.Dropout object at 0x7f80860cd5f8>`). Found by saving as .h5, loading and then trying to save as saved_model.
- I believe attention_dropout is already being applied to the attention weights in the MultiHeadAttention layer, so probably unnecessary to add another dropout to the latter layer's outputs.