### PR TITLE
Fixes Neutral Style Transfer example

### DIFF
--- a/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
+++ b/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
@@ -828,7 +828,7 @@
         "  init_image = load_and_process_img(content_path)\n",
         "  init_image = tf.Variable(init_image, dtype=tf.float32)\n",
         "  # Create our optimizer\n",
-        "  opt = tf.train.AdamOptimizer(learning_rate=5, beta1=0.99, epsilon=1e-1)\n",
+        "  opt = tf.optimizers.Adam(learning_rate=5, epsilon=1e-1)\n",
         "\n",
         "  # For displaying intermediate images \n",
         "  iter_count = 1\n",

--- a/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
+++ b/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
@@ -171,7 +171,7 @@
         "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "\n",
-        "from tensorflow.python.keras.preprocessing import image as kp_image\n",
+        "from tensorflow.keras.utils import image_dataset_from_directory as kp_image\n",
         "from tensorflow.python.keras import models \n",
         "from tensorflow.python.keras import losses\n",
         "from tensorflow.python.keras import layers\n",

--- a/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
+++ b/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
@@ -182,30 +182,6 @@
     },
     {
       "metadata": {
-        "id": "L7sjDODq67HQ",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "We’ll begin by enabling [eager execution](https://www.tensorflow.org/guide/eager). Eager execution allows us to work through this technique in the clearest and most readable way. "
-      ]
-    },
-    {
-      "metadata": {
-        "id": "sfjsSAtNrqQx",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "tf.enable_eager_execution()\n",
-        "print(\"Eager execution: {}\".format(tf.executing_eagerly()))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
         "id": "IOiGrIV1iERH",
         "colab_type": "code",
         "colab": {}

--- a/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
+++ b/research/nst_blogpost/4_Neural_Style_Transfer_with_Eager_Execution.ipynb
@@ -945,6 +945,8 @@
       "cell_type": "code",
       "source": [
         "#from google.colab import files\n",
+        "#final_img = Image.fromarray(best)\n",
+        "#final_img.save('wave_turtle.png')\n",
         "#files.download('wave_turtle.png')"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Fixes tensorflow/models#9451 by creating image from example that can be downloaded.

# Description

A Neutral Style Transfer example from 2018 has never worked fully because it offers a cue to download a file that is never generated in the code. This PR generates that file, so the example will generate a downloadable image.

https://blog.tensorflow.org/2018/08/neural-style-transfer-creating-art-with-deep-learning.html

I found the issue in https://github.com/tensorflow/models/issues/9451 but it has not yet been solved.


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

N/A

**Test Configuration**:

## Checklist

- [ x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have made corresponding changes to the documentation.
- [ x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
