### PR TITLE
Fix learning rate scheduler for BERT models

### DIFF
--- a/official/nlp/optimization.py
+++ b/official/nlp/optimization.py
@@ -51,7 +51,7 @@ class WarmUp(tf.keras.optimizers.schedules.LearningRateSchedule):
       return tf.cond(
           global_step_float < warmup_steps_float,
           lambda: warmup_learning_rate,
-          lambda: self.decay_schedule_fn(step),
+          lambda: self.decay_schedule_fn(step - self.warmup_steps),
           name=name)
 
   def get_config(self):
@@ -74,7 +74,7 @@ def create_optimizer(init_lr,
   # Implements linear decay of the learning rate.
   lr_schedule = tf.keras.optimizers.schedules.PolynomialDecay(
       initial_learning_rate=init_lr,
-      decay_steps=num_train_steps,
+      decay_steps=num_train_steps - num_warmup_steps,
       end_learning_rate=end_lr)
   if num_warmup_steps:
     lr_schedule = WarmUp(


### PR DESCRIPTION
# Description

**Root Cause**
Fix wrong learning rate scheduling for BERT models.
The root cause is that the PolynomialDecay starts the decay from first training step, where the warm up period may still be in effect. So then warm up period ends, the learning rate is at the highest value, the PolynomialDecay kicks in and the effective learning rate is lower than it should be at that step because it has alredy started decaying from the first step.

This fix is to ensure that we start the decay at the end of warm up period and end the decay correctly at the last training step with the correct target value.

## Type of change

- [ /] Bug fix (non-breaking change which fixes an issue)

## Tests

**Test Configuration**:

Testing steps:

Calling the **official.nlp.optimization.create_optimizer** with the parameters below and plot effective learning rate:
  init_lr = 0.005,
  num_train_steps = 40000,
  num_warmup_steps = 10000,
  end_lr=0.0,
  optimizer_type='adamw'

You can see the result that the effective learning rate has the discontinued value when polynomial decay starts working:
![image](https://user-images.githubusercontent.com/11656659/107120889-0dd5ed80-68c2-11eb-8ddf-79f1eb7cde0f.png)

After this fix, the effective learning rate will be like below:
![image](https://user-images.githubusercontent.com/11656659/107120904-1e866380-68c2-11eb-9d0b-26f34b3df5be.png)

## Checklist

- [ /] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ /] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ /] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ /] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ /] I have commented my code, particularly in hard-to-understand areas.
- [ /] I have made corresponding changes to the documentation.
- [ /] My changes generate no new warnings.
- [ /] I have added tests that prove my fix is effective or that my feature works.
