### PR TITLE
Fix fine_tuning_bert.ipynb notebook

### DIFF
--- a/official/colab/fine_tuning_bert.ipynb
+++ b/official/colab/fine_tuning_bert.ipynb
@@ -51,23 +51,23 @@
         "id": "hYEwGTeCXnnX"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/official_models/tutorials/fine_tune_bert.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/models/official/colab/fine_tuning_bert.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://tfhub.dev/tensorflow/bert_en_uncased_L-12_H-768_A-12/2\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/hub_logo_32px.png\" /\u003eSee TF Hub model\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/official_models/tutorials/fine_tune_bert.ipynb\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/models/official/colab/fine_tuning_bert.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://tfhub.dev/tensorflow/bert_en_uncased_L-12_H-768_A-12/2\"><img src=\"https://www.tensorflow.org/images/hub_logo_32px.png\" />See TF Hub model</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -245,7 +245,7 @@
       "source": [
         "### Get the dataset from TensorFlow Datasets\n",
         "\n",
-        "The Microsoft Research Paraphrase Corpus (Dolan \u0026 Brockett, 2005) is a corpus of sentence pairs automatically extracted from online news sources, with human annotations for whether the sentences in the pair are semantically equivalent.\n",
+        "The Microsoft Research Paraphrase Corpus (Dolan & Brockett, 2005) is a corpus of sentence pairs automatically extracted from online news sources, with human annotations for whether the sentences in the pair are semantically equivalent.\n",
         "\n",
         "*   Number of labels: 2.\n",
         "*   Size of training dataset: 3668.\n",
@@ -1151,7 +1151,7 @@
         "id": "SaC1RlFawUpc"
       },
       "source": [
-        "\u003ca id=re_encoding_tools\u003e\u003c/a\u003e\n",
+        "<a id=re_encoding_tools></a>\n",
         "### Re-encoding a large dataset"
       ]
     },
@@ -1400,7 +1400,7 @@
         "id": "QbklKt-w_CiI"
       },
       "source": [
-        "\u003ca id=\"hub_bert\"\u003e\u003c/a\u003e\n",
+        "<a id=\"hub_bert\"></a>\n",
         "\n",
         "### TFModels BERT on TFHub\n",
         "\n",
@@ -1556,7 +1556,7 @@
         "id": "ZxSqH0dNAgXV"
       },
       "source": [
-        "\u003ca id=\"model_builder_functions\"\u003e\u003c/a\u003e\n",
+        "<a id=\"model_builder_functions\"></a>\n",
         "\n",
         "### Low level model building\n",
         "\n",
@@ -1593,6 +1593,7 @@
         "          stddev=transformer_config.pop('initializer_range'))\n",
         "transformer_config['max_sequence_length'] = transformer_config.pop('max_position_embeddings')\n",
         "transformer_config['num_layers'] = transformer_config.pop('num_hidden_layers')\n",
+        "transformer_config['sequence_length'] = None\n",
         "\n",
         "transformer_config"
       ]
@@ -1709,7 +1710,7 @@
         "id": "E6AJlOSyIO1L"
       },
       "source": [
-        "\u003ca id=\"optiizer_schedule\"\u003e\u003c/a\u003e\n",
+        "<a id=\"optiizer_schedule\"></a>\n",
         "\n",
         "### Optimizers and schedules\n",
         "\n",


### PR DESCRIPTION
Running fine_tuning_bert.ipynb in colaboratory raises an error in [this](https://colab.research.google.com/github/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb#scrollTo=hlVdgJKmj389&line=1&uniqifier=1) cell:
`ValueError: Input 0 is incompatible with layer transformer_encoder_2: expected shape=(None, 512), found shape=(2, 23)`

This is because `manual_encoder`, that was created [here](https://colab.research.google.com/github/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb#scrollTo=rIO8MI7LLijh&line=1&uniqifier=1), expects batch with length 512. That is strange, because it must work with batch of every length (the longest sequence in batch). That's why there should be one more config option in `trainsformer_config` [here](https://colab.research.google.com/github/tensorflow/models/blob/master/official/colab/fine_tuning_bert.ipynb#scrollTo=5r_yqhBFSVEM&line=1&uniqifier=1):
`transformer_config['sequence_length'] = None`
After that code works as expected up to the end of the notebook without errors.

P.S: there are some auto changes in unicode symbols, think it was done automatically by my VS Code (windows 10). Hope it didn't make things worse.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
> * Just open notebook in colab, then Runtime -> Run all. Previous version on notebook raises an error, that was mentioned earlier .

**Test Configuration**:
google colab

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.