### PR TITLE
Replace `git.io` link with the actual URL

### DIFF
--- a/official/projects/deepmac_maskrcnn/README.md
+++ b/official/projects/deepmac_maskrcnn/README.md
@@ -107,7 +107,7 @@ SpienNet-143 | Hourglass-52 | `deep_mask_head_rcnn_voc_spinenet143_hg52.yaml` | 
 
 *   [DeepMAC model](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/deepmac.md)
     in the Object Detection API code base.
-*   Project website - [git.io/deepmac](https://git.io/deepmac)
+*   Project website - [git.io/deepmac](https://google.github.io/deepmac/)
 
 ## Citation
 

--- a/research/object_detection/README.md
+++ b/research/object_detection/README.md
@@ -108,7 +108,7 @@ Please see links below for more details
 *   [DeepMAC Colab](./colab_tutorials/deepmac_colab.ipynb) that lets you run a
     pre-trained DeepMAC model on user-specified boxes. Note that you are not
     restricted to COCO classes!
-*   Project website - [git.io/deepmac](https://git.io/deepmac)
+*   Project website - [git.io/deepmac](https://google.github.io/deepmac/)
 
 <b>Thanks to contributors</b>: Vighnesh Birodkar, Zhichao Lu, Siyang Li,
  Vivek Rathod, Jonathan Huang

--- a/research/object_detection/g3doc/deepmac.md
+++ b/research/object_detection/g3doc/deepmac.md
@@ -81,7 +81,7 @@ Resolution | Mask head     | Config name                                | Mask m
 
 *   [Mask RCNN code](https://github.com/tensorflow/models/tree/master/official/vision/beta/projects/deepmac_maskrcnn)
     in TF Model garden code base.
-*   Project website - [git.io/deepmac](https://git.io/deepmac)
+*   Project website - [git.io/deepmac](https://google.github.io/deepmac/)
 
 ## Citation
 


### PR DESCRIPTION
# Description

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace `https://git.io/deepmac` with `https://google.github.io/deepmac/`

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

- [x] Documentation update

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
