### PR TITLE
fix contrast()

### DIFF
--- a/official/vision/ops/augment.py
+++ b/official/vision/ops/augment.py
@@ -844,6 +844,8 @@ def color(image: tf.Tensor, factor: float) -> tf.Tensor:
 
 def contrast(image: tf.Tensor, factor: float) -> tf.Tensor:
   """Equivalent of PIL Contrast."""
+  image_height = tf.shape(image)[0]
+  image_width = tf.shape(image)[1]
   degenerate = tf.image.rgb_to_grayscale(image)
   # Cast before calling tf.histogram.
   degenerate = tf.cast(degenerate, tf.int32)
@@ -852,7 +854,8 @@ def contrast(image: tf.Tensor, factor: float) -> tf.Tensor:
   # and create a constant image size of that value.  Use that as the
   # blending degenerate target of the original image.
   hist = tf.histogram_fixed_width(degenerate, [0, 255], nbins=256)
-  mean = tf.reduce_sum(tf.cast(hist, tf.float32)) / 256.0
+  mean = tf.reduce_sum(
+      tf.cast(hist, tf.float32) * tf.linspace(0., 255., 256)) / float(image_height * image_width)
   degenerate = tf.ones_like(degenerate, dtype=tf.float32) * mean
   degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
   degenerate = tf.image.grayscale_to_rgb(tf.cast(degenerate, tf.uint8))

--- a/official/vision/ops/augment.py
+++ b/official/vision/ops/augment.py
@@ -844,22 +844,7 @@ def color(image: tf.Tensor, factor: float) -> tf.Tensor:
 
 def contrast(image: tf.Tensor, factor: float) -> tf.Tensor:
   """Equivalent of PIL Contrast."""
-  image_height = tf.shape(image)[0]
-  image_width = tf.shape(image)[1]
-  degenerate = tf.image.rgb_to_grayscale(image)
-  # Cast before calling tf.histogram.
-  degenerate = tf.cast(degenerate, tf.int32)
-
-  # Compute the grayscale histogram, then compute the mean pixel value,
-  # and create a constant image size of that value.  Use that as the
-  # blending degenerate target of the original image.
-  hist = tf.histogram_fixed_width(degenerate, [0, 255], nbins=256)
-  mean = tf.reduce_sum(
-      tf.cast(hist, tf.float32) * tf.linspace(0., 255., 256)) / float(image_height * image_width)
-  degenerate = tf.ones_like(degenerate, dtype=tf.float32) * mean
-  degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
-  degenerate = tf.image.grayscale_to_rgb(tf.cast(degenerate, tf.uint8))
-  return blend(degenerate, image, factor)
+  return tf.image.adjust_contrast(image, factor)
 
 
 def brightness(image: tf.Tensor, factor: float) -> tf.Tensor:


### PR DESCRIPTION
# Description

The mean pixel value should be weighted average of the histogram. [google-research/big_vision](https://github.com/google-research/big_vision) and [tensorflow/tpu](https://github.com/tensorflow/tpu) have the same bug so ideally should be fixed in the same way.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

See https://github.com/google-research/big_vision/issues/109 for details.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] My changes generate no new warnings.
