### PR TITLE
Added default missing hyperparameters

### DIFF
--- a/official/projects/yolo/configs/darknet_classification.py
+++ b/official/projects/yolo/configs/darknet_classification.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 from official.core import config_definitions as cfg
 from official.core import exp_factory
 from official.modeling import hyperparams
+from official.modeling import optimization
 from official.projects.yolo.configs import backbones
 from official.vision.configs import common
 from official.vision.configs import image_classification as imc
@@ -44,6 +45,9 @@ class Losses(hyperparams.Config):
   one_hot: bool = True
   label_smoothing: float = 0.0
   l2_weight_decay: float = 0.0
+  loss_weight: float = 1.0
+  soft_labels: bool = False
+  use_binary_cross_entropy: bool = False
 
 
 @dataclasses.dataclass
@@ -56,6 +60,7 @@ class ImageClassificationTask(cfg.TaskConfig):
   losses: Losses = Losses()
   gradient_clip_norm: float = 0.0
   logging_dir: Optional[str] = None
+  freeze_backbone: bool = False
 
 
 @exp_factory.register_config_factory('darknet_classification')
@@ -63,7 +68,27 @@ def darknet_classification() -> cfg.ExperimentConfig:
   """Image classification general."""
   return cfg.ExperimentConfig(
       task=ImageClassificationTask(),
-      trainer=cfg.TrainerConfig(),
+      trainer=cfg.TrainerConfig(
+        optimizer_config=optimization.OptimizationConfig({
+              'optimizer': {
+                  'type': 'sgd',
+                  'sgd': {
+                      'momentum': 0.9
+                  }
+              },
+              'learning_rate': {
+                  'type': 'polynomial',
+                  'initial_learning_rate': 0.1,
+
+              },
+              'warmup': {
+                  'type': 'linear',
+                  'linear': {
+                      'warmup_learning_rate': 0,
+                  }
+              }
+          })
+      ),
       restrictions=[
           'task.train_data.is_training != None',
           'task.validation_data.is_training != None'


### PR DESCRIPTION
# Description

While training darknet image classification some of the default parameters are not present and causing error while trained using `official,core.train_lib.run_experiment`.


## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)


## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
