### PR TITLE
fix: BoxPredictor was not an abstract class as ABC was missing

### DIFF
--- a/research/object_detection/core/box_predictor.py
+++ b/research/object_detection/core/box_predictor.py
@@ -26,7 +26,7 @@ in our detection models.
 These modules are separated from the main model since the same
 few box predictor architectures are shared across many models.
 """
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 import tensorflow.compat.v1 as tf
 
 BOX_ENCODINGS = 'box_encodings'
@@ -34,7 +34,7 @@ CLASS_PREDICTIONS_WITH_BACKGROUND = 'class_predictions_with_background'
 MASK_PREDICTIONS = 'mask_predictions'
 
 
-class BoxPredictor(object):
+class BoxPredictor(ABC):
   """BoxPredictor."""
 
   def __init__(self, is_training, num_classes):


### PR DESCRIPTION
# Description
The class `BoxPredictor` is supposed to be an abstract class as it has an abstract method `_predict`, but currently it is initialize-able as it is not marked as an abstract class using `ABC`. This pull request fixes that.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Tests
I have not written any tests to verify the change. But since the class is supposed to be an abstract class, it is expected to work perfectly.

**Test Configuration**: None

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
