### PR TITLE
Updated `parse_policy_info` function in augment.py

### DIFF
--- a/official/vision/ops/augment.py
+++ b/official/vision/ops/augment.py
@@ -1869,7 +1869,7 @@ def _parse_policy_info(name: str,
   func = NAME_TO_FUNC[name]
 
   if level_std > 0:
-    level += tf.random.normal([], dtype=tf.float32)
+    level += level_std*tf.random.normal([], dtype=tf.float32)
     level = tf.clip_by_value(level, 0., _MAX_LEVEL)
 
   args = level_to_arg(cutout_const, translate_const)[name](level)


### PR DESCRIPTION
This PR is raised to add more flexible control over the randomness in the augmentation process by changing `level += tf.random.normal([], dtype=tf.float32)` to `level += level_std * tf.random.normal([], dtype=tf.float32)` to the function `parse_policy_info` instead of standard deviation always 1.
