### PR TITLE
Fixed vggish_smoke_test failures due to resampy changes.

### DIFF
--- a/research/audioset/vggish/README.md
+++ b/research/audioset/vggish/README.md
@@ -57,7 +57,7 @@ Here's a sample installation and test session:
 $ sudo python -m pip install --upgrade pip wheel
 
 # Install all dependences.
-$ sudo pip install numpy resampy tensorflow tf_slim six soundfile
+$ sudo pip install -r requirements.txt
 
 # Clone TensorFlow models repo into a 'models' directory.
 $ git clone https://github.com/tensorflow/models.git

--- a/research/audioset/vggish/requirements.txt
+++ b/research/audioset/vggish/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+resampy
+tensorflow
+tf_slim
+six
+soundfile

--- a/research/audioset/vggish/vggish_input.py
+++ b/research/audioset/vggish/vggish_input.py
@@ -53,7 +53,6 @@ def waveform_to_examples(data, sample_rate):
   # Convert to mono.
   if len(data.shape) > 1:
     data = np.mean(data, axis=1)
-  print('before resampling, waveform:', data)
   # Resample to the rate assumed by VGGish.
   if sample_rate != vggish_params.SAMPLE_RATE:
     data = resampy.resample(data, sample_rate, vggish_params.SAMPLE_RATE)

--- a/research/audioset/vggish/vggish_input.py
+++ b/research/audioset/vggish/vggish_input.py
@@ -53,6 +53,7 @@ def waveform_to_examples(data, sample_rate):
   # Convert to mono.
   if len(data.shape) > 1:
     data = np.mean(data, axis=1)
+  print('before resampling, waveform:', data)
   # Resample to the rate assumed by VGGish.
   if sample_rate != vggish_params.SAMPLE_RATE:
     data = resampy.resample(data, sample_rate, vggish_params.SAMPLE_RATE)

--- a/research/audioset/vggish/vggish_smoke_test.py
+++ b/research/audioset/vggish/vggish_smoke_test.py
@@ -48,11 +48,10 @@ pca_params_path = 'vggish_pca_params.npz'
 # Relative tolerance of errors in mean and standard deviation of embeddings.
 rel_error = 0.1  # Up to 10%
 
-# Generate a 1 kHz sine wave at 44.1 kHz (we use a high sampling rate
-# to test resampling to 16 kHz during feature extraction).
+# Generate a 1 kHz sine wave at 16 kHz.
 num_secs = 3
 freq = 1000
-sr = 44100
+sr = 16000
 t = np.arange(0, num_secs, 1 / sr)
 x = np.sin(2 * np.pi * freq * t)
 
@@ -76,19 +75,28 @@ with tf.Graph().as_default(), tf.Session() as sess:
   [embedding_batch] = sess.run([embedding_tensor],
                                feed_dict={features_tensor: input_batch})
   print('VGGish embedding: ', embedding_batch[0])
-  expected_embedding_mean = -0.0333
-  expected_embedding_std = 0.380
-  np.testing.assert_allclose(
-      [np.mean(embedding_batch), np.std(embedding_batch)],
-      [expected_embedding_mean, expected_embedding_std],
-      rtol=rel_error)
+  print('embedding mean/stddev', np.mean(embedding_batch), np.std(embedding_batch))
 
 # Postprocess the results to produce whitened quantized embeddings.
 pproc = vggish_postprocess.Postprocessor(pca_params_path)
 postprocessed_batch = pproc.postprocess(embedding_batch)
 print('Postprocessed VGGish embedding: ', postprocessed_batch[0])
