### PR TITLE
Fix Dimension Mismatch in CutMix Augmentation

### DIFF
--- a/official/vision/ops/augment.py
+++ b/official/vision/ops/augment.py
@@ -2735,7 +2735,7 @@ class MixupAndCutmix:
     cut_height = tf.cast(
         ratio * tf.cast(image_height, dtype=tf.float32), dtype=tf.int32)
     cut_width = tf.cast(
-        ratio * tf.cast(image_height, dtype=tf.float32), dtype=tf.int32)
+        ratio * tf.cast(image_width, dtype=tf.float32), dtype=tf.int32)
 
     random_center_height = tf.random.uniform(
         shape=[batch_size], minval=0, maxval=image_height, dtype=tf.int32)


### PR DESCRIPTION
## Description
This pull request addresses a bug in the CutMix augmentation implementation where the `cut_width` was incorrectly calculated based on `image_height` instead of `image_width`.

* **Motivation**: Correct bounding box dimensions in CutMix by using `image_width` to calculate `cut_width`.
* **Context**: The current code calculates both `cut_height` and `cut_width` using `image_height`.
* **Change**: Update `cut_width` calculation to use `image_width`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] My changes generate no new warnings.