### PR TITLE
Fix the Bert2Bert call when padded_decode is set to True

### DIFF
--- a/official/nlp/modeling/ops/beam_search.py
+++ b/official/nlp/modeling/ops/beam_search.py
@@ -152,9 +152,7 @@ class SequenceBeamSearch(tf.Module):
     Returns:
       finished_seq and finished_scores.
     """
-    batch_size = (
-        initial_ids.shape.as_list()[0]
-        if self.padded_decode else tf.shape(initial_ids)[0])
+    batch_size = tf.shape(initial_ids)[0]
     state, state_shapes = self._create_initial_state(initial_ids, initial_cache,
                                                      batch_size)
 
@@ -455,19 +453,19 @@ class SequenceBeamSearch(tf.Module):
               tf.TensorShape([]),
           _StateKeys.ALIVE_SEQ:
               tf.TensorShape(
-                  [batch_size, self.beam_size, self.max_decode_length + 1]),
+                  [None, self.beam_size, self.max_decode_length + 1]),
           _StateKeys.ALIVE_LOG_PROBS:
-              tf.TensorShape([batch_size, self.beam_size]),
+              tf.TensorShape([None, self.beam_size]),
           _StateKeys.ALIVE_CACHE:
               tf.nest.map_structure(lambda state: state.get_shape(),
                                     alive_cache),
           _StateKeys.FINISHED_SEQ:
               tf.TensorShape(
-                  [batch_size, self.beam_size, self.max_decode_length + 1]),
+                  [None, self.beam_size, self.max_decode_length + 1]),
           _StateKeys.FINISHED_SCORES:
-              tf.TensorShape([batch_size, self.beam_size]),
+              tf.TensorShape([None, self.beam_size]),
           _StateKeys.FINISHED_FLAGS:
-              tf.TensorShape([batch_size, self.beam_size])
+              tf.TensorShape([None, self.beam_size])
       }
     else:
       state_shape_invariants = {


### PR DESCRIPTION
# Description

As mentioned in the following [issue](https://github.com/tensorflow/models/issues/10222), it was impossible to call a Bert2Bert model with the configuration option `padded_decode` set to True.

It comes from how the beam search modules deals with batch size. The special case implemented when `padded_decode` is True doesn't seem useful and caused the following error:

```
TypeError: Failed to convert object of type <class 'list'> to Tensor. Contents: [None, 1]. Consider casting elements to a supported type.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

I have added a naive unittest which failed before my modification and passes now.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
