### PR TITLE
Add --add_postprocessing_op to object detection TF2 saved model exporter

### DIFF
--- a/research/object_detection/export_tflite_graph_tf2.py
+++ b/research/object_detection/export_tflite_graph_tf2.py
@@ -27,7 +27,9 @@ One input:
   NOTE: See the `preprocess` function defined in the feature extractor class
   in the object_detection/models directory.
 
-Four Outputs:
+Outputs:
+If add_postprocessing_op is true: exported adds a
+  TFLite_Detection_PostProcess custom op node which has four outputs:
   detection_boxes: a float32 tensor of shape [1, num_boxes, 4] with box
   locations
   detection_classes: a float32 tensor of shape [1, num_boxes]
@@ -35,6 +37,13 @@ Four Outputs:
   detection_scores: a float32 tensor of shape [1, num_boxes]
   with class scores
   num_boxes: a float32 tensor of size 1 containing the number of detected boxes
+else:
+  the graph has two outputs:
+   'box_encodings': a float32 tensor of shape [1, num_anchors, 4]
+    containing the encoded box predictions.
+   'class_predictions': a float32 tensor of shape
+    [1, num_anchors, num_classes] containing the class scores for each anchor
+    after applying score conversion.
 
 Example Usage:
 --------------
@@ -121,6 +130,8 @@ flags.DEFINE_bool(
     'ssd_use_regular_nms', False,
     'Flag to set postprocessing op to use Regular NMS instead of Fast NMS '
     '(Default false).')
+flags.DEFINE_bool('ssd_add_postprocessing_op', True,
+                  'Add TFLite custom op for postprocessing to the graph.')
 # CenterNet-specific flags
 flags.DEFINE_bool(
     'centernet_include_keypoints', False,


### PR DESCRIPTION
# Description

Added `--add_postprocessing_op` to object detection TF2 saved model exporter. Unlike the `export_tflite_ssd_graph.py` exporter, the `export_tflite_graph_tf2.py` one lacks the `--add_postprocessing_op` argument switching which helps creating a **valid** model intended to be used with TensorFlow (not TfLite) as is or to be converted to any other nnet framework format by not adding the fake `TFLite_Detection_PostProcess` op.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

I ran the `export_tflite_graph_tf2.py` script with and without the `--add_postprocessing_op` argument and validated the resultant saved model to contain the expected outputs.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
