### PR TITLE
Add a dedicated padding token to beam search to avoid padding with the start sentence token

### DIFF
--- a/official/nlp/modeling/ops/beam_search_test.py
+++ b/official/nlp/modeling/ops/beam_search_test.py
@@ -150,6 +150,36 @@ class BeamSearchTests(tf.test.TestCase, parameterized.TestCase):
     else:
       self.assertAllEqual([[[0, 1, 0, 1], [0, 1, 1, 2]]], predictions)
 
+  def test_sequence_beam_search_with_truncated_prediction(self):
+    # batch_size*beam_size, max_decode_length, vocab_size
+    probabilities = tf.constant([[[0.2, 0.7, 0.1], [0.2, 0.3, 0.5], [0.1, 0.8, 0.1]]])
+    # batch_size, max_decode_length, num_heads, embed_size per head
+    x = tf.zeros([1, 3, 2, 32], dtype=tf.float32)
+    cache = {'layer_%d' % layer: {'k': x, 'v': x} for layer in range(2)}
+    
+    def _get_test_symbols_to_logits_fn():
+      """Test function that returns logits for next token."""
+        
+      def symbols_to_logits_fn(_, i, cache):
+        logits = tf.cast(probabilities[:, i, :], tf.float32)
+        return logits, cache
+
+      return symbols_to_logits_fn
+
+    predictions, _ = beam_search.sequence_beam_search(
+        symbols_to_logits_fn=_get_test_symbols_to_logits_fn(),
+        initial_ids=tf.zeros([1], dtype=tf.int32),
+        initial_cache=cache,
+        vocab_size=3,
+        beam_size=1,
+        alpha=0.6,
+        max_decode_length=3,
+        eos_id=2,
+        padded_decode=True,
+        pad_id=42,
+        dtype=tf.float32)
+    self.assertAllEqual([[[0, 1, 2, 42]]], predictions)
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
# Description

So far, the beam search module pads its predictions using the initial token ids, it is more modular and easy to use to have the capacity to specify the padding token. By default this padding token should be zero and not the initial token id.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

I have added a naive unittest which failed before my modification and passes now.

## Checklist

- [ ] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ ] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [ ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [ ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
