### PR TITLE
Update create_coco_tf_record.py

### DIFF
--- a/official/vision/data/create_coco_tf_record.py
+++ b/official/vision/data/create_coco_tf_record.py
@@ -356,7 +356,8 @@ def create_tf_example(image,
   if feature_dict_len == len(feature_dict):
     example = None
   else:
-    example = tf.train.Example(features=tf.train.Features(feature=feature_dict))
+    example = tf.train.Example(
+        features=tf.train.Features(feature=feature_dict))
 
   return example, num_annotations_skipped
 

--- a/official/vision/data/create_coco_tf_record.py
+++ b/official/vision/data/create_coco_tf_record.py
@@ -350,8 +350,7 @@ def create_tf_example(image,
           'image/panoptic/category_mask': tfrecord_lib.convert_to_feature(
               encoded_panoptic_masks['category_mask']),
           'image/panoptic/instance_mask': tfrecord_lib.convert_to_feature(
-              encoded_panoptic_masks['instance_mask'])
-            })
+              encoded_panoptic_masks['instance_mask'])})
 
   if feature_dict_len == len(feature_dict):
     example = None

--- a/official/vision/data/create_coco_tf_record.py
+++ b/official/vision/data/create_coco_tf_record.py
@@ -213,27 +213,27 @@ def bbox_annotations_to_feature_dict(
   feature_dict = {}
     
   if not (len(bbox_annotations) == num_skipped):
-      feature_dict = {
-          'image/object/bbox/xmin':
-              tfrecord_lib.convert_to_feature(data['xmin']),
-          'image/object/bbox/xmax':
-              tfrecord_lib.convert_to_feature(data['xmax']),
-          'image/object/bbox/ymin':
-              tfrecord_lib.convert_to_feature(data['ymin']),
-          'image/object/bbox/ymax':
-              tfrecord_lib.convert_to_feature(data['ymax']),
-          'image/object/class/text':
-              tfrecord_lib.convert_to_feature(data['category_names']),
-          'image/object/class/label':
-              tfrecord_lib.convert_to_feature(data['category_id']),
-          'image/object/is_crowd':
-              tfrecord_lib.convert_to_feature(data['is_crowd']),
-          'image/object/area':
-              tfrecord_lib.convert_to_feature(data['area'], 'float_list')
-      }
-      if include_masks:
-        feature_dict['image/object/mask'] = (
-            tfrecord_lib.convert_to_feature(data['encoded_mask_png']))
+    feature_dict = {
+        'image/object/bbox/xmin':
+            tfrecord_lib.convert_to_feature(data['xmin']),
+        'image/object/bbox/xmax':
+            tfrecord_lib.convert_to_feature(data['xmax']),
+        'image/object/bbox/ymin':
+            tfrecord_lib.convert_to_feature(data['ymin']),
+        'image/object/bbox/ymax':
+            tfrecord_lib.convert_to_feature(data['ymax']),
+        'image/object/class/text':
+            tfrecord_lib.convert_to_feature(data['category_names']),
+        'image/object/class/label':
+            tfrecord_lib.convert_to_feature(data['category_id']),
+        'image/object/is_crowd':
+            tfrecord_lib.convert_to_feature(data['is_crowd']),
+        'image/object/area':
+            tfrecord_lib.convert_to_feature(data['area'], 'float_list')
+    }
+    if include_masks:
+      feature_dict['image/object/mask'] = (
+          tfrecord_lib.convert_to_feature(data['encoded_mask_png']))
 
   return feature_dict, num_skipped
 

--- a/official/vision/data/create_coco_tf_record.py
+++ b/official/vision/data/create_coco_tf_record.py
@@ -319,6 +319,7 @@ def create_tf_example(image,
   feature_dict = tfrecord_lib.image_info_to_feature_dict(
       image_height, image_width, filename, image_id, encoded_jpg, 'jpg')
 
+  feature_dict_len = len(feature_dict)
   num_annotations_skipped = 0
   if bbox_annotations:
     box_feature_dict, num_skipped = bbox_annotations_to_feature_dict(
@@ -352,7 +353,11 @@ def create_tf_example(image,
               encoded_panoptic_masks['instance_mask'])
             })
 
-  example = tf.train.Example(features=tf.train.Features(feature=feature_dict))
+  if feature_dict_len == len(feature_dict):
+    example = None
+  else:
+    example = tf.train.Example(features=tf.train.Features(feature=feature_dict))
+
   return example, num_annotations_skipped
 
 

--- a/official/vision/data/create_coco_tf_record.py
+++ b/official/vision/data/create_coco_tf_record.py
@@ -210,27 +210,30 @@ def bbox_annotations_to_feature_dict(
   data, num_skipped = coco_annotations_to_lists(
       bbox_annotations, id_to_name_map, image_height, image_width,
       include_masks)
-  feature_dict = {
-      'image/object/bbox/xmin':
-          tfrecord_lib.convert_to_feature(data['xmin']),
-      'image/object/bbox/xmax':
-          tfrecord_lib.convert_to_feature(data['xmax']),
-      'image/object/bbox/ymin':
-          tfrecord_lib.convert_to_feature(data['ymin']),
-      'image/object/bbox/ymax':
-          tfrecord_lib.convert_to_feature(data['ymax']),
-      'image/object/class/text':
-          tfrecord_lib.convert_to_feature(data['category_names']),
-      'image/object/class/label':
-          tfrecord_lib.convert_to_feature(data['category_id']),
-      'image/object/is_crowd':
-          tfrecord_lib.convert_to_feature(data['is_crowd']),
-      'image/object/area':
-          tfrecord_lib.convert_to_feature(data['area'], 'float_list')
-  }
-  if include_masks:
-    feature_dict['image/object/mask'] = (
-        tfrecord_lib.convert_to_feature(data['encoded_mask_png']))
+  feature_dict = {}
+    
+  if not (len(bbox_annotations) == num_skipped):
+      feature_dict = {
+          'image/object/bbox/xmin':
+              tfrecord_lib.convert_to_feature(data['xmin']),
+          'image/object/bbox/xmax':
+              tfrecord_lib.convert_to_feature(data['xmax']),
+          'image/object/bbox/ymin':
+              tfrecord_lib.convert_to_feature(data['ymin']),
+          'image/object/bbox/ymax':
+              tfrecord_lib.convert_to_feature(data['ymax']),
+          'image/object/class/text':
+              tfrecord_lib.convert_to_feature(data['category_names']),
+          'image/object/class/label':
+              tfrecord_lib.convert_to_feature(data['category_id']),
+          'image/object/is_crowd':
+              tfrecord_lib.convert_to_feature(data['is_crowd']),
+          'image/object/area':
+              tfrecord_lib.convert_to_feature(data['area'], 'float_list')
+      }
+      if include_masks:
+        feature_dict['image/object/mask'] = (
+            tfrecord_lib.convert_to_feature(data['encoded_mask_png']))
 
   return feature_dict, num_skipped
 

--- a/official/vision/data/tfrecord_lib.py
+++ b/official/vision/data/tfrecord_lib.py
@@ -168,7 +168,8 @@ def write_tf_record_dataset(output_path, annotation_iterator,
       logging.info('On image %d', idx)
 
     total_num_annotations_skipped += num_annotations_skipped
-    writers[idx % num_shards].write(tf_example.SerializeToString())
+    if tf_example:
+      writers[idx % num_shards].write(tf_example.SerializeToString())
 
   if multiple_processes is None or multiple_processes > 0:
     pool.close()

--- a/official/vision/data/tfrecord_lib_test.py
+++ b/official/vision/data/tfrecord_lib_test.py
@@ -21,7 +21,8 @@ from absl.testing import parameterized
 import tensorflow as tf
 
 from official.vision.data import tfrecord_lib
-from official.vision.data.create_coco_tf_record import generate_annotations, create_tf_example
+from official.vision.data.create_coco_tf_record import generate_annotations
+from official.vision.data.create_coco_tf_record import create_tf_example
 
 
 FLAGS = flags.FLAGS
@@ -92,49 +93,43 @@ class TfrecordLibTest(parameterized.TestCase):
   def test_obj_annotation_tf_example(self):
 
     images = [
-                {
-                  "id": 0,
-                  "file_name": "example1.jpg",
-                  "height": 512,
-                  "width": 512,
-                },
-                {
-                  "id": 1,
-                  "file_name": "example2.jpg",
-                  "height": 512,
-                  "width": 512,
-                }
-              ]
+        {
+            "id": 0,
+            "file_name": "example1.jpg",
+            "height": 512,
+            "width": 512,
+        },
+       {
+            "id": 1,
+            "file_name": "example2.jpg",
+            "height": 512,
+            "width": 512,
+        },
+    ]
     img_to_obj_annotation = {
-                              0: 
-                              [
-                                {
-                                  "id": 0,
-                                  "image_id": 0,
-                                  "category_id": 1,
-                                  "bbox": [3, 1, 511, 510],
-                                  "area": 260610.00,
-                                  "segmentation": [],
-                                  "iscrowd": 0
-                                }
-                              ],
-                              1:
-                              [
-                                {
-                                  "id": 1,
-                                  "image_id": 1,
-                                  "category_id": 1,
-                                  "bbox": [1, 1, 100, 150],
-                                  "area": 15000.00,
-                                  "segmentation": [],
-                                  "iscrowd": 0
-                                }
-                              ]
-                            }
+        0: [{
+            "id": 0,
+            "image_id": 0,
+            "category_id": 1,
+            "bbox": [3, 1, 511, 510],
+            "area": 260610.00,
+            "segmentation": [],
+            "iscrowd": 0,
+        }],
+        1: [{
+            "id": 1,
+            "image_id": 1,
+            "category_id": 1,
+            "bbox": [1, 1, 100, 150],
+            "area": 15000.00,
+            "segmentation": [],
+            "iscrowd": 0,
+        }],
+    }
     id_to_name_map = {
-                        0: 'Super-Class', 
-                        1: 'Class-1'
-                      }
+        0: 'Super-Class',
+        1: 'Class-1',
+    }
 
     temp_dir = FLAGS.test_tmpdir
     image_dir = os.path.join(temp_dir, 'data')
