### PR TITLE
Update keras layer BatchNormalization with synchronized argument

### DIFF
--- a/official/vision/modeling/backbones/efficientnet.py
+++ b/official/vision/modeling/backbones/efficientnet.py
@@ -151,10 +151,7 @@ class EfficientNet(tf.keras.Model):
     self._norm_epsilon = norm_epsilon
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       bn_axis = -1
@@ -178,7 +175,10 @@ class EfficientNet(tf.keras.Model):
         bias_regularizer=self._bias_regularizer)(
             inputs)
     x = self._norm(
-        axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
+        axis=bn_axis, 
+        momentum=norm_momentum, 
+        epsilon=norm_epsilon,
+        synchronized=use_sync_bn)(
             x)
     x = tf_utils.get_activation(activation)(x)
 
@@ -210,7 +210,10 @@ class EfficientNet(tf.keras.Model):
         bias_regularizer=self._bias_regularizer)(
             x)
     x = self._norm(
-        axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
+        axis=bn_axis, 
+        momentum=norm_momentum, 
+        epsilon=norm_epsilon,
+        synchronized=use_sync_bn)(
             x)
     endpoints[str(endpoint_level)] = tf_utils.get_activation(activation)(x)
 

--- a/official/vision/modeling/backbones/mobilenet.py
+++ b/official/vision/modeling/backbones/mobilenet.py
@@ -91,15 +91,12 @@ class Conv2DBNBlock(tf.keras.layers.Layer):
     self._use_sync_bn = use_sync_bn
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
+    self._norm = tf.keras.layers.BatchNormalization
 
     if use_explicit_padding and kernel_size > 1:
       self._padding = 'valid'
     else:
       self._padding = 'same'
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -141,7 +138,8 @@ class Conv2DBNBlock(tf.keras.layers.Layer):
       self._norm0 = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)
     self._activation_layer = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 

