### PR TITLE
[Orbit] Add min_delta parameter to NewBestMetric

### DIFF
--- a/orbit/actions/new_best_metric_test.py
+++ b/orbit/actions/new_best_metric_test.py
@@ -89,6 +89,17 @@ class NewBestMetricTest(tf.test.TestCase):
     actions.JSONPersistedValue(value, tempfile)
     self.assertTrue(tf.io.gfile.exists(tempfile))
 
+  def test_new_best_metric_with_min_delta(self):
+    new_best_metric = actions.NewBestMetric(
+      lambda x: x['value'], higher_is_better=True, min_delta=0.1)
+    self.assertTrue(new_best_metric.commit({'value': 0.5}))
+    self.assertFalse(new_best_metric.test({'value': 0.55}))
+    self.assertTrue(new_best_metric.test({'value': 0.61}))
+    new_best_metric_loss = actions.NewBestMetric(
+      'value', higher_is_better=False, min_delta=0.1)
+    self.assertTrue(new_best_metric_loss.commit({'value': 1.0}))
+    self.assertFalse(new_best_metric_loss.test({'value': 0.95}))
+    self.assertTrue(new_best_metric_loss.test({'value': 0.89}))
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
# Description

This PR adds a min_delta parameter to NewBestMetric. Motivation: In many training scenarios, we want to avoid saving checkpoints or triggering actions for negligible improvements (e.g., floating point noise). min_delta allows users to specify a minimum threshold for improvement. Changes:

Added min_delta to NewBestMetric.__init__.

Updated test() logic to require new_value > best_value + min_delta (if higher is better).

Added unit test test_new_best_metric_with_min_delta in new_best_metric_test.py.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Tests
I added a new test case `test_new_best_metric_with_min_delta` in `orbit/actions/new_best_metric_test.py` to verify the new functionality.


**Test Configuration**:

* **OS**: Windows  11
* **Python Version**: 3.10
* **Command**: `python -m orbit.actions.new_best_metric_test`
* **Result**: Passed 

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
