### PR TITLE
Explicit signatures for tflite.  Using ideas from #9688

### DIFF
--- a/research/audioset/yamnet/export.py
+++ b/research/audioset/yamnet/export.py
@@ -44,20 +44,24 @@ def log(msg):
 
 
 class YAMNet(tf.Module):
-  "''A TF2 Module wrapper around YAMNet."""
+  """A TF2 Module wrapper around YAMNet."""
   def __init__(self, weights_path, params):
     super().__init__()
     self._yamnet = yamnet.yamnet_frames_model(params)
     self._yamnet.load_weights(weights_path)
     self._class_map_asset = tf.saved_model.Asset('yamnet_class_map.csv')
 
-  @tf.function
+  @tf.function(input_signature=[])
   def class_map_path(self):
     return self._class_map_asset.asset_path
 
-  @tf.function(input_signature=(tf.TensorSpec(shape=[None], dtype=tf.float32),))
+  @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.float32)])
   def __call__(self, waveform):
-    return self._yamnet(waveform)
+    predictions, embeddings, log_mel_spectrogram = self._yamnet(waveform)
+
+    return {'predictions': predictions,
+            'embeddings': embeddings, 
+            'log_mel_spectrogram': log_mel_spectrogram}
 
 
 def check_model(model_fn, class_map_path, params):
@@ -65,7 +69,10 @@ def check_model(model_fn, class_map_path, params):
 
   """Applies yamnet_test's sanity checks to an instance of YAMNet."""
   def clip_test(waveform, expected_class_name, top_n=10):
-    predictions, embeddings, log_mel_spectrogram = model_fn(waveform)
+    results = model_fn(waveform)
+    predictions = results['predictions']
+    embeddings = results['embeddings']
+    log_mel_spectrogram = results['log_mel_spectrogram']
     clip_predictions = np.mean(predictions, axis=0)
     top_n_indices = np.argsort(clip_predictions)[-top_n:]
     top_n_scores = clip_predictions[top_n_indices]
@@ -106,7 +113,9 @@ def make_tf2_export(weights_path, export_dir):
 
   # Make TF2 SavedModel export.
   log('Making TF2 SavedModel export ...')
-  tf.saved_model.save(yamnet, export_dir)
+  tf.saved_model.save(
+    yamnet, export_dir,
+    signatures={'serving_default': yamnet.__call__.get_concrete_function()})
   log('Done')
 
   # Check export with TF-Hub in TF2.
@@ -143,7 +152,9 @@ def make_tflite_export(weights_path, export_dir):
   log('Making TF-Lite SavedModel export ...')
   saved_model_dir = os.path.join(export_dir, 'saved_model')
   os.makedirs(saved_model_dir)
-  tf.saved_model.save(yamnet, saved_model_dir)
+  tf.saved_model.save(
+    yamnet, saved_model_dir,
+    signatures={'serving_default': yamnet.__call__.get_concrete_function()})
   log('Done')
 
   # Check that the export can be loaded and works.
@@ -154,7 +165,8 @@ def make_tflite_export(weights_path, export_dir):
 
   # Make a TF-Lite model from the SavedModel.
   log('Making TF-Lite model ...')
-  tflite_converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
+  tflite_converter = tf.lite.TFLiteConverter.from_saved_model(
+    saved_model_dir, signature_keys=['serving_default'])
   tflite_model = tflite_converter.convert()
   tflite_model_path = os.path.join(export_dir, 'yamnet.tflite')
   with open(tflite_model_path, 'wb') as f:
@@ -164,18 +176,11 @@ def make_tflite_export(weights_path, export_dir):
   # Check the TF-Lite export.
   log('Checking TF-Lite model ...')
   interpreter = tf.lite.Interpreter(tflite_model_path)
-  audio_input_index = interpreter.get_input_details()[0]['index']
-  scores_output_index = interpreter.get_output_details()[0]['index']
-  embeddings_output_index = interpreter.get_output_details()[1]['index']
-  spectrogram_output_index = interpreter.get_output_details()[2]['index']
+  runner = interpreter.get_signature_runner('serving_default')
   def run_model(waveform):
-    interpreter.resize_tensor_input(audio_input_index, [len(waveform)], strict=True)
-    interpreter.allocate_tensors()
-    interpreter.set_tensor(audio_input_index, waveform)
-    interpreter.invoke()
-    return (interpreter.get_tensor(scores_output_index),
-            interpreter.get_tensor(embeddings_output_index),
-            interpreter.get_tensor(spectrogram_output_index))
+    # Signature provides the desired dict of results with entries for
+    # 'predictions', 'embeddings', and 'log_mel_spectrogram'.
+    return runner(waveform=waveform)
   check_model(run_model, 'yamnet_class_map.csv', params)
   log('Done')
 


### PR DESCRIPTION
# Description
Update mechanism for choosing outputs from tflite-oriented saved model export.  Explicitly sets up the serving_default signature in the saved_models to provide named outputs for 'predictions', 'embeddings', and 'log_mel_spectrogram'.

## Type of change

- [v] Bug fix for #10246
- [v] Enhancement to construct saved_models (and tflite outputs) with explicit outputs.

## Tests

```
$ python3 export.py yamnet.h5 export
```
now runs to completion instead of crashing.

## Checklist

- [v] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [v] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [v] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [v] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [v] I have commented my code, particularly in hard-to-understand areas.
- [n/a] I have made corresponding changes to the documentation.
- [v] My changes generate no new warnings.
- [n/a] I have added tests that prove my fix is effective or that my feature works.
