### PR TITLE
added `checkpoint_max_to_keep` flag

### DIFF
--- a/research/object_detection/model_main_tf2.py
+++ b/research/object_detection/model_main_tf2.py
@@ -68,6 +68,8 @@ flags.DEFINE_boolean('record_summaries', True,
                       ' or the training pipeline. This does not impact the'
                       ' summaries of the loss values which are always'
                       ' recorded.'))
+flags.DEFINE_integer(
+    'checkpoint_max_to_keep', 7, 'The number of most recent checkpoints to keep in the model directory.')
 
 FLAGS = flags.FLAGS
 
@@ -108,6 +110,7 @@ def main(unused_argv):
           train_steps=FLAGS.num_train_steps,
           use_tpu=FLAGS.use_tpu,
           checkpoint_every_n=FLAGS.checkpoint_every_n,
+          checkpoint_max_to_keep=FLAGS.checkpoint_max_to_keep,
           record_summaries=FLAGS.record_summaries)
 
 if __name__ == '__main__':


### PR DESCRIPTION
After working with TF Object Detection for quite a long time, the API found that it would be convenient to pass the checkpoint_max_to_keep argument directly through the console, especially the `train_loop` function it supports him. As tests, I just started test training, no other tests are required.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
