### PR TITLE
Add output_stride parameter to quantize.md

### DIFF
--- a/research/deeplab/g3doc/quantize.md
+++ b/research/deeplab/g3doc/quantize.md
@@ -56,6 +56,7 @@ First use the following commandline to export your trained model.
 # From tensorflow/models/research/
 python deeplab/export_model.py \
     --checkpoint_path=${CHECKPOINT_PATH} \
+    --output_stride=16 \
     --quantize_delay_step=0 \
     --export_path=${OUTPUT_DIR}/frozen_inference_graph.pb
 


### PR DESCRIPTION
# Description

The default output_stride in export_model.py is 8. The example in quantize.md is a model that expects an output_stride of 16. So if you try to use export_model.py without setting the output_stride, the resulting model will convert to tflite fine but with the wrong output_stride. This likely produces an invalid model. In my use case where I wanted to compile the model for an edgetpu, I suspect that this issue with the resulting model was causing the compiler to abort. 

Thanks for sharing your amazing code! (-:

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

- [x ] Documentation update

## Checklist

- [x ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
