### PR TITLE
Added option to return boxes in visualization_utils.py

### DIFF
--- a/research/object_detection/utils/visualization_utils.py
+++ b/research/object_detection/utils/visualization_utils.py
@@ -621,7 +621,6 @@ def draw_bounding_boxes_on_image_tensors(images,
   images = tf.map_fn(draw_boxes, elems, dtype=tf.uint8, back_prop=False)
   return images
 
-
 def draw_side_by_side_evaluation_image(eval_dict,
                                        category_index,
                                        max_boxes_to_draw=20,
@@ -1101,6 +1100,7 @@ def visualize_boxes_and_labels_on_image_array(
     classes,
     scores,
     category_index,
+    return_coordinates=False,
     instance_masks=None,
     instance_boundaries=None,
     keypoints=None,
@@ -1180,6 +1180,9 @@ def visualize_boxes_and_labels_on_image_array(
   box_to_track_ids_map = {}
   if not max_boxes_to_draw:
     max_boxes_to_draw = boxes.shape[0]
+
+  box = ()
+  class_name = ''
   for i in range(boxes.shape[0]):
     if max_boxes_to_draw == len(box_to_color_map):
       break
@@ -1270,7 +1273,11 @@ def visualize_boxes_and_labels_on_image_array(
           keypoint_edge_color=color,
           keypoint_edge_width=line_thickness // 2)
 
+  if return_coordinates == True:
+    return box, class_name
+    
   return image
+  
 
 
 def add_cdf_image_summary(values, name):


### PR DESCRIPTION
# Description
Made a slight modification to visualize_boxes_and_labels_on_image_array function in order to return box coordinates and class names if requested.
Motivation: I was building a project where I needed both visualization and box coordinates of the thresholded score. I could not find any utils function that would do both at the same time.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Tests

Called the function in the following way and printed the box coordinates
```
box, class_name = vis_utils.visualize_boxes_and_labels_on_image_array(
                image_np_with_detections,
                detections['detection_boxes'],
                det_classes_with_offset,
                detections['detection_scores'],
                return_coordinates=True,
                category_index,
                use_normalized_coordinates=True,
                max_boxes_to_draw=1,
                min_score_thresh=conf_thresh,
                agnostic_mode=False,
                )
```

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