@@ -160,7 +155,8 @@ class TfrecordLibTest(parameterized.TestCase):
         include_masks=False)
     
     tfrecord_lib.write_tf_record_dataset(
-        output_path, coco_annotations_iter, create_tf_example, 1, multiple_processes=0)
+        output_path, coco_annotations_iter,
+        create_tf_example, 1, multiple_processes=0)
     
     tfrecord_files = tf.io.gfile.glob(output_path + '*')
 

--- a/official/vision/data/tfrecord_lib_test.py
+++ b/official/vision/data/tfrecord_lib_test.py
@@ -21,6 +21,7 @@ from absl.testing import parameterized
 import tensorflow as tf
 
 from official.vision.data import tfrecord_lib
+from official.vision.data.create_coco_tf_record import generate_annotations, create_tf_example
 
 
 FLAGS = flags.FLAGS
@@ -87,7 +88,90 @@ class TfrecordLibTest(parameterized.TestCase):
 
     proto = tfrecord_lib.convert_to_feature([b'123', b'456'])
     self.assertSequenceAlmostEqual(proto.bytes_list.value, [b'123', b'456'])
+  
+  def test_obj_annotation_tf_example(self):
 
+    images = [
+                {
+                  "id": 0,
+                  "file_name": "example1.jpg",
+                  "height": 512,
+                  "width": 512,
+                },
+                {
+                  "id": 1,
+                  "file_name": "example2.jpg",
+                  "height": 512,
+                  "width": 512,
+                }
+              ]
+    img_to_obj_annotation = {
+                              0: 
+                              [
+                                {
+                                  "id": 0,
+                                  "image_id": 0,
+                                  "category_id": 1,
+                                  "bbox": [3, 1, 511, 510],
+                                  "area": 260610.00,
+                                  "segmentation": [],
+                                  "iscrowd": 0
+                                }
+                              ],
+                              1:
+                              [
+                                {
+                                  "id": 1,
+                                  "image_id": 1,
+                                  "category_id": 1,
+                                  "bbox": [1, 1, 100, 150],
+                                  "area": 15000.00,
+                                  "segmentation": [],
+                                  "iscrowd": 0
+                                }
+                              ]
+                            }
+    id_to_name_map = {
+                        0: 'Super-Class', 
+                        1: 'Class-1'
+                      }
+
+    temp_dir = FLAGS.test_tmpdir
+    image_dir = os.path.join(temp_dir, 'data')
+    if not os.path.exists(image_dir):
+      os.mkdir(image_dir)
+    
+    for image in images:
+      image_path = os.path.join(image_dir, image['file_name'])
+      tf.keras.utils.save_img(
+        image_path, tf.ones(shape=(image['height'], image['width'], 3)).numpy())
+
+    output_path = os.path.join(image_dir, 'train')
+    coco_annotations_iter = generate_annotations(
+        images=images,
+        image_dirs=[image_dir],
+        panoptic_masks_dir=None,
+        img_to_obj_annotation=img_to_obj_annotation,
+        img_to_caption_annotation=None,
+        img_to_panoptic_annotation=None,
+        is_category_thing=None,
+        id_to_name_map=id_to_name_map,
+        include_panoptic_masks=False,
+        include_masks=False)
+    
+    tfrecord_lib.write_tf_record_dataset(
+        output_path, coco_annotations_iter, create_tf_example, 1, multiple_processes=0)
+    
+    tfrecord_files = tf.io.gfile.glob(output_path + '*')
+
+    self.assertLen(tfrecord_files, 1)
+
+    ds = tf.data.TFRecordDataset(tfrecord_files)
+    assertion_count = 0
+    for _ in ds:
+      assertion_count += 1
+
+    self.assertEqual(assertion_count, 1)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/official/vision/data/tfrecord_lib_test.py
+++ b/official/vision/data/tfrecord_lib_test.py
@@ -99,7 +99,7 @@ class TfrecordLibTest(parameterized.TestCase):
             "height": 512,
             "width": 512,
         },
-       {
+        {
             "id": 1,
             "file_name": "example2.jpg",
             "height": 512,
@@ -139,7 +139,8 @@ class TfrecordLibTest(parameterized.TestCase):
     for image in images:
       image_path = os.path.join(image_dir, image['file_name'])
       tf.keras.utils.save_img(
-        image_path, tf.ones(shape=(image['height'], image['width'], 3)).numpy())
+          image_path,
+          tf.ones(shape=(image['height'], image['width'], 3)).numpy())
 
     output_path = os.path.join(image_dir, 'train')
     coco_annotations_iter = generate_annotations(


### PR DESCRIPTION
# Description
Code breaks when bounding box coordinates  crosses the original image width or height itself. 

* When number of `bbox_annotations` is same as `num_annotations_skipped` in a single example include a check, not to create the `feature_dict` and just return any empty `feature_dict`.
* Later included another check in `tfrecord_lib.py` whether `tf_example` is not empty while writing to output `tfrecord` file.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
