### PR TITLE
Fix the object_detection_tutorial.ipynb link

### DIFF
--- a/research/object_detection/g3doc/running_notebook.md
+++ b/research/object_detection/g3doc/running_notebook.md
@@ -14,5 +14,5 @@ jupyter notebook
 ```
 
 The notebook should open in your favorite web browser. Click the
-[`object_detection_tutorial.ipynb`](../object_detection_tutorial.ipynb) link to
+[`object_detection_tutorial.ipynb`](../colab_tutorials/object_detection_tutorial.ipynb) link to
 open the demo.


### PR DESCRIPTION

# Description

Fix the link of `object_detection_tutorial.ipynb`.

## Type of change

- [x] Documentation update
