### PR TITLE
Fix the object detection API pascal metrics low scores issue

### DIFF
--- a/research/object_detection/utils/object_detection_evaluation.py
+++ b/research/object_detection/utils/object_detection_evaluation.py
@@ -228,10 +228,17 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
         standard_fields.InputDataFields.groundtruth_classes,
         standard_fields.InputDataFields.groundtruth_difficult,
         standard_fields.InputDataFields.groundtruth_instance_masks,
+        standard_fields.InputDataFields.num_groundtruth_boxes,
         standard_fields.DetectionResultFields.detection_boxes,
         standard_fields.DetectionResultFields.detection_scores,
         standard_fields.DetectionResultFields.detection_classes,
         standard_fields.DetectionResultFields.detection_masks
+    ])
+    self._expected_gt_keys = set([
+        standard_fields.InputDataFields.groundtruth_boxes,
+        standard_fields.InputDataFields.groundtruth_classes,
+        standard_fields.InputDataFields.groundtruth_difficult,
+        standard_fields.InputDataFields.groundtruth_instance_masks,
     ])
     self._build_metric_names()
 
@@ -504,12 +511,30 @@ class ObjectDetectionEvaluator(DetectionEvaluator):
       if np.isscalar(image_id):
         single_example_dict = dict(
             zip(eval_dict_keys, eval_dict_batched_as_list))
+
+        # Cut the length of the ground truth results to the actual number
+        # of ground truth.
+        num_gt_box = single_example_dict[
+          standard_fields.InputDataFields.num_groundtruth_boxes]
+        for key, value in single_example_dict.items():
+          if key in self._expected_gt_keys:
+            single_example_dict[key] = value[:num_gt_box]
+
         self.add_single_ground_truth_image_info(image_id, single_example_dict)
         self.add_single_detected_image_info(image_id, single_example_dict)
       else:
         for unzipped_tuple in zip(*eval_dict_batched_as_list):
           single_example_dict = dict(zip(eval_dict_keys, unzipped_tuple))
           image_id = single_example_dict[standard_fields.InputDataFields.key]
+
+          # Cut the length of the ground truth results to the actual number
+          # of ground truth.
+          num_gt_box = single_example_dict[
+            standard_fields.InputDataFields.num_groundtruth_boxes]
+          for key, value in single_example_dict.items():
+            if key in self._expected_gt_keys:
+              single_example_dict[key] = value[:num_gt_box]
+
           self.add_single_ground_truth_image_info(image_id, single_example_dict)
           self.add_single_detected_image_info(image_id, single_example_dict)
 


### PR DESCRIPTION
# Description

Currently, if we use `pascal_voc_detection_metrics` or `weighted_pascal_voc_detection_metrics` in **object detection** as evaluation metrics, the scores are very low (less than 0.01) when comparing with COCO metrics.

The reason is we are padding the input tensors (in`inputs.pad_input_data_to_static_shapes`) which will make the ground_truth tensors' length as long as the parameter of `max_number_of_boxes`). This will make the ground truth result very long, therefore cause this bug.

But the COCO metrics are ok, the reason is in `metrics/coco_evaluation.py -> CocoDetectionEvaluator -> add_eval_dict -> update_op` function, we cut the ground truth length, as shown below:

```python
          self.add_single_ground_truth_image_info(
              image_id, {
                  'groundtruth_boxes': gt_box[:num_gt_box],
                  'groundtruth_classes': gt_class[:num_gt_box],
                  'groundtruth_is_crowd': gt_is_crowd[:num_gt_box],
                  'groundtruth_labeled_classes': gt_labeled_classes
              })
```

So, if we apply the same logic to pascal metrics, we can solve this issue.

Updates:

I updated `utils/object_detection_evaluation.py -> ObjectDetectionEvaluator`:

- Added a new variable named `_expected_gt_keys` which indicates which dict value we need to *cut*.
- Updated the `ObjectDetectionEvaluator -> add_eval_dict -> update_op` function to cut GT values to real length.


## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Manually test:
- Setup a new object detection project with `pascal_voc_detection_metrics` and `coco_detection_metrics` metrics settings in `eval-config`. (COCO for comparing here)
- Train and eval with a demo SSD model
- We can see very low pascal voc scores vs COCO's normal scores.
- Apply this fix
- We can see normal pascal voc scores compares with COCO's.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