--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -179,10 +179,7 @@ class ResNet(tf.keras.Model):
     self._activation = activation
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
     self._kernel_initializer = kernel_initializer
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
@@ -238,6 +235,7 @@ class ResNet(tf.keras.Model):
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
           trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn,
       )(x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
     elif self._stem_type == 'v1':
@@ -256,6 +254,7 @@ class ResNet(tf.keras.Model):
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
           trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn,
       )(x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
       x = layers.Conv2D(
@@ -273,6 +272,7 @@ class ResNet(tf.keras.Model):
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
           trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn,
       )(x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
       x = layers.Conv2D(
@@ -290,6 +290,7 @@ class ResNet(tf.keras.Model):
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
           trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn,
       )(x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
     else:
@@ -311,6 +312,7 @@ class ResNet(tf.keras.Model):
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
           trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn,
       )(x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
     else:

--- a/official/vision/modeling/backbones/resnet_3d.py
+++ b/official/vision/modeling/backbones/resnet_3d.py
@@ -145,10 +145,7 @@ class ResNet3D(tf.keras.Model):
     self._activation = activation
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
     self._kernel_initializer = kernel_initializer
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
@@ -232,7 +229,8 @@ class ResNet3D(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(x)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(x)
       x = tf_utils.get_activation(self._activation)(x)
     elif stem_type == 'v1':
       x = layers.Conv3D(
@@ -248,7 +246,8 @@ class ResNet3D(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(x)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(x)
       x = tf_utils.get_activation(self._activation)(x)
       x = layers.Conv3D(
           filters=32,
@@ -263,7 +262,8 @@ class ResNet3D(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(x)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(x)
       x = tf_utils.get_activation(self._activation)(x)
       x = layers.Conv3D(
           filters=64,
@@ -278,7 +278,8 @@ class ResNet3D(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(x)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(x)
       x = tf_utils.get_activation(self._activation)(x)
     else:
       raise ValueError(f'Stem type {stem_type} not supported.')

--- a/official/vision/modeling/backbones/resnet_deeplab.py
+++ b/official/vision/modeling/backbones/resnet_deeplab.py
@@ -126,10 +126,7 @@ class DilatedResNet(tf.keras.Model):
     self._activation = activation
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
     self._kernel_initializer = kernel_initializer
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
@@ -159,8 +156,10 @@ class DilatedResNet(tf.keras.Model):
           bias_regularizer=self._bias_regularizer)(
               inputs)
       x = self._norm(
-          axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
-              x)
+          axis=bn_axis, 
+          momentum=norm_momentum, 
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
       x = tf_utils.get_activation(activation)(x)
     elif stem_type == 'v1':
       x = layers.Conv2D(
@@ -174,8 +173,10 @@ class DilatedResNet(tf.keras.Model):
           bias_regularizer=self._bias_regularizer)(
               inputs)
       x = self._norm(
-          axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
-              x)
+          axis=bn_axis, 
+          momentum=norm_momentum, 
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
       x = tf_utils.get_activation(activation)(x)
       x = layers.Conv2D(
           filters=64,
@@ -188,8 +189,10 @@ class DilatedResNet(tf.keras.Model):
           bias_regularizer=self._bias_regularizer)(
               x)
       x = self._norm(
-          axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
-              x)
+          axis=bn_axis, 
+          momentum=norm_momentum, 
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
       x = tf_utils.get_activation(activation)(x)
       x = layers.Conv2D(
           filters=128,
@@ -202,8 +205,10 @@ class DilatedResNet(tf.keras.Model):
           bias_regularizer=self._bias_regularizer)(
               x)
       x = self._norm(
-          axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
-              x)
+          axis=bn_axis, 
+          momentum=norm_momentum, 
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
       x = tf_utils.get_activation(activation)(x)
     else:
       raise ValueError('Stem type {} not supported.'.format(stem_type))
@@ -220,8 +225,10 @@ class DilatedResNet(tf.keras.Model):
           bias_regularizer=self._bias_regularizer)(
               x)
       x = self._norm(
-          axis=bn_axis, momentum=norm_momentum, epsilon=norm_epsilon)(
-              x)
+          axis=bn_axis, 
+          momentum=norm_momentum, 
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
       x = tf_utils.get_activation(activation, use_keras_layer=True)(x)
     else:
       x = layers.MaxPool2D(pool_size=3, strides=2, padding='same')(x)

--- a/official/vision/modeling/backbones/revnet.py
+++ b/official/vision/modeling/backbones/revnet.py
@@ -93,10 +93,7 @@ class RevNet(tf.keras.Model):
     self._norm_epsilon = norm_epsilon
     self._kernel_initializer = kernel_initializer
     self._kernel_regularizer = kernel_regularizer
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
 
     axis = -1 if tf.keras.backend.image_data_format() == 'channels_last' else 1
 
@@ -109,7 +106,10 @@ class RevNet(tf.keras.Model):
         kernel_initializer=self._kernel_initializer,
         kernel_regularizer=self._kernel_regularizer)(inputs)
     x = self._norm(
-        axis=axis, momentum=norm_momentum, epsilon=norm_epsilon)(x)
+        axis=axis, 
+        momentum=norm_momentum, 
+        epsilon=norm_epsilon,
+        synchronized=self._use_sync_bn)(x)
     x = tf_utils.get_activation(activation)(x)
     x = tf.keras.layers.MaxPool2D(pool_size=3, strides=2, padding='same')(x)
 

--- a/official/vision/modeling/backbones/spinenet.py
+++ b/official/vision/modeling/backbones/spinenet.py
@@ -205,11 +205,7 @@ class SpineNet(tf.keras.Model):
     self._num_init_blocks = 2
 
     self._set_activation_fn(activation)
-
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -303,8 +299,9 @@ class SpineNet(tf.keras.Model):
     x = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)(
-            x)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)(
+          x)
     x = tf_utils.get_activation(self._activation_fn)(x)
     x = layers.MaxPool2D(pool_size=3, strides=2, padding='same')(x)
 
@@ -434,7 +431,8 @@ class SpineNet(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(
               x)
       x = tf_utils.get_activation(self._activation_fn)(x)
       endpoints[str(level)] = x
@@ -466,7 +464,8 @@ class SpineNet(tf.keras.Model):
     x = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)(
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)(
             x)
     x = tf_utils.get_activation(self._activation_fn)(x)
 
@@ -485,7 +484,8 @@ class SpineNet(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(
               x)
       x = tf_utils.get_activation(self._activation_fn)(x)
       input_width /= 2
@@ -511,7 +511,8 @@ class SpineNet(tf.keras.Model):
     x = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)(
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)(
             x)
     return x
 

--- a/official/vision/modeling/backbones/spinenet_mobile.py
+++ b/official/vision/modeling/backbones/spinenet_mobile.py
@@ -205,11 +205,7 @@ class SpineNetMobile(tf.keras.Model):
     self._norm_epsilon = norm_epsilon
     self._use_keras_upsampling_2d = use_keras_upsampling_2d
     self._num_init_blocks = 2
-
-    if use_sync_bn:
-      self._norm = layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = layers.BatchNormalization
+    self._norm = layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -290,7 +286,8 @@ class SpineNetMobile(tf.keras.Model):
     x = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)(
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)(
             x)
     x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
 
@@ -428,7 +425,8 @@ class SpineNetMobile(tf.keras.Model):
       x = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)(
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)(
               x)
       x = tf_utils.get_activation(self._activation, use_keras_layer=True)(x)
       endpoints[str(level)] = x
@@ -476,7 +474,8 @@ class SpineNetMobile(tf.keras.Model):
     x = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)(
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)(
             x)
     return x
 

--- a/official/vision/modeling/classification_model.py
+++ b/official/vision/modeling/classification_model.py
@@ -62,10 +62,7 @@ class ClassificationModel(tf.keras.Model):
       skip_logits_layer: `bool`, whether to skip the prediction layer.
       **kwargs: keyword arguments to be passed.
     """
-    if use_sync_bn:
-      norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      norm = tf.keras.layers.BatchNormalization
+    norm = tf.keras.layers.BatchNormalization
     axis = -1 if tf.keras.backend.image_data_format() == 'channels_last' else 1
 
     inputs = tf.keras.Input(shape=input_specs.shape[1:], name=input_specs.name)
@@ -73,7 +70,11 @@ class ClassificationModel(tf.keras.Model):
     x = endpoints[max(endpoints.keys())]
 
     if add_head_batch_norm:
-      x = norm(axis=axis, momentum=norm_momentum, epsilon=norm_epsilon)(x)
+      x = norm(
+        axis=axis, 
+        momentum=norm_momentum, 
+        epsilon=norm_epsilon,
+        synchronized=use_sync_bn)(x)
 
     # Depending on the backbone type, backbone's output can be
     # [batch_size, height, weight, channel_size] or

--- a/official/vision/modeling/classification_model.py
+++ b/official/vision/modeling/classification_model.py
@@ -71,10 +71,10 @@ class ClassificationModel(tf.keras.Model):
 
     if add_head_batch_norm:
       x = norm(
-        axis=axis,
-        momentum=norm_momentum,
-        epsilon=norm_epsilon,
-        synchronized=use_sync_bn)(x)
+          axis=axis,
+          momentum=norm_momentum,
+          epsilon=norm_epsilon,
+          synchronized=use_sync_bn)(x)
 
     # Depending on the backbone type, backbone's output can be
     # [batch_size, height, weight, channel_size] or

--- a/official/vision/modeling/classification_model.py
+++ b/official/vision/modeling/classification_model.py
@@ -71,8 +71,8 @@ class ClassificationModel(tf.keras.Model):
 
     if add_head_batch_norm:
       x = norm(
-        axis=axis, 
-        momentum=norm_momentum, 
+        axis=axis,
+        momentum=norm_momentum,
         epsilon=norm_epsilon,
         synchronized=use_sync_bn)(x)
 

--- a/official/vision/modeling/decoders/fpn.py
+++ b/official/vision/modeling/decoders/fpn.py
@@ -97,10 +97,8 @@ class FPN(tf.keras.Model):
       conv2d = tf.keras.layers.SeparableConv2D
     else:
       conv2d = tf.keras.layers.Conv2D
-    if use_sync_bn:
-      norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      norm = tf.keras.layers.BatchNormalization
+    
+    norm = tf.keras.layers.BatchNormalization
     activation_fn = tf_utils.get_activation(activation, use_keras_layer=True)
 
     # Build input feature pyramid.
@@ -185,7 +183,8 @@ class FPN(tf.keras.Model):
           axis=bn_axis,
           momentum=norm_momentum,
           epsilon=norm_epsilon,
-          name=f'norm_{level}')(
+          name=f'norm_{level}',
+          synchronized=use_sync_bn)(
               feats[str(level)])
 
     self._output_specs = {

--- a/official/vision/modeling/decoders/nasfpn.py
+++ b/official/vision/modeling/decoders/nasfpn.py
@@ -137,9 +137,7 @@ class NASFPN(tf.keras.Model):
     self._conv_op = (tf.keras.layers.SeparableConv2D
                      if self._config_dict['use_separable_conv']
                      else tf.keras.layers.Conv2D)
-    self._norm_op = (tf.keras.layers.experimental.SyncBatchNormalization
-                     if self._config_dict['use_sync_bn']
-                     else tf.keras.layers.BatchNormalization)
+    self._norm_op = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -148,6 +146,7 @@ class NASFPN(tf.keras.Model):
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn']
     }
     self._activation = tf_utils.get_activation(activation)
 

--- a/official/vision/modeling/heads/dense_prediction_heads.py
+++ b/official/vision/modeling/heads/dense_prediction_heads.py
@@ -125,6 +125,7 @@ class RetinaNetHead(tf.keras.layers.Layer):
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     self._classifier_kwargs = {
@@ -224,11 +225,7 @@ class RetinaNetHead(tf.keras.layers.Layer):
         if self._config_dict['use_separable_conv']
         else tf.keras.layers.Conv2D
     )
-    bn_op = (
-        tf.keras.layers.experimental.SyncBatchNormalization
-        if self._config_dict['use_sync_bn']
-        else tf.keras.layers.BatchNormalization
-    )
+    bn_op = tf.keras.layers.BatchNormalization
 
     # Class net.
     self._cls_convs = []
@@ -495,13 +492,12 @@ class RPNHead(tf.keras.layers.Layer):
               stddev=0.01),
           'kernel_regularizer': self._config_dict['kernel_regularizer'],
       })
-    bn_op = (tf.keras.layers.experimental.SyncBatchNormalization
-             if self._config_dict['use_sync_bn']
-             else tf.keras.layers.BatchNormalization)
+    bn_op = tf.keras.layers.BatchNormalization
     bn_kwargs = {
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     self._convs = []

--- a/official/vision/modeling/heads/instance_heads.py
+++ b/official/vision/modeling/heads/instance_heads.py
@@ -120,13 +120,12 @@ class DetectionHead(tf.keras.layers.Layer):
           'kernel_regularizer': self._config_dict['kernel_regularizer'],
           'bias_regularizer': self._config_dict['bias_regularizer'],
       })
-    bn_op = (tf.keras.layers.experimental.SyncBatchNormalization
-             if self._config_dict['use_sync_bn']
-             else tf.keras.layers.BatchNormalization)
+    bn_op = tf.keras.layers.BatchNormalization
     bn_kwargs = {
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     self._convs = []
@@ -314,13 +313,12 @@ class MaskHead(tf.keras.layers.Layer):
           'kernel_regularizer': self._config_dict['kernel_regularizer'],
           'bias_regularizer': self._config_dict['bias_regularizer'],
       })
-    bn_op = (tf.keras.layers.experimental.SyncBatchNormalization
-             if self._config_dict['use_sync_bn']
-             else tf.keras.layers.BatchNormalization)
+    bn_op = tf.keras.layers.BatchNormalization
     bn_kwargs = {
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     self._convs = []

--- a/official/vision/modeling/heads/segmentation_heads.py
+++ b/official/vision/modeling/heads/segmentation_heads.py
@@ -108,13 +108,12 @@ class MaskScoring(tf.keras.Model):
         'kernel_regularizer': self._config_dict['kernel_regularizer'],
         'bias_regularizer': self._config_dict['bias_regularizer'],
     })
-    bn_op = (tf.keras.layers.experimental.SyncBatchNormalization
-             if self._config_dict['use_sync_bn']
-             else tf.keras.layers.BatchNormalization)
+    bn_op = tf.keras.layers.BatchNormalization
     bn_kwargs = {
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     self._convs = []
@@ -324,13 +323,12 @@ class SegmentationHead(tf.keras.layers.Layer):
     """Creates the variables of the segmentation head."""
     use_depthwise_convolution = self._config_dict['use_depthwise_convolution']
     conv_op = tf.keras.layers.Conv2D
-    bn_op = (tf.keras.layers.experimental.SyncBatchNormalization
-             if self._config_dict['use_sync_bn']
-             else tf.keras.layers.BatchNormalization)
+    bn_op = tf.keras.layers.BatchNormalization
     bn_kwargs = {
         'axis': self._bn_axis,
         'momentum': self._config_dict['norm_momentum'],
         'epsilon': self._config_dict['norm_epsilon'],
+        'synchronized': self._config_dict['use_sync_bn'],
     }
 
     if self._config_dict['feature_fusion'] in {'deeplabv3plus',

--- a/official/vision/modeling/layers/deeplab.py
+++ b/official/vision/modeling/layers/deeplab.py
@@ -91,10 +91,7 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
 
     self.aspp_layers = []
 
-    if self.use_sync_bn:
-      bn_op = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      bn_op = tf.keras.layers.BatchNormalization
+    bn_op = tf.keras.layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       bn_axis = -1
@@ -112,7 +109,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
         bn_op(
             axis=bn_axis,
             momentum=self.batchnorm_momentum,
-            epsilon=self.batchnorm_epsilon),
+            epsilon=self.batchnorm_epsilon,
+            synchronized=self.use_sync_bn),
         tf.keras.layers.Activation(self.activation)
     ])
     self.aspp_layers.append(conv_sequential)
@@ -143,7 +141,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
           bn_op(
               axis=bn_axis,
               momentum=self.batchnorm_momentum,
-              epsilon=self.batchnorm_epsilon),
+              epsilon=self.batchnorm_epsilon,
+              synchronized=self.use_sync_bn),
           tf.keras.layers.Activation(self.activation)
       ])
       self.aspp_layers.append(conv_sequential)
@@ -168,7 +167,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
             bn_op(
                 axis=bn_axis,
                 momentum=self.batchnorm_momentum,
-                epsilon=self.batchnorm_epsilon),
+                epsilon=self.batchnorm_epsilon,
+                synchronized=self.use_sync_bn),
             tf.keras.layers.Activation(self.activation)
         ]))
 
@@ -185,7 +185,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
         bn_op(
             axis=bn_axis,
             momentum=self.batchnorm_momentum,
-            epsilon=self.batchnorm_epsilon),
+            epsilon=self.batchnorm_epsilon,
+            synchronized=self.use_sync_bn),
         tf.keras.layers.Activation(self.activation),
         tf.keras.layers.Dropout(rate=self.dropout)
     ])

--- a/official/vision/modeling/layers/nn_blocks.py
+++ b/official/vision/modeling/layers/nn_blocks.py
@@ -123,11 +123,8 @@ class ResidualBlock(tf.keras.layers.Layer):
     self._norm_epsilon = norm_epsilon
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
-
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
+    
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -150,7 +147,8 @@ class ResidualBlock(tf.keras.layers.Layer):
           axis=self._bn_axis,
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
-          trainable=self._bn_trainable)
+          trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn)
 
     conv1_padding = 'same'
     # explicit padding here is added for centernet
@@ -171,7 +169,8 @@ class ResidualBlock(tf.keras.layers.Layer):
         axis=self._bn_axis,
         momentum=self._norm_momentum,
         epsilon=self._norm_epsilon,
-        trainable=self._bn_trainable)
+        trainable=self._bn_trainable,
+        synchronized=self._use_sync_bn)
 
     self._conv2 = tf.keras.layers.Conv2D(
         filters=self._filters,
@@ -186,7 +185,8 @@ class ResidualBlock(tf.keras.layers.Layer):
         axis=self._bn_axis,
         momentum=self._norm_momentum,
         epsilon=self._norm_epsilon,
-        trainable=self._bn_trainable)
+        trainable=self._bn_trainable,
+        synchronized=self._use_sync_bn)
 
     if self._se_ratio and self._se_ratio > 0 and self._se_ratio <= 1:
       self._squeeze_excitation = nn_layers.SqueezeExcitation(
@@ -321,10 +321,7 @@ class BottleneckBlock(tf.keras.layers.Layer):
     self._norm_epsilon = norm_epsilon
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -360,7 +357,8 @@ class BottleneckBlock(tf.keras.layers.Layer):
           axis=self._bn_axis,
           momentum=self._norm_momentum,
           epsilon=self._norm_epsilon,
-          trainable=self._bn_trainable)
+          trainable=self._bn_trainable,
+          synchronized=self._use_sync_bn)
 
     self._conv1 = tf.keras.layers.Conv2D(
         filters=self._filters,
@@ -374,7 +372,8 @@ class BottleneckBlock(tf.keras.layers.Layer):
         axis=self._bn_axis,
         momentum=self._norm_momentum,
         epsilon=self._norm_epsilon,
-        trainable=self._bn_trainable)
+        trainable=self._bn_trainable,
+        synchronized=self._use_sync_bn)
     self._activation1 = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 
@@ -392,7 +391,8 @@ class BottleneckBlock(tf.keras.layers.Layer):
         axis=self._bn_axis,
         momentum=self._norm_momentum,
         epsilon=self._norm_epsilon,
-        trainable=self._bn_trainable)
+        trainable=self._bn_trainable,
+        synchronized=self._use_sync_bn)
     self._activation2 = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 
@@ -408,7 +408,8 @@ class BottleneckBlock(tf.keras.layers.Layer):
         axis=self._bn_axis,
         momentum=self._norm_momentum,
         epsilon=self._norm_epsilon,
-        trainable=self._bn_trainable)
+        trainable=self._bn_trainable,
+        synchronized=self._use_sync_bn)
     self._activation3 = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 
@@ -589,11 +590,8 @@ class InvertedBottleneckBlock(tf.keras.layers.Layer):
     self._bias_regularizer = bias_regularizer
     self._expand_se_in_filters = expand_se_in_filters
     self._output_intermediate_endpoints = output_intermediate_endpoints
+    self._norm = tf.keras.layers.BatchNormalization
 
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -628,7 +626,8 @@ class InvertedBottleneckBlock(tf.keras.layers.Layer):
       self._norm0 = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)
       self._activation_layer = tf_utils.get_activation(
           self._activation, use_keras_layer=True)
 
@@ -648,7 +647,8 @@ class InvertedBottleneckBlock(tf.keras.layers.Layer):
       self._norm1 = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)
       self._depthwise_activation_layer = tf_utils.get_activation(
           self._depthwise_activation, use_keras_layer=True)
 
@@ -686,7 +686,8 @@ class InvertedBottleneckBlock(tf.keras.layers.Layer):
     self._norm2 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     if self._stochastic_depth_drop_rate:
       self._stochastic_depth = nn_layers.StochasticDepth(
@@ -812,11 +813,7 @@ class ResidualInner(tf.keras.layers.Layer):
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
     self._batch_norm_first = batch_norm_first
-
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -829,7 +826,8 @@ class ResidualInner(tf.keras.layers.Layer):
       self._batch_norm_0 = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)
 
     self._conv2d_1 = tf.keras.layers.Conv2D(
         filters=self.filters,
@@ -843,7 +841,8 @@ class ResidualInner(tf.keras.layers.Layer):
     self._batch_norm_1 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self._conv2d_2 = tf.keras.layers.Conv2D(
         filters=self.filters,
@@ -938,11 +937,7 @@ class BottleneckResidualInner(tf.keras.layers.Layer):
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
     self._batch_norm_first = batch_norm_first
-
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -955,7 +950,8 @@ class BottleneckResidualInner(tf.keras.layers.Layer):
       self._batch_norm_0 = self._norm(
           axis=self._bn_axis,
           momentum=self._norm_momentum,
-          epsilon=self._norm_epsilon)
+          epsilon=self._norm_epsilon,
+          synchronized=self._use_sync_bn)
     self._conv2d_1 = tf.keras.layers.Conv2D(
         filters=self.filters,
         kernel_size=1,
@@ -967,7 +963,8 @@ class BottleneckResidualInner(tf.keras.layers.Layer):
     self._batch_norm_1 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
     self._conv2d_2 = tf.keras.layers.Conv2D(
         filters=self.filters,
         kernel_size=3,
@@ -979,7 +976,8 @@ class BottleneckResidualInner(tf.keras.layers.Layer):
     self._batch_norm_2 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
     self._conv2d_3 = tf.keras.layers.Conv2D(
         filters=self.filters * 4,
         kernel_size=1,
@@ -1257,11 +1255,8 @@ class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
     self._use_sync_bn = use_sync_bn
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
+    self._norm = tf.keras.layers.BatchNormalization
 
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -1301,7 +1296,8 @@ class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
     self._norm0 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self._conv1 = tf.keras.layers.Conv2D(
         filters=self._filters,
@@ -1314,7 +1310,8 @@ class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
     self._norm1 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     super(DepthwiseSeparableConvBlock, self).build(input_shape)
 
@@ -1398,11 +1395,8 @@ class TuckerConvBlock(tf.keras.layers.Layer):
     self._norm_epsilon = norm_epsilon
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
+    self._norm = tf.keras.layers.BatchNormalization
 
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -1426,7 +1420,8 @@ class TuckerConvBlock(tf.keras.layers.Layer):
     self._norm0 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
     self._activation_layer0 = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 
@@ -1447,7 +1442,8 @@ class TuckerConvBlock(tf.keras.layers.Layer):
     self._norm1 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
     self._activation_layer1 = tf_utils.get_activation(
         self._activation, use_keras_layer=True)
 
@@ -1464,7 +1460,8 @@ class TuckerConvBlock(tf.keras.layers.Layer):
     self._norm2 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     if self._stochastic_depth_drop_rate:
       self._stochastic_depth = nn_layers.StochasticDepth(

--- a/official/vision/modeling/layers/nn_blocks_3d.py
+++ b/official/vision/modeling/layers/nn_blocks_3d.py
@@ -130,11 +130,8 @@ class BottleneckBlock3D(tf.keras.layers.Layer):
     self._norm_epsilon = norm_epsilon
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
-
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
+    
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
     else:
@@ -161,7 +158,8 @@ class BottleneckBlock3D(tf.keras.layers.Layer):
     self._norm0 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self._temporal_conv = tf.keras.layers.Conv3D(
         filters=self._filters,
@@ -175,7 +173,8 @@ class BottleneckBlock3D(tf.keras.layers.Layer):
     self._norm1 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self._spatial_conv = tf.keras.layers.Conv3D(
         filters=self._filters,
@@ -189,7 +188,8 @@ class BottleneckBlock3D(tf.keras.layers.Layer):
     self._norm2 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self._expand_conv = tf.keras.layers.Conv3D(
         filters=4 * self._filters,
@@ -203,7 +203,8 @@ class BottleneckBlock3D(tf.keras.layers.Layer):
     self._norm3 = self._norm(
         axis=self._bn_axis,
         momentum=self._norm_momentum,
-        epsilon=self._norm_epsilon)
+        epsilon=self._norm_epsilon,
+        synchronized=self._use_sync_bn)
 
     if self._se_ratio and self._se_ratio > 0 and self._se_ratio <= 1:
       self._squeeze_excitation = nn_layers.SqueezeExcitation(

--- a/official/vision/modeling/layers/nn_layers.py
+++ b/official/vision/modeling/layers/nn_layers.py
@@ -1136,10 +1136,7 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
     self._pool_kernel_size = pool_kernel_size
     self._use_depthwise_convolution = use_depthwise_convolution
     self._activation_fn = tf_utils.get_activation(activation)
-    if self._use_sync_bn:
-      self._bn_op = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._bn_op = tf.keras.layers.BatchNormalization
+    self._bn_op = tf.keras.layers.BatchNormalization
 
     if tf.keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -1162,7 +1159,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
     norm1 = self._bn_op(
         axis=self._bn_axis,
         momentum=self._batchnorm_momentum,
-        epsilon=self._batchnorm_epsilon)
+        epsilon=self._batchnorm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self.aspp_layers.append([conv1, norm1])
 
@@ -1196,7 +1194,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
       norm_dilation = self._bn_op(
           axis=self._bn_axis,
           momentum=self._batchnorm_momentum,
-          epsilon=self._batchnorm_epsilon)
+          epsilon=self._batchnorm_epsilon,
+          synchronized=self._use_sync_bn)
 
       self.aspp_layers.append(conv_dilation + [norm_dilation])
 
@@ -1217,7 +1216,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
     norm2 = self._bn_op(
         axis=self._bn_axis,
         momentum=self._batchnorm_momentum,
-        epsilon=self._batchnorm_epsilon)
+        epsilon=self._batchnorm_epsilon,
+        synchronized=self._use_sync_bn)
 
     self.aspp_layers.append(pooling + [conv2, norm2])
 
@@ -1235,7 +1235,8 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
         self._bn_op(
             axis=self._bn_axis,
             momentum=self._batchnorm_momentum,
-            epsilon=self._batchnorm_epsilon)
+            epsilon=self._batchnorm_epsilon,
+            synchronized=self._use_sync_bn)
     ]
     self._dropout_layer = tf.keras.layers.Dropout(rate=self._dropout)
     self._concat_layer = tf.keras.layers.Concatenate(axis=-1)


### PR DESCRIPTION
# Description

Existing `tf.keras.layers.experimental.SyncBatchNormalization` has been deprecated in **tensorflow-2.12.0**, so updated the `tf.keras.layers.BatchNormalization` with `synchronized` argument.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
