### PR TITLE
Fixed GLDv2 baseline Link

### DIFF
--- a/research/delf/README.md
+++ b/research/delf/README.md
@@ -163,7 +163,7 @@ datasets.
 ### GLDv2 baseline
 
 Please follow
-[these instructions](delf/python/google_landmarks_dataset/README.md). At the
+[these instructions](delf/python/datasets/google_landmarks_dataset/README.md). At the
 end, you should obtain image retrieval results on the Revisited Oxford/Paris
 datasets.
 


### PR DESCRIPTION
# Description
Updated a broken link for the GLDv2 baseline link to include the subdirectory **datasets**

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Documentation update

## Tests
1- Tried clicking the [link](https://github.com/tensorflow/models/blob/master/research/delf/delf/python/google_landmarks_dataset/README.md) and it took me to the [corresponding page](https://github.com/tensorflow/models/tree/master/research/delf/delf/python/datasets/google_landmarks_dataset) instead of the error produced previously.

**Test Configuration**:
N.A
## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [N.A] I have added tests that prove my fix is effective or that my feature works.
