### PR TITLE
Fixed no module named object_detection error in object detection tutorial

### DIFF
--- a/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
+++ b/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
@@ -174,7 +174,9 @@
       "source": [
         "%%bash \n",
         "cd models/research\n",
-        "pip install ."
+        "protoc object_detection/protos/*.proto --python_out=.",
+        "cp object_detection/packages/tf2/setup.py .",
+        "python -m pip install ."
       ]
     },
     {

--- a/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
+++ b/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
@@ -153,29 +153,14 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "PY41vdYYNlXc"
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "cd models/research/\n",
-        "protoc object_detection/protos/*.proto --python_out=."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "s62yJyQUcYbp"
       },
       "outputs": [],
       "source": [
         "%%bash \n",
         "cd models/research\n",
-        "protoc object_detection/protos/*.proto --python_out=.",
-        "cp object_detection/packages/tf2/setup.py .",
+        "protoc object_detection/protos/*.proto --python_out=.\n",
+        "cp object_detection/packages/tf2/setup.py .\n",
         "python -m pip install ."
       ]
     },


### PR DESCRIPTION
# Description

I modified the installation of the Object Detection to reflect the steps provided in the [Object Detection API with TensorFlow 2](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2.md) tutorial.

I want to use the TensorFlow object detection API for my high school research project, but the provided sample code wouldn't run in Google Colab.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Tests

I ran the code in Google Colab and it managed to detect the objects as it expected.

**Test Configuration**: Google Colab

## Checklist

- [X] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [X] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [X] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [X] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
