### PR TITLE
Fix visualization_export_dir and keep_image_id_for_visualization_expo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,7 @@ ENV/
 # PyCharm
 .idea/
 
+.vscode/
+
 # For mac
 .DS_Store

--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -621,6 +621,10 @@ def create_model_fn(detection_model_fn, configs, hparams=None, use_tpu=False,
         eval_dict[fields.InputDataFields.image_additional_channels] = features[
             fields.InputDataFields.image_additional_channels]
 
+      if fields.InputDataFields.source_id in features:
+        eval_dict[fields.InputDataFields.source_id] = features[
+            fields.InputDataFields.source_id]
+
       if class_agnostic:
         category_index = label_map_util.create_class_agnostic_category_index()
       else:
@@ -637,7 +641,10 @@ def create_model_fn(detection_model_fn, configs, hparams=None, use_tpu=False,
             max_boxes_to_draw=eval_config.max_num_boxes_to_visualize,
             min_score_thresh=eval_config.min_score_threshold,
             use_normalized_coordinates=False,
-            keypoint_edges=keypoint_edges or None)
+            keypoint_edges=keypoint_edges or None,
+            viz_export_dir=eval_config.visualization_export_dir,
+            keep_img_id_for_viz_export=
+              eval_config.keep_image_id_for_visualization_export)
         vis_metric_ops = eval_metric_op_vis.get_estimator_eval_metric_ops(
             eval_dict)
 

