### PR TITLE
added '--allow-growth' flag

### DIFF
--- a/research/object_detection/model_main_tf2.py
+++ b/research/object_detection/model_main_tf2.py
@@ -68,6 +68,9 @@ flags.DEFINE_boolean('record_summaries', True,
                      ('Whether or not to record summaries during'
                       ' training.'))
 
+flags.DEFINE_boolean('allow_growth', False,
+                     ('Whether or not to limit gpu memory growth.'))
+
 FLAGS = flags.FLAGS
 
 
@@ -75,6 +78,17 @@ def main(unused_argv):
   flags.mark_flag_as_required('model_dir')
   flags.mark_flag_as_required('pipeline_config_path')
   tf.config.set_soft_device_placement(True)
+  
+  if FLAGS.allow_growth:
+    gpus = tf.config.list_physical_devices('GPU')
+    if gpus:
+      try:
+        # Currently, memory growth needs to be the same across GPUs
+        for gpu in gpus:
+          tf.config.experimental.set_memory_growth(gpu, True)
+      except RuntimeError as e:
+        # Memory growth must be set before GPUs have been initialized
+        pass
 
   if FLAGS.checkpoint_dir:
     model_lib_v2.eval_continuously(


### PR DESCRIPTION
added '--allow-growth' flag to choose to limit GPU growth. This solves _**failed to create cublas handle: CUBLAS_STATUS_NOT_INITIALIZED**_ issue if caused due to GPU memory limit.  

# Description

While executing training for object detection model in TF 2.x, the following error was thrown:

**failed to create cublas handle: CUBLAS_STATUS_NOT_INITIALIZED**

Issue [#35029](https://github.com/tensorflow/tensorflow/issues/35029) already discusses the solution. Hence incorporated the same into `model_main_tf2.py`. Users can now opt to limit GPU memory growth by setting the `--allow-growth` flag while executing `model_main_tf2.py`. 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
