### PR TITLE
Fix download urls for mobilenet ckpts

### DIFF
--- a/research/object_detection/g3doc/tf2_classification_zoo.md
+++ b/research/object_detection/g3doc/tf2_classification_zoo.md
@@ -21,5 +21,5 @@ Model name |
 [Resnet V1 101](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/resnet101_v1.tar.gz)       |
 [Resnet V1 152](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/resnet152_v1.tar.gz)       |
 [Inception Resnet V2](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/inception_resnet_v2.tar.gz) |
-[MobileNet V1](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/mobilnet_v1.tar.gz)        |
-[MobileNet V2](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/mobilnet_v2.tar.gz)        |
+[MobileNet V1](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/mobilenet_v1.tar.gz)        |
+[MobileNet V2](http://download.tensorflow.org/models/object_detection/classification/tf2/20200710/mobilenet_v2.tar.gz)        |


### PR DESCRIPTION
# Description

Fix typo in the download urls for TF2 mobilenet v1 and v2 classification checkpoints.

# Change type

- [x] Documentation update

# Tests

Not relevant since it's just a docs update.