### PR TITLE
Fixed movielens dataset URL

### DIFF
--- a/official/recommendation/README.md
+++ b/official/recommendation/README.md
@@ -17,7 +17,7 @@ Some abbreviations used the code base include:
   - ml-20m: MovieLens 20 million dataset
 
 ## Dataset
-The [MovieLens datasets](http://files.grouplens.org/datasets/movielens/) are used for model training and evaluation. Specifically, we use two datasets: **ml-1m** (short for MovieLens 1 million) and **ml-20m** (short for MovieLens 20 million).
+The [MovieLens datasets](https://files.grouplens.org/datasets/movielens/) are used for model training and evaluation. Specifically, we use two datasets: **ml-1m** (short for MovieLens 1 million) and **ml-20m** (short for MovieLens 20 million).
 
 ### ml-1m
 ml-1m dataset contains 1,000,209 anonymous ratings of approximately 3,706 movies made by 6,040 users who joined MovieLens in 2000. All ratings are contained in the file "ratings.dat" without header row, and are in the following format:

--- a/official/recommendation/movielens.py
+++ b/official/recommendation/movielens.py
@@ -49,7 +49,7 @@ RATINGS_FILE = "ratings.csv"
 MOVIES_FILE = "movies.csv"
 
 # URL to download dataset
-_DATA_URL = "http://files.grouplens.org/datasets/movielens/"
+_DATA_URL = "https://files.grouplens.org/datasets/movielens/"
 
 GENRE_COLUMN = "genres"
 ITEM_COLUMN = "item_id"  # movies


### PR DESCRIPTION
# Description
Changed the movielens dataset URL as the earlier one isn't accessible.

The URL http://files.grouplens.org/datasets/movielens/  is no more accessible via `http`. It is accessible using `https`. So, updated the url in the script from where the movielens dataset is downloaded.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

```
         python movielens.py --data_dir=./data --dataset=ml-1m
         python ncf_keras_main.py --data_dir=./data --dataset=ml-1m --distribution_strategy=one_device --num_gpus=1
```
**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