--- a/research/object_detection/model_main.py
+++ b/research/object_detection/model_main.py
@@ -32,7 +32,7 @@ flags.DEFINE_string('pipeline_config_path', None, 'Path to pipeline config '
 flags.DEFINE_integer('num_train_steps', None, 'Number of train steps.')
 flags.DEFINE_boolean('eval_training_data', False,
                      'If training data should be evaluated for this job. Note '
-                     'that one call only use this in eval-only mode, and '
+                     'that one can only use this in eval-only mode, and '
                      '`checkpoint_dir` must be supplied.')
 flags.DEFINE_integer('sample_1_of_n_eval_examples', 1, 'Will sample one of '
                      'every n eval input examples, where n is provided.')

--- a/research/object_detection/protos/eval.proto
+++ b/research/object_detection/protos/eval.proto
@@ -6,7 +6,11 @@ package object_detection.protos;
 // Next id - 36
 message EvalConfig {
   optional uint32 batch_size = 25 [default = 1];
-  // Number of visualization images to generate.
+  
+  // Number of visualization images to generate for TensorBoard. Note that
+  // TensorBoard visualizations are currently accumulated in memory until the
+  // end of the evaluation phase when they are saved, which can require a lot of
+  // memory for high settings of `num_visualizations`.
   optional uint32 num_visualizations = 1 [default = 10];
 
   // Number of examples to process of evaluation.
@@ -21,8 +25,14 @@ message EvalConfig {
   // Whether the TensorFlow graph used for evaluation should be saved to disk.
   optional bool save_graph = 5 [default = false];
 
-  // Path to directory to store visualizations in. If empty, visualization
-  // images are not exported (only shown on Tensorboard).
+  // Path to directory in which to save visualization images. If the directory
+  // does not exist it will be created. This setting is not limited by
+  // `num_visualizations`, so setting `visualization_export_dir` will cause
+  // *all* eval images to be written to disk. Note that because in
+  // train_and_eval, evaluation is performed more than once, using this setting
+  // may potentially write/overwrite images to this directory multiple times.
+  // Because of this and the performance hit of writing images to disk on every
+  // eval phase, it may be more practical to use this setting in eval-only mode.
   optional string visualization_export_dir = 6 [default = ""];
 
   // BNS name of the TensorFlow master.
@@ -71,8 +81,9 @@ message EvalConfig {
   // Box color for visualizing groundtruth boxes.
   optional string groundtruth_box_visualization_color = 18 [default = "black"];
 
-  // Whether to keep image identifier in filename when exported to
-  // visualization_export_dir.
+  // Whether to use source_id field in filename when exporting to
+  // `visualization_export_dir`. `include_source_id` must 
+  // also be set in the eval input config for this to work.
   optional bool keep_image_id_for_visualization_export = 19 [default = false];
 
   // Whether to retain original images (i.e. not pre-processed) in the tensor

--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 
 import abc
 import collections
+import pathlib
 # Set headless-friendly backend.
 import matplotlib; matplotlib.use('Agg')  # pylint: disable=multiple-statements
 import matplotlib.pyplot as plt  # pylint: disable=g-import-not-at-top
@@ -1350,7 +1351,9 @@ class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
                min_score_thresh=0.2,
                use_normalized_coordinates=True,
                summary_name_prefix='evaluation_image',
-               keypoint_edges=None):
+               keypoint_edges=None,
+               viz_export_dir=None,
+               keep_img_id_for_viz_export=False):
     """Creates an EvalMetricOpsVisualization.
 
     Args:
@@ -1365,6 +1368,10 @@ class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
       keypoint_edges: A list of tuples with keypoint indices that specify which
         keypoints should be connected by an edge, e.g. [(0, 1), (2, 4)] draws
         edges from keypoint 0 to 1 and from keypoint 2 to 4.
+      viz_export_dir: the output directory to which viz images are written.
+        If this is empty (default), then images are not exported
+      keep_img_id_for_viz_export: whether or not to use the source_id in the
+        file names of the saved image visualizations
     """
 
     self._category_index = category_index
@@ -1375,12 +1382,49 @@ class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
     self._summary_name_prefix = summary_name_prefix
     self._keypoint_edges = keypoint_edges
     self._images = []
+    self._viz_export_dir = viz_export_dir
+    self._keep_img_id_for_viz_export = keep_img_id_for_viz_export
+    self._img_export_counter = 0
+    self._EXPORT_VISUALIZATIONS_NAME = 'EXPORT_VISUALIZATIONS'
 
   def clear(self):
     self._images = []
 
-  def add_images(self, images):
-    """Store a list of images, each with shape [1, H, W, C]."""
+  def add_images(self, images, source_id):
+    """Store a list of images for export
+
+    Store `self._max_examples_to_draw` images for TensorBoard. If
+    `self._viz_export_dir` is set, save *all* images to disk. Note that
+    storing `self._max_examples_to_draw` images for export to TensorBoard
+    means that they are all stored in memory as all the metric update_op's
+    are run until the final value_op is run and they are saved.
+    
+    Args:
+      images: a list of images, each with shape [1, H, 2*W, C]
+      source_id: The source_id of the image if it is to be used in the export
+        file names, '' otherwise.
+    """
+
+    if self._viz_export_dir:
+      pathlib.Path(self._viz_export_dir).mkdir(exist_ok=True, parents=True)
+
+      if source_id:
+        counter = self._img_export_counter
+        file_name = f"export-{source_id.decode('utf-8')}-{counter}.png"
+      else:
+        file_name = f"export-{self._img_export_counter}.png"
+
+      export_path = pathlib.Path(self._viz_export_dir, file_name)
+
+      save_image_array_as_png(np.squeeze(images[0], axis=0), str(export_path))
+
+      # TODO(xdhmoore) The old code used the batch index in the file name, but
+      # I was unable to figure out how to get that here. I tried to use the
+      # current EVAL_STEP, but was unable to get that either. I'm not sure if
+      # using self._img_export_counter is thread-safe...
+
+      self._img_export_counter += 1
+
     if len(self._images) >= self._max_examples_to_draw:
       return
 
@@ -1438,7 +1482,7 @@ class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
       groundtruth. Each `value_op` holds the tf.summary.image string for a given
       image.
     """
-    if self._max_examples_to_draw == 0:
+    if self._max_examples_to_draw == 0 and not self._viz_export_dir:
       return {}
     images = self.images_from_evaluation_dict(eval_dict)
 
@@ -1457,18 +1501,37 @@ class EvalMetricOpsVisualization(six.with_metaclass(abc.ABCMeta, object)):
           lambda: tf.summary.image(summary_name, image),
           lambda: tf.constant(''))
 
+    source_id = ''
+    if self._viz_export_dir and self._keep_img_id_for_viz_export:
+      if fields.InputDataFields.source_id not in eval_dict:
+        raise LookupError("eval_config.keep_image_id_for_visualization_export "
+          "was set but source_id is not available. Make sure that "
+          "eval_input_reader.include_source_id is set to true in the config.")
+      source_id = eval_dict[fields.InputDataFields.source_id][0]
+
     if tf.executing_eagerly():
-      update_op = self.add_images([[images[0]]])
+
+      # TODO(xdhmoore) I think this first argument has one too many nested
+      # lists, and instead should be [images[0]], but I'm not running eager
+      # execution currently so I'm not able to test it. Also, add_images()
+      # doesn't return anything, so update_op may be incorrect here.
+
+      update_op = self.add_images([[images[0]]], source_id)
       image_tensors = get_images()
     else:
-      update_op = tf.py_func(self.add_images, [[images[0]]], [])
+      update_op = tf.py_func(self.add_images, [[images[0]], source_id], [])
       image_tensors = tf.py_func(
           get_images, [], [tf.uint8] * self._max_examples_to_draw)
     eval_metric_ops = {}
-    for i, image in enumerate(image_tensors):
-      summary_name = self._summary_name_prefix + '/' + str(i)
-      value_op = image_summary_or_default_string(summary_name, image)
-      eval_metric_ops[summary_name] = (value_op, update_op)
+    if type(image_tensors) in (list, tuple):
+      for i, image in enumerate(image_tensors):
+        summary_name = self._summary_name_prefix + '/' + str(i)
+        value_op = image_summary_or_default_string(summary_name, image)
+        eval_metric_ops[summary_name] = (value_op, update_op)
+    else:
+      # If self._max_examples_to_draw is 0, there will be no fetched tf summary
+      # ops to trigger the add_images ops/exports. So we add the op explicitly:
+      eval_metric_ops[self._EXPORT_VISUALIZATIONS_NAME] = (image_tensors, update_op)
     return eval_metric_ops
 
   @abc.abstractmethod
@@ -1497,7 +1560,9 @@ class VisualizeSingleFrameDetections(EvalMetricOpsVisualization):
                min_score_thresh=0.2,
                use_normalized_coordinates=True,
                summary_name_prefix='Detections_Left_Groundtruth_Right',
-               keypoint_edges=None):
+               keypoint_edges=None,
+               viz_export_dir=None,
+               keep_img_id_for_viz_export=False):
     super(VisualizeSingleFrameDetections, self).__init__(
         category_index=category_index,
         max_examples_to_draw=max_examples_to_draw,
@@ -1505,7 +1570,9 @@ class VisualizeSingleFrameDetections(EvalMetricOpsVisualization):
         min_score_thresh=min_score_thresh,
         use_normalized_coordinates=use_normalized_coordinates,
         summary_name_prefix=summary_name_prefix,
-        keypoint_edges=keypoint_edges)
+        keypoint_edges=keypoint_edges,
+        viz_export_dir=viz_export_dir,
+        keep_img_id_for_viz_export=keep_img_id_for_viz_export)
 
   def images_from_evaluation_dict(self, eval_dict):
     return draw_side_by_side_evaluation_image(eval_dict, self._category_index,


### PR DESCRIPTION
# Description

> :memo: This is an attempt to fix #6137 , the existing but broken eval_config options: `visualization_export_dir` and `keep_image_id_for_visualization_export`, which allow you to export image visualizations to png files. This used to be possible but right now visualizations can only be exported via event files to TensorBoard. This new implementation of `visualization_export_dir` also does not accumulate all the images in memory like the TensorBoard export does, which makes it possible to export all the images in a data set.
>  
> This reuses the legacy visualization export code, but now that code is called from within the existing TensorBoard Summary metric's update function, where the TensorBoard images are accumulated, so it also takes advantage of the existing visualizations which the TensorBoard Summary visualization metric is already generating. I'm not sure if writing to disk (synchronously, I think) inside a py_func is bad practice, but this seemed the most low-impact way of adding back the functionality. There is a performance impact when the flag is enabled, but there should not be when the flag is off.
>
> As I've implemented it, when "train and eval" jobs are run, the repeated invocations of the eval phase can cause visualizations of the same images to overwrite those from the last phase. Because of this and because of the performance hit, it may be advisable to only use this setting in eval-only mode. I've added a comment to `eval.proto` to that effect.
>
> I've also updated the comment over the `keep_image_id_for_visualization_export` in the proto file to specify that it uses specifically `source_id`. It appears that the only id available was a `key` field that was a hash of the `source_id`, which wasn't very helpful, so I added a tweak to pass through the `source_id`, thinking that tying this config setting specifically to `source_id` makes sense since other id options like the input field `image/key/sha256` are not currently being passed through.
>
> Because I needed something that would export all images, this setting now doesn't abide by `eval_config.num_visualizations`. Setting `visualization_export_dir` will export *all* images that are evaluated. This is because the TensorBoard export that uses `num_visualizations` accumulates all the images in memory, making it infeasible for large amounts of images, at least on my machine.
>
> There are also a couple TODOs where I was unsure about the best way to do something.
>
> * Context: I am working on an analysis for my master's thesis that relies on categorizing a large number of detector false positives, for which I need a large number of visualizations. I attempted setting `num_visualizations` == number of images in data set, but it used more memory than my machine could handle.
>
> * New dependencies: none

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
> I have run eval-only and train-and-eval object detection jobs using model_main.py and TF1, similar to the pascal pets example.
>
> 1. Automated: I've written a new unit test in `visualization_utils_test.py`
> 2. Manual eval-only:
>     a. Set `eval_config.visualization_export_dir`
>     b. Run eval job with model_main.py
>     c. The images should be created with names like "export-1.png" etc.
> 3. Manual eval-only w/source-id:
>     a. Set `eval_config.visualization_export_dir`
>     b. In addition set `eval_config.keep_image_id_for_visualization_export` to `true`, as well as `eval_input_reader.include_source_id` to `true`.
>     c. Run an eval job with model_main.py
>     d. The images should be created with names like "export-<source_id>-1.png".
> 4. Manual train_and_eval w/source-id
>     a. Set `eval_config.visualization_export_dir`
>     b. In addition set `eval_config.keep_image_id_for_visualization_export` to `true`, as well as `eval_input_reader.include_source_id` to `true`.
>     c. Run train_and_eval job with model_main.py
>     d. Wait for first eval phase to occur/finish.
>     e. The images should be created with names like "export-<source_id>-1.png".
>     f. Wait for 2nd eval phase to occur
>     g. The image file timestamps indicate the 2nd phase overwrites images from the first phase.

## Untested:
> * Eager execution - tried briefly but was unable to turn on eager execution in model_main.py
> * TF2 (from what I can gather, this code is only called by model_main.py, so TF2 isn't applicable)
> * Batch size > 1 - I've only tested with eval_config.batch_size = 1.

## Checklist

- [X] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [X] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [X] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [X] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.

