### PR TITLE
Added a flag to allow skipping the first projection in small ResNets

### DIFF
--- a/official/vision/modeling/backbones/resnet.py
+++ b/official/vision/modeling/backbones/resnet.py
@@ -135,6 +135,7 @@ class ResNet(tf_keras.Model):
       kernel_regularizer: Optional[tf_keras.regularizers.Regularizer] = None,
       bias_regularizer: Optional[tf_keras.regularizers.Regularizer] = None,
       bn_trainable: bool = True,
+      use_first_projection: bool = True,
       **kwargs):
     """Initializes a ResNet model.
 
@@ -164,6 +165,8 @@ class ResNet(tf_keras.Model):
         Default to None.
       bn_trainable: A `bool` that indicates whether batch norm layers should be
         trainable. Default to True.
+      use_first_projection: A `bool` of whether to use the first projection
+        shortcut for small ResNets. See https://github.com/tensorflow/models/issues/10583.
       **kwargs: Additional keyword arguments to be passed.
     """
     self._model_id = model_id
@@ -184,6 +187,7 @@ class ResNet(tf_keras.Model):
     self._kernel_regularizer = kernel_regularizer
     self._bias_regularizer = bias_regularizer
     self._bn_trainable = bn_trainable
+    self._use_first_projection = use_first_projection
 
     if tf_keras.backend.image_data_format() == 'channels_last':
       self._bn_axis = -1
@@ -202,12 +206,18 @@ class ResNet(tf_keras.Model):
         block_fn = nn_blocks.BottleneckBlock
       else:
         raise ValueError('Block fn `{}` is not supported.'.format(spec[0]))
+      use_first_projection = (
+        spec[0] == 'bottleneck'
+        or i > 0
+        or self._use_first_projection
+      )
       x = self._block_group(
           inputs=x,
           filters=int(spec[1] * self._depth_multiplier),
           strides=(1 if i == 0 else 2),
           block_fn=block_fn,
           block_repeats=spec[2],
+          use_first_projection=use_first_projection,
           stochastic_depth_drop_rate=nn_layers.get_stochastic_depth_rate(
               self._init_stochastic_depth_rate, i + 2, 5),
           name='block_group_l{}'.format(i + 2))
@@ -326,6 +336,7 @@ class ResNet(tf_keras.Model):
                    strides: int,
                    block_fn: Callable[..., tf_keras.layers.Layer],
                    block_repeats: int = 1,
+                   use_first_projection: bool = True,
                    stochastic_depth_drop_rate: float = 0.0,
                    name: str = 'block_group'):
     """Creates one group of blocks for the ResNet model.
@@ -339,6 +350,8 @@ class ResNet(tf_keras.Model):
       block_fn: The type of block group. Either `nn_blocks.ResidualBlock` or
         `nn_blocks.BottleneckBlock`.
       block_repeats: An `int` number of blocks contained in the layer.
+      use_first_projection: A `bool` to determine whether to use the first
+        projection shortcut.
       stochastic_depth_drop_rate: A `float` of drop rate of the current block
         group.
       name: A `str` name for the block.
@@ -349,7 +362,7 @@ class ResNet(tf_keras.Model):
     x = block_fn(
         filters=filters,
         strides=strides,
-        use_projection=True,
+        use_projection=use_first_projection,
         stochastic_depth_drop_rate=stochastic_depth_drop_rate,
         se_ratio=self._se_ratio,
         resnetd_shortcut=self._resnetd_shortcut,
@@ -400,7 +413,8 @@ class ResNet(tf_keras.Model):
         'kernel_initializer': self._kernel_initializer,
         'kernel_regularizer': self._kernel_regularizer,
         'bias_regularizer': self._bias_regularizer,
-        'bn_trainable': self._bn_trainable
+        'bn_trainable': self._bn_trainable,
+        'use_first_projection': self._use_first_projection
     }
     return config_dict
 
@@ -441,4 +455,5 @@ def build_resnet(
       norm_momentum=norm_activation_config.norm_momentum,
       norm_epsilon=norm_activation_config.norm_epsilon,
       kernel_regularizer=l2_regularizer,
-      bn_trainable=backbone_cfg.bn_trainable)
+      bn_trainable=backbone_cfg.bn_trainable,
+      use_first_projection=backbone_cfg.use_first_projection)

--- a/official/vision/modeling/backbones/resnet_test.py
+++ b/official/vision/modeling/backbones/resnet_test.py
@@ -67,6 +67,38 @@ class ResNetTest(parameterized.TestCase, tf.test.TestCase):
     self.assertAllEqual(
         [1, input_size / 2**5, input_size / 2**5, 512 * endpoint_filter_scale],
         endpoints['5'].shape.as_list())
+    
+    @parameterized.parameters(
+      (128, 18, 1),
+      (128, 34, 1),
+  )
+  def test_network_creation_no_first_shortcut(self, input_size, model_id,
+                                              endpoint_filter_scale):
+    """Test creation of ResNet family models."""
+    resnet_params = {
+        18: 11186112,
+        34: 21301696,
+    }
+    tf.keras.backend.set_image_data_format('channels_last')
+
+    network = resnet.ResNet(model_id=model_id, use_first_projection=False)
+    self.assertEqual(network.count_params(), resnet_params[model_id])
+
+    inputs = tf.keras.Input(shape=(input_size, input_size, 3), batch_size=1)
+    endpoints = network(inputs)
+
+    self.assertAllEqual(
+        [1, input_size / 2**2, input_size / 2**2, 64 * endpoint_filter_scale],
+        endpoints['2'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**3, input_size / 2**3, 128 * endpoint_filter_scale],
+        endpoints['3'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**4, input_size / 2**4, 256 * endpoint_filter_scale],
+        endpoints['4'].shape.as_list())
+    self.assertAllEqual(
+        [1, input_size / 2**5, input_size / 2**5, 512 * endpoint_filter_scale],
+        endpoints['5'].shape.as_list())
 
   @combinations.generate(
       combinations.combine(
@@ -137,7 +169,8 @@ class ResNetTest(parameterized.TestCase, tf.test.TestCase):
         kernel_initializer='VarianceScaling',
         kernel_regularizer=None,
         bias_regularizer=None,
-        bn_trainable=True)
+        bn_trainable=True,
+        use_first_projection=True)
     network = resnet.ResNet(**kwargs)
 
     expected_config = dict(kwargs)


### PR DESCRIPTION
# Description

This should fix #10583
In this issue, I described how the small ResNets implemented here have an extra convolution (for projection), that is neither present in the original paper or in PyTorch.
This PR allows to get rid of this extra convolution with a keyword argument that defaults to the previous behaviour so that this remains a non-breaking change.

This  PR created from https://github.com/tensorflow/models/pull/10584 as it is having problem to merge in codebase with manual copybara sync.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note:I didn't wait for a discussion because this seemed like a relatively small and simple change,
so it's not bothering for me to have written it even if rejected in the end.

- [ ] New feature (non-breaking change which adds functionality)

## Tests

I added tests to check the parameter count.
I also offline checked the number of non-trainable parameters to checked that it matched against PyTorch's one.


## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
