### PR TITLE
Update object_detection_tutorial.ipynb

### DIFF
--- a/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
+++ b/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
@@ -173,7 +173,7 @@
       "outputs": [],
       "source": [
         "%%bash \n",
-        "cd models/research\n",
+        "cp object_detection/packages/tf2/setup.py .\n",
         "pip install ."
       ]
     },


### PR DESCRIPTION
Currently the Object Detection API installation fails due to missing `setup.py`
This PR tries to fix it and points to TF2 `setup.py`.