### PR TITLE
[Orbit] Fix type hints in new_best_metric.py

### DIFF
--- a/orbit/actions/new_best_metric.py
+++ b/orbit/actions/new_best_metric.py
@@ -174,7 +174,7 @@ class JSONPersistedValue:
 
   def __init__(self,
                initial_value: Any,
-               filename: str,
+               filename: Optional[str],
                write_value: bool = True):
     """Initializes the instance.
 
@@ -206,11 +206,11 @@ class JSONPersistedValue:
     if self._value is None:
       self.write(initial_value)
 
-  def read(self):
+  def read(self) -> Any:
     """Returns the value."""
     return self._value
 
-  def write(self, value):
+  def write(self, value: Any) -> None:
     """Writes the value, updating the backing store if one was provided."""
     self._value = value
     if self._filename is not None and self._write_value:


### PR DESCRIPTION
…sing return types

# Description

The filename argument in JSONPersistedValue was annotated as str, but the implementation explicitly checks if self._filename is not None, implying it should be Optional[str]
This PR:
Changes filename: str to filename: Optional[str].
Adds missing return type hints (-> Any, -> None) for read and write methods.
Verified with python -m orbit.actions.new_best_metric_test.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests
I ran the existing unit tests to verify that the type hint changes didn't break any functionality.

**Test Configuration**:

OS: Windows 
Python Version: Python 3.10 
Command: python -m orbit.actions.new_best_metric_test
Result: All tests passed.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
