### PR TITLE
Update Open CV installation in docs

### DIFF
--- a/docs/nlp/fine_tune_bert.ipynb
+++ b/docs/nlp/fine_tune_bert.ipynb
@@ -116,7 +116,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip uninstall -y opencv-python"
+        "!pip install -q opencv-python"
       ]
     },
     {

--- a/docs/nlp/index.ipynb
+++ b/docs/nlp/index.ipynb
@@ -103,9 +103,7 @@
       },
       "outputs": [],
       "source": [
-        "# Uninstall colab's opencv-python, it conflicts with `opencv-python-headless`\n",
-        "# which is installed by tf-models-official\n",
-        "!pip uninstall -y opencv-python"
+        "!pip install -q opencv-python"
       ]
     },
     {

--- a/docs/orbit/index.ipynb
+++ b/docs/orbit/index.ipynb
@@ -101,9 +101,8 @@
       },
       "outputs": [],
       "source": [
-        "# Uninstall opencv-python to avoid a conflict (in Colab) with the opencv-python-headless package that tf-models uses.\n",
-        "!pip uninstall -y opencv-python\n",
-        "!pip install -U -q \"tensorflow\u003e=2.9.0\" \"tf-models-official\""
+        "!pip install -q opencv-python\n",
+        "!pip install tensorflow>=2.9.0 tf-models-official"
       ]
     },
     {


### PR DESCRIPTION
@MarkDaoust @markmcd 

Currently, importing TF Models throws an `ImportError` as there's no `cv2` dependency. This PR should fix this step with `pip install opencv-python`.