### PR TITLE
fix(waste_identification_ml): correct logger.exception calls in inference_pipeline

### DIFF
--- a/official/projects/waste_identification_ml/Triton_TF_Cloud_Deployment/client/inference_pipeline.py
+++ b/official/projects/waste_identification_ml/Triton_TF_Cloud_Deployment/client/inference_pipeline.py
@@ -201,9 +201,9 @@ def main(_) -> None:
       else:
         logger.info("Zero predictions after threshold.")
         continue
-    except (KeyError, IndexError, TypeError, ValueError) as e:
+    except (KeyError, IndexError, TypeError, ValueError):
       logger.info("Failed to filter out predictions.")
-      logger.exception("Exception occured:", e)
+      logger.exception("Exception occurred.")
 
     try:
       # Convert bbox coordinates into normalized coordinates.
@@ -246,9 +246,9 @@ def main(_) -> None:
       else:
         logger.info("Zero predictions after processing.")
         continue
-    except (KeyError, IndexError, TypeError, ValueError) as e:
+    except (KeyError, IndexError, TypeError, ValueError):
       logger.info("Issue in post processing predictions results.")
-      logger.exception("Exception occured:", e)
+      logger.exception("Exception occurred.")
 
     try:
       if result["num_detections"][0]:
@@ -266,9 +266,9 @@ def main(_) -> None:
             threshold=PREDICTION_THRESHOLD.value,
         )
         logger.info("Visualization saved.")
-    except (KeyError, IndexError, TypeError, ValueError) as e:
+    except (KeyError, IndexError, TypeError, ValueError):
       logger.info("Issue in saving visualization of results.")
-      logger.exception("Exception occured:", e)
+      logger.exception("Exception occurred.")
 
     try:
       # Resize an image for object tracking..
@@ -393,7 +393,7 @@ def main(_) -> None:
   except (KeyError, IndexError, TypeError, ValueError):
     logger.info("Issue in cropping objects")
     logger.info("Failed to crop objects.")
-    logger.exception("Exception occured:", e)
+    logger.exception("Exception occurred.")
 
   if isinstance(agg_features, pd.DataFrame) and not agg_features.empty:
     try:


### PR DESCRIPTION

**Repo:** tensorflow/models (⭐ 77668)
**Type:** bugfix
**Files changed:** 1
**Lines:** +7/-7

## What
Fixes four misuses of `logger.exception()` in `official/projects/waste_identification_ml/Triton_TF_Cloud_Deployment/client/inference_pipeline.py`. Each call passed the bound exception variable `e` as an extra positional arg (`logger.exception("Exception occured:", e)`), which the `logging` module treats as a format arg — not as traceback information — and which can raise a formatting error. The final call in the cropping block referenced `e` despite its `except` clause not binding a name, which would raise `NameError` if that branch ever executed. All four sites are now `logger.exception("Exception occurred.")`, and the unused `as e` bindings are dropped. Also corrects the misspelling "occured" → "occurred".

## Why
`logger.exception` automatically attaches the current exception's traceback (it's equivalent to `logger.error(..., exc_info=True)`). Passing the exception object as a second arg is both redundant and incorrect: the message contains no `%s`, so `logging` tries to format with a stray arg. More seriously, the cropping block's handler (`except (...) :` with no `as e`) references an undefined `e`, so a genuine failure there turns into a `NameError` that masks the original error.

## Testing
- `python3 -m py_compile` / `ast.parse` on the modified file: passes.
- Manual inspection of all four except blocks: each now uses `logger.exception` with a plain message; the bound name is removed where it is no longer needed.
- No behavior change on the happy path; error paths now log the real traceback instead of crashing on a `NameError`/format mismatch.

## Risk
Low — change is confined to four `except` blocks inside one file; purely corrects error-logging calls and a typo, no control-flow change.
