### PR TITLE
Added a flag to allow skipping the first projection in small ResNets

### DIFF
--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -402,7 +402,7 @@ class ResNet(tf.keras.Model):
         'kernel_regularizer': self._kernel_regularizer,
         'bias_regularizer': self._bias_regularizer,
         'bn_trainable': self._bn_trainable,
-        'use_first_projection': self.use_first_projection,
+        'use_first_projection': self._use_first_projection,
     }
     return config_dict
 

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -300,7 +300,7 @@ class ResNet(tf.keras.Model):
       use_first_projection = (
         spec[0] == 'bottleneck'
         or i > 0
-        or (i == 0 and self._use_first_projection)
+        or self._use_first_projection
       )
       x = self._block_group(
           inputs=x,

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -441,4 +441,5 @@ def build_resnet(
       norm_momentum=norm_activation_config.norm_momentum,
       norm_epsilon=norm_activation_config.norm_epsilon,
       kernel_regularizer=l2_regularizer,
-      bn_trainable=backbone_cfg.bn_trainable)
+      bn_trainable=backbone_cfg.bn_trainable,
+      use_first_projection=backbone_cfg.use_first_projection)

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -298,8 +298,9 @@ class ResNet(tf.keras.Model):
       else:
         raise ValueError('Block fn `{}` is not supported.'.format(spec[0]))
       use_first_projection = (
-          not (i == 0 and spec[0] == 'residual') and
-          not self._use_first_projection
+        spec[0] == 'bottleneck'
+        or i > 0
+        or (i == 0 and self._use_first_projection)
       )
       x = self._block_group(
           inputs=x,

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -298,8 +298,8 @@ class ResNet(tf.keras.Model):
       else:
         raise ValueError('Block fn `{}` is not supported.'.format(spec[0]))
       use_first_projection = (
-        not(i==0 and spec[0] == 'residual') and
-        not self._use_first_projection
+          not (i == 0 and spec[0] == 'residual') and
+          not self._use_first_projection
       )
       x = self._block_group(
           inputs=x,

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -400,7 +400,8 @@ class ResNet(tf.keras.Model):
         'kernel_initializer': self._kernel_initializer,
         'kernel_regularizer': self._kernel_regularizer,
         'bias_regularizer': self._bias_regularizer,
-        'bn_trainable': self._bn_trainable
+        'bn_trainable': self._bn_trainable,
+        'use_first_projection': self.use_first_projection,
     }
     return config_dict
 

--- a/official/vision/modeling/backbones/resnet_test.py
+++ b/official/vision/modeling/backbones/resnet_test.py
@@ -74,8 +74,8 @@ class ResNetTest(parameterized.TestCase, tf.test.TestCase):
                                               endpoint_filter_scale):
     """Test creation of ResNet family models."""
     resnet_params = {
-        18: 11699112,
-        34: 21814696,
+        18: 11186112,
+        34: 21301696,
     }
     tf.keras.backend.set_image_data_format('channels_last')
 

--- a/official/vision/modeling/backbones/resnet_test.py
+++ b/official/vision/modeling/backbones/resnet_test.py
@@ -167,7 +167,8 @@ class ResNetTest(parameterized.TestCase, tf.test.TestCase):
         kernel_initializer='VarianceScaling',
         kernel_regularizer=None,
         bias_regularizer=None,
-        bn_trainable=True)
+        bn_trainable=True,
+        use_first_projection=True)
     network = resnet.ResNet(**kwargs)
 
     expected_config = dict(kwargs)

--- a/official/vision/modeling/backbones/resnet_test.py
+++ b/official/vision/modeling/backbones/resnet_test.py
@@ -66,6 +66,38 @@ class ResNetTest(parameterized.TestCase, tf.test.TestCase):
         [1, input_size / 2**5, input_size / 2**5, 512 * endpoint_filter_scale],
         endpoints['5'].shape.as_list())
 
+  @parameterized.parameters(
+      (128, 18, 1),
+      (128, 34, 1),
+  )
+  def test_network_creation_no_first_shortcut(self, input_size, model_id,
+                                              endpoint_filter_scale):
+    """Test creation of ResNet family models."""
+    resnet_params = {
+        18: 11699112,
+        34: 21814696,
+    }
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = resnet.ResNet(model_id=model_id, use_first_projection=False)
+    self.assertEqual(network.count_params(), resnet_params[model_id])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual(
+        [1, input_size / 2**2, input_size / 2**2, 64 * endpoint_filter_scale],
+        endpoints['2'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**3, input_size / 2**3, 128 * endpoint_filter_scale],
+        endpoints['3'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**4, input_size / 2**4, 256 * endpoint_filter_scale],
+        endpoints['4'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**5, input_size / 2**5, 512 * endpoint_filter_scale],
+        endpoints['5'].shape.as_list())
+
   @combinations.generate(
       combinations.combine(
           strategy=[


### PR DESCRIPTION
# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

This should fix https://github.com/tensorflow/models/issues/10583
In this issue, I described how the small ResNets implemented here have an extra convolution (for projection), that is neither present in the original paper or in PyTorch.
This PR allows to get rid of this extra convolution with a keyword argument that defaults to the previous behaviour so that this remains a non-breaking change.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request. 

Note: I didn't wait for a discussion because this seemed like a relatively small and simple change,
so it's not bothering for me to have written it even if rejected in the end.


- [x] New feature (non-breaking change which adds functionality)


## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

I added tests to check the parameter count.
I also offline checked the number of non-trainable parameters to checked that it matched against PyTorch's one.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.