### PR TITLE
Fixed deprecated tf.flags

### DIFF
--- a/research/attention_ocr/python/common_flags.py
+++ b/research/attention_ocr/python/common_flags.py
@@ -17,7 +17,7 @@
 import logging
 import sys
 
-from tensorflow.python.platform import flags
+from tensorflow.compat.v1 import flags
 
 import datasets
 import model

--- a/research/attention_ocr/python/datasets/fsns_test.py
+++ b/research/attention_ocr/python/datasets/fsns_test.py
@@ -22,8 +22,9 @@ from tensorflow.contrib import slim
 
 from datasets import fsns
 from datasets import unittest_utils
+from tensorflow.compat.v1 import flags
 
-FLAGS = tf.flags.FLAGS
+FLAGS = flags.FLAGS
 
 
 def get_test_split():

--- a/research/attention_ocr/python/demo_inference.py
+++ b/research/attention_ocr/python/demo_inference.py
@@ -19,7 +19,7 @@ import numpy as np
 import PIL.Image
 
 import tensorflow as tf
-from tensorflow.python.platform import flags
+from tensorflow.compat.v1 import flags
 from tensorflow.python.training import monitored_session
 
 import common_flags

--- a/research/attention_ocr/python/demo_inference_test.py
+++ b/research/attention_ocr/python/demo_inference_test.py
@@ -4,6 +4,7 @@ import os
 import demo_inference
 import tensorflow as tf
 from tensorflow.python.training import monitored_session
+from tensorflow.compat.v1 import flags
 
 _CHECKPOINT = 'model.ckpt-399731'
 _CHECKPOINT_URL = 'http://download.tensorflow.org/models/attention_ocr_2017_08_09.tar.gz'
@@ -19,7 +20,7 @@ class DemoInferenceTest(tf.test.TestCase):
                           'Please download and extract it from %s' %
                           (filename, _CHECKPOINT_URL))
     self._batch_size = 32
-    tf.flags.FLAGS.dataset_dir = os.path.join(
+    flags.FLAGS.dataset_dir = os.path.join(
         os.path.dirname(__file__), 'datasets/testdata/fsns')
 
   def test_moving_variables_properly_loaded_from_a_checkpoint(self):

--- a/research/attention_ocr/python/eval.py
+++ b/research/attention_ocr/python/eval.py
@@ -21,7 +21,7 @@ python eval.py
 import tensorflow as tf
 from tensorflow.contrib import slim
 from tensorflow import app
-from tensorflow.python.platform import flags
+from tensorflow.compat.v1 import flags
 
 import data_provider
 import common_flags

--- a/research/attention_ocr/python/model_export.py
+++ b/research/attention_ocr/python/model_export.py
@@ -25,7 +25,7 @@ import os
 import tensorflow as tf
 from tensorflow import app
 from tensorflow.contrib import slim
-from tensorflow.python.platform import flags
+from tensorflow.compat.v1 import flags
 
 import common_flags
 import model_export_lib

--- a/research/attention_ocr/python/model_export_test.py
+++ b/research/attention_ocr/python/model_export_test.py
@@ -19,6 +19,7 @@ import os
 import numpy as np
 from absl.testing import flagsaver
 import tensorflow as tf
+from tensorflow.compat.v1 import flags
 
 import common_flags
 import model_export
@@ -51,9 +52,9 @@ class AttentionOcrExportTest(tf.test.TestCase):
           msg='Missing checkpoint file %s. '
           'Please download and extract it from %s' %
           (filename, _CHECKPOINT_URL))
-    tf.flags.FLAGS.dataset_name = 'fsns'
-    tf.flags.FLAGS.checkpoint = _CHECKPOINT
-    tf.flags.FLAGS.dataset_dir = os.path.join(
+    flags.FLAGS.dataset_name = 'fsns'
+    flags.FLAGS.checkpoint = _CHECKPOINT
+    flags.FLAGS.dataset_dir = os.path.join(
         os.path.dirname(__file__), 'datasets/testdata/fsns')
     tf.test.TestCase.setUp(self)
     _clean_up()

--- a/research/attention_ocr/python/train.py
+++ b/research/attention_ocr/python/train.py
@@ -23,7 +23,7 @@ import logging
 import tensorflow as tf
 from tensorflow.contrib import slim
 from tensorflow import app
-from tensorflow.python.platform import flags
+from tensorflow.compat.v1 import flags
 from tensorflow.contrib.tfprof import model_analyzer
 
 import data_provider


### PR DESCRIPTION
# Description

This PR aims to help migrate the TensorFlow code from 1.x to 2.x for the AttentionOCR model in the research folder by updating deprecated tf.flags references.

The changes will partly address #8703

## Type of change

- [x] TensorFlow 2 migration

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
