### PR TITLE
Added task definition and configs for Panoptic Mask R-CNN  (#10165)

### DIFF
--- a/official/vision/beta/projects/panoptic_maskrcnn/configs/panoptic_maskrcnn.py
+++ b/official/vision/beta/projects/panoptic_maskrcnn/configs/panoptic_maskrcnn.py
@@ -47,12 +47,10 @@ class Parser(maskrcnn.Parser):
       default_factory=list)
   segmentation_ignore_label: int = 255
 
-
 @dataclasses.dataclass
 class DataConfig(maskrcnn.DataConfig):
   """Input config for training."""
   parser: Parser = Parser()
-
 
 @dataclasses.dataclass
 class PanopticMaskRCNN(maskrcnn.MaskRCNN):


### PR DESCRIPTION
# Description

Added task definition for Panoptic Mask R-CNN

Contribution from @srihari-humbarwadi (https://github.com/tensorflow/models/pull/10165)

* added PanopticMaskRCNNTask config
* added tests for config
* added Panoptic MaskRCNN task
* added tests for Panoptic MaskRCNN task
* fixed typo
* set default segmentation loss weight to 1.0
* added class docstrings
* support `segmentation_decoder` checkpoint
* added `init_checkpoint_modules` description
* compute `steps_per_epoch` with `train_batch_size`
* flattened semantic_segmentation loss attributes

