### PR TITLE
Fix center net parameter parsing

### DIFF
--- a/research/object_detection/builders/model_builder.py
+++ b/research/object_detection/builders/model_builder.py
@@ -946,7 +946,8 @@ def object_center_proto_to_params(oc_config):
   if oc_config.keypoint_weights_for_center:
     keypoint_weights_for_center = list(oc_config.keypoint_weights_for_center)
 
-  if oc_config.center_head_params:
+  if (oc_config.center_head_params.num_filters and
+      oc_config.center_head_params.kernel_sizes):
     center_head_num_filters = list(oc_config.center_head_params.num_filters)
     center_head_kernel_sizes = list(oc_config.center_head_params.kernel_sizes)
   else:


### PR DESCRIPTION
This commit https://github.com/tensorflow/models/commit/6e5c5a1bd50e07aab485fddf7bab958b80d95bee seems to have introduced a slight bug in the parameter parsing. This issue is in the following line:

https://github.com/tensorflow/models/blob/6e5c5a1bd50e07aab485fddf7bab958b80d95bee/research/object_detection/builders/model_builder.py#L950

That evaluates to `True` even if the pipeline config does not have the `center_head_params` set to anything. A fix is to change the line to something like (which is what my commit does):

```
if oc_config.center_head_params.num_filters and oc_config.center_head_params.kernel_sizes:
```

That restores the original default behavior and seems to match the author's intent. Issue https://github.com/tensorflow/models/issues/9880 contains complete instructions as to how to reproduce the environment and to test the code.