### PR TITLE
Removed duplicated parameter

### DIFF
--- a/research/object_detection/g3doc/tf2_training_and_evaluation.md
+++ b/research/object_detection/g3doc/tf2_training_and_evaluation.md
@@ -152,7 +152,6 @@ launched using the following command:
 PIPELINE_CONFIG_PATH={path to pipeline config file}
 MODEL_DIR={path to model directory}
 CHECKPOINT_DIR=${MODEL_DIR}
-MODEL_DIR={path to model directory}
 python object_detection/model_main_tf2.py \
     --pipeline_config_path=${PIPELINE_CONFIG_PATH} \
     --model_dir=${MODEL_DIR} \


### PR DESCRIPTION
Removed duplicated parameter from the documentation

# Description

While i was reading the documentation, I noticed a variable which was declared twice.
So i removed it! 

## Type of change

- [ ] Documentation update

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] I have made corresponding changes to the documentation.
