### PR TITLE
Switched YAMNet to stick with Keras 2.

### DIFF
--- a/research/audioset/yamnet/README.md
+++ b/research/audioset/yamnet/README.md
@@ -15,11 +15,13 @@ YAMNet depends on the following Python packages:
 * [`numpy`](http://www.numpy.org/)
 * [`resampy`](http://resampy.readthedocs.io/en/latest/)
 * [`tensorflow`](http://www.tensorflow.org/)
+* [`tf_keras`](https://github.com/keras-team/tf-keras)
 * [`pysoundfile`](https://pysoundfile.readthedocs.io/)
 
 These are all easily installable via, e.g., `pip install numpy` (as in the
 example command sequence below). Any reasonably recent version of these
-packages should work.
+packages should work. Note that YAMNet currently relies on Keras 2 and is
+incompatible with Keras 3 (the default as of TF 2.16).
 
 YAMNet also requires downloading the following data file:
 

--- a/research/audioset/yamnet/yamnet.py
+++ b/research/audioset/yamnet/yamnet.py
@@ -19,7 +19,7 @@ import csv
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras import Model, layers
+from tf_keras import Model, layers
 
 import features as features_lib
 


### PR DESCRIPTION
# Description

Switched YAMNet to stick with Keras 2. TF 2.16 switched the default to Keras 3
which is backwards incompatible.

closes #11212 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Installed latest versions of all dependences (including new tf_keras) and
ran yamnet_test.py


**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
