### PR TITLE
Fix tf-keras installation error

### DIFF
--- a/research/audioset/yamnet/README.md
+++ b/research/audioset/yamnet/README.md
@@ -15,7 +15,7 @@ YAMNet depends on the following Python packages:
 * [`numpy`](http://www.numpy.org/)
 * [`resampy`](http://resampy.readthedocs.io/en/latest/)
 * [`tensorflow`](http://www.tensorflow.org/)
-* [`tf_keras`](https://github.com/keras-team/tf-keras)
+* [`tf-keras`](https://github.com/keras-team/tf-keras)
 * [`pysoundfile`](https://pysoundfile.readthedocs.io/)
 
 These are all easily installable via, e.g., `pip install numpy` (as in the
@@ -39,7 +39,7 @@ Here's a sample installation and test session:
 python -m pip install --upgrade pip wheel
 
 # Install dependences.
-pip install numpy resampy tensorflow soundfile
+pip install numpy resampy tensorflow soundfile tf-keras
 
 # Clone TensorFlow models repo into a 'models' directory.
 git clone https://github.com/tensorflow/models.git


### PR DESCRIPTION
# Description

> :memo: Please include a summary of the change. 
>  
> * Please also include relevant motivation and context.  
> * List any dependencies that are required for this change.  
using the provided document lead to error of tf_keras module not being found. I added installation of tf-keras package in the instructions which fixes it.
## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ .] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  
try running python yamnet_test.py without first installing tf-keras package and then after installing it.
**Test Configuration**:

## Checklist

- [ .] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [ .] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [. ] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [. ] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [. ] I have made corresponding changes to the documentation.
- [ .] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
