### PR TITLE
add a get_config implementation.

### DIFF
--- a/official/projects/vit/modeling/vit.py
+++ b/official/projects/vit/modeling/vit.py
@@ -172,6 +172,22 @@ class Encoder(tf.keras.layers.Layer):
       x = encoder_layer(x, training=training)
     x = self._norm(x)
     return x
+  def get_config(self):
+    config = {
+        'num_layers': self._num_layers,
+        'mlp_dim': self._mlp_dim,
+        'num_heads': self._num_heads,
+        'dropout_rate': self._dropout_rate,
+        'attention_dropout_rate': self._attention_dropout_rate,
+        'kernel_regularizer': self._kernel_regularizer,
+        'inputs_positions': self._inputs_positions,
+        'init_stochastic_depth_rate': self._init_stochastic_depth_rate,
+        'kernel_initializer': self._kernel_initializer,
+        'add_pos_embed': self._add_pos_embed,
+    }
+    base_config = super().get_config()
+    return dict(list(base_config.items()) + list(config.items()))
+
 
 
 class VisionTransformer(tf.keras.Model):


### PR DESCRIPTION
# Description
add a get_config implementation, and  thus eliminating the error:
```
WARNING:tensorflow:Model failed to serialize as JSON. Ignoring... 
Layer Encoder has arguments ['self', 'num_layers', 'mlp_dim', 'num_heads', 'dropout_rate', 'attention_dropout_rate', 'kernel_regularizer', 'inputs_positions', 'init_stochastic_depth_rate', 'kernel_initializer', 'add_pos_embed']
in `__init__` and therefore must override `get_config()`.
```

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  
I ran the model again and the error has been eliminated.
**Test Configuration**:

## Checklist

- [X] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [X] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [X] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [X] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works (it's a bugfix) .
