### PR TITLE
Update centernet_on_device.ipynb

### DIFF
--- a/research/object_detection/colab_tutorials/centernet_on_device.ipynb
+++ b/research/object_detection/colab_tutorials/centernet_on_device.ipynb
@@ -639,7 +639,7 @@
         "# Note that CenterNet doesn't require any pre-processing except resizing to\r\n",
         "# input size that the TensorFlow Lite Interpreter was generated with.\r\n",
         "input_tensor = tf.image.resize(input_tensor, (320, 320))\r\n",
-        "(boxes, classes, scores, num_detections, kpts, kpts_scores) = detect(\r\n",
+        "(classes, num_detections, boxes, scores, kpts, kpts_scores) = detect(\r\n",
         "    interpreter, input_tensor, include_keypoint=True)\r\n",
         "\r\n",
         "vis_image = plot_detections(\r\n",


### PR DESCRIPTION
fix the order of outputs for the keypoints model

# Description

fix the order of outputs for the keypoints model. This is the right output order.

## Type of change

there's no new feature.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

use existing code to visualize the result (keypoint and bboxes).

**Test Configuration**: run the colab file.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
