### PR TITLE
Update vid2depth README.md.

### DIFF
--- a/research/vid2depth/README.md
+++ b/research/vid2depth/README.md
@@ -21,6 +21,11 @@ ArXiv: [https://arxiv.org/pdf/1802.05522.pdf](https://arxiv.org/pdf/1802.05522.p
 <a href="https://sites.google.com/view/vid2depth"><img src='https://storage.googleapis.com/vid2depth/media/approach.png' width=400></a>
 </p>
 
+## Update: TF2 version.
+
+Please see [https://github.com/IAMAl/vid2depth_tf2](https://github.com/IAMAl/vid2depth_tf2)
+for a TF2 implementation of vid2depth.
+
 ## 1. Installation
 
 ### Requirements
@@ -35,10 +40,6 @@ pip install numpy
 pip install scipy
 pip install tensorflow
 ```
-
-#### For building the ICP op (work in progress)
-
-* Bazel: https://bazel.build/
 
 ### Download vid2depth
 
@@ -60,10 +61,26 @@ unzip "*.zip"
 
 ### Download Cityscapes dataset (110GB) (optional)
 
-You will need to register in order to download the data.  Download the following files:
+You will need to register in order to download the data.  Download the following
+files:
 
 * leftImg8bit_sequence_trainvaltest.zip
 * camera_trainvaltest.zip
+
+### Download Bike dataset (34GB) (optional)
+
+Please see [https://research.google/tools/datasets/bike-video/](https://research.google/tools/datasets/bike-video/)
+for info on the bike video dataset.
+
+Special thanks to [Guangming Wang](https://guangmingw.github.io/) for helping us
+restore this dataset after it was accidentally deleted.
+
+```shell
+mkdir -p ~/vid2depth/bike-uncompressed
+cd ~/vid2depth/bike-uncompressed
+wget https://storage.googleapis.com/vid2depth/dataset/BikeVideoDataset.tar
+tar xvf BikeVideoDataset.tar
+```
 
 ## 3. Inference
 
@@ -113,23 +130,28 @@ python dataset/gen_data.py \
   --seq_length 3
 ```
 
-### Compile the ICP op (work in progress)
-
-The ICP op depends on multiple software packages (TensorFlow, Point Cloud
-Library, FLANN, Boost, HDF5).  The Bazel build system requires individual BUILD
-files for each of these packages.  We have included a partial implementation of
-these BUILD files inside the third_party directory.  But they are not ready for
-compiling the op.  If you manage to build the op, please let us know so we can
-include your contribution.
+### Prepare Bike training sequences (optional)
 
 ```shell
+# Prepare training sequences.
 cd tensorflow/models/research/vid2depth
-bazel build ops:pcl_demo  # Build test program using PCL only.
-bazel build ops:icp_op.so
+python dataset/gen_data.py \
+  --dataset_name bike \
+  --dataset_dir ~/vid2depth/bike-uncompressed \
+  --data_dir ~/vid2depth/data/bike \
+  --seq_length 3
 ```
 
-For the time being, it is possible to run inference on the pre-trained model and
-run training without the icp loss.
+### Compile the ICP op
+
+The pre-trained model is trained using the ICP loss.  It is possible to run
+inference on this pre-trained model without compiling the ICP op.  It is also
+possible to train a new model from scratch without compiling the ICP op by
+setting the icp loss to zero.
+
+If you would like to compile the op and run a new training job using it, please
+use the CMakeLists.txt file at
+[https://github.com/IAMAl/vid2depth_tf2/tree/master/ops](https://github.com/IAMAl/vid2depth_tf2/tree/master/ops).
 
 ### Run training
 


### PR DESCRIPTION
# Description

Update bike video dataset path.

Add link to TF2 port with build file for compiling the ICP op.

Fixes #9158.

Merges changes from #10091.

## Type of change

- [X] Documentation update