-expected_postprocessed_mean = 122.0
-expected_postprocessed_std = 93.5
+print('postproc embedding mean/stddev', np.mean(postprocessed_batch), np.std(postprocessed_batch))
+
+# Expected mean/stddev were measured to 3 significant places on 07/25/23 with
+# NumPy 1.21.6 / TF 2.8.2 (dating to Apr-May 2022)
+# NumPy 1.24.3 / TF 2.13.0 (representative of July 2023)
+# with Python 3.10 on a Debian-like Linux system. Both configs produced identical results.
+
+expected_embedding_mean = 0.000657
+expected_embedding_std = 0.343
+np.testing.assert_allclose(
+    [np.mean(embedding_batch), np.std(embedding_batch)],
+    [expected_embedding_mean, expected_embedding_std],
+    rtol=rel_error)
+
+expected_postprocessed_mean = 126.0
+expected_postprocessed_std = 89.3
 np.testing.assert_allclose(
     [np.mean(postprocessed_batch), np.std(postprocessed_batch)],
     [expected_postprocessed_mean, expected_postprocessed_std],

--- a/research/audioset/vggish/vggish_smoke_test.py
+++ b/research/audioset/vggish/vggish_smoke_test.py
@@ -32,6 +32,7 @@ Usage:
 from __future__ import print_function
 
 import numpy as np
+import resampy
 import tensorflow.compat.v1 as tf
 
 import vggish_input
@@ -48,12 +49,18 @@ pca_params_path = 'vggish_pca_params.npz'
 # Relative tolerance of errors in mean and standard deviation of embeddings.
 rel_error = 0.1  # Up to 10%
 
-# Generate a 1 kHz sine wave at 16 kHz.
+# Generate a 1 kHz sine wave at 16 kHz, the preferred sample rate of VGGish.
 num_secs = 3
 freq = 1000
 sr = 16000
 t = np.arange(0, num_secs, 1 / sr)
 x = np.sin(2 * np.pi * freq * t)
+
+# Check that we can resample a signal. Don't use the resampled signal to
+# produce an embedding where we check the results because we don't want
+# to depend on the resampler never changing too much.
+resampled_x = resampy.resample(x, sr, sr * 0.75)
+print('Resampling via resampy works!')
 
 # Produce a batch of log mel spectrogram examples.
 input_batch = vggish_input.waveform_to_examples(x, sr)

--- a/research/audioset/vggish/vggish_smoke_test.py
+++ b/research/audioset/vggish/vggish_smoke_test.py
@@ -32,7 +32,7 @@ Usage:
 from __future__ import print_function
 
 import numpy as np
-import resampy
+import resampy  # pylint: disable=import-error
 import tensorflow.compat.v1 as tf
 
 import vggish_input

--- a/research/audioset/vggish/vggish_smoke_test.py
+++ b/research/audioset/vggish/vggish_smoke_test.py
@@ -82,18 +82,21 @@ with tf.Graph().as_default(), tf.Session() as sess:
   [embedding_batch] = sess.run([embedding_tensor],
                                feed_dict={features_tensor: input_batch})
   print('VGGish embedding: ', embedding_batch[0])
-  print('embedding mean/stddev', np.mean(embedding_batch), np.std(embedding_batch))
+  print('embedding mean/stddev', np.mean(embedding_batch),
+        np.std(embedding_batch))
 
 # Postprocess the results to produce whitened quantized embeddings.
 pproc = vggish_postprocess.Postprocessor(pca_params_path)
 postprocessed_batch = pproc.postprocess(embedding_batch)
 print('Postprocessed VGGish embedding: ', postprocessed_batch[0])
-print('postproc embedding mean/stddev', np.mean(postprocessed_batch), np.std(postprocessed_batch))
+print('postproc embedding mean/stddev', np.mean(postprocessed_batch),
+      np.std(postprocessed_batch))
 
 # Expected mean/stddev were measured to 3 significant places on 07/25/23 with
 # NumPy 1.21.6 / TF 2.8.2 (dating to Apr-May 2022)
 # NumPy 1.24.3 / TF 2.13.0 (representative of July 2023)
-# with Python 3.10 on a Debian-like Linux system. Both configs produced identical results.
+# with Python 3.10 on a Debian-like Linux system. Both configs produced
+# identical results.
 
 expected_embedding_mean = 0.000657
 expected_embedding_std = 0.343


### PR DESCRIPTION
# Description

Fixed vggish_smoke_test failures due to resampy changes.

https://github.com/bmcfee/resampy/pull/98 seems to have updated
resampy's default filters in a way that made the VGGish smoke
test's embedding outputs drift too far from the expected values
when upgrading from resampy 0.2.2 to 0.3.0 or later.

Fixed the test by not resampling in the critical path of generating
an embedding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Tested by running the smoke test on a config from last summer and a recent representative config

**Test Configuration**:
Debian-based Linux system, Python 3.10
NumPy 1.21.6 / TF 2.8.2
NumPy 1.24.3 / TF 2.13.0

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
