### PR TITLE
fixes #9927: pascal_voc_detection_metrics low scores for first catategory in label_map

### DIFF
--- a/research/object_detection/model_lib_v2.py
+++ b/research/object_detection/model_lib_v2.py
@@ -776,7 +776,7 @@ def prepare_eval_dict(detections, groundtruth, features):
   else:
     groundtruth_classes_one_hot = groundtruth[
         fields.InputDataFields.groundtruth_classes]
-  label_id_offset = 1  # Applying label id offset (b/63711816)
+  label_id_offset = np.any(array, axis=2) # Applying label id offset (b/63711816)
   groundtruth_classes = (
       tf.argmax(groundtruth_classes_one_hot, axis=2) + label_id_offset)
   groundtruth[fields.InputDataFields.groundtruth_classes] = groundtruth_classes


### PR DESCRIPTION
Only add 1 if there is at least one element greater than 0 per row
#9927

# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Tests

Evaluate results with metric pascal voc evaluator that has unusual low scores on the first class. 
you can stop on the changed line and see if there are row entries in the ground truth variable with only zeros

See also #9927 

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
