### PR TITLE
"dataclasses;python_version<'3.7'" for https://github.com/tensorflow/…

### DIFF
--- a/official/requirements.txt
+++ b/official/requirements.txt
@@ -13,7 +13,7 @@ tensorflow-datasets
 tensorflow-addons==0.8.3
 tensorflow-hub>=0.6.0
 tensorflow-model-optimization>=0.2.1
-dataclasses
+dataclasses;python_version<"3.7"
 gin-config
 typing==3.7.4.1
 sentencepiece


### PR DESCRIPTION
…models/issues/9760

PiperOrigin-RevId: 359996828

# Description

The file models/official/requirements.txt contains the line

dataclasses

Which should be changed to

dataclasses;python_version<"3.7"

Because

Since 3.7 dataclassesis a part of standard library and installation of this package is not needed.
Pandas (e.g., 1.2.1) cannot work with the installed package 'dataclasses' which causes tensorflow to fail when it calls to pandas during import.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Tests

- Pull official from repository
- Modify models/official/requirements.txt (dataclasses --> dataclasses;python_version<"3.7")
- Create wheel, by using "pip wheel"
- Install created wheel
 
**Test Configuration**:
- Connection to models git repository
- Python 3.6 (to check that dataclasses package is installed), Python 3.7 (to check that it is not).

## Checklist

The change has been already committed by saberkun to the models master branch (https://github.com/tensorflow/models/commit/0f1f2c4014f62a49067e3f943ed0d8f71699f724) as a response to the issue #9760, so check list probably is not necessary, but anyway:

- [X] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [X] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
 - [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
