### PR TITLE
Removes redundant normalization/denomalization of boxes in postprocess_ops

### DIFF
--- a/official/vision/detection/ops/postprocess_ops.py
+++ b/official/vision/detection/ops/postprocess_ops.py
@@ -270,11 +270,6 @@ def _generate_detections_batched(boxes, scores, max_total_size,
       `valid_detections` boxes are valid detections.
   """
   with tf.name_scope('generate_detections'):
-    # TODO(tsungyi): Removes normalization/denomalization once the
-    # tf.image.combined_non_max_suppression is coordinate system agnostic.
-    # Normalizes maximum box cooridinates to 1.
-    normalizer = tf.reduce_max(boxes)
-    boxes /= normalizer
     (nmsed_boxes, nmsed_scores, nmsed_classes,
      valid_detections) = tf.image.combined_non_max_suppression(
          boxes,
@@ -284,9 +279,7 @@ def _generate_detections_batched(boxes, scores, max_total_size,
          iou_threshold=nms_iou_threshold,
          score_threshold=score_threshold,
          pad_per_class=False,
-     )
-    # De-normalizes box cooridinates.
-    nmsed_boxes *= normalizer
+         clip_boxes=False)
   nmsed_classes = tf.cast(nmsed_classes, tf.int32)
   return nmsed_boxes, nmsed_scores, nmsed_classes, valid_detections
 


### PR DESCRIPTION
same as https://github.com/tensorflow/models/pull/9053

# Description
sets `clip_boxes=False`, as it makes `tf.image.combined_non_max_suppression` coordinate agnostic after https://github.com/tensorflow/tensorflow/commit/35e39cd3f102d663d198074e95ff77197d2e0a1d


## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [x] Other

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
