### PR TITLE
loading a2 rather than a0

### DIFF
--- a/official/projects/movinet/movinet_tutorial.ipynb
+++ b/official/projects/movinet/movinet_tutorial.ipynb
@@ -439,7 +439,7 @@
       "source": [
         "## Run Streaming Model Inference with TensorFlow Hub and Plot Predictions\n",
         "\n",
-        "We will load MoViNet-A0-Stream from TensorFlow Hub as part of the [MoViNet collection](https://tfhub.dev/google/collections/movinet/).\n",
+        "We will load MoViNet-A2-Stream from TensorFlow Hub as part of the [MoViNet collection](https://tfhub.dev/google/collections/movinet/).\n",
         "\n",
         "The following code will:\n",
         "\n",


### PR DESCRIPTION
In the documentation that is provided for MoViNet tutorial, it says we will download MoViNet-A0-Stream. But In the code MoViNet-A2 is downloaded and used.