### PR TITLE
Dict union operator replaced by traditional solution

### DIFF
--- a/official/core/base_trainer.py
+++ b/official/core/base_trainer.py
@@ -439,7 +439,7 @@ class Trainer(_AsyncTrainer):
           passthrough_logs.keys(),
       )
 
-    return passthrough_logs | logs
+    return {**passthrough_logs, **logs}
 
   def eval_end(self, aggregated_logs=None):
     """Processes evaluation results."""


### PR DESCRIPTION
# Description

Dict union operator `d1 | d2` was replaced by `{ **d1, **d2 }`. The repo should be compatible with Python 3.8 but the dict union operator `|` is available in Python 3.9 and newer.

Incompatibility with Python 3.8 is unlucky, because the newest standard Tensorflow Docker images available from https://hub.docker.com/r/tensorflow/tensorflow/tags have Python version 3.8. The following error occurs:
```
TypeError: in user code:

    File "/usr/local/lib/python3.8/dist-packages/official/core/base_trainer.py", line 442, in eval_step  *
        return passthrough_logs | logs

    TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Tests

I ran my code incl. the change and the previous error no longer occurs.

**Test Configuration**:
Docker image `tensorflow/tensorflow:2.12.0-gpu-jupyter`
Ubuntu 20.04
Nvidia 1080ti

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
