### PR TITLE
Fix TF version mismatch error in the Colab training tutorial (#10423)

### DIFF
--- a/research/object_detection/colab_tutorials/eager_few_shot_od_training_tf2_colab.ipynb
+++ b/research/object_detection/colab_tutorials/eager_few_shot_od_training_tf2_colab.ipynb
@@ -31,19 +31,6 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "LBZ9VWZZFUCT"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install -U --pre tensorflow==\"2.2.0\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "oi28cqGGFWnY"
       },
       "outputs": [],


### PR DESCRIPTION
# Description
This is a fix for issue #10423, which raised `UnknownError` at `detection_model.predict(image, shapes)`.
I modified the code so that the latest TensorFlow installation (which is pre-installed in Colab VMs) is used, since the  cause of the issue is TF/CUDA-cuDNN version mismatch (Colab switched to use CUDA11.2 / cuDNN 7.6.5).

Another option I thought about was to install `tensorflow==2.7.0` instead of `2.2.0`, but I discarded it because that would not prevent similar versioning issues in the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

**Test Configuration**:

1. Open this notebook in Colab.
2. Switch the runtime to GPU.
3. (optional) Uncomment the ready-made `gt_boxes` and comment out `colab_utils.annotate()`.
4. Execute all cells, and verify that `UnknownError` is not raised.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
(comment: see above)
