### PR TITLE
Remove opencv-python-headless version requirement

### DIFF
--- a/official/requirements.txt
+++ b/official/requirements.txt
@@ -19,7 +19,7 @@ matplotlib
 # Loader becomes a required positional argument in 6.0 in yaml.load
 pyyaml>=5.1,<6.0
 # CV related dependencies
-opencv-python-headless==4.5.2.52
+opencv-python-headless
 Pillow
 pycocotools
 # NLP related dependencies


### PR DESCRIPTION
# Description

Remove the opencv-python-headless version requirement for the 2.10 release so that it can install on python 3.10.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

I built the pip package on python3.10 and it installed fine now, with opencv-python-headless=4.6.0.66

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
