### PR TITLE
add synchronized argument for batch norm

### DIFF
--- a/official/projects/movinet/modeling/movinet.py
+++ b/official/projects/movinet/modeling/movinet.py
@@ -386,10 +386,7 @@ class Movinet(tf.keras.Model):
     self._gating_activation = gating_activation
     self._norm_momentum = norm_momentum
     self._norm_epsilon = norm_epsilon
-    if use_sync_bn:
-      self._norm = tf.keras.layers.experimental.SyncBatchNormalization
-    else:
-      self._norm = tf.keras.layers.BatchNormalization
+    self._norm = tf.keras.layers.BatchNormalization
     self._kernel_initializer = kernel_initializer
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
@@ -469,6 +466,7 @@ class Movinet(tf.keras.Model):
             batch_norm_layer=self._norm,
             batch_norm_momentum=self._norm_momentum,
             batch_norm_epsilon=self._norm_epsilon,
+            use_sync_bn=self._use_sync_bn,
             state_prefix='state_stem',
             name='stem')
         x, states = layer_obj(x, states=states)
@@ -508,6 +506,7 @@ class Movinet(tf.keras.Model):
               batch_norm_layer=self._norm,
               batch_norm_momentum=self._norm_momentum,
               batch_norm_epsilon=self._norm_epsilon,
+              use_sync_bn=self._use_sync_bn,
               state_prefix=f'state_{name}',
               name=name)
           x, states = layer_obj(x, states=states)
@@ -524,6 +523,7 @@ class Movinet(tf.keras.Model):
             batch_norm_layer=self._norm,
             batch_norm_momentum=self._norm_momentum,
             batch_norm_epsilon=self._norm_epsilon,
+            use_sync_bn=self._use_sync_bn,
             average_pooling_type=self._average_pooling_type,
             state_prefix='state_head',
             name='head')


### PR DESCRIPTION
# Description

Remove deprecated `tf.keras.layers.experimental.SyncBatchNormalization` and added `synchronized` as argument in `tf.keras.layers.BatchNormalization`.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
