### PR TITLE
Fix broken link in eager_few_shot_od_training_tflite.ipynb

### DIFF
--- a/research/object_detection/colab_tutorials/eager_few_shot_od_training_tflite.ipynb
+++ b/research/object_detection/colab_tutorials/eager_few_shot_od_training_tflite.ipynb
@@ -338,7 +338,7 @@
         "\n",
         "**NOTE**: TensorFlow Lite only supports SSD models for now.\n",
         "\n",
-        "For simplicity, we have hardcoded a number of things in this colab for the specific SSD architecture at hand (including assuming that the image size will always be 320x320), however it is not difficult to generalize to other model configurations (`pipeline.config` in the zip downloaded from the [Model Zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.)).\n",
+        "For simplicity, we have hardcoded a number of things in this colab for the specific SSD architecture at hand (including assuming that the image size will always be 320x320), however it is not difficult to generalize to other model configurations (`pipeline.config` in the zip downloaded from the [Model Zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.md)).\n",
         "\n",
         "\n"
       ]


### PR DESCRIPTION
# Description

In this PR I fix a broken link to the TF2 model zoo markdown file.

## Type of change

- [x] Documentation update

## Tests

N/A

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
