### PR TITLE
Updated learning rate and warmup_learning_rate

### DIFF
--- a/research/object_detection/configs/tf2/ssd_mobilenet_v2_320x320_coco17_tpu-8.config
+++ b/research/object_detection/configs/tf2/ssd_mobilenet_v2_320x320_coco17_tpu-8.config
@@ -161,9 +161,9 @@ train_config: {
     momentum_optimizer: {
       learning_rate: {
         cosine_decay_learning_rate {
-          learning_rate_base: .8
+          learning_rate_base: .08
           total_steps: 50000
-          warmup_learning_rate: 0.13333
+          warmup_learning_rate: 0.013333
           warmup_steps: 2000
         }
       }


### PR DESCRIPTION
Looks like this is a typo. All the other models uses small learning rate excepti this specific model. As the user mentioned below, the loss spikes with this learning rate.

Updated learning rate and warmup_learning_rate based on the following GH issue

Fixes https://github.com/tensorflow/models/issues/10509

