### PR TITLE
fix(research): replace deprecated np.int with int in mobilenet_v3

### DIFF
--- a/research/slim/nets/mobilenet/mobilenet_v3.py
+++ b/research/slim/nets/mobilenet/mobilenet_v3.py
@@ -748,7 +748,7 @@ def _reduce_consecutive_layers(conv_defs, start_id, end_id, multiplier=0.5):
   defs = copy.deepcopy(conv_defs)
   for d in defs['spec'][start_id:end_id+1]:
     d.params.update({
-        'num_outputs': np.int(np.round(d.params['num_outputs'] * multiplier))
+        'num_outputs': int(np.round(d.params['num_outputs'] * multiplier))
     })
   return defs
 


### PR DESCRIPTION
## Description
This PR fixes a compatibility issue with NumPy 1.24+ in the MobileNet V3 implementation.

**The Problem:**
NumPy 1.20 deprecated `np.int`, and NumPy 1.24 completely removed it. This causes an `AttributeError: module 'numpy' has no attribute 'int'` when `_reduce_consecutive_layers` is called (e.g., when building Minimalistic or EdgeTPU variants of MobileNetV3).

**The Fix:**
Replaced the removed `np.int(...)` with Python's built-in `int(...)`.

## Changes
- Modified `research/slim/nets/mobilenet/mobilenet_v3.py`: Replaced `np.int` with `int` in the `_reduce_consecutive_layers` function.

## Verification
- Confirmed that `num_outputs` in `conv_defs` is strictly scalar, ensuring `int()` is the correct and safe replacement.
- This change restores the ability to instantiate MobileNetV3 models in environments using modern NumPy versions.