### PR TITLE
Add fuse for RepConv

### DIFF
--- a/official/projects/yolo/modeling/layers/nn_blocks_test.py
+++ b/official/projects/yolo/modeling/layers/nn_blocks_test.py
@@ -376,5 +376,23 @@ class RepConvTest(tf.test.TestCase, parameterized.TestCase):
     self.assertNotIn(None, grad)
     return
 
+  @parameterized.named_parameters(
+    ('test', 3, 32, 32),
+    ('test1 infilters!=outfilters', 3, 16, 32),
+    ('test2 kernelsize=4', 4, 32, 32),
+    ('test3 strides=2', 3, 32, 32, 2),
+    ('test4 strides=2 infilters!=outfilters', 3, 16, 32, 2),
+    ('test5 kernelsize=4 strides=2', 4, 32, 32, 2),
+    ('test6 strides=4', 3, 32, 32, 4))
+  def test_fuse_and_unfuse_result(self, kernel_size, infilters, outfilters, strides=1):
+    batch_size = 1
+    height = width = 224
+    inputs = tf.random.uniform([batch_size, height, width, infilters])
+    test_layer = nn_blocks.RepConv(outfilters, kernel_size=kernel_size, strides=strides)
+    unfuse = test_layer(inputs)
+    test_layer.fuse()
+    fuse = test_layer(inputs)
+    self.assertAllClose(unfuse, fuse, atol=1.0e-5)
+
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
# Description

### Summary

Add fuse function for RepConv

### Motivation and Context

Fuse the multiple conv and bn layer, give me less latency and smaller model size

### Dependencies

None

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

An unit test function is added in `official/projects/yolo/modeling/layers/nn_blocks_test.RepConvTest`, named `test_fuse_and_unfuse_result`.

The test function checks the different of the two output values.

**Test Configuration**:

OS: ubuntu 16
Env：Python=3.10 TensorFlow=2.12.0

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
