### PR TITLE
FIX - Copy setup script before pip

### DIFF
--- a/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
+++ b/research/object_detection/colab_tutorials/object_detection_tutorial.ipynb
@@ -155,7 +155,8 @@
       "source": [
         "%%bash \n",
         "cd models/research\n",
-        "pip install ."
+        "cp object_detection/packages/tf2/setup.py .",
+        "pip install . --upgrade"
       ]
     },
     {


### PR DESCRIPTION
# Description

When running `pip install .` fails to find setup.py, to avoid that first one must copy the setup script to `models/research/`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Tests

Run it inside Google Colab

**Test Configuration**:

Google Colab's default config

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
