### PR TITLE
Update link to Embedding Colab

### DIFF
--- a/research/audioset/vggish/README.md
+++ b/research/audioset/vggish/README.md
@@ -170,8 +170,7 @@ the postprocessor can be run after inference.
 If you don't need to use the released embeddings or YouTube-8M, then you could
 skip postprocessing and use raw embeddings.
 
-A [Colab](https://colab.research.google.com/)
-showing how to download the model and calculate the embeddings on your
+A Colab showing how to download the model and calculate the embeddings on your
 own sound data is available here:
-[AudioSet Embedding Colab](https://colab.research.google.com/drive/1TbX92UL9sYWbdwdGE0rJ9owmezB-Rl1C).
+[VGGish Embedding Colab](https://colab.research.google.com/drive/1E3CaPAqCai9P9QhJ3WYPNCVmrJU4lAhF).
 


### PR DESCRIPTION

# Description

The original VGGish embedding Colab by malcolmslaney didn't work with the current VGGish and tensorflow.  
This PR changes the link to an updated Colab doc.

Fixes issue #9220 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] TensorFlow 2 migration

## Tests

I ran the new Colab in both Chrome and MacOS Safari, using the latest TensorFlow and TensorFlow/models distros.

## Checklist

- [v] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [v] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [v] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [v] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [v] I have commented my code, particularly in hard-to-understand areas.
- [v] I have made corresponding changes to the documentation.
- [v] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